### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 AEC-Bench contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -423,3 +423,7 @@ uv run ruff format src/ tests/
 - `docs/INVARIANTS.md` — 10 non-negotiable architectural rules
 - `docs/CONTRACTS.md` — Data shapes at every boundary
 - `docs/AGENTS.md` — Agent guide with conventions and shared utilities
+
+## License
+
+AEC-Bench is distributed under the MIT License. See [LICENSE](LICENSE).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "aec-bench"
 version = "0.1.0"
 description = "Benchmark platform for evaluating AI agents on AEC engineering tasks"
 readme = "README.md"
+license = "MIT"
 requires-python = ">=3.13"
 dependencies = [
     "harbor>=0.1.45",
@@ -57,6 +58,7 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.sdist]
 include = [
     "/README.md",
+    "/LICENSE",
     "/.env.example",
     "/pyproject.toml",
     "/uv.lock",


### PR DESCRIPTION

## Summary

- Add a root `LICENSE` file with the MIT license text.
- Mark the Python project metadata as MIT licensed.
- Include `LICENSE` in the source distribution and add a short README license section.

## Validation

- `uv run ruff format --check src/ tests/`
- `uv run ruff check src/ tests/`
- `uv build`
- Verified the built sdist contains `LICENSE`.
- Verified the built wheel metadata reports `License-Expression: MIT` and `License-File: LICENSE`.

## Notes

- Full pytest was skipped because this is a license-only change.
- `uv run mypy src/aec_bench/contracts/` currently fails on the clean `origin/main` worktree with unrelated pre-existing contract typing issues.
