### PR TITLE
Fix agent skill drift against runtime APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ AEC-Bench loads `.env` from the project root when the CLI starts. Start from
 `.env.example` and fill only the providers you use; the example file contains
 placeholder names only and no real credentials.
 
+For Azure AI Foundry deployments that expose the v1 OpenAI-compatible API, set
+`AZURE_OPENAI_ENDPOINT` to the `/openai/v1/` endpoint, set
+`AZURE_OPENAI_API_KEY`, and run with the deployment name as `--model`. The
+`pydantic_ai`, `rlm`, and local Pydantic tool-loop paths use those settings.
+
+For Together AI, set `TOGETHER_API_KEY` and use an explicit `together:` model
+prefix, for example `--model "together:Qwen/Qwen3.7-Max"`. The prefix keeps
+Together model IDs from being routed to Azure when Azure credentials are also
+present.
+
 ## What This Does
 
 AEC-Bench lets you:
@@ -66,8 +76,8 @@ uv run aec-bench generate task --template path/to/template/ --instances 3
 # Preview without writing files
 uv run aec-bench generate task terzaghi-bearing-capacity --dry-run
 
-# Generate a full dataset from a suite configuration
-uv run aec-bench generate dataset --config suite.toml
+# Generate a full suite from a suite configuration
+uv run aec-bench generate suite --config suite.toml
 
 # List built-in templates
 uv run aec-bench generate list-templates
@@ -355,7 +365,7 @@ class MyToolAgent(BaseAgent):
 Ready-to-use agents in `agents/`:
 - `script_anthropic.py`, `script_azure_openai.py` — single-turn
 - `tool_loop_anthropic.py`, `tool_loop_azure_openai.py` — multi-turn with tools
-- `pydantic_ai_agent.py` — multimodal with chart generation support (provider-agnostic)
+- `pydantic_ai_agent.py` — legacy PydanticAI script agent with chart generation support
 
 ## Task Disciplines
 

--- a/docs/users/user-guide.md
+++ b/docs/users/user-guide.md
@@ -42,10 +42,10 @@ aec-bench search "bearing capacity"
 # (created by `aec-bench init`)
 
 # Generate instances
-aec-bench generate dataset --config suite.toml
+aec-bench generate suite --config suite.toml
 
 # Preview what would be generated (without writing files)
-aec-bench generate dataset --config suite.toml --dry-run
+aec-bench generate suite --config suite.toml --dry-run
 ```
 
 ### suite.toml format
@@ -79,7 +79,7 @@ aec-bench generate task terzaghi-bearing-capacity --instances 3 --seed 42
 aec-bench run tasks/ground/shallow-foundations/terzaghi-bearing-capacity \
   --model "<model-id>"
 
-# Run with the PydanticAI agent (required for multimodal tasks)
+# Run with the PydanticAI-backed tool-loop alias
 aec-bench run tasks/electrical/pf-droop \
   --model "<model-id>" \
   --adapter pydantic_ai
@@ -97,8 +97,44 @@ aec-bench evaluate
 | Adapter | When to use |
 |---------|------------|
 | `tool_loop` | Default. Text-only tasks with bash + custom tools. |
-| `pydantic_ai` | Multimodal tasks (charts, images). Requires `pydantic-ai` in container. |
-| `script` | Single-turn tasks (no tool use). |
+| `pydantic_ai` | Compatibility alias for the PydanticAI-backed tool loop. |
+| `rlm` | RLM reasoning adapter for scaffolded/report-style tasks. |
+| `lambda-rlm` | Template-driven RLM report adapter. |
+| `direct` | Single-turn tasks with no tool use. |
+
+### Azure AI Foundry Models
+
+Foundry deployments that expose the v1 OpenAI-compatible API can run through
+the PydanticAI-backed adapters. Put the endpoint and key in `.env`, then pass
+the deployment name exactly as Foundry shows it:
+
+```bash
+AZURE_OPENAI_ENDPOINT=https://example.services.ai.azure.com/openai/v1/
+AZURE_OPENAI_API_KEY=
+
+aec-bench run tasks/electrical/pf-droop \
+  --model "DeepSeek-V4-Flash" \
+  --adapter pydantic_ai
+```
+
+For classic Azure OpenAI deployments, use the same environment variables with
+the normal Azure OpenAI endpoint and `AZURE_OPENAI_API_VERSION`.
+
+### Together AI Models
+
+Together models use the OpenAI-compatible chat-completions endpoint. Put the
+key in `.env`, then prefix the model with `together:` so provider routing stays
+explicit:
+
+```bash
+TOGETHER_API_KEY=
+
+aec-bench run tasks/electrical/pf-droop \
+  --model "together:Qwen/Qwen3.7-Max" \
+  --adapter pydantic_ai
+```
+
+The prefix is stripped before the request is sent to Together.
 
 ---
 
@@ -129,9 +165,9 @@ aec-bench run tasks/<discipline>/<category>/<template-name> \
 
 ---
 
-## Journey 4: Create a Multimodal Task
+## Journey 4: Create a Chart-Generating Task
 
-Build a task where the agent generates charts or diagrams as part of its workflow.
+Build a task where the agent generates charts or diagrams as part of its workflow. The current unified entrypoint treats generated image paths as text output; binary image self-review is only available on legacy script routes.
 
 ```bash
 # Step 1: Create the task directory
@@ -147,7 +183,7 @@ version = "1.0"
 [metadata]
 difficulty = "medium"
 category = "power-systems"
-tags = ["electrical", "multimodal"]
+tags = ["electrical", "chart-generation"]
 
 [agent]
 timeout_sec = 600.0
@@ -181,7 +217,7 @@ aec-bench generate dockerfiles tasks/
 | `task.toml` | Metadata, extensions, tool declarations |
 | `instruction.md` | What the agent must do |
 | `ground_truth.json` | Expected numeric outputs |
-| `environment/tools/create_chart.py` | Chart generator (prints `IMAGE:/path` for multimodal) |
+| `environment/tools/create_chart.py` | Optional chart generator script used by the task |
 | `tests/verify.py` | Scores agent output against ground truth |
 
 ### Run it
@@ -192,7 +228,7 @@ aec-bench run tasks/electrical/my-task \
   --adapter pydantic_ai
 ```
 
-See `tasks/electrical/pf-droop/` and `tasks/electrical/qv-droop/` for complete examples.
+See `tasks/electrical/pf-droop/` and `tasks/electrical/qv-droop/` for manually authored chart-generation examples.
 
 ---
 
@@ -233,7 +269,7 @@ extensions = ["claude-cli", "multimodal"]
 | Extension | What it adds | When to use |
 |-----------|-------------|-------------|
 | `claude-cli` | curl, procps, Claude Code CLI | Tasks using Claude Code as the agent |
-| `multimodal` | pydantic-ai, matplotlib | Tasks with chart/image generation |
+| `multimodal` | pydantic-ai, matplotlib | Tasks with chart/image generation dependencies |
 | `ocr` | tesseract, poppler-utils | Tasks requiring OCR or PDF processing |
 
 ### Generating Dockerfiles
@@ -254,7 +290,7 @@ Tasks that declare `extensions` get auto-generated Dockerfiles. Tasks without `e
 
 ## Image-Returning Tools
 
-Tools can return images to the agent for multimodal self-review. Declare `returns_image = true` in task.toml:
+Tasks can declare image-producing tools with `returns_image = true` in task.toml:
 
 ```toml
 [[environment.tools]]
@@ -264,17 +300,17 @@ description = "Generate a chart from computed data."
 returns_image = true
 ```
 
-The tool script prints `IMAGE:/path/to/file.png` to stdout. The PydanticAI agent detects this, reads the image, and injects it into the conversation so the model can visually review its own output.
+The legacy script agent path can consume `IMAGE:/path/to/file.png` markers. The current unified entrypoint records tool output as text and does not expose binary image returns to the model, so do not rely on multimodal self-review unless you are intentionally using that legacy route.
 
 ### How it works
 
 ```
 Agent computes values → calls create_chart tool → tool generates PNG
-→ tool prints IMAGE:/workspace/chart.png → agent sees the chart
-→ agent reviews visually → submits final answer
+→ tool prints IMAGE:/workspace/chart.png → output is available as text
+→ verifier scores the submitted answer
 ```
 
-This requires the `pydantic_ai` adapter (`--adapter pydantic_ai`).
+Treat `returns_image = true` as partial support in the unified entrypoint.
 
 ---
 
@@ -286,7 +322,7 @@ This requires the `pydantic_ai` adapter (`--adapter pydantic_ai`).
 | `aec-bench search <query>` | Find templates and seeds |
 | `aec-bench generate list-templates` | List available templates |
 | `aec-bench generate task <name>` | Generate instances from a template |
-| `aec-bench generate dataset --config suite.toml` | Generate a full dataset |
+| `aec-bench generate suite --config suite.toml` | Generate a full suite |
 | `aec-bench generate dockerfiles tasks/` | Regenerate Dockerfiles from extensions |
 | `aec-bench generate validate-template <dir>` | Validate a template |
 | `aec-bench run <path> --model <model>` | Run an experiment |

--- a/src/aec_bench/adapters/local_registry.py
+++ b/src/aec_bench/adapters/local_registry.py
@@ -19,15 +19,19 @@ AdapterBuilder = Callable[..., Any]
 # Provider detection prefixes — shared across adapter types
 _AZURE_PREFIXES = ("gpt-", "gpt4", "o1-", "o3-", "o4-")
 _ANTHROPIC_PREFIXES = ("claude-",)
+_TOGETHER_PREFIX = "together:"
 
 
 def detect_direct_provider(model_name: str) -> str:
     """Detect the direct client provider from the model name.
 
-    Returns ``"anthropic"`` or ``"azure"``.  Defaults to ``"anthropic"``
-    for unknown models (Anthropic API is the most common local use case).
+    Returns ``"anthropic"``, ``"azure"``, or ``"together"``.  Defaults to
+    ``"anthropic"`` for unknown models (Anthropic API is the most common
+    local use case).
     """
     lower = model_name.lower()
+    if lower.startswith(_TOGETHER_PREFIX):
+        return "together"
     if any(lower.startswith(p) for p in _AZURE_PREFIXES):
         return "azure"
     return "anthropic"
@@ -164,6 +168,10 @@ def _build_direct(
             from aec_bench.adapters.direct_providers import AzureOpenAIChatDirectClient
 
             client = AzureOpenAIChatDirectClient()
+        elif provider == "together":
+            from aec_bench.adapters.direct_providers import TogetherChatDirectClient
+
+            client = TogetherChatDirectClient()
         else:
             from aec_bench.adapters.direct_providers import AnthropicDirectClient
 
@@ -271,6 +279,7 @@ def _build_tool_loop(
     workspace: str,
     client: Any | None = None,
     trajectory_writer: Any | None = None,
+    adapter_name: str = "tool_loop",
     **_kwargs: Any,
 ) -> Any:
     """Build a tool-loop adapter for local execution with bash tool.
@@ -330,7 +339,7 @@ def _build_tool_loop(
     executor = BashToolExecutor(workspace=workspace)
 
     return ToolLoopAdapter(
-        adapter_name="tool_loop",
+        adapter_name=adapter_name,
         model_name=model_name,
         client=client,
         tool_executor=executor,
@@ -339,12 +348,29 @@ def _build_tool_loop(
     )
 
 
+def _build_pydantic_ai(
+    *,
+    model_name: str,
+    workspace: str,
+    **kwargs: Any,
+) -> Any:
+    """Build the PydanticAI-backed tool-loop adapter through its public alias."""
+    return _build_tool_loop(
+        model_name=model_name,
+        workspace=workspace,
+        adapter_name="pydantic_ai",
+        **kwargs,
+    )
+
+
 # Default builder registry
 _DEFAULT_BUILDERS: dict[str, AdapterBuilder] = {
     "rlm": _build_rlm,
     "direct": _build_direct,
     "lambda-rlm": _build_lambda_rlm,
+    "lambda_rlm": _build_lambda_rlm,
     "tool_loop": _build_tool_loop,
+    "pydantic_ai": _build_pydantic_ai,
 }
 
 
@@ -354,8 +380,9 @@ class LocalAdapterRegistry:
     Each builder creates a fully-wired adapter for in-process local
     execution.  Provider credentials are read from environment variables.
 
-    The registry ships with builders for ``"rlm"`` and ``"direct"``.
-    Additional builders can be registered via :meth:`register`.
+    The registry ships with builders for the built-in local adapters and
+    compatibility aliases. Additional builders can be registered via
+    :meth:`register`.
     """
 
     def __init__(self) -> None:

--- a/src/aec_bench/cli/commands/config.py
+++ b/src/aec_bench/cli/commands/config.py
@@ -44,7 +44,7 @@ def view() -> None:
 
     Examples:
       aec-bench config view
-      aec-bench config view --json | jq '.data.settings.tasks_root'
+      aec-bench --json config view | jq '.data.settings.tasks_root'
     """
     start = time.monotonic()
     config = _load_config()

--- a/src/aec_bench/cli/commands/dataset.py
+++ b/src/aec_bench/cli/commands/dataset.py
@@ -255,7 +255,7 @@ def list_datasets_cmd(
 
     Examples:
       aec-bench dataset list
-      aec-bench dataset list --json | jq '.data[].name'
+      aec-bench --json dataset list | jq '.data[].name'
     """
     import time
 
@@ -325,7 +325,7 @@ def dataset_info(
 
     Examples:
       aec-bench dataset info electrical-only@1.0.0
-      aec-bench dataset info electrical-only --json | jq '.data.integrity'
+      aec-bench --json dataset info electrical-only | jq '.data.integrity'
     """
     import time
 
@@ -469,7 +469,7 @@ def validate_dataset(
 
     Examples:
       aec-bench dataset validate electrical-only@1.0.0
-      aec-bench dataset validate electrical-only --json | jq '.data.is_clean'
+      aec-bench --json dataset validate electrical-only | jq '.data.is_clean'
     """
     import time
 
@@ -546,7 +546,7 @@ def dataset_results_cmd(
 
     Examples:
       aec-bench dataset results electrical-only@1.0.0
-      aec-bench dataset results electrical-only --json | jq '.data.summary'
+      aec-bench --json dataset results electrical-only | jq '.data.summary'
     """
     import time
 

--- a/src/aec_bench/cli/commands/evaluate.py
+++ b/src/aec_bench/cli/commands/evaluate.py
@@ -51,7 +51,7 @@ def evaluate_experiment(
 
     Examples:
       aec-bench evaluate --experiment exp-001 --ledger-root jobs/
-      aec-bench evaluate --experiment exp-001 --json | jq '.data.summary'
+      aec-bench --json evaluate --experiment exp-001 | jq '.data.summary'
     """
     from aec_bench.communication.html_report import build_evaluation_report
     from aec_bench.evaluation.artifact import (

--- a/src/aec_bench/cli/commands/generate.py
+++ b/src/aec_bench/cli/commands/generate.py
@@ -55,7 +55,7 @@ def generate_task(
 
     Examples:
       aec-bench generate task voltage-drop --instances 5 --difficulty easy,medium
-      aec-bench generate task voltage-drop --dry-run --json | jq '.data.instances'
+      aec-bench --json generate task voltage-drop --dry-run | jq '.data.instances'
     """
     import time
 
@@ -242,7 +242,7 @@ def list_templates(
 
     Examples:
       aec-bench generate list-templates --discipline electrical
-      aec-bench generate list-templates --json | jq '.data[].name'
+      aec-bench --json generate list-templates | jq '.data[].name'
     """
     import time
 
@@ -309,7 +309,7 @@ def validate_template_cmd(
 
     Examples:
       aec-bench generate validate-template src/aec_bench/templates/builtin/voltage-drop
-      aec-bench generate validate-template ./my-template --json | jq '.data.valid'
+      aec-bench --json generate validate-template ./my-template | jq '.data.valid'
     """
     import time
 
@@ -370,7 +370,7 @@ def generate_suite(
 
     Examples:
       aec-bench generate suite --config suite.toml --dry-run
-      aec-bench generate suite --config suite.toml --json | jq '.data.total_instances'
+      aec-bench --json generate suite --config suite.toml | jq '.data.total_instances'
     """
     import time
 
@@ -516,7 +516,7 @@ def generate_suite(
 
 
 def _render_plan_table(data: dict) -> None:
-    """Render the plan summary table for generate dataset output."""
+    """Render the plan summary table for generate suite output."""
     table = Table(title=f"Dataset: {data['suite_name']} ({data['total_instances']} instances)")
     table.add_column("Category", style="bold")
     table.add_column("Breakdown")

--- a/src/aec_bench/cli/commands/import_job.py
+++ b/src/aec_bench/cli/commands/import_job.py
@@ -21,7 +21,7 @@ def import_job(
 
     Examples:
       aec-bench import jobs/exp-001-run-1
-      aec-bench import jobs/exp-001-run-1 --json | jq '.data.imported'
+      aec-bench --json import jobs/exp-001-run-1 | jq '.data.imported'
     """
     start = time.monotonic()
     resolved_ledger = resolve_path("ledger_root", cli_override=ledger_root)

--- a/src/aec_bench/cli/commands/ledger.py
+++ b/src/aec_bench/cli/commands/ledger.py
@@ -32,7 +32,7 @@ def list_trials(
 
     Examples:
       aec-bench ledger list --experiment-id exp-001
-      aec-bench ledger list --adapter tool_loop --json | jq '.data[].reward'
+      aec-bench --json ledger list --adapter tool_loop | jq '.data[].reward'
     """
     start = time.monotonic()
     resolved_ledger = resolve_path("ledger_root", cli_override=ledger_root)

--- a/src/aec_bench/cli/commands/report.py
+++ b/src/aec_bench/cli/commands/report.py
@@ -29,7 +29,7 @@ def summary(
 
     Examples:
       aec-bench report summary --experiment-id exp-001
-      aec-bench report summary -e exp-001 --json | jq '.data.mean_reward'
+      aec-bench --json report summary -e exp-001 | jq '.data.mean_reward'
     """
     start = time.monotonic()
     resolved_ledger = resolve_path("ledger_root", cli_override=ledger_root)
@@ -89,7 +89,7 @@ def leaderboard(
 
     Examples:
       aec-bench report leaderboard --experiment-id exp-001
-      aec-bench report leaderboard --json | jq '.data.leaderboard.entries[]'
+      aec-bench --json report leaderboard | jq '.data.leaderboard.entries[]'
     """
     start = time.monotonic()
     resolved_ledger = resolve_path("ledger_root", cli_override=ledger_root)
@@ -154,7 +154,7 @@ def traces(
 
     Examples:
       aec-bench report traces --experiment-id exp-001 --output traces.json
-      aec-bench report traces -e exp-001 --json | jq '.data[].n_turns'
+      aec-bench --json report traces -e exp-001 | jq '.data[].n_turns'
     """
     start = time.monotonic()
     resolved_ledger = resolve_path("ledger_root", cli_override=ledger_root)
@@ -216,8 +216,8 @@ def behavioral(
 
     Examples:
       aec-bench report behavioral -e exp-001 --classifier claude-sonnet-4-20250514
-      aec-bench report behavioral -e exp-001 --classifier claude-sonnet-4-20250514 \\
-        --json | jq '.data.trials'
+      aec-bench --json report behavioral -e exp-001 \\
+        --classifier claude-sonnet-4-20250514 | jq '.data.trials'
     """
     start = time.monotonic()
     resolved_ledger = resolve_path("ledger_root", cli_override=ledger_root)

--- a/src/aec_bench/cli/commands/run.py
+++ b/src/aec_bench/cli/commands/run.py
@@ -26,7 +26,7 @@ def run_experiment(
         "tool_loop",
         "--adapter",
         "--harness",
-        help="Agent harness: tool_loop, pydantic_ai, script, rlm",
+        help="Agent harness: tool_loop, pydantic_ai, direct, rlm, lambda-rlm",
     ),
     backend: str = typer.Option(
         "modal",
@@ -53,7 +53,7 @@ def run_experiment(
 
     Examples:
       aec-bench run tasks/electrical/voltage-drop --model gpt-4.1-mini --dry-run
-      aec-bench run --config experiment.yaml --json | jq '.data.experiment_id'
+      aec-bench --json run --config experiment.yaml | jq '.data.experiment_id'
     """
     start = time.monotonic()
 

--- a/src/aec_bench/cli/commands/run_local.py
+++ b/src/aec_bench/cli/commands/run_local.py
@@ -439,7 +439,7 @@ def run_local(
         "--adapter",
         "--harness",
         "-a",
-        help="Agent harness: rlm, direct (default: rlm)",
+        help="Agent harness: rlm, direct, tool_loop, pydantic_ai, lambda-rlm (default: rlm)",
     ),
     output_dir: str | None = typer.Option(
         None,

--- a/src/aec_bench/cli/commands/search.py
+++ b/src/aec_bench/cli/commands/search.py
@@ -34,7 +34,7 @@ def search_command(
 
     Examples:
       aec-bench search "voltage drop" --discipline electrical
-      aec-bench search "cable sizing" --json | jq '.data[].name'
+      aec-bench --json search "cable sizing" | jq '.data[].name'
     """
     start = time.monotonic()
     config = load_config()

--- a/src/aec_bench/harness/execution_entrypoint.py
+++ b/src/aec_bench/harness/execution_entrypoint.py
@@ -19,9 +19,14 @@ from aec_bench.adapters.direct import (
     replay_direct_client_from_payload,
 )
 from aec_bench.adapters.direct_providers import (
+    AnthropicDirectClient,
+    AzureOpenAIChatDirectClient,
+    TogetherChatDirectClient,
     anthropic_direct_client_from_payload,
     azure_openai_chat_client_from_payload,
+    together_chat_client_from_payload,
 )
+from aec_bench.adapters.local_registry import detect_direct_provider
 from aec_bench.adapters.rlm.providers import make_rlm_client
 from aec_bench.adapters.tool_loop import (
     ToolExecutionResult,
@@ -53,6 +58,7 @@ class ExecutionClientRegistry:
             "replay": replay_direct_client_from_payload,
             "anthropic_api": anthropic_direct_client_from_payload,
             "azure_openai_chat": azure_openai_chat_client_from_payload,
+            "together_chat": together_chat_client_from_payload,
         }
     )
     tool_loop_client_factories: dict[str, ToolLoopClientFactory] = field(
@@ -93,10 +99,14 @@ class DirectExecutionDriver:
     client_registry: ExecutionClientRegistry
 
     def execute(self, bundle: ExecutionBundle) -> AdapterResult:
+        if _payload_has_client(bundle.execution.payload):
+            client = self.client_registry.build_direct_client(_client_spec(bundle.execution.payload))
+        else:
+            client = _default_direct_client_for_model(bundle.execution.resolved_model)
         adapter = DirectAdapter(
             adapter_name=bundle.execution.adapter_name,
             model_name=bundle.execution.resolved_model,
-            client=self.client_registry.build_direct_client(_client_spec(bundle.execution.payload)),
+            client=client,
         )
         return adapter.execute(_adapter_request(bundle))
 
@@ -108,10 +118,17 @@ class ToolLoopExecutionDriver:
 
     def execute(self, bundle: ExecutionBundle) -> AdapterResult:
         tools = [ToolSpec.model_validate(tool_payload) for tool_payload in bundle.request.tools]
+        if _payload_has_client(bundle.execution.payload):
+            client = self.client_registry.build_tool_loop_client(_client_spec(bundle.execution.payload))
+        else:
+            client = _default_tool_loop_client_for_model(
+                bundle.execution.resolved_model,
+                self.workspace_dir,
+            )
         adapter = ToolLoopAdapter(
             adapter_name=bundle.execution.adapter_name,
             model_name=bundle.execution.resolved_model,
-            client=self.client_registry.build_tool_loop_client(_client_spec(bundle.execution.payload)),
+            client=client,
             tool_executor=TaskToolExecutor(
                 registry=ToolExecutorRegistry(workspace_dir=self.workspace_dir),
                 tools=tools,
@@ -250,15 +267,20 @@ def run_execution_bundle(
 
 def default_execution_driver_registry(*, workspace_dir: Path) -> ExecutionDriverRegistry:
     client_registry = ExecutionClientRegistry()
+    direct_driver = DirectExecutionDriver(client_registry=client_registry)
+    tool_loop_driver = ToolLoopExecutionDriver(
+        workspace_dir=workspace_dir,
+        client_registry=client_registry,
+    )
+    lambda_rlm_driver = LambdaRlmExecutionDriver(workspace_dir=workspace_dir)
     return ExecutionDriverRegistry(
         drivers={
-            "direct": DirectExecutionDriver(client_registry=client_registry),
-            "tool_loop": ToolLoopExecutionDriver(
-                workspace_dir=workspace_dir,
-                client_registry=client_registry,
-            ),
+            "direct": direct_driver,
+            "tool_loop": tool_loop_driver,
+            "pydantic_ai": tool_loop_driver,
             "rlm": RlmExecutionDriver(workspace_dir=workspace_dir),
-            "lambda_rlm": LambdaRlmExecutionDriver(workspace_dir=workspace_dir),
+            "lambda-rlm": lambda_rlm_driver,
+            "lambda_rlm": lambda_rlm_driver,
         }
     )
 
@@ -297,6 +319,31 @@ def _client_spec(payload: dict[str, Any]) -> SerializedClientSpec:
     return SerializedClientSpec(
         client_kind=cast(str, client_payload["client_kind"]),
         payload=cast(dict[str, Any], client_payload.get("payload", {})),
+    )
+
+
+def _payload_has_client(payload: dict[str, Any]) -> bool:
+    return isinstance(payload.get("client"), dict)
+
+
+def _default_direct_client_for_model(model_name: str) -> DirectClient:
+    provider = detect_direct_provider(model_name)
+    if provider == "azure":
+        return AzureOpenAIChatDirectClient()
+    if provider == "together":
+        return TogetherChatDirectClient()
+    return AnthropicDirectClient()
+
+
+def _default_tool_loop_client_for_model(
+    model_name: str,
+    workspace_dir: Path,
+) -> ToolLoopClient:
+    from aec_bench.adapters.tool_loop_local import PydanticAiToolLoopClient
+
+    return PydanticAiToolLoopClient(
+        model_name,
+        workspace=str(workspace_dir),
     )
 
 

--- a/src/aec_bench/init/scaffold.py
+++ b/src/aec_bench/init/scaffold.py
@@ -29,6 +29,7 @@ _SCAFFOLD_DIRS: tuple[str, ...] = (
     "tasks",
     "seeds",
     "artefacts/ledger",
+    "artefacts/datasets",
 )
 
 _PROJECT_CONFIG_TEMPLATE = """\
@@ -39,6 +40,7 @@ name = "{project_name}"
 tasks = "tasks"
 seeds = "seeds"
 ledger = "artefacts/ledger"
+datasets = "artefacts/datasets"
 feedback = "artefacts/feedback"
 jobs = "jobs"
 templates = "templates"
@@ -49,7 +51,7 @@ backend = "modal"
 
 _SUITE_TOML_CONTENT = """\
 # Suite configuration — defines which templates to generate instances from.
-# Run with: aec-bench generate dataset --config suite.toml
+# Run with: aec-bench generate suite --config suite.toml
 #
 # Each [[dataset]] entry specifies a template, instance count, and optional
 # filters. Templates are listed with: aec-bench generate list-templates
@@ -202,7 +204,7 @@ def _locate_bundled_source(package_name: str, fallback_dir: str) -> Path | None:
 def copy_skills(target: Path) -> None:
     """Copy packaged skills into ``<target>/.claude/skills/``.
 
-    Only the four packaged skill directories are written. User-added skill
+    Only the packaged skill directories are written. User-added skill
     directories are left untouched.
     """
     source = _locate_bundled_source("aec_bench.init.skill_data", ".claude/skills")

--- a/src/aec_bench/init/skill_data/add-task/references/manual-task-guidance.md
+++ b/src/aec_bench/init/skill_data/add-task/references/manual-task-guidance.md
@@ -73,6 +73,8 @@ description = "Generate a chart from computed data."
 returns_image = true
 ```
 
+`returns_image = true` documents that the tool may produce image files. The unified entrypoint currently passes tool output as text, so binary image self-review requires an intentionally selected legacy script route.
+
 ---
 
 ## 2. instruction.md
@@ -244,8 +246,8 @@ See existing task instances for reference implementations:
 
 - **Generated tasks:** `tasks/ground/` and `tasks/electrical/` contain instances
   produced by generation templates. These follow all conventions correctly.
-- **Multimodal tasks:** `tasks/electrical/pf-droop/` and `tasks/electrical/qv-droop/`
-  are manually-authored multimodal tasks with tool declarations and chart generation.
+- **Chart-generation tasks:** `tasks/electrical/pf-droop/` and `tasks/electrical/qv-droop/`
+  are manually-authored tasks with tool declarations and chart generation.
 - **Seed tasks:** `tasks/civil/`, `tasks/mechanical/`, and `tasks/structural/`
   contain seed inventories that describe tasks but may not yet have full instance
   directories.

--- a/src/aec_bench/init/skill_data/configure-experiment/SKILL.md
+++ b/src/aec_bench/init/skill_data/configure-experiment/SKILL.md
@@ -101,27 +101,34 @@ Show available agent types:
 
 ```
 Available agents:
-  1. tool_loop   — Multi-turn tool use (Anthropic, Azure OpenAI)
-  2. pydantic_ai — PydanticAI framework (all providers, multimodal support)
-                   Note: requires harbor_import_path override
-  3. direct      — Single-turn, no tools (Anthropic, Azure OpenAI)
+  1. tool_loop    — Multi-turn bash tool use with PydanticAI provider routing
+  2. pydantic_ai  — Compatibility alias for the Pydantic-backed tool loop
+  3. rlm          — RLM reasoning adapter for scaffolded/report-style tasks
+  4. lambda-rlm   — Template-driven RLM report adapter
+  5. direct       — Single-turn, no tools (Anthropic, Azure OpenAI, Together)
 ```
 
 Add contextual notes based on the selected tasks:
 - If tasks have tools: "X of your Y tasks declare tools — tool_loop or pydantic_ai will use them, direct won't."
-- If tasks have `returns_image: true`: "Z tasks have image-returning tools — pydantic_ai handles those natively."
+- If tasks have `returns_image: true`: "Z tasks have image-returning tools — binary image returns are not exposed by the unified entrypoint yet, so treat this as a gap unless you are intentionally using a legacy script agent."
+- If tasks include `lambda-rlm.toml` or `report_template.toml`, mention `lambda-rlm` as the adapter that consumes those files.
 
 Ask: **Which agent type?**
 
 If they choose `pydantic_ai`, explain:
-> "PydanticAI isn't in the default Harbor dispatch table yet. You'll need to provide the import path to your PydanticAI agent class. For example: `agents.pydantic_ai_anthropic:PydanticAIAnthropicAgent`"
+> "`pydantic_ai` is a public compatibility name for the Pydantic-backed tool loop. Use it when older configs expect that adapter name, or when you want the PydanticAI provider-routing path."
+
+If they choose `lambda-rlm`, explain:
+> "`lambda-rlm` expects a `lambda-rlm.toml` or compatible `rlm.toml` plus a report template in the task workspace."
 
 Ask: **Which model?**
 
 Suggest models based on the agent-provider matrix:
 - tool_loop + Anthropic: `claude-sonnet-4-20250514`, `claude-haiku-4-5-20251001`
 - tool_loop + Azure OpenAI: `gpt-4o`, `o3`, `o4-mini`
-- pydantic_ai: any of the above plus `gemini-2.5-pro`
+- Together: `together:Qwen/Qwen3.7-Max` (requires `TOGETHER_API_KEY`)
+- rlm / lambda-rlm: same PydanticAI provider routing as tool_loop, including Bedrock-style model IDs and `together:*`
+- pydantic_ai: same PydanticAI provider routing as tool_loop
 - direct: same as tool_loop
 
 Ask: **Custom system prompt file?** (default: none)

--- a/src/aec_bench/init/skill_data/configure-experiment/references/agent-provider-matrix.md
+++ b/src/aec_bench/init/skill_data/configure-experiment/references/agent-provider-matrix.md
@@ -4,9 +4,12 @@
 
 | Agent Type | Providers | Model Patterns | Tool Support | Multimodal |
 |------------|-----------|---------------|--------------|------------|
-| `tool_loop` | anthropic, azure_openai | `claude-*`, `gpt-*`, `o1-*`, `o3-*`, `o4-*` | Yes (bash + declared tools) | No |
-| `pydantic_ai` | anthropic, openai, azure_openai, bedrock, gemini | All above + `gemini-*` | Yes (bash + declared tools + image return) | Yes |
-| `direct` | anthropic, azure_openai | Same as tool_loop | No | No |
+| `tool_loop` | anthropic, azure_openai, bedrock, together, PydanticAI auto | `claude-*`, `gpt-*`, `o1-*`, `o3-*`, `o4-*`, Bedrock-prefixed IDs, `together:*`, provider-native names | Yes (bash tool loop) | No |
+| `pydantic_ai` | Same as `tool_loop` | Same as `tool_loop` | Yes (compatibility alias for Pydantic-backed tool loop) | No |
+| `rlm` | anthropic, azure_openai, bedrock, together, PydanticAI auto | Same as `tool_loop` | RLM REPL/scaffolded reasoning path | No |
+| `lambda-rlm` | Same as `rlm` | Same as `rlm` | Template-driven RLM report path | No |
+| `lambda_rlm` | Same as `lambda-rlm` | Same as `lambda-rlm` | Compatibility alias for `lambda-rlm` | No |
+| `direct` | anthropic, azure_openai, together | `claude-*`, `gpt-*`, `o1-*`, `o3-*`, `o4-*`, `together:*` | No | No |
 
 ## Provider Inference from Model Name
 
@@ -14,7 +17,9 @@ The provider is automatically inferred from the model name:
 
 - `claude-*` → anthropic (uses `ANTHROPIC_API_KEY`)
 - `gpt-*`, `o1-*`, `o3-*`, `o4-*` → azure_openai (uses `AZURE_OPENAI_API_KEY` + `AZURE_OPENAI_ENDPOINT`)
-- `gemini-*` → gemini (pydantic_ai only)
+- `together:*` → together (uses `TOGETHER_API_KEY`; prefix is stripped before the API request)
+- Unknown deployment names route through Azure when `AZURE_OPENAI_ENDPOINT` + `AZURE_OPENAI_API_KEY` are set for PydanticAI-backed agents
+- Bedrock-prefixed names such as `us.anthropic.*`, `amazon.*`, `meta.llama*`, `mistral.*`, `cohere.*`, and `ai21.*` route through Bedrock for PydanticAI-backed agents
 
 Override with `client.kind` if the default inference is wrong (e.g., using OpenAI directly instead of Azure).
 
@@ -28,20 +33,30 @@ Multi-turn agent with tool use. The agent gets a bash tool (always) plus any too
 
 ### pydantic_ai
 
-Uses the PydanticAI framework for the agent loop. Supports all providers (not just Anthropic and Azure OpenAI). Native multimodal support via `ToolReturn` + `BinaryContent` for image-returning tools.
+Compatibility alias for the PydanticAI-backed tool loop. It uses the same runtime as `tool_loop`, but keeps older manifests that name `pydantic_ai` working.
 
-**Use when:** tasks have image-returning tools (`returns_image = true`), or you need providers beyond Anthropic/Azure OpenAI (e.g., Gemini, Bedrock).
+**Use when:** older configs use `adapter: pydantic_ai`, or you want the public adapter name to signal the PydanticAI provider-routing path.
 
-**Important:** `pydantic_ai` is not in the default Harbor dispatch table. You must provide a `harbor_import_path` in the agent parameters pointing to your PydanticAI agent class:
+Use `adapter: pydantic_ai` directly in manifests:
 
 ```yaml
 agents:
   - name: pydantic-sonnet
     adapter: pydantic_ai
     model: claude-sonnet-4-20250514
-    parameters:
-      harbor_import_path: "agents.pydantic_ai_anthropic:PydanticAIAnthropicAgent"
 ```
+
+### rlm
+
+RLM reasoning adapter for tasks that benefit from scaffolded reasoning, scratchpad state, and optional `rlm.toml` configuration.
+
+**Use when:** a task or experiment is explicitly designed for the RLM adapter.
+
+### lambda-rlm
+
+Template-driven RLM report adapter. Looks for `lambda-rlm.toml`, falling back to `rlm.toml`, plus the configured report template.
+
+**Use when:** the workspace contains a report template and λ-RLM configuration.
 
 ### direct
 
@@ -66,5 +81,5 @@ Older single-turn agent variant. Prefer `direct` for new experiments.
 - `o3` — reasoning-focused
 - `o4-mini` — compact reasoning
 
-### Google (pydantic_ai only)
-- `gemini-2.5-pro` — multimodal, strong reasoning
+### Together AI
+- `together:Qwen/Qwen3.7-Max` — OpenAI-compatible Together model route

--- a/src/aec_bench/init/skill_data/configure-experiment/references/example-configs.md
+++ b/src/aec_bench/init/skill_data/configure-experiment/references/example-configs.md
@@ -87,8 +87,6 @@ agents:
   - name: sonnet-pydantic
     adapter: pydantic_ai
     model: claude-sonnet-4-20250514
-    parameters:
-      harbor_import_path: "agents.pydantic_ai_anthropic:PydanticAIAnthropicAgent"
   - name: gpt4o-tool-loop
     adapter: tool_loop
     model: gpt-4o

--- a/src/aec_bench/init/skill_data/configure-experiment/references/manifest-schema.md
+++ b/src/aec_bench/init/skill_data/configure-experiment/references/manifest-schema.md
@@ -10,6 +10,7 @@ The experiment config YAML maps directly to the `ExperimentManifest` Pydantic co
 | `name` | string | Yes | — | Human-readable name shown in reports and TUI. |
 | `description` | string | No | null | Optional longer description of the experiment's purpose. |
 | `repetitions` | positive int | No | 1 | How many times each task-agent combination runs. |
+| `disable_verification` | bool | No | false | Disable Harbor verifier wiring for runs that should only collect agent output. |
 
 ## tasks (TaskSelector)
 
@@ -17,6 +18,7 @@ Controls which tasks are included in the experiment.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
+| `dataset` | string | No | null | Versioned dataset selector, as `name` or `name@version`. |
 | `include_patterns` | list[string] | No | [] | Glob patterns matching task paths (e.g., `electrical/*`, `ground/terzaghi-*`). |
 | `exclude_patterns` | list[string] | No | [] | Inverse patterns — tasks matching these are removed. |
 | `domains` | list[string] | No | [] | Discipline filter. Values come from the task directory structure (e.g., `civil`, `electrical`, `ground`, `mechanical`, `structural`). Empty means all domains. |
@@ -31,21 +33,21 @@ At least one agent is required. Each agent specifies how to run tasks.
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `name` | string | Yes | — | Identifier for this agent in results (e.g., `tool_loop-sonnet`). |
-| `adapter` | string | Yes | — | Agent type: `tool_loop`, `pydantic_ai`, `direct`. |
+| `adapter` | string | Yes | — | Agent type: `tool_loop`, `pydantic_ai`, `direct`, `rlm`, `lambda-rlm`, or `lambda_rlm`. |
 | `model` | string | Yes | — | Full model name (e.g., `claude-sonnet-4-20250514`, `gpt-4o`). |
-| `client` | object | No | null | Provider override. Has `kind` (string) and `settings` (dict). |
+| `client` | object | No | null | Provider override accepted by the contract. The unified entrypoint usually derives clients from `model`; only use this when the active runner explicitly supports the client payload. |
 | `parameters` | dict | No | {} | Agent-specific config (e.g., `max_turns: 20`, `command_timeout: 180`). |
 | `system_prompt_file` | string | No | null | Path to custom system prompt file, relative to the config file's directory. |
 
 ### Client Config
 
-Only needed when the default provider inference is wrong (e.g., using OpenAI directly instead of Azure):
+Only needed when the active runner documents a serialized client payload. Most unified-entrypoint runs infer the provider from `model`.
 
 ```yaml
 client:
-  kind: openai_chat
+  kind: azure_openai_chat
   settings:
-    api_base: https://api.openai.com/v1
+    deployment: gpt-4o
 ```
 
 ## compute (ComputeConfig)

--- a/src/aec_bench/init/skill_data/create-dataset/SKILL.md
+++ b/src/aec_bench/init/skill_data/create-dataset/SKILL.md
@@ -112,13 +112,14 @@ Execute the pipeline:
 
 1. **Generate instances** (if using templates):
    ```bash
-   aec-bench generate dataset --config suite.toml --seed 42
+   aec-bench generate suite --config suite.toml --seed 42
    ```
 
 2. **Create the dataset manifest**:
    ```bash
-   aec-bench dataset create --config suite.toml --name "<name>" --version "<version>" --summary "<summary>"
+   aec-bench dataset create --from-suite-output <manifest_path> --name "<name>" --version "<version>" --summary "<summary>"
    ```
+   Use the `manifest_path` returned by `generate suite` for `<manifest_path>`.
 
 3. **Verify integrity**:
    ```bash

--- a/src/aec_bench/init/skill_data/create-template/references/template-contract.md
+++ b/src/aec_bench/init/skill_data/create-template/references/template-contract.md
@@ -305,7 +305,7 @@ Every param declared in `[params.*]` is available as a top-level template variab
 
 ### Conditional Blocks for Hidden Params
 
-Use Jinja2 `{% if ... is defined %}` guards around params that may be hidden at harder difficulties. When a param is in `hidden_params`, it is removed from `visible_params` but the direct-access variable is still set (from `all_params`). Use `is defined` to test whether a param should be shown:
+Use Jinja2 `{% if ... is defined %}` guards around params that may be hidden at harder difficulties. When a param is in `hidden_params`, it is removed from `visible_params` and is not injected as a direct-access variable. Use `is defined` to test whether a param should be shown:
 
 ```jinja2
 {% if cohesion_kpa is defined %}
@@ -313,7 +313,7 @@ Use Jinja2 `{% if ... is defined %}` guards around params that may be hidden at 
 {% endif %}
 ```
 
-**Important:** The renderer populates ALL param values (from `all_params`) into the template context, so direct-access variables are always defined. The `is defined` pattern works because the existing templates use it as a convention for params that _may_ be hidden. If you need true conditional rendering based on visibility, check against `visible_params` list or use a custom filter. The existing convention of `{% if param is defined %}` serves as documentation of which params are hideable.
+**Important:** The renderer only exposes visible param values as direct template variables. Hidden params remain available to the engine and verifier, but not to the instruction template through names like `{{ cohesion_kpa }}`. The `is defined` pattern is the intended way to exclude hidden params from generated instructions.
 
 ### Archetype Description Block
 

--- a/src/aec_bench/init/skill_data/hardening-pass/SKILL.md
+++ b/src/aec_bench/init/skill_data/hardening-pass/SKILL.md
@@ -104,10 +104,10 @@ Read all instance files: `task.toml`, `instruction.md`, and check for `environme
 
 Read `task.toml` and check:
 
-- [ ] **Required sections** — does it have `[meta]`, `[difficulty]`?
-- [ ] **Difficulty level** — is it set to one of easy/medium/hard?
-- [ ] **Tags** — are tags present and include the discipline?
-- [ ] **Tools** — if `[tools]` is declared, do the referenced tool files exist?
+- [ ] **Required sections** — does it have `[metadata]`, `[agent]`, `[verifier]`, and `[environment]`?
+- [ ] **Difficulty level** — is `[metadata].difficulty` set to one of easy/medium/hard?
+- [ ] **Tags** — are `[metadata].tags` present and include the discipline?
+- [ ] **Tools** — if `[[environment.tools]]` is declared, do the referenced tool files exist?
 
 #### 3b. Instruction
 

--- a/src/aec_bench/init/skill_data/hardening-pass/references/checklist-summary.md
+++ b/src/aec_bench/init/skill_data/hardening-pass/references/checklist-summary.md
@@ -30,10 +30,10 @@
 
 | # | Category | Check | Severity if Failed |
 |---|----------|-------|--------------------|
-| I1 | Metadata | task.toml has [meta] and [difficulty] | High |
-| I2 | Metadata | Difficulty level is valid (easy/medium/hard) | Medium |
-| I3 | Metadata | Tags present and include discipline | Low |
-| I4 | Metadata | Declared tool files exist | High |
+| I1 | Metadata | task.toml has [metadata], [agent], [verifier], and [environment] | High |
+| I2 | Metadata | [metadata].difficulty is valid (easy/medium/hard) | Medium |
+| I3 | Metadata | [metadata].tags present and include discipline | Low |
+| I4 | Metadata | [[environment.tools]] entries point to existing files | High |
 | I5 | Instruction | No template placeholders remaining | Critical |
 | I6 | Instruction | Output format specified | High |
 | I7 | Instruction | All values are concrete (no ranges/descriptions) | High |

--- a/tests/adapters/test_local_registry.py
+++ b/tests/adapters/test_local_registry.py
@@ -25,6 +25,9 @@ class TestDetectDirectProvider:
         assert detect_direct_provider("gpt-4.1-mini") == "azure"
         assert detect_direct_provider("o3-mini") == "azure"
 
+    def test_together_models(self) -> None:
+        assert detect_direct_provider("together:Qwen/Qwen3.7-Max") == "together"
+
     def test_bedrock_models(self) -> None:
         assert detect_direct_provider("us.anthropic.claude-sonnet-4-6") == "anthropic"
         # Bedrock models use the Anthropic API pattern through the prefix
@@ -37,11 +40,15 @@ class TestLocalAdapterRegistry:
     """Tests for the registry itself."""
 
     def test_registered_adapter_kinds(self) -> None:
-        """Registry should know about rlm and direct at minimum."""
+        """Registry should know about the local execution adapters."""
         registry = LocalAdapterRegistry()
         kinds = registry.available_adapters()
         assert "rlm" in kinds
         assert "direct" in kinds
+        assert "lambda-rlm" in kinds
+        assert "lambda_rlm" in kinds
+        assert "tool_loop" in kinds
+        assert "pydantic_ai" in kinds
 
     def test_unknown_adapter_raises(self) -> None:
         registry = LocalAdapterRegistry()
@@ -112,6 +119,61 @@ class TestBuildDirect:
         )
         assert hasattr(adapter, "execute")
         assert adapter.adapter_name() == "direct"
+        assert adapter.resolved_model() == "test-model"
+
+
+class TestBuildAdapterAliases:
+    """Tests for compatibility aliases advertised by skills and CLI help."""
+
+    def test_build_lambda_rlm_accepts_underscore_alias(self, tmp_path: Path) -> None:
+        """lambda_rlm should build the same canonical lambda-rlm adapter."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        (workspace / "report_template.toml").write_text(
+            """
+[[sections]]
+id = "intro"
+title = "Intro"
+writing_guidance = ["one line"]
+generation_mode = "prose"
+input_mapping = []
+"""
+        )
+        (workspace / "lambda-rlm.toml").write_text(
+            """
+[template]
+tier = "dependency_tree"
+definition = "report_template.toml"
+"""
+        )
+
+        registry = LocalAdapterRegistry()
+        adapter = registry.build(
+            adapter_kind="lambda_rlm",
+            model_name="test-model",
+            workspace=str(workspace),
+            client=MagicMock(),
+        )
+
+        assert hasattr(adapter, "execute")
+        assert adapter.adapter_name() == "lambda-rlm"
+        assert adapter.resolved_model() == "test-model"
+
+    def test_build_pydantic_ai_alias_uses_tool_loop_runtime(self, tmp_path: Path) -> None:
+        """pydantic_ai should be a working local alias for the Pydantic-backed tool loop."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        registry = LocalAdapterRegistry()
+        adapter = registry.build(
+            adapter_kind="pydantic_ai",
+            model_name="test-model",
+            workspace=str(workspace),
+            client=MagicMock(),
+        )
+
+        assert hasattr(adapter, "execute")
+        assert adapter.adapter_name() == "pydantic_ai"
         assert adapter.resolved_model() == "test-model"
 
 

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -22,6 +22,7 @@ def test_create_scaffold_creates_directories(tmp_path: Path) -> None:
     assert (tmp_path / "tasks").is_dir()
     assert (tmp_path / "seeds").is_dir()
     assert (tmp_path / "artefacts" / "ledger").is_dir()
+    assert (tmp_path / "artefacts" / "datasets").is_dir()
     assert result.created
 
 
@@ -32,6 +33,7 @@ def test_create_scaffold_skips_existing_dirs(tmp_path: Path) -> None:
     result = create_scaffold(tmp_path)
     assert result.created
     assert (tmp_path / "artefacts" / "ledger").is_dir()
+    assert (tmp_path / "artefacts" / "datasets").is_dir()
 
 
 def test_write_project_config_creates_toml(tmp_path: Path) -> None:
@@ -42,6 +44,7 @@ def test_write_project_config_creates_toml(tmp_path: Path) -> None:
     content = config_path.read_text(encoding="utf-8")
     assert "my-bench" in content
     assert "[paths]" in content
+    assert 'datasets = "artefacts/datasets"' in content
     assert "[compute]" in content
 
 

--- a/tests/harness/test_execution_entrypoint.py
+++ b/tests/harness/test_execution_entrypoint.py
@@ -10,6 +10,7 @@ from aec_bench.adapters.tool_loop import (
     ToolLoopCompletionResponse,
 )
 from aec_bench.contracts.task_definition import ToolSpec
+from aec_bench.harness import execution_entrypoint as execution_entrypoint_module
 from aec_bench.harness.execution_entrypoint import (
     default_execution_driver_registry,
     run_execution_bundle,
@@ -112,6 +113,150 @@ def test_execution_entrypoint_runs_tool_loop_bundle_and_writes_result(
     result = read_execution_result(result_path)
 
     assert result.adapter_name == "tool-loop"
+    assert result.raw_output_text == '{"findings": []}'
+
+
+def test_execution_entrypoint_runs_pydantic_ai_alias_bundle_and_writes_result(
+    tmp_path: Path,
+) -> None:
+    """pydantic_ai should dispatch through the same tool-loop execution driver."""
+    bundle_path = write_execution_bundle(
+        path=tmp_path / "bundle.json",
+        bundle=ExecutionBundle(
+            execution=SerializedAdapterExecution(
+                adapter_kind="pydantic_ai",
+                adapter_name="pydantic_ai",
+                resolved_model="gpt-5.4-mini",
+                payload={
+                    "client": ReplayToolLoopClient(
+                        responses=[
+                            ToolLoopCompletionResponse(
+                                output_text='{"findings": []}',
+                                done=True,
+                            )
+                        ]
+                    )
+                    .serialize_client()
+                    .__dict__
+                },
+            ),
+            request=AdapterRequestPayload(
+                instruction="Review the task.",
+                system_prompt=None,
+                tools=[],
+                configuration={"max_turns": 4},
+                output_path="/workspace/output.jsonl",
+                output_format="jsonl",
+            ),
+        ),
+    )
+
+    result_path = run_execution_bundle(
+        bundle_path=bundle_path,
+        result_path=tmp_path / "result.json",
+        registry=default_execution_driver_registry(workspace_dir=tmp_path),
+    )
+    result = read_execution_result(result_path)
+
+    assert result.adapter_name == "pydantic_ai"
+    assert result.raw_output_text == '{"findings": []}'
+
+
+def test_execution_entrypoint_runs_direct_bundle_without_serialized_client(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Direct Harbor bundles may omit payload; the driver should derive the client from model."""
+
+    class _StubDirectClient:
+        def complete(self, request):  # noqa: ANN001
+            return DirectCompletionResponse(output_text=f"model={request.model}")
+
+    monkeypatch.setattr(
+        execution_entrypoint_module,
+        "_default_direct_client_for_model",
+        lambda model_name: _StubDirectClient(),
+    )
+
+    bundle_path = write_execution_bundle(
+        path=tmp_path / "bundle.json",
+        bundle=ExecutionBundle(
+            execution=SerializedAdapterExecution(
+                adapter_kind="direct",
+                adapter_name="direct",
+                resolved_model="gpt-5.4",
+                payload={},
+            ),
+            request=AdapterRequestPayload(
+                instruction="Review the task.",
+                system_prompt=None,
+                tools=[],
+                configuration={},
+                output_path="/workspace/output.jsonl",
+                output_format="jsonl",
+            ),
+        ),
+    )
+
+    result_path = run_execution_bundle(
+        bundle_path=bundle_path,
+        result_path=tmp_path / "result.json",
+        registry=default_execution_driver_registry(workspace_dir=tmp_path),
+    )
+    result = read_execution_result(result_path)
+
+    assert result.adapter_name == "direct"
+    assert result.raw_output_text == "model=gpt-5.4"
+
+
+def test_execution_entrypoint_runs_pydantic_ai_bundle_without_serialized_client(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Pydantic-backed Harbor bundles may omit payload; the driver should build a client."""
+    replay_client = ReplayToolLoopClient(
+        responses=[
+            ToolLoopCompletionResponse(
+                output_text='{"findings": []}',
+                done=True,
+            )
+        ]
+    )
+
+    monkeypatch.setattr(
+        execution_entrypoint_module,
+        "_default_tool_loop_client_for_model",
+        lambda model_name, workspace_dir: replay_client,
+    )
+
+    bundle_path = write_execution_bundle(
+        path=tmp_path / "bundle.json",
+        bundle=ExecutionBundle(
+            execution=SerializedAdapterExecution(
+                adapter_kind="pydantic_ai",
+                adapter_name="pydantic_ai",
+                resolved_model="gpt-5.4-mini",
+                payload={},
+            ),
+            request=AdapterRequestPayload(
+                instruction="Review the task.",
+                system_prompt=None,
+                tools=[],
+                configuration={"max_turns": 4},
+                output_path="/workspace/output.jsonl",
+                output_format="jsonl",
+            ),
+        ),
+    )
+
+    result_path = run_execution_bundle(
+        bundle_path=bundle_path,
+        result_path=tmp_path / "result.json",
+        registry=default_execution_driver_registry(workspace_dir=tmp_path),
+    )
+    result = read_execution_result(result_path)
+
+    assert result.adapter_name == "pydantic_ai"
     assert result.raw_output_text == '{"findings": []}'
 
 
@@ -257,3 +402,13 @@ def test_execution_entrypoint_runs_lambda_rlm_bundle_and_writes_result(
         assert result.adapter_name == "lambda-rlm"
         assert result.raw_output_text is not None
         assert len(result.raw_output_text) > 0
+
+
+def test_default_execution_registry_exposes_documented_adapter_aliases(
+    tmp_path: Path,
+) -> None:
+    """Execution registry should accept the adapter names exposed to users."""
+    registry = default_execution_driver_registry(workspace_dir=tmp_path)
+
+    assert registry.resolve("lambda-rlm") is registry.resolve("lambda_rlm")
+    assert registry.resolve("pydantic_ai") is registry.resolve("tool_loop")

--- a/tests/harness/test_harbor_dispatch.py
+++ b/tests/harness/test_harbor_dispatch.py
@@ -112,7 +112,7 @@ def test_resolve_import_path_returns_entrypoint_agent_for_all_adapters() -> None
     from aec_bench.contracts.experiment_manifest import AgentConfig
     from aec_bench.harness.harbor_dispatch import _resolve_import_path
 
-    for adapter in ("rlm", "direct", "tool_loop", "lambda_rlm", "pydantic_ai"):
+    for adapter in ("rlm", "direct", "tool_loop", "lambda-rlm", "lambda_rlm", "pydantic_ai"):
         agent = AgentConfig(name="test", adapter=adapter, model="claude-sonnet-4-20250514")
         path = _resolve_import_path(agent)
         assert path == "agents.entrypoint_agent:EntrypointAgent", f"Failed for adapter={adapter}"

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -13,6 +13,7 @@ def test_sdist_manifest_is_release_scoped() -> None:
 
     assert set(sdist["include"]) == {
         "/.env.example",
+        "/LICENSE",
         "/README.md",
         "/pyproject.toml",
         "/uv.lock",


### PR DESCRIPTION
## Summary
- add runtime support for documented adapter aliases including pydantic_ai and lambda-rlm/lambda_rlm
- refresh packaged agent skills, scaffold defaults, and existing user docs to match the current CLI/runtime contracts
- correct CLI help examples for top-level --json and align the release manifest test with the new LICENSE include

## Verification
- uv run pytest -> 3619 passed, 20 skipped, 5 warnings
- uv run ruff check on the touched Python files -> All checks passed
- uv run ruff check . currently reports pre-existing lint issues in scripts/debug_evolver.py and generated/manual task files under tasks/, outside this PR scope