### PR TITLE
Add Morph Cloud Harbor backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,10 @@ ANTHROPIC_API_KEY=
 # OpenAI direct API
 OPENAI_API_KEY=
 
-# Azure OpenAI
+# Together AI OpenAI-compatible API
+TOGETHER_API_KEY=
+
+# Azure OpenAI or Azure AI Foundry v1 OpenAI-compatible endpoint
 AZURE_OPENAI_ENDPOINT=
 AZURE_OPENAI_API_KEY=
 AZURE_OPENAI_API_VERSION=2024-10-21
@@ -18,6 +21,9 @@ AWS_DEFAULT_REGION=
 AWS_BEDROCK_ENDPOINT=
 AWS_BEARER_TOKEN=
 AWS_BEARER_TOKEN_BEDROCK=
+
+# Morph Cloud sandbox backend
+MORPH_API_KEY=
 
 # Optional token for non-loopback Web UI internal routes.
 AEC_BENCH_INTERNAL_TOKEN=

--- a/README.md
+++ b/README.md
@@ -102,7 +102,12 @@ uv run aec-bench run --config experiment.yaml --tasks-root tasks/
 
 # Dry run to see the plan
 uv run aec-bench run tasks/mechanical/heat-load --model "<model-id>" --dry-run
+
+# Run through Morph Cloud via Harbor
+uv run aec-bench run tasks/electrical/pf-droop --model "<model-id>" --backend morph
 ```
+
+`aec-bench run` defaults to Harbor's `modal` backend. Morph Cloud runs use Harbor's normal task, agent, artifact, and verifier lifecycle through `--backend morph`; set `MORPH_API_KEY` in `.env` before using it.
 
 ### Prime Lab Export
 

--- a/docs/evolution-guide.md
+++ b/docs/evolution-guide.md
@@ -213,7 +213,7 @@ Both modes use the same engine (classify → analyse → evolve → gate), the s
 | `generate.difficulties` | list | `["easy","medium"]` | Difficulty levels to include |
 | `tasks.domains` | list | required | Engineering disciplines to filter tasks |
 | `strategy` | string | `"hill_climb"` | Selection mode: `"hill_climb"` or `"qd"` |
-| `backend` | string | `"local"` | Execution backend |
+| `backend` | string | `"local"` | Execution backend. Use `local` for default evolution; `morph` is available for direct Morph-backed solve runs when solver config and Morph credentials are present. |
 | `batch_size` | int | 10 | Tasks per cycle |
 | `max_cycles` | int | 20 | Maximum evolution iterations |
 | `improvement_threshold` | float | 0.02 | Minimum improvement to accept a mutation |

--- a/docs/harness-guide.md
+++ b/docs/harness-guide.md
@@ -62,7 +62,19 @@ Every compute boundary must provide the equivalent of:
 - resource enforcement,
 - teardown.
 
-For the immediate Python path, those capabilities should be satisfied by Harbor wherever possible rather than reimplemented directly. Domain logic should not know whether execution ultimately lands on local Docker, remote Docker, Modal, or a future backend.
+For the immediate Python path, those capabilities should be satisfied by Harbor wherever possible rather than reimplemented directly. Domain logic should not know whether execution ultimately lands on local Docker, remote Docker, Modal, Morph Cloud, or a future backend.
+
+Direct Python compute backends may exist for parity checks and focused smoke runs, but vendor-specific transport code belongs outside `harness/`. For example, the direct Morph Cloud runner keeps trial orchestration in `harness/` while SDK calls, file transfer, Docker host setup, and snapshot cleanup live under `providers/`.
+
+### Morph Cloud Through Harbor
+
+Morph Cloud support is additive to the earlier direct provider spike. It does not immediately supersede that work.
+
+The normal `aec-bench run --backend morph` path should go through Harbor. Python emits a Harbor environment config with an import path of `aec_bench.providers.morph_harbor:MorphHarborEnvironment`; Harbor still owns task staging, agent invocation, artifact collection, and verifier invocation. The Morph adapter only translates Harbor's `BaseEnvironment` calls into Morph Cloud operations.
+
+The direct `MorphSandboxRunner` remains useful for provider-level smoke tests, direct evolution execution, and backend parity checks. It should not become the main experiment CLI route unless Harbor cannot express the workflow.
+
+Morph-specific SDK calls and remote Docker host handling belong under `providers/`. The harness may select `morph`, validate the contract, and ingest results, but it should not import the Morph SDK directly.
 
 ---
 

--- a/docs/swarm-guide.md
+++ b/docs/swarm-guide.md
@@ -180,7 +180,7 @@ _swarm_runs/
 |-------|------|---------|-------------|
 | `parallel` | bool | true | Run agent evals concurrently |
 | `timeout` | int | 300 | Seconds per task execution |
-| `backend` | string | "local" | `"local"`, `"modal"`, or `"e2b"` |
+| `backend` | string | "local" | Reserved backend selector. Config accepts `"local"`, `"modal"`, `"e2b"`, or `"morph"`, but the current swarm CLI only executes `"local"`. |
 
 ### `evolution`
 

--- a/docs/users/user-guide.md
+++ b/docs/users/user-guide.md
@@ -88,9 +88,21 @@ aec-bench run tasks/electrical/pf-droop \
 aec-bench run tasks/ground/shallow-foundations/terzaghi-bearing-capacity \
   --model "<model-id>" --dry-run
 
+# Run through Morph Cloud via Harbor
+aec-bench run tasks/electrical/pf-droop \
+  --model "<model-id>" \
+  --adapter pydantic_ai \
+  --backend morph
+
 # Evaluate results
 aec-bench evaluate
 ```
+
+### Backend Selection
+
+`aec-bench run` executes through Harbor. The default backend is `modal`; supported run backends are `modal`, `morph`, `e2b`, `daytona`, and `docker`.
+
+Use `--backend morph` when you want Harbor's normal task/agent/verifier flow to run on Morph Cloud. Morph runs require the `morphcloud` package and `MORPH_API_KEY` in `.env`.
 
 ### Adapter types
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "ribs[visualize]>=0.9.0",
     "pdfplumber>=0.11.9",
     "pymupdf>=1.27.2.2",
+    "morphcloud>=0.1.111",
 ]
 
 [project.scripts]

--- a/src/aec_bench/cli/commands/run.py
+++ b/src/aec_bench/cli/commands/run.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import typer
-import yaml
+import yaml  # type: ignore[import-untyped]
 
 if TYPE_CHECKING:
     from aec_bench.contracts.experiment_manifest import ExperimentManifest
@@ -32,7 +32,7 @@ def run_experiment(
         "modal",
         "--backend",
         "-b",
-        help="Execution backend: modal, e2b, daytona, docker",
+        help="Harbor execution backend: modal, morph, e2b, daytona, docker.",
     ),
     repetitions: int = typer.Option(1, "--repetitions", "-n", help="Repetitions"),
     dry_run: bool = typer.Option(False, "--dry-run", help="Show plan without executing"),
@@ -174,8 +174,22 @@ def _execute_manifest(
     dry_run: bool,
     start: float,
 ) -> None:
+    from aec_bench.harness.harbor_dispatch import HARBOR_RUN_BACKENDS
     from aec_bench.harness.scheduler import build_trial_plan, select_manifest_tasks
     from aec_bench.tasks.registry import TaskRegistry
+
+    if manifest.compute.backend not in HARBOR_RUN_BACKENDS:
+        supported = ", ".join(HARBOR_RUN_BACKENDS)
+        emit(
+            "run",
+            data=None,
+            errors=[
+                f"backend '{manifest.compute.backend}' is not supported by 'aec-bench run'; "
+                f"or choose one of: {supported}"
+            ],
+            start_time=start,
+        )
+        return
 
     registry = TaskRegistry(tasks_root=tasks_root)
     registry.reload()
@@ -195,6 +209,7 @@ def _execute_manifest(
     if dry_run:
         plan_data = {
             "experiment_id": manifest.experiment_id,
+            "backend": manifest.compute.backend,
             "selected_tasks": len(selected_tasks),
             "planned_trials": len(plan),
             "agents": [a.name for a in manifest.agents],
@@ -202,8 +217,9 @@ def _execute_manifest(
             "trials": [{"trial_id": t.trial_id, "task_id": t.task_id, "agent": t.agent.name} for t in plan],
         }
 
-        def _render_dry_run(d: dict) -> None:
+        def _render_dry_run(d: dict[str, Any]) -> None:
             console.print(f"[bold]Dry Run: {d['experiment_id']}[/bold]")
+            console.print(f"  Backend:    {d['backend']}")
             console.print(f"  Tasks:      {d['selected_tasks']}")
             console.print(f"  Agents:     {', '.join(d['agents'])}")
             console.print(f"  Repetitions: {d['repetitions']}")
@@ -260,7 +276,7 @@ def _execute_manifest(
         "duplicates": result.import_result.duplicate_trials if result.import_result else 0,
     }
 
-    def _render_result(d: dict) -> None:
+    def _render_result(d: dict[str, Any]) -> None:
         print_success(f"Completed: {d['imported']} trials imported into ledger")
 
     emit("run", result_data, start_time=start, human_renderer=_render_result)

--- a/src/aec_bench/cli/commands/swarm.py
+++ b/src/aec_bench/cli/commands/swarm.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import typer
 
@@ -31,6 +32,10 @@ def swarm_run(
     except Exception as exc:
         print_error(f"Invalid config: {exc}")
         raise typer.Exit(1) from exc
+
+    if config.evaluation.backend != "local":
+        print_error(f"Swarm currently supports only local evaluation; configured backend: {config.evaluation.backend}")
+        raise typer.Exit(1)
 
     console.print(f"[bold green]Swarm starting:[/bold green] {config.agents.count} agents")
     console.print(f"  Budget: ${config.budget.max_cost_usd:.2f}")
@@ -60,10 +65,12 @@ def swarm_run(
     console.print(f"  Tasks: {len(task_dirs)} task instances")
 
     # Read adapter from workspace manifest
-    import yaml as _yaml
+    import yaml as _yaml  # type: ignore[import-untyped]
 
-    manifest_data = _yaml.safe_load((workspace_path / "manifest.yaml").read_text())
-    adapter = manifest_data.get("agent_adapter", "rlm")
+    raw_manifest: object = _yaml.safe_load((workspace_path / "manifest.yaml").read_text())
+    manifest_data = {str(k): v for k, v in raw_manifest.items()} if isinstance(raw_manifest, dict) else {}
+    adapter_value = manifest_data.get("agent_adapter", "rlm")
+    adapter = adapter_value if isinstance(adapter_value, str) else "rlm"
     console.print(f"  Adapter: {adapter}")
 
     # Build LLM clients
@@ -164,7 +171,7 @@ def swarm_history(
 ) -> None:
     """List past swarm runs."""
     state_path = Path(state_dir)
-    runs: list[dict] = []
+    runs: list[dict[str, Any]] = []
     for event_file in sorted(state_path.glob("**/events.jsonl")):
         from aec_bench.evolution.swarm.resume import rebuild_state
 

--- a/src/aec_bench/evolution/runner.py
+++ b/src/aec_bench/evolution/runner.py
@@ -42,6 +42,7 @@ def build_evolution_runner(
 
     # 4. Build solve function — local execution when task_dirs provided, stub otherwise
     experiment_id = f"evo-{workspace.manifest.name}"
+    solve_fn: SolveFn
     if task_dirs:
         solve_fn = make_local_solve_fn(
             task_dirs=task_dirs,
@@ -118,8 +119,8 @@ def build_evolution_runner_from_config(
 
     # 6. Build solve function based on config.backend
     experiment_id = f"evo-{workspace.manifest.name}"
-    if config.backend in ("harbor", "modal") and config.solver is not None:
-        solve_fn = _build_harbor_solve_fn(
+    if config.backend in ("harbor", "modal", "morph") and config.solver is not None:
+        solve_fn = _build_remote_solve_fn(
             config=config,
             task_dirs=task_dirs,
             experiment_id=experiment_id,
@@ -134,7 +135,7 @@ def build_evolution_runner_from_config(
             workspace_root=Path(config.workspace_path),
         )
     else:
-        if config.backend in ("harbor", "modal"):
+        if config.backend in ("harbor", "modal", "morph"):
             _log.warning(
                 "backend=%r requires solver config (via harness_config or explicit solver). "
                 "Falling back to stub solve function.",
@@ -238,27 +239,26 @@ def generate_task_instances(gen_config: TaskGenerateConfig) -> list[Path]:
     return generated_dirs
 
 
-def _build_harbor_solve_fn(
+def _build_remote_solve_fn(
     *,
     config: EvolutionConfig,
     task_dirs: list[Path],
     experiment_id: str,
 ) -> SolveFn:
-    """Build a harbor solve function from config.
+    """Build a remote solve function from config.
 
-    Constructs ModalBackend, adapter, and resolved tasks from the solver config.
+    Constructs a remote ComputeBackend, adapter, and resolved tasks from the solver config.
     All harness imports are deferred to avoid requiring Modal SDK at module load.
-    Falls back to the stub solve function when the Modal SDK is not installed.
+    Falls back to the stub solve function when backend dependencies are not installed.
     """
     try:
         from aec_bench.adapters.factory import build_remote_adapter
         from aec_bench.evolution.backends.harbor import make_harbor_solve_fn
-        from aec_bench.harness.modal_runner import ModalSandboxRunner, ModalSdkOperations
         from aec_bench.harness.trial_runner import TrialRunner
         from aec_bench.tasks.instance import ResolvedTaskInstance, resolve_instance_paths
         from aec_bench.tasks.loader import load_task_definition
     except ImportError as exc:
-        _log.error("Harbor backend requires Modal SDK. Install with: uv add modal. Error: %s", exc)
+        _log.error("Remote backend wiring failed to import common dependencies. Error: %s", exc)
         return make_stub_solve_fn([])
 
     assert config.solver is not None  # caller guarantees this
@@ -269,13 +269,31 @@ def _build_harbor_solve_fn(
     # Build artifacts dir alongside the workspace
     artifacts_dir = Path(config.workspace_path) / "artifacts"
 
-    # Build Modal backend — operations requires the real Modal SDK at runtime
-    modal_operations = ModalSdkOperations()
-    modal_runner = ModalSandboxRunner(
-        operations=modal_operations,
-        artifacts_dir=artifacts_dir,
-    )
-    backend = modal_runner
+    backend: object
+    if config.backend == "morph":
+        try:
+            from aec_bench.harness.morph_runner import MorphSandboxRunner
+            from aec_bench.providers.morph_cloud import MorphCloudOperations
+        except ImportError as exc:
+            _log.error(
+                "Morph backend requires Morph Cloud dependencies. Install with: uv add morphcloud. Error: %s",
+                exc,
+            )
+            return make_stub_solve_fn([])
+        backend = MorphSandboxRunner(
+            operations=MorphCloudOperations(),
+            artifacts_dir=artifacts_dir,
+        )
+    else:
+        try:
+            from aec_bench.harness.modal_runner import ModalSandboxRunner, ModalSdkOperations
+        except ImportError as exc:
+            _log.error("Harbor/modal backend requires Modal SDK. Install with: uv add modal. Error: %s", exc)
+            return make_stub_solve_fn([])
+        backend = ModalSandboxRunner(
+            operations=ModalSdkOperations(),
+            artifacts_dir=artifacts_dir,
+        )
 
     # Resolve task instances — tasks_root is the parent of the first task dir's
     # discipline segment, inferred as the common ancestor two levels up from each
@@ -295,10 +313,12 @@ def _build_harbor_solve_fn(
     # Build trial runner
     trial_runner = TrialRunner(artifacts_dir=artifacts_dir)
 
+    backend_tasks: list[object] = list(resolved_tasks)
+
     return make_harbor_solve_fn(
         trial_runner=trial_runner,
         backend=backend,
-        tasks=resolved_tasks,
+        tasks=backend_tasks,
         adapter=adapter,
         experiment_id=experiment_id,
         runtime_image=f"evolution-{config.solver.adapter}",

--- a/src/aec_bench/evolution/swarm/config.py
+++ b/src/aec_bench/evolution/swarm/config.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Literal
 
-import yaml
+import yaml  # type: ignore[import-untyped]
 from pydantic import PositiveInt
 
 from aec_bench.contracts.validators import NonEmptyStr, StrictModel
@@ -67,7 +67,7 @@ class SwarmEvalConfig(StrictModel):
 
     parallel: bool = True
     timeout: PositiveInt = 300
-    backend: Literal["local", "modal", "e2b"] = "local"
+    backend: Literal["local", "modal", "e2b", "morph"] = "local"
 
 
 class SwarmEvolutionConfig(StrictModel):

--- a/src/aec_bench/harness/harbor_contract.py
+++ b/src/aec_bench/harness/harbor_contract.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from pydantic import Field, ValidationError, field_validator
+from pydantic import Field, ValidationError, field_validator, model_validator
 
 from aec_bench.contracts.validators import LenientModel, ensure_non_empty_string
 
@@ -37,12 +37,30 @@ class HarborAgentConfig(LenientModel):
 
 
 class HarborEnvironmentConfig(LenientModel):
-    type: str
+    type: str | None = None
+    import_path: str | None = None
+    kwargs: dict[str, Any] = Field(default_factory=dict)
 
     @field_validator("type")
     @classmethod
-    def validate_type(cls, value: str) -> str:
+    def validate_type(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
         return ensure_non_empty_string(value)
+
+    @field_validator("import_path")
+    @classmethod
+    def validate_import_path(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return ensure_non_empty_string(value)
+
+    @model_validator(mode="after")
+    def validate_environment_reference(self) -> "HarborEnvironmentConfig":
+        if self.type is None and self.import_path is None:
+            msg = "environment must include type or import_path"
+            raise ValueError(msg)
+        return self
 
 
 class HarborTrialConfig(LenientModel):

--- a/src/aec_bench/harness/harbor_dispatch.py
+++ b/src/aec_bench/harness/harbor_dispatch.py
@@ -8,11 +8,16 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
 
-import yaml
+import yaml  # type: ignore[import-untyped]
 
 from aec_bench.contracts.experiment_manifest import AgentConfig, ExperimentManifest
 from aec_bench.contracts.task_definition import TaskDefinition
 from aec_bench.harness.scheduler import build_trial_plan
+
+MORPH_BACKEND = "morph"
+MORPH_HARBOR_ENVIRONMENT_IMPORT_PATH = "aec_bench.providers.morph_harbor:MorphHarborEnvironment"
+HARBOR_NATIVE_BACKENDS = ("modal", "e2b", "daytona", "docker")
+HARBOR_RUN_BACKENDS = (*HARBOR_NATIVE_BACKENDS, MORPH_BACKEND)
 
 
 class HarborDispatchError(Exception):
@@ -88,12 +93,7 @@ def build_harbor_job_config(
             "n_concurrent_trials": int(manifest.compute.resource_limits.get("n_concurrent_trials", 1)),
             "quiet": False,
         },
-        "environment": {
-            "type": manifest.compute.backend,
-            "force_build": False,
-            "delete": True,
-            "kwargs": {},
-        },
+        "environment": _harbor_environment_config(manifest.compute.backend),
         "agents": [_harbor_agent_config(agent) for agent in manifest.agents],
         "datasets": [],
         "tasks": [{"path": f"tasks/{task.task_id}"} for task in tasks],
@@ -110,6 +110,22 @@ def build_harbor_job_config(
     if manifest.disable_verification:
         config["verifier"] = {"disable": True}
     return config
+
+
+def _harbor_environment_config(backend: str) -> dict[str, Any]:
+    if backend == MORPH_BACKEND:
+        return {
+            "import_path": MORPH_HARBOR_ENVIRONMENT_IMPORT_PATH,
+            "force_build": False,
+            "delete": True,
+            "kwargs": {"compute_backend": MORPH_BACKEND},
+        }
+    return {
+        "type": backend,
+        "force_build": False,
+        "delete": True,
+        "kwargs": {},
+    }
 
 
 ENTRYPOINT_AGENT_IMPORT_PATH = "agents.entrypoint_agent:EntrypointAgent"

--- a/src/aec_bench/harness/harbor_import.py
+++ b/src/aec_bench/harness/harbor_import.py
@@ -25,9 +25,11 @@ from aec_bench.contracts.trial_record import (
 from aec_bench.contracts.validators import infer_output_format, normalize_workspace_path
 from aec_bench.harness.harbor_contract import (
     HarborArtifactContractError,
+    HarborEnvironmentConfig,
     HarborTrialResult,
     read_harbor_trial_result,
 )
+from aec_bench.harness.harbor_dispatch import MORPH_BACKEND, MORPH_HARBOR_ENVIRONMENT_IMPORT_PATH
 from aec_bench.harness.verifier_artifacts import read_verifier_artifacts
 from aec_bench.tasks.loader import load_task_definition
 
@@ -153,7 +155,7 @@ def import_harbor_trial(
         ),
         environment=EnvironmentSnapshot(
             runtime_image=_runtime_image(task_relative_path=task_relative_path),
-            compute_backend=harbor_result.config.environment.type,
+            compute_backend=_compute_backend(harbor_result.config.environment),
             tool_versions=None,
         ),
         inputs=InputRecord(
@@ -322,6 +324,17 @@ def _resolved_model(*, harbor_result: HarborTrialResult) -> str:
 
 def _runtime_image(*, task_relative_path: str) -> str:
     return f"harbor-dockerfile:{task_relative_path}/environment/Dockerfile"
+
+
+def _compute_backend(environment: HarborEnvironmentConfig) -> str:
+    if environment.type is not None:
+        return environment.type
+    raw_backend = environment.kwargs.get("compute_backend")
+    if isinstance(raw_backend, str) and raw_backend:
+        return raw_backend
+    if environment.import_path == MORPH_HARBOR_ENVIRONMENT_IMPORT_PATH:
+        return MORPH_BACKEND
+    raise HarborImportError("unable to resolve compute backend from Harbor result")
 
 
 def _setup_duration_seconds(*, harbor_result: HarborTrialResult) -> float | None:

--- a/src/aec_bench/harness/morph_runner.py
+++ b/src/aec_bench/harness/morph_runner.py
@@ -1,0 +1,265 @@
+# ABOUTME: Morph Cloud compute-backend orchestration for aec-bench trials.
+# ABOUTME: Keeps task execution flow backend-neutral while provider code owns Morph transport details.
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol, cast
+
+from aec_bench.adapters.base import SerializedClientSpec
+from aec_bench.adapters.direct_providers import required_env_values_for_client_spec
+from aec_bench.harness.backend import (
+    BackendExecutionRequest,
+    BackendExecutionResult,
+    CollectedArtifacts,
+    TrialHandle,
+)
+from aec_bench.harness.execution_payload import (
+    read_execution_result,
+    write_execution_bundle,
+)
+from aec_bench.providers.morph_cloud import morph_object_id
+
+REMOTE_WORKSPACE_DIR = "/workspace"
+REMOTE_LOGS_DIR = "/logs/verifier"
+REMOTE_AEC_BENCH_DIR = "/workspace/.aec-bench"
+REMOTE_EXECUTION_BUNDLE_PATH = f"{REMOTE_AEC_BENCH_DIR}/execution-bundle.json"
+REMOTE_EXECUTION_RESULT_PATH = f"{REMOTE_AEC_BENCH_DIR}/adapter-result.json"
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+PROJECT_SRC_DIR = PROJECT_ROOT / "src" / "aec_bench"
+RUNTIME_PYTHON_PACKAGES = (
+    "httpx>=0.28,<0.29",
+    "polars>=1.30,<2",
+    "pydantic>=2.11,<2.12",
+    "PyYAML>=6.0,<7",
+)
+
+
+class MorphOperations(Protocol):
+    def build_runtime_snapshot(
+        self,
+        *,
+        dockerfile_path: Path,
+        context_dir: Path,
+        project_src_dir: Path,
+        runtime_packages: tuple[str, ...],
+    ) -> object: ...
+
+    def start_instance(self, *, snapshot: object) -> Any: ...
+
+    def upload_directory(self, *, instance: Any, local_path: Path, remote_path: str) -> None: ...
+
+    def start_trial_container(self, *, instance: Any, workspace_dir: str, logs_dir: str) -> None: ...
+
+    def write_instance_file(self, *, instance: Any, remote_path: str, content: bytes) -> None: ...
+
+    def run_container_command(
+        self,
+        *,
+        instance: Any,
+        command: tuple[str, ...],
+        workdir: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> None: ...
+
+    def read_container_file(self, *, instance: Any, remote_path: str) -> bytes | None: ...
+
+    def stop_instance(self, *, instance: Any) -> None: ...
+
+
+@dataclass
+class MorphSession:
+    snapshot: object
+    instance: Any
+    workspace_dir: Path
+    execution_request: BackendExecutionRequest | None = None
+
+
+@dataclass
+class MorphSandboxRunner:
+    operations: MorphOperations
+    artifacts_dir: Path
+
+    def __post_init__(self) -> None:
+        self._snapshots: dict[str, object] = {}
+        self._sessions: dict[str, MorphSession] = {}
+
+    def build_environment(self, *, task_dir: Path) -> str:
+        dockerfile_path = task_dir / "environment" / "Dockerfile"
+        snapshot = self.operations.build_runtime_snapshot(
+            dockerfile_path=dockerfile_path,
+            context_dir=task_dir,
+            project_src_dir=PROJECT_SRC_DIR,
+            runtime_packages=RUNTIME_PYTHON_PACKAGES,
+        )
+        image_ref = f"morph-snapshot:{morph_object_id(snapshot)}"
+        self._snapshots[image_ref] = snapshot
+        return image_ref
+
+    def launch_trial(self, *, image_ref: str, workspace_dir: Path) -> TrialHandle:
+        snapshot = self._snapshots[image_ref]
+        instance = self.operations.start_instance(snapshot=snapshot)
+        self.operations.upload_directory(
+            instance=instance,
+            local_path=workspace_dir,
+            remote_path=REMOTE_WORKSPACE_DIR,
+        )
+        self.operations.start_trial_container(
+            instance=instance,
+            workspace_dir=REMOTE_WORKSPACE_DIR,
+            logs_dir=REMOTE_LOGS_DIR,
+        )
+
+        handle_id = morph_object_id(instance)
+        self._sessions[handle_id] = MorphSession(
+            snapshot=snapshot,
+            instance=instance,
+            workspace_dir=workspace_dir,
+        )
+        return TrialHandle(backend_name="morph", handle_id=handle_id)
+
+    def execute_trial(
+        self,
+        *,
+        handle: TrialHandle,
+        request: BackendExecutionRequest,
+    ) -> BackendExecutionResult:
+        handle_id = handle.handle_id
+        session = self._sessions[handle_id]
+        session.execution_request = request
+        local_artifact_dir = self.artifacts_dir / handle_id
+        local_artifact_dir.mkdir(parents=True, exist_ok=True)
+        bundle_path = write_execution_bundle(
+            path=local_artifact_dir / "execution-bundle.json",
+            bundle=request.execution_bundle,
+        )
+        self.operations.write_instance_file(
+            instance=session.instance,
+            remote_path=REMOTE_EXECUTION_BUNDLE_PATH,
+            content=bundle_path.read_bytes(),
+        )
+
+        self.operations.run_container_command(
+            instance=session.instance,
+            command=(
+                "python",
+                "-m",
+                "aec_bench.harness.execution_entrypoint",
+                "--bundle",
+                REMOTE_EXECUTION_BUNDLE_PATH,
+                "--result",
+                REMOTE_EXECUTION_RESULT_PATH,
+            ),
+            workdir=REMOTE_WORKSPACE_DIR,
+            env=_execution_environment(request.execution_bundle),
+        )
+
+        result_path = self._read_artifact(
+            instance=session.instance,
+            remote_candidates=[REMOTE_EXECUTION_RESULT_PATH],
+            local_artifact_dir=local_artifact_dir,
+        )
+        if result_path is None:
+            msg = "missing adapter execution result artifact"
+            raise FileNotFoundError(msg)
+        adapter_result = read_execution_result(result_path)
+
+        verifier_command = (
+            "bash",
+            _remote_workspace_path(
+                workspace_dir=session.workspace_dir,
+                local_path=request.verifier_script,
+            ),
+        )
+        self.operations.run_container_command(
+            instance=session.instance,
+            command=verifier_command,
+            workdir=REMOTE_WORKSPACE_DIR,
+            env=None,
+        )
+
+        return BackendExecutionResult(
+            adapter_result=adapter_result,
+            collected_artifacts=self.collect_outputs(handle=handle),
+        )
+
+    def collect_outputs(self, *, handle: TrialHandle) -> CollectedArtifacts:
+        handle_id = handle.handle_id
+        session = self._sessions[handle_id]
+        local_artifact_dir = self.artifacts_dir / handle_id
+        local_artifact_dir.mkdir(parents=True, exist_ok=True)
+
+        output_candidates = ["/output.jsonl", "/output.md"]
+        reward_candidates = ["/reward.json"]
+        details_candidates = ["/details.json"]
+        if session.execution_request is not None:
+            output_candidates = [session.execution_request.execution_bundle.request.output_path]
+            reward_candidates = [session.execution_request.verifier_reward_path]
+            if session.execution_request.verifier_details_path is not None:
+                details_candidates = [session.execution_request.verifier_details_path]
+            else:
+                details_candidates = []
+
+        output_path = self._read_artifact(
+            instance=session.instance,
+            remote_candidates=output_candidates,
+            local_artifact_dir=local_artifact_dir,
+        )
+        reward_path = self._read_artifact(
+            instance=session.instance,
+            remote_candidates=reward_candidates,
+            local_artifact_dir=local_artifact_dir,
+        )
+        details_path = self._read_artifact(
+            instance=session.instance,
+            remote_candidates=details_candidates,
+            local_artifact_dir=local_artifact_dir,
+        )
+
+        return CollectedArtifacts(
+            output_path=output_path,
+            verifier_reward_path=reward_path,
+            verifier_details_path=details_path,
+        )
+
+    def teardown(self, *, handle: TrialHandle) -> None:
+        session = self._sessions.pop(handle.handle_id)
+        self.operations.stop_instance(instance=session.instance)
+
+    def _read_artifact(
+        self,
+        *,
+        instance: Any,
+        remote_candidates: list[str],
+        local_artifact_dir: Path,
+    ) -> Path | None:
+        for remote_path in remote_candidates:
+            content = self.operations.read_container_file(
+                instance=instance,
+                remote_path=remote_path,
+            )
+            if content is None:
+                continue
+            local_path = local_artifact_dir / Path(remote_path).name
+            local_path.write_bytes(content)
+            return local_path
+        return None
+
+
+def _remote_workspace_path(*, workspace_dir: Path, local_path: Path) -> str:
+    relative_path = local_path.relative_to(workspace_dir)
+    return f"{REMOTE_WORKSPACE_DIR}/{relative_path.as_posix()}"
+
+
+def _execution_environment(bundle: object) -> dict[str, str] | None:
+    from aec_bench.harness.execution_payload import ExecutionBundle
+
+    execution_bundle = cast(ExecutionBundle, bundle)
+    client_payload = cast(dict[str, Any], execution_bundle.execution.payload.get("client", {}))
+    if not client_payload:
+        return None
+    spec = SerializedClientSpec(
+        client_kind=cast(str, client_payload["client_kind"]),
+        payload=cast(dict[str, Any], client_payload.get("payload", {})),
+    )
+    env = required_env_values_for_client_spec(spec)
+    return env or None

--- a/src/aec_bench/providers/__init__.py
+++ b/src/aec_bench/providers/__init__.py
@@ -6,9 +6,11 @@ from aec_bench.providers.behavioral_llm import (
     BedrockBehavioralLLMClient,
     build_behavioral_llm_client,
 )
+from aec_bench.providers.morph_cloud import MorphCloudOperations
 
 __all__ = [
     "AnthropicBehavioralLLMClient",
     "BedrockBehavioralLLMClient",
+    "MorphCloudOperations",
     "build_behavioral_llm_client",
 ]

--- a/src/aec_bench/providers/morph_cloud.py
+++ b/src/aec_bench/providers/morph_cloud.py
@@ -1,0 +1,510 @@
+# ABOUTME: Morph Cloud provider operations for remote sandbox instances.
+# ABOUTME: Keeps Morph SDK calls, file transfer, and Docker host commands outside harness orchestration.
+
+import base64
+import hashlib
+import inspect
+import io
+import logging
+import shlex
+import shutil
+import tarfile
+import tempfile
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Any, cast
+from uuid import uuid4
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class MorphCloudOperations:
+    base_image_id: str = "morphvm-sandbox"
+    vcpus: int = 2
+    memory_mb: int = 4096
+    disk_size_mb: int = 20_480
+    snapshot_ttl_seconds: int = 604_800
+    instance_ttl_seconds: int = 900
+    command_timeout_seconds: int = 900
+    build_timeout_seconds: int = 1_800
+    build_root: str = "/tmp/aec-bench-runtime-build"
+    runtime_image_name: str = "aec-bench-task-runtime"
+    base_task_image_name: str = "aec-bench-task-base"
+    trial_container_name: str = "aec-bench-trial"
+    client_factory: Callable[[], Any] = field(default_factory=lambda: _morph_client)
+
+    def build_runtime_snapshot(
+        self,
+        *,
+        dockerfile_path: Path,
+        context_dir: Path,
+        project_src_dir: Path,
+        runtime_packages: tuple[str, ...],
+    ) -> object:
+        del dockerfile_path
+        client = self.client_factory()
+        base_snapshot = _call_with_supported_kwargs(
+            client.snapshots.create,
+            image_id=self.base_image_id,
+            vcpus=self.vcpus,
+            memory=self.memory_mb,
+            disk_size=self.disk_size_mb,
+            metadata={"aec-bench-role": "runtime-build"},
+            ttl_seconds=self.snapshot_ttl_seconds,
+        )
+        builder: Any | None = None
+        try:
+            builder = self.start_instance(snapshot=base_snapshot)
+            if hasattr(builder, "wait_until_ready"):
+                builder.wait_until_ready()
+            self._prepare_docker_host(builder)
+            self._run_host_command(builder, f"rm -rf {shlex.quote(self.build_root)}")
+            self._run_host_command(builder, f"mkdir -p {shlex.quote(self.build_root)}")
+            self.upload_directory(
+                instance=builder,
+                local_path=context_dir,
+                remote_path=f"{self.build_root}/task",
+            )
+            self.upload_directory(
+                instance=builder,
+                local_path=project_src_dir,
+                remote_path=f"{self.build_root}/src/aec_bench",
+            )
+            self.write_instance_file(
+                instance=builder,
+                remote_path=f"{self.build_root}/Dockerfile",
+                content=_runtime_dockerfile(runtime_packages=runtime_packages).encode(),
+            )
+            self._run_host_command(
+                builder,
+                shlex.join(
+                    (
+                        "docker",
+                        "build",
+                        "-t",
+                        self.base_task_image_name,
+                        "-f",
+                        f"{self.build_root}/task/environment/Dockerfile",
+                        f"{self.build_root}/task",
+                    )
+                ),
+                command_timeout_seconds=self.build_timeout_seconds,
+            )
+            self._run_host_command(
+                builder,
+                shlex.join(
+                    (
+                        "docker",
+                        "build",
+                        "-t",
+                        self.runtime_image_name,
+                        "-f",
+                        f"{self.build_root}/Dockerfile",
+                        self.build_root,
+                    )
+                ),
+                command_timeout_seconds=self.build_timeout_seconds,
+            )
+            return _call_with_supported_kwargs(
+                builder.snapshot,
+                digest=_runtime_digest(
+                    context_dir=context_dir,
+                    project_src_dir=project_src_dir,
+                    runtime_packages=runtime_packages,
+                ),
+                metadata={"aec-bench-role": "runtime"},
+                ttl_seconds=self.snapshot_ttl_seconds,
+            )
+        finally:
+            if builder is not None:
+                self.stop_instance(instance=builder)
+            _delete_snapshot(snapshot=base_snapshot)
+
+    def start_instance(self, *, snapshot: object) -> Any:
+        client = self.client_factory()
+        instance = _call_with_supported_kwargs(
+            client.instances.start,
+            snapshot_id=morph_object_id(snapshot),
+            metadata={"aec-bench-role": "trial"},
+            ttl_seconds=self.instance_ttl_seconds,
+            ttl_action="stop",
+            timeout=self.command_timeout_seconds,
+        )
+        if hasattr(instance, "wait_until_ready"):
+            instance.wait_until_ready()
+        return instance
+
+    def upload_directory(self, *, instance: Any, local_path: Path, remote_path: str) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            archive_path = Path(temp_dir) / "payload.tar.gz"
+            _write_directory_archive(local_path=local_path, archive_path=archive_path)
+            remote_archive_path = f"/tmp/aec-bench-upload-{uuid4().hex}.tar.gz"
+            self.write_instance_file(
+                instance=instance,
+                remote_path=remote_archive_path,
+                content=archive_path.read_bytes(),
+            )
+            self._run_host_command(
+                instance,
+                " && ".join(
+                    (
+                        f"mkdir -p {shlex.quote(remote_path)}",
+                        f"tar -xzf {shlex.quote(remote_archive_path)} -C {shlex.quote(remote_path)}",
+                        f"rm -f {shlex.quote(remote_archive_path)}",
+                    )
+                ),
+            )
+
+    def start_trial_container(self, *, instance: Any, workspace_dir: str, logs_dir: str) -> None:
+        self._run_host_command(
+            instance,
+            " && ".join((f"mkdir -p {shlex.quote(workspace_dir)}", f"mkdir -p {shlex.quote(logs_dir)}")),
+        )
+        self._run_host_command(
+            instance,
+            f"docker rm -f {shlex.quote(self.trial_container_name)} >/dev/null 2>&1 || true",
+        )
+        self._run_host_command(
+            instance,
+            shlex.join(
+                (
+                    "docker",
+                    "run",
+                    "--detach",
+                    "--name",
+                    self.trial_container_name,
+                    "--workdir",
+                    workspace_dir,
+                    "--volume",
+                    f"{workspace_dir}:{workspace_dir}",
+                    "--volume",
+                    f"{logs_dir}:{logs_dir}",
+                    self.runtime_image_name,
+                    "sleep",
+                    "infinity",
+                )
+            ),
+        )
+
+    def write_instance_file(self, *, instance: Any, remote_path: str, content: bytes) -> None:
+        parent_dir = str(PurePosixPath(remote_path).parent)
+        if parent_dir not in {"", ".", "/"}:
+            self._run_host_command(instance, f"mkdir -p {shlex.quote(parent_dir)}")
+        with tempfile.NamedTemporaryFile() as file_handle:
+            file_handle.write(content)
+            file_handle.flush()
+            instance.upload(file_handle.name, remote_path, recursive=False)
+
+    def run_container_command(
+        self,
+        *,
+        instance: Any,
+        command: tuple[str, ...],
+        workdir: str | None = None,
+        env: dict[str, str] | None = None,
+        timeout_seconds: int | None = None,
+    ) -> None:
+        self.run_container_command_result(
+            instance=instance,
+            command=command,
+            workdir=workdir,
+            env=env,
+            timeout_seconds=timeout_seconds,
+        )
+
+    def run_container_command_result(
+        self,
+        *,
+        instance: Any,
+        command: tuple[str, ...],
+        workdir: str | None = None,
+        env: dict[str, str] | None = None,
+        timeout_seconds: int | None = None,
+    ) -> "MorphCommandResult":
+        return self._run_container_command_result(
+            instance=instance,
+            command=command,
+            workdir=workdir,
+            env=env,
+            timeout_seconds=timeout_seconds,
+        )
+
+    def read_container_file(self, *, instance: Any, remote_path: str) -> bytes | None:
+        script = (
+            "import base64,pathlib,sys;"
+            "path=pathlib.Path(sys.argv[1]);"
+            "sys.exit(44) if not path.exists() else "
+            "sys.stdout.write(base64.b64encode(path.read_bytes()).decode())"
+        )
+        result = self._run_container_command_result(
+            instance=instance,
+            command=("python", "-c", script, remote_path),
+            workdir=None,
+            env=None,
+            check=False,
+        )
+        if result.exit_code == 44:
+            return None
+        if result.exit_code != 0:
+            raise RuntimeError(_command_failure_message(result=result))
+        return base64.b64decode(result.stdout.encode())
+
+    def read_container_directory_archive(self, *, instance: Any, remote_path: str) -> bytes | None:
+        script = (
+            "import base64,io,pathlib,sys,tarfile;"
+            "root=pathlib.Path(sys.argv[1]);"
+            "sys.exit(44) if not root.is_dir() else None;"
+            "buf=io.BytesIO();"
+            "tar=tarfile.open(fileobj=buf,mode='w:gz');"
+            "[tar.add(p,arcname=str(p.relative_to(root))) for p in sorted(root.rglob('*'))];"
+            "tar.close();"
+            "sys.stdout.write(base64.b64encode(buf.getvalue()).decode())"
+        )
+        result = self._run_container_command_result(
+            instance=instance,
+            command=("python", "-c", script, remote_path),
+            workdir=None,
+            env=None,
+            check=False,
+        )
+        if result.exit_code == 44:
+            return None
+        if result.exit_code != 0:
+            raise RuntimeError(_command_failure_message(result=result))
+        return base64.b64decode(result.stdout.encode())
+
+    def stop_instance(self, *, instance: Any) -> None:
+        instance.stop()
+
+    def _prepare_docker_host(self, instance: Any) -> None:
+        self._run_host_command(
+            instance,
+            "command -v docker >/dev/null 2>&1 || "
+            "(apt-get update && apt-get install -y docker.io && service docker start)",
+            command_timeout_seconds=self.build_timeout_seconds,
+        )
+        self._run_host_command(instance, "service docker start >/dev/null 2>&1 || true")
+
+    def _run_container_command_result(
+        self,
+        *,
+        instance: Any,
+        command: tuple[str, ...],
+        workdir: str | None,
+        env: dict[str, str] | None,
+        timeout_seconds: int | None = None,
+        check: bool = True,
+    ) -> "MorphCommandResult":
+        return self._run_host_command(
+            instance,
+            _docker_exec_command(
+                container_name=self.trial_container_name,
+                command=command,
+                workdir=workdir,
+                env=env,
+            ),
+            check=check,
+            command_timeout_seconds=timeout_seconds,
+        )
+
+    def _run_host_command(
+        self,
+        instance: Any,
+        command: str,
+        *,
+        check: bool = True,
+        command_timeout_seconds: int | None = None,
+    ) -> "MorphCommandResult":
+        timeout_seconds = command_timeout_seconds or self.command_timeout_seconds
+        raw_result = instance.exec(command, timeout=timeout_seconds)
+        result = _normalize_command_result(raw_result)
+        if check and result.exit_code != 0:
+            raise RuntimeError(_command_failure_message(result=result))
+        return result
+
+
+@dataclass(frozen=True)
+class MorphCommandResult:
+    exit_code: int
+    stdout: str
+    stderr: str
+
+
+def morph_object_id(value: object) -> str:
+    if isinstance(value, dict):
+        mapped_id = cast(object, value.get("id"))
+        if isinstance(mapped_id, str):
+            return mapped_id
+    for attribute in ("id", "object_id"):
+        object_id = getattr(value, attribute, None)
+        if isinstance(object_id, str):
+            return object_id
+    msg = f"cannot resolve Morph object id from {type(value).__name__}"
+    raise ValueError(msg)
+
+
+def _morph_client() -> Any:
+    try:
+        from morphcloud.api import MorphCloudClient
+    except ImportError as exc:
+        msg = "Morph Cloud support requires the morphcloud package and MORPH_API_KEY configuration."
+        raise RuntimeError(msg) from exc
+    return MorphCloudClient()
+
+
+def _call_with_supported_kwargs(function: Any, **kwargs: object) -> Any:
+    try:
+        signature = inspect.signature(function)
+    except (TypeError, ValueError):
+        return function(**kwargs)
+    if any(parameter.kind == inspect.Parameter.VAR_KEYWORD for parameter in signature.parameters.values()):
+        return function(**kwargs)
+    accepted_kwargs = {name: value for name, value in kwargs.items() if name in signature.parameters}
+    return function(**accepted_kwargs)
+
+
+def _delete_snapshot(*, snapshot: object) -> None:
+    delete = getattr(snapshot, "delete", None)
+    if not callable(delete):
+        return
+    try:
+        delete()
+    except Exception:
+        logger.warning("failed to delete Morph build snapshot: %s", morph_object_id(snapshot), exc_info=True)
+
+
+def _runtime_dockerfile(*, runtime_packages: tuple[str, ...]) -> str:
+    quoted_packages = " ".join(shlex.quote(package) for package in runtime_packages)
+    return "\n".join(
+        (
+            "FROM aec-bench-task-base",
+            "RUN (python3 -m pip --version >/dev/null 2>&1 || "
+            "python -m pip --version >/dev/null 2>&1 || "
+            "(apt-get update && apt-get install -y python3-pip && rm -rf /var/lib/apt/lists/*))",
+            f"RUN (python3 -m pip install --no-cache-dir {quoted_packages} || "
+            f"python -m pip install --no-cache-dir {quoted_packages})",
+            "COPY src/aec_bench /opt/aec_bench/aec_bench",
+            "ENV PYTHONPATH=/opt/aec_bench",
+            "",
+        )
+    )
+
+
+def extract_archive(*, archive_bytes: bytes, target_dir: Path) -> None:
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target_root = target_dir.resolve()
+    with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:gz") as archive:
+        for member in archive.getmembers():
+            destination = _archive_member_destination(target_root=target_root, member_name=member.name)
+            if member.isdir():
+                destination.mkdir(parents=True, exist_ok=True)
+                continue
+            if not member.isfile():
+                msg = f"unsupported archive member type: {member.name}"
+                raise RuntimeError(msg)
+            source = archive.extractfile(member)
+            if source is None:
+                msg = f"missing archive member content: {member.name}"
+                raise RuntimeError(msg)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            with source, destination.open("wb") as target_file:
+                shutil.copyfileobj(source, target_file)
+
+
+def _archive_member_destination(*, target_root: Path, member_name: str) -> Path:
+    if not member_name or Path(member_name).is_absolute():
+        msg = f"unsafe archive member: {member_name}"
+        raise RuntimeError(msg)
+    destination = (target_root / member_name).resolve()
+    if destination != target_root and target_root not in destination.parents:
+        msg = f"unsafe archive member: {member_name}"
+        raise RuntimeError(msg)
+    return destination
+
+
+def _write_directory_archive(*, local_path: Path, archive_path: Path) -> None:
+    with tarfile.open(archive_path, "w:gz") as archive:
+        if local_path.is_dir():
+            for child in sorted(local_path.iterdir()):
+                archive.add(child, arcname=child.name)
+        else:
+            archive.add(local_path, arcname=local_path.name)
+
+
+def _docker_exec_command(
+    *,
+    container_name: str,
+    command: tuple[str, ...],
+    workdir: str | None,
+    env: dict[str, str] | None,
+) -> str:
+    docker_command = ["docker", "exec"]
+    if workdir is not None:
+        docker_command.extend(("--workdir", workdir))
+    if env is not None:
+        for key, value in sorted(env.items()):
+            docker_command.extend(("--env", f"{key}={value}"))
+    docker_command.append(container_name)
+    docker_command.extend(command)
+    return shlex.join(docker_command)
+
+
+def _normalize_command_result(raw_result: object) -> MorphCommandResult:
+    if isinstance(raw_result, str | bytes):
+        return MorphCommandResult(exit_code=0, stdout=_as_text(raw_result), stderr="")
+    exit_code_value = getattr(raw_result, "exit_code", getattr(raw_result, "returncode", 0))
+    if exit_code_value is None:
+        exit_code = 0
+    else:
+        exit_code = int(cast(int | str, exit_code_value))
+    return MorphCommandResult(
+        exit_code=exit_code,
+        stdout=_as_text(getattr(raw_result, "stdout", "")),
+        stderr=_as_text(getattr(raw_result, "stderr", "")),
+    )
+
+
+def _as_text(value: object) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    if isinstance(value, str):
+        return value
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _command_failure_message(*, result: MorphCommandResult) -> str:
+    message = f"Morph command failed with exit code {result.exit_code}"
+    if result.stderr:
+        message = f"{message}\nstderr:\n{result.stderr}"
+    if result.stdout:
+        message = f"{message}\nstdout:\n{result.stdout}"
+    return message
+
+
+def _runtime_digest(
+    *,
+    context_dir: Path,
+    project_src_dir: Path,
+    runtime_packages: tuple[str, ...],
+) -> str:
+    digest = hashlib.sha256()
+    _hash_directory(digest=digest, directory=context_dir)
+    _hash_directory(digest=digest, directory=project_src_dir)
+    for package in runtime_packages:
+        digest.update(package.encode())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _hash_directory(*, digest: "hashlib._Hash", directory: Path) -> None:
+    for path in sorted(directory.rglob("*")):
+        if path.is_dir() or "__pycache__" in path.parts or path.suffix == ".pyc":
+            continue
+        digest.update(str(path.relative_to(directory)).encode())
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")

--- a/src/aec_bench/providers/morph_harbor.py
+++ b/src/aec_bench/providers/morph_harbor.py
@@ -1,0 +1,225 @@
+# ABOUTME: Harbor BaseEnvironment adapter backed by Morph Cloud instances.
+# ABOUTME: Translates Harbor async environment calls into Morph provider operations.
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+from harbor.environments.base import BaseEnvironment, ExecResult  # type: ignore[import-untyped]
+from harbor.models.environment_type import EnvironmentType  # type: ignore[import-untyped]
+from harbor.models.task.config import EnvironmentConfig  # type: ignore[import-untyped]
+from harbor.models.trial.paths import TrialPaths  # type: ignore[import-untyped]
+
+from aec_bench.providers.morph_cloud import (
+    MorphCloudOperations,
+    MorphCommandResult,
+    extract_archive,
+)
+
+REMOTE_WORKSPACE_DIR = "/workspace"
+REMOTE_LOGS_DIR = "/logs"
+PROJECT_SRC_DIR = Path(__file__).resolve().parents[1]
+RUNTIME_PYTHON_PACKAGES = (
+    "pydantic>=2.11",
+    "pydantic-ai[anthropic,openai]",
+    "httpx>=0.28",
+    "PyYAML>=6.0",
+    "polars>=1.30,<2",
+)
+
+
+class MorphHarborOperations(Protocol):
+    def build_runtime_snapshot(
+        self,
+        *,
+        dockerfile_path: Path,
+        context_dir: Path,
+        project_src_dir: Path,
+        runtime_packages: tuple[str, ...],
+    ) -> object: ...
+
+    def start_instance(self, *, snapshot: object) -> object: ...
+
+    def start_trial_container(self, *, instance: object, workspace_dir: str, logs_dir: str) -> None: ...
+
+    def run_container_command_result(
+        self,
+        *,
+        instance: object,
+        command: tuple[str, ...],
+        workdir: str | None = None,
+        env: dict[str, str] | None = None,
+        timeout_seconds: int | None = None,
+    ) -> MorphCommandResult: ...
+
+    def write_instance_file(self, *, instance: object, remote_path: str, content: bytes) -> None: ...
+
+    def upload_directory(self, *, instance: object, local_path: Path, remote_path: str) -> None: ...
+
+    def read_container_file(self, *, instance: object, remote_path: str) -> bytes | None: ...
+
+    def read_container_directory_archive(self, *, instance: object, remote_path: str) -> bytes | None: ...
+
+    def stop_instance(self, *, instance: object) -> None: ...
+
+
+@dataclass
+class MorphHarborState:
+    snapshot: object
+    instance: object
+
+
+class MorphHarborEnvironment(BaseEnvironment):  # type: ignore[misc]
+    def __init__(
+        self,
+        environment_dir: Path,
+        environment_name: str,
+        session_id: str,
+        trial_paths: TrialPaths,
+        task_env_config: EnvironmentConfig,
+        *,
+        compute_backend: str = "morph",
+        operations: MorphHarborOperations | None = None,
+        project_src_dir: Path = PROJECT_SRC_DIR,
+        runtime_packages: tuple[str, ...] = RUNTIME_PYTHON_PACKAGES,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            environment_dir=environment_dir,
+            environment_name=environment_name,
+            session_id=session_id,
+            trial_paths=trial_paths,
+            task_env_config=task_env_config,
+            **kwargs,
+        )
+        self.compute_backend = compute_backend
+        self._operations = operations or MorphCloudOperations(
+            vcpus=task_env_config.cpus,
+            memory_mb=task_env_config.memory_mb,
+            disk_size_mb=task_env_config.storage_mb,
+        )
+        self._project_src_dir = project_src_dir
+        self._runtime_packages = runtime_packages
+        self._state: MorphHarborState | None = None
+
+    @staticmethod
+    def type() -> EnvironmentType:
+        return EnvironmentType.DOCKER
+
+    @property
+    def is_mounted(self) -> bool:
+        return False
+
+    @property
+    def supports_gpus(self) -> bool:
+        return False
+
+    @property
+    def can_disable_internet(self) -> bool:
+        return False
+
+    @property
+    def _environment_definition_path(self) -> Path:
+        return Path(self.environment_dir) / "Dockerfile"
+
+    def _validate_definition(self) -> None:
+        if not self._environment_definition_path.exists():
+            msg = f"{self._environment_definition_path} not found. Please ensure the file exists."
+            raise FileNotFoundError(msg)
+
+    async def start(self, force_build: bool) -> None:
+        del force_build
+        snapshot = await asyncio.to_thread(
+            self._operations.build_runtime_snapshot,
+            dockerfile_path=self._environment_definition_path,
+            context_dir=self.environment_dir.parent,
+            project_src_dir=self._project_src_dir,
+            runtime_packages=self._runtime_packages,
+        )
+        instance = await asyncio.to_thread(self._operations.start_instance, snapshot=snapshot)
+        await asyncio.to_thread(
+            self._operations.start_trial_container,
+            instance=instance,
+            workspace_dir=REMOTE_WORKSPACE_DIR,
+            logs_dir=REMOTE_LOGS_DIR,
+        )
+        self._state = MorphHarborState(snapshot=snapshot, instance=instance)
+        await self.exec("mkdir -p /logs/agent /logs/verifier /logs/artifacts /workspace")
+
+    async def stop(self, delete: bool) -> None:
+        del delete
+        if self._state is None:
+            return
+        await asyncio.to_thread(self._operations.stop_instance, instance=self._state.instance)
+        self._state = None
+
+    async def upload_file(self, source_path: Path | str, target_path: str) -> None:
+        source = Path(source_path)
+        await asyncio.to_thread(
+            self._operations.write_instance_file,
+            instance=self._require_instance(),
+            remote_path=target_path,
+            content=source.read_bytes(),
+        )
+
+    async def upload_dir(self, source_dir: Path | str, target_dir: str) -> None:
+        await asyncio.to_thread(
+            self._operations.upload_directory,
+            instance=self._require_instance(),
+            local_path=Path(source_dir),
+            remote_path=target_dir,
+        )
+
+    async def download_file(self, source_path: str, target_path: Path | str) -> None:
+        content = await asyncio.to_thread(
+            self._operations.read_container_file,
+            instance=self._require_instance(),
+            remote_path=source_path,
+        )
+        if content is None:
+            msg = f"file not found in Morph environment: {source_path}"
+            raise FileNotFoundError(msg)
+        target = Path(target_path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
+
+    async def download_dir(self, source_dir: str, target_dir: Path | str) -> None:
+        archive = await asyncio.to_thread(
+            self._operations.read_container_directory_archive,
+            instance=self._require_instance(),
+            remote_path=source_dir,
+        )
+        if archive is None:
+            msg = f"directory not found in Morph environment: {source_dir}"
+            raise FileNotFoundError(msg)
+        extract_archive(archive_bytes=archive, target_dir=Path(target_dir))
+
+    async def exec(
+        self,
+        command: str,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        timeout_sec: int | None = None,
+    ) -> ExecResult:
+        result = await asyncio.to_thread(
+            self._operations.run_container_command_result,
+            instance=self._require_instance(),
+            command=("bash", "-lc", command),
+            workdir=cwd,
+            env=env,
+            timeout_seconds=timeout_sec,
+        )
+        return ExecResult(
+            stdout=result.stdout,
+            stderr=result.stderr,
+            return_code=result.exit_code,
+        )
+
+    def _require_instance(self) -> object:
+        if self._state is None:
+            msg = "Morph Harbor environment has not been started"
+            raise RuntimeError(msg)
+        return self._state.instance

--- a/src/aec_bench/web/frontend/src/lib/types.ts
+++ b/src/aec_bench/web/frontend/src/lib/types.ts
@@ -32,6 +32,7 @@ export interface TrialRow {
   task_id: string;
   model: string;
   adapter: string;
+  compute_backend?: string;
   discipline: string;
   reward: number;
   reward_class: string;
@@ -77,6 +78,7 @@ export interface ViewerMeta {
   task_id: string;
   model: string;
   adapter: string;
+  compute_backend?: string;
   reward: number;
   reward_class: string;
   steps: StepSummary[];

--- a/src/aec_bench/web/routes/triage.py
+++ b/src/aec_bench/web/routes/triage.py
@@ -109,6 +109,7 @@ class TrialRow:
     task_id: str
     model: str
     adapter: str
+    compute_backend: str
     discipline: str
     reward: float
     reward_class: str
@@ -290,6 +291,7 @@ def get_triage_api(
                 task_id=record.task.task_id,
                 model=record.agent.model,
                 adapter=record.agent.adapter,
+                compute_backend=record.environment.compute_backend,
                 discipline=extract_discipline(record.task.task_id),
                 reward=record.evaluation.reward,
                 reward_class=reward_css_class(record.evaluation.reward),

--- a/src/aec_bench/web/routes/viewer.py
+++ b/src/aec_bench/web/routes/viewer.py
@@ -147,9 +147,12 @@ def _load_symbolic_state(traj_path_str: str | None) -> dict[str, Any]:
     if not ss_path.exists():
         return {}
     try:
-        return json.loads(ss_path.read_text(encoding="utf-8"))
+        data: object = json.loads(ss_path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return {}
+    if not isinstance(data, dict):
+        return {}
+    return {str(key): value for key, value in data.items()}
 
 
 def _load_scratchpad(traj_path_str: str | None) -> dict[str, Any]:
@@ -160,9 +163,12 @@ def _load_scratchpad(traj_path_str: str | None) -> dict[str, Any]:
     if not sp_path.exists():
         return {}
     try:
-        return json.loads(sp_path.read_text(encoding="utf-8"))
+        data: object = json.loads(sp_path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return {}
+    if not isinstance(data, dict):
+        return {}
+    return {str(key): value for key, value in data.items()}
 
 
 def _load_plan_state(traj_path_str: str | None) -> dict[str, Any] | None:
@@ -277,6 +283,7 @@ def viewer_api_meta(
         task_id=record.task.task_id,
         model=record.agent.model,
         adapter=record.agent.adapter,
+        compute_backend=record.environment.compute_backend,
         reward=record.evaluation.reward,
         reward_class=reward_css_class(record.evaluation.reward),
         steps=steps,

--- a/src/aec_bench/web/schemas.py
+++ b/src/aec_bench/web/schemas.py
@@ -44,6 +44,7 @@ class TrialRowSchema(BaseModel):
     task_id: str
     model: str
     adapter: str
+    compute_backend: str = ""
     discipline: str
     reward: float
     reward_class: str
@@ -98,6 +99,7 @@ class ViewerMetaResponse(BaseModel):
     task_id: str
     model: str
     adapter: str
+    compute_backend: str = ""
     reward: float
     reward_class: str
     steps: list[StepSummarySchema]
@@ -536,7 +538,7 @@ class GraveyardEntrySchema(BaseModel):
     failure_reason: str
     field_failures: dict[str, str] | None = None
     detected_patterns: list[str] | None = None
-    mutation_actions: list[dict] | None = None
+    mutation_actions: list[dict[str, Any]] | None = None
     investigation_summary: str | None = None
 
 

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -1,0 +1,78 @@
+# ABOUTME: Tests for the manifest and inline aec-bench run CLI entry point.
+# ABOUTME: Verifies backend planning output and Harbor-backed Morph routing.
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from aec_bench.cli.main import app
+
+runner = CliRunner()
+
+
+def _write_minimal_task(tasks_root: Path) -> Path:
+    task_dir = tasks_root / "electrical" / "voltage-drop" / "demo-instance"
+    (task_dir / "tests").mkdir(parents=True)
+    (task_dir / "instruction.md").write_text(
+        "Calculate the answer and write it to /workspace/output.jsonl.\n",
+        encoding="utf-8",
+    )
+    (task_dir / "task.toml").write_text(
+        '[metadata]\nvisibility = "public"\n\n[agent]\ntimeout_sec = 60\n',
+        encoding="utf-8",
+    )
+    (task_dir / "tests" / "test.sh").write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    return task_dir
+
+
+def test_run_dry_run_reports_selected_backend(tmp_path: Path) -> None:
+    tasks_root = tmp_path / "tasks"
+    task_dir = _write_minimal_task(tasks_root)
+
+    result = runner.invoke(
+        app,
+        [
+            "--json",
+            "run",
+            str(task_dir),
+            "--model",
+            "test-model",
+            "--tasks-root",
+            str(tasks_root),
+            "--backend",
+            "modal",
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    envelope = json.loads(result.output)
+    assert envelope["data"]["backend"] == "modal"
+
+
+def test_run_dry_run_accepts_morph_backend(tmp_path: Path) -> None:
+    tasks_root = tmp_path / "tasks"
+    task_dir = _write_minimal_task(tasks_root)
+
+    result = runner.invoke(
+        app,
+        [
+            "--json",
+            "run",
+            str(task_dir),
+            "--model",
+            "test-model",
+            "--tasks-root",
+            str(tasks_root),
+            "--backend",
+            "morph",
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    envelope = json.loads(result.output)
+    assert envelope["data"]["backend"] == "morph"

--- a/tests/evolution/swarm/test_cli.py
+++ b/tests/evolution/swarm/test_cli.py
@@ -4,8 +4,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
-import yaml
+import yaml  # type: ignore[import-untyped]
 from typer.testing import CliRunner
 
 from aec_bench.cli.main import app
@@ -13,7 +14,7 @@ from aec_bench.cli.main import app
 runner = CliRunner()
 
 # Minimal valid config matching SwarmConfig required fields
-_MINIMAL_CONFIG = {
+_MINIMAL_CONFIG: dict[str, Any] = {
     "task": {
         "workspace": "./workspaces/test",
         "task_path": "tasks/electrical/voltage-drop",
@@ -46,6 +47,16 @@ def test_swarm_run_validates_config(tmp_path: Path) -> None:
     config_path.write_text(yaml.dump({"agents": {"count": 4}}))
     result = runner.invoke(app, ["swarm", "run", str(config_path)])
     assert result.exit_code != 0
+
+
+def test_swarm_run_rejects_non_local_backend_before_workspace_resolution(tmp_path: Path) -> None:
+    config_path = tmp_path / "swarm.yaml"
+    config_path.write_text(yaml.dump({**_MINIMAL_CONFIG, "evaluation": {"backend": "morph"}}))
+
+    result = runner.invoke(app, ["swarm", "run", str(config_path)])
+
+    assert result.exit_code != 0
+    assert "currently supports only local evaluation" in result.output
 
 
 def test_swarm_run_missing_workspace(tmp_path: Path) -> None:

--- a/tests/evolution/swarm/test_config.py
+++ b/tests/evolution/swarm/test_config.py
@@ -4,14 +4,15 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
-import yaml
+import yaml  # type: ignore[import-untyped]
 from pydantic import ValidationError
 
 from aec_bench.evolution.swarm.config import SwarmConfig, load_swarm_config
 
-MINIMAL_YAML = {
+MINIMAL_YAML: dict[str, Any] = {
     "task": {
         "workspace": "./workspaces/test",
         "task_path": "tasks/electrical/voltage-drop",
@@ -44,6 +45,17 @@ def test_config_defaults() -> None:
     assert config.evaluation.backend == "local"
     assert config.evolution.batch_size == 1
     assert config.heartbeat.pivot_after == 5
+
+
+def test_config_accepts_morph_backend_name() -> None:
+    data = {
+        **MINIMAL_YAML,
+        "evaluation": {
+            "backend": "morph",
+        },
+    }
+    config = SwarmConfig.model_validate(data)
+    assert config.evaluation.backend == "morph"
 
 
 def test_config_rejects_missing_budget() -> None:

--- a/tests/evolution/test_runner.py
+++ b/tests/evolution/test_runner.py
@@ -4,7 +4,7 @@
 from pathlib import Path
 
 import pytest
-import yaml
+import yaml  # type: ignore[import-untyped]
 
 from aec_bench.contracts.evolution import EvolutionConfig, EvolverModelConfig, TaskGenerateConfig
 from aec_bench.contracts.experiment_manifest import AgentConfig, ClientConfig, TaskSelector
@@ -149,6 +149,34 @@ class TestBuildEvolutionRunnerHarborFallback:
         runner = build_evolution_runner_from_config(config=config)
         assert hasattr(runner, "run")
 
+    def test_morph_without_solver_warns_and_stubs(self, tmp_path: Path) -> None:
+        ws_root = _scaffold_workspace(tmp_path / "ws")
+        config = EvolutionConfig(
+            workspace_path=str(ws_root),
+            models=EvolverModelConfig(classifier="haiku", evolver="sonnet"),
+            task_selector=TaskSelector(),
+            backend="morph",
+        )
+        runner = build_evolution_runner_from_config(config=config)
+        assert hasattr(runner, "run")
+
+    def test_morph_with_solver_builds_remote_solve_fn_without_connecting(self, tmp_path: Path) -> None:
+        ws_root = _scaffold_workspace(tmp_path / "ws")
+        config = EvolutionConfig(
+            workspace_path=str(ws_root),
+            models=EvolverModelConfig(classifier="haiku", evolver="sonnet"),
+            task_selector=TaskSelector(),
+            solver=AgentConfig(
+                name="evo-solver",
+                adapter="direct",
+                model="replay-direct",
+                client=ClientConfig(kind="replay", settings={"output_text": '{"findings": []}'}),
+            ),
+            backend="morph",
+        )
+        runner = build_evolution_runner_from_config(config=config)
+        assert callable(runner._solve_fn)
+
 
 class TestResolveTemplate:
     def test_resolves_builtin_by_name(self) -> None:
@@ -184,8 +212,8 @@ class TestRunnerStrategyWiring:
 
         config = EvolutionConfig(
             workspace_path=str(ws_path),
-            models={"classifier": "claude-haiku-4", "evolver": "claude-sonnet-4-6"},
-            task_selector={},
+            models=EvolverModelConfig(classifier="claude-haiku-4", evolver="claude-sonnet-4-6"),
+            task_selector=TaskSelector(),
             strategy="qd",
         )
 
@@ -206,8 +234,8 @@ class TestRunnerStrategyWiring:
 
         config = EvolutionConfig(
             workspace_path=str(ws_path),
-            models={"classifier": "claude-haiku-4", "evolver": "claude-sonnet-4-6"},
-            task_selector={},
+            models=EvolverModelConfig(classifier="claude-haiku-4", evolver="claude-sonnet-4-6"),
+            task_selector=TaskSelector(),
         )
 
         runner = build_evolution_runner_from_config(config=config)

--- a/tests/harness/test_harbor_contract.py
+++ b/tests/harness/test_harbor_contract.py
@@ -27,6 +27,35 @@ def test_read_harbor_trial_result_accepts_real_trial_result() -> None:
     assert result.agent_info.name == "tool-loop-anthropic"
 
 
+def test_read_harbor_trial_result_accepts_import_path_environment(tmp_path: Path) -> None:
+    payload = {
+        "trial_name": "trial-morph",
+        "task_checksum": "sha256-task",
+        "config": {
+            "task": {"path": "tasks/mechanical/heat-load/alpha"},
+            "agent": {"name": "entrypoint", "model_name": "test-model"},
+            "environment": {
+                "type": None,
+                "import_path": "aec_bench.providers.morph_harbor:MorphHarborEnvironment",
+                "kwargs": {"compute_backend": "morph"},
+            },
+            "job_id": "experiment-001",
+        },
+        "agent_info": {"name": "entrypoint", "version": "1.0.0"},
+        "agent_result": {},
+        "started_at": "2026-06-05T00:00:00Z",
+        "finished_at": "2026-06-05T00:00:01Z",
+    }
+    result_path = tmp_path / "result.json"
+    result_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = read_harbor_trial_result(result_path)
+
+    assert result.config.environment.type is None
+    assert result.config.environment.import_path == "aec_bench.providers.morph_harbor:MorphHarborEnvironment"
+    assert result.config.environment.kwargs["compute_backend"] == "morph"
+
+
 @_skip_no_job_data
 def test_read_harbor_trial_result_rejects_missing_task_path(tmp_path: Path) -> None:
     payload = json.loads(HARBOR_TRIAL_RESULT.read_text(encoding="utf-8"))

--- a/tests/harness/test_harbor_dispatch.py
+++ b/tests/harness/test_harbor_dispatch.py
@@ -3,7 +3,7 @@
 
 from pathlib import Path
 
-import yaml
+import yaml  # type: ignore[import-untyped]
 
 from aec_bench.contracts.experiment_manifest import (
     AgentConfig,
@@ -12,6 +12,7 @@ from aec_bench.contracts.experiment_manifest import (
     TaskSelector,
 )
 from aec_bench.harness.harbor_dispatch import (
+    MORPH_HARBOR_ENVIRONMENT_IMPORT_PATH,
     HarborExperimentDispatcher,
     build_harbor_job_config,
 )
@@ -62,6 +63,42 @@ def test_build_harbor_job_config_uses_precise_task_paths() -> None:
         {"path": "tasks/mechanical/heat-load/alpha"},
         {"path": "tasks/mechanical/heat-load/beta"},
     ]
+
+
+def test_build_harbor_job_config_maps_morph_to_import_path_environment() -> None:
+    manifest = ExperimentManifest(
+        experiment_id="experiment-001",
+        name="Morph dispatch config",
+        tasks=TaskSelector(domains=["mechanical"]),
+        agents=[AgentConfig(name="tool-loop", adapter="tool_loop", model="claude-sonnet-4-6")],
+        compute=ComputeConfig(backend="morph"),
+    )
+    tasks = [make_task_definition(task_id="mechanical/heat-load/alpha")]
+
+    config = build_harbor_job_config(manifest=manifest, tasks=tasks)
+
+    assert "type" not in config["environment"]
+    assert config["environment"]["import_path"] == MORPH_HARBOR_ENVIRONMENT_IMPORT_PATH
+    assert config["environment"]["kwargs"]["compute_backend"] == "morph"
+
+
+def test_build_harbor_job_config_for_morph_validates_as_harbor_config() -> None:
+    from harbor.models.job.config import JobConfig  # type: ignore[import-untyped]
+
+    manifest = ExperimentManifest(
+        experiment_id="experiment-001",
+        name="Morph dispatch config",
+        tasks=TaskSelector(domains=["mechanical"]),
+        agents=[AgentConfig(name="tool-loop", adapter="tool_loop", model="claude-sonnet-4-6")],
+        compute=ComputeConfig(backend="morph"),
+    )
+    tasks = [make_task_definition(task_id="mechanical/heat-load/alpha")]
+
+    config = build_harbor_job_config(manifest=manifest, tasks=tasks)
+
+    parsed = JobConfig.model_validate(config)
+    assert parsed.environment.import_path == MORPH_HARBOR_ENVIRONMENT_IMPORT_PATH
+    assert parsed.environment.type is None
 
 
 def test_dispatcher_writes_yaml_and_executes_harbor_command(tmp_path: Path) -> None:

--- a/tests/harness/test_harbor_import.py
+++ b/tests/harness/test_harbor_import.py
@@ -66,6 +66,53 @@ def test_import_harbor_trial_maps_real_successful_trial() -> None:
     assert record.completeness is Completeness.PARTIAL
 
 
+def test_import_harbor_trial_derives_morph_backend_from_import_path_environment(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    task_dir = repo_root / "tasks" / "mechanical" / "heat-load" / "alpha"
+    trial_dir = repo_root / "jobs" / "job-001" / "trial-morph"
+    (task_dir / "tests").mkdir(parents=True)
+    (trial_dir / "artifacts" / "agent").mkdir(parents=True)
+    (trial_dir / "verifier").mkdir(parents=True)
+    (task_dir / "instruction.md").write_text(
+        "Write your answer to /workspace/output.md.\n",
+        encoding="utf-8",
+    )
+    (task_dir / "task.toml").write_text(
+        '[metadata]\nvisibility = "public"\n\n[agent]\ntimeout_sec = 60\n',
+        encoding="utf-8",
+    )
+    (task_dir / "tests" / "test.sh").write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    (trial_dir / "artifacts" / "agent" / "output.md").write_text("answer\n", encoding="utf-8")
+    (trial_dir / "verifier" / "reward.json").write_text('{"reward": 1.0}\n', encoding="utf-8")
+    (trial_dir / "result.json").write_text(
+        """
+{
+  "trial_name": "trial-morph",
+  "task_checksum": "sha256-task",
+  "config": {
+    "task": {"path": "tasks/mechanical/heat-load/alpha"},
+    "agent": {"name": "entrypoint", "model_name": "test-model", "kwargs": {"adapter": "tool_loop"}},
+    "environment": {
+      "type": null,
+      "import_path": "aec_bench.providers.morph_harbor:MorphHarborEnvironment",
+      "kwargs": {"compute_backend": "morph"}
+    },
+    "job_id": "experiment-001"
+  },
+  "agent_info": {"name": "entrypoint", "version": "1.0.0"},
+  "agent_result": {},
+  "started_at": "2026-06-05T00:00:00Z",
+  "finished_at": "2026-06-05T00:00:01Z"
+}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    record = import_harbor_trial(trial_dir=trial_dir, repo_root=repo_root)
+
+    assert record.environment.compute_backend == "morph"
+
+
 @_skip_no_job_data
 def test_import_harbor_trial_rejects_missing_result_json(tmp_path: Path) -> None:
     with pytest.raises(HarborImportError, match="missing Harbor result artifact"):

--- a/tests/harness/test_morph_runner.py
+++ b/tests/harness/test_morph_runner.py
@@ -1,0 +1,252 @@
+# ABOUTME: Tests for the Morph sandbox runner in aec-bench Python.
+# ABOUTME: Covers runtime snapshot selection, workspace staging, execution, artifacts, and teardown.
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from aec_bench.adapters.base import AdapterResult, SerializedAdapterExecution
+from aec_bench.adapters.transcript import TranscriptEntry, TranscriptRole
+from aec_bench.contracts.agent_output import AgentOutput, AgentOutputStatus
+from aec_bench.harness.backend import BackendExecutionRequest, TrialHandle
+from aec_bench.harness.execution_payload import (
+    AdapterRequestPayload,
+    ExecutionBundle,
+    read_execution_bundle,
+    write_execution_result,
+)
+from aec_bench.harness.morph_runner import (
+    REMOTE_EXECUTION_BUNDLE_PATH,
+    REMOTE_EXECUTION_RESULT_PATH,
+    REMOTE_LOGS_DIR,
+    REMOTE_WORKSPACE_DIR,
+    MorphSandboxRunner,
+)
+
+
+@dataclass
+class FakeMorphInstance:
+    id: str
+
+
+@dataclass
+class FakeMorphOperations:
+    snapshots: list[dict[str, Any]] = field(default_factory=list)
+    uploads: list[tuple[str, Path, str]] = field(default_factory=list)
+    containers: list[tuple[str, str, str]] = field(default_factory=list)
+    commands: list[tuple[str, tuple[str, ...], str | None, dict[str, str] | None]] = field(default_factory=list)
+    stopped: list[str] = field(default_factory=list)
+    files: dict[tuple[str, str], bytes] = field(default_factory=dict)
+
+    def build_runtime_snapshot(
+        self,
+        *,
+        dockerfile_path: Path,
+        context_dir: Path,
+        project_src_dir: Path,
+        runtime_packages: tuple[str, ...],
+    ) -> object:
+        snapshot = {
+            "id": "snapshot-123",
+            "dockerfile_path": dockerfile_path,
+            "context_dir": context_dir,
+            "project_src_dir": project_src_dir,
+            "runtime_packages": runtime_packages,
+        }
+        self.snapshots.append(snapshot)
+        return snapshot
+
+    def start_instance(self, *, snapshot: object) -> Any:
+        del snapshot
+        return FakeMorphInstance(id="inst-123")
+
+    def upload_directory(self, *, instance: Any, local_path: Path, remote_path: str) -> None:
+        self.uploads.append((instance.id, local_path, remote_path))
+
+    def start_trial_container(self, *, instance: Any, workspace_dir: str, logs_dir: str) -> None:
+        self.containers.append((instance.id, workspace_dir, logs_dir))
+
+    def write_instance_file(self, *, instance: Any, remote_path: str, content: bytes) -> None:
+        self.files[(instance.id, remote_path)] = content
+
+    def run_container_command(
+        self,
+        *,
+        instance: Any,
+        command: tuple[str, ...],
+        workdir: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> None:
+        self.commands.append((instance.id, command, workdir, env))
+        if command[:3] == ("python", "-m", "aec_bench.harness.execution_entrypoint"):
+            bundle_file = Path("/tmp/fake-morph-bundle.json")
+            bundle_file.write_bytes(self.files[(instance.id, command[4])])
+            bundle = read_execution_bundle(bundle_file)
+            result_file = Path("/tmp/fake-morph-result.json")
+            write_execution_result(path=result_file, result=_result_from_bundle(bundle))
+            self.files[(instance.id, command[6])] = result_file.read_bytes()
+            raw_output_text = bundle.execution.payload["raw_output_text"]
+            self.files[(instance.id, bundle.request.output_path)] = raw_output_text.encode()
+
+    def read_container_file(self, *, instance: Any, remote_path: str) -> bytes | None:
+        return self.files.get((instance.id, remote_path))
+
+    def stop_instance(self, *, instance: Any) -> None:
+        self.stopped.append(instance.id)
+
+
+@dataclass
+class FakeAdapter:
+    def serialize_execution(self) -> SerializedAdapterExecution:
+        return SerializedAdapterExecution(
+            adapter_kind="test-fixture",
+            adapter_name="tool_loop",
+            resolved_model="gpt-5.4-mini",
+            payload={
+                "configuration_record": {"model": "gpt-5.4-mini"},
+                "assistant_content": '{"findings": []}',
+                "raw_output_text": '{"findings": []}\n',
+            },
+        )
+
+
+def test_morph_runner_builds_snapshot_from_task_dockerfile(tmp_path: Path) -> None:
+    task_dir = _task_dir(tmp_path)
+    operations = FakeMorphOperations()
+    runner = MorphSandboxRunner(operations=operations, artifacts_dir=tmp_path / "artifacts")
+
+    image_ref = runner.build_environment(task_dir=task_dir)
+
+    assert image_ref == "morph-snapshot:snapshot-123"
+    assert operations.snapshots[0]["dockerfile_path"] == task_dir / "environment" / "Dockerfile"
+    assert operations.snapshots[0]["context_dir"] == task_dir
+    assert operations.snapshots[0]["project_src_dir"].name == "aec_bench"
+    assert "pydantic>=2.11,<2.12" in operations.snapshots[0]["runtime_packages"]
+
+
+def test_morph_runner_launches_trial_and_stages_workspace(tmp_path: Path) -> None:
+    task_dir = _task_dir(tmp_path)
+    operations = FakeMorphOperations()
+    runner = MorphSandboxRunner(operations=operations, artifacts_dir=tmp_path / "artifacts")
+
+    image_ref = runner.build_environment(task_dir=task_dir)
+    handle = runner.launch_trial(image_ref=image_ref, workspace_dir=task_dir)
+
+    assert isinstance(handle, TrialHandle)
+    assert handle.backend_name == "morph"
+    assert handle.handle_id == "inst-123"
+    assert operations.uploads == [("inst-123", task_dir, REMOTE_WORKSPACE_DIR)]
+    assert operations.containers == [("inst-123", REMOTE_WORKSPACE_DIR, REMOTE_LOGS_DIR)]
+
+
+def test_morph_runner_executes_adapter_verifier_and_collects_artifacts(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "secret-key")
+    task_dir = _task_dir(tmp_path)
+    operations = FakeMorphOperations()
+    runner = MorphSandboxRunner(operations=operations, artifacts_dir=tmp_path / "artifacts")
+    image_ref = runner.build_environment(task_dir=task_dir)
+    handle = runner.launch_trial(image_ref=image_ref, workspace_dir=task_dir)
+
+    instance = runner._sessions[handle.handle_id].instance
+    operations.files[(instance.id, "/logs/verifier/reward.json")] = b'{"reward": 1.0}\n'
+    operations.files[(instance.id, "/logs/verifier/details.json")] = b'{"matched": 2}\n'
+
+    execution = runner.execute_trial(
+        handle=handle,
+        request=BackendExecutionRequest(
+            execution_bundle=ExecutionBundle(
+                execution=SerializedAdapterExecution(
+                    adapter_kind="direct",
+                    adapter_name="direct-anthropic",
+                    resolved_model="claude-sonnet-4-20250514",
+                    payload={
+                        "client": {
+                            "client_kind": "anthropic_api",
+                            "payload": {
+                                "api_key_env": "ANTHROPIC_API_KEY",
+                                "max_tokens": 1024,
+                            },
+                        },
+                        "configuration_record": {"model": "claude-sonnet-4-20250514"},
+                        "assistant_content": '{"findings": []}',
+                        "raw_output_text": '{"findings": []}\n',
+                    },
+                ),
+                request=AdapterRequestPayload(
+                    instruction="Review the task.",
+                    system_prompt=None,
+                    tools=[],
+                    configuration={},
+                    output_path="/workspace/output.jsonl",
+                    output_format="jsonl",
+                ),
+            ),
+            verifier_script=task_dir / "tests" / "test.sh",
+        ),
+    )
+
+    assert operations.files[(instance.id, REMOTE_EXECUTION_BUNDLE_PATH)]
+    assert execution.adapter_result.raw_output_text == '{"findings": []}\n'
+    assert execution.collected_artifacts.output_path is not None
+    assert execution.collected_artifacts.verifier_reward_path is not None
+    assert execution.collected_artifacts.verifier_details_path is not None
+    assert operations.commands == [
+        (
+            "inst-123",
+            (
+                "python",
+                "-m",
+                "aec_bench.harness.execution_entrypoint",
+                "--bundle",
+                REMOTE_EXECUTION_BUNDLE_PATH,
+                "--result",
+                REMOTE_EXECUTION_RESULT_PATH,
+            ),
+            REMOTE_WORKSPACE_DIR,
+            {"ANTHROPIC_API_KEY": "secret-key"},
+        ),
+        ("inst-123", ("bash", "/workspace/tests/test.sh"), REMOTE_WORKSPACE_DIR, None),
+    ]
+
+
+def test_morph_runner_tears_down_instance(tmp_path: Path) -> None:
+    task_dir = _task_dir(tmp_path)
+    operations = FakeMorphOperations()
+    runner = MorphSandboxRunner(operations=operations, artifacts_dir=tmp_path / "artifacts")
+
+    image_ref = runner.build_environment(task_dir=task_dir)
+    handle = runner.launch_trial(image_ref=image_ref, workspace_dir=task_dir)
+    runner.teardown(handle=handle)
+
+    assert operations.stopped == ["inst-123"]
+
+
+def _task_dir(tmp_path: Path) -> Path:
+    task_dir = tmp_path / "task-instance"
+    (task_dir / "environment").mkdir(parents=True)
+    (task_dir / "tests").mkdir(parents=True)
+    (task_dir / "environment" / "Dockerfile").write_text("FROM python:3.13\n", encoding="utf-8")
+    (task_dir / "tests" / "test.sh").write_text("#!/bin/bash\n", encoding="utf-8")
+    return task_dir
+
+
+def _result_from_bundle(bundle: ExecutionBundle) -> AdapterResult:
+    payload = bundle.execution.payload
+    return AdapterResult(
+        adapter_name=bundle.execution.adapter_name,
+        resolved_model=bundle.execution.resolved_model,
+        configuration_record=payload["configuration_record"],
+        agent_output=AgentOutput(
+            status=AgentOutputStatus.COMPLETED,
+            output_path=bundle.request.output_path,
+            output_format=bundle.request.output_format,
+        ),
+        transcript=[
+            TranscriptEntry(role=TranscriptRole.USER, content=bundle.request.instruction),
+            TranscriptEntry(role=TranscriptRole.ASSISTANT, content=payload["assistant_content"]),
+        ],
+        raw_output_text=payload["raw_output_text"],
+    )

--- a/tests/providers/test_morph_cloud.py
+++ b/tests/providers/test_morph_cloud.py
@@ -1,0 +1,234 @@
+# ABOUTME: Tests for Morph Cloud provider operations in aec-bench Python.
+# ABOUTME: Covers SDK command/upload adapters and build-snapshot cleanup behavior.
+
+import io
+import tarfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from aec_bench.providers.morph_cloud import (
+    MorphCloudOperations,
+    MorphCommandResult,
+    extract_archive,
+)
+
+
+def test_morph_cloud_operations_runs_host_commands_through_instance_exec() -> None:
+    instance = FakeMorphInstance()
+    operations = MorphCloudOperations(command_timeout_seconds=31)
+
+    result = operations._run_host_command(instance, "echo ok")
+
+    assert result == MorphCommandResult(exit_code=0, stdout="ok\n", stderr="")
+    assert instance.commands == [("echo ok", 31)]
+
+
+def test_morph_cloud_operations_uploads_files_through_instance_upload() -> None:
+    instance = FakeMorphInstance()
+    operations = MorphCloudOperations()
+
+    operations.write_instance_file(
+        instance=instance,
+        remote_path="/tmp/aec-bench-smoke/payload.txt",
+        content=b"hello morph\n",
+    )
+
+    assert instance.commands == [("mkdir -p /tmp/aec-bench-smoke", 900)]
+    assert len(instance.uploads) == 1
+    local_path, remote_path, recursive, content = instance.uploads[0]
+    assert remote_path == "/tmp/aec-bench-smoke/payload.txt"
+    assert recursive is False
+    assert Path(local_path).name
+    assert content == b"hello morph\n"
+
+
+def test_morph_cloud_operations_deletes_build_snapshot_after_runtime_snapshot(tmp_path: Path) -> None:
+    task_dir = tmp_path / "task"
+    project_src_dir = tmp_path / "src" / "aec_bench"
+    (task_dir / "environment").mkdir(parents=True)
+    project_src_dir.mkdir(parents=True)
+    (task_dir / "environment" / "Dockerfile").write_text("FROM python:3.13-slim\n", encoding="utf-8")
+    (project_src_dir / "__init__.py").write_text("", encoding="utf-8")
+
+    build_snapshot = FakeMorphSnapshot(id="snapshot-build")
+    runtime_snapshot = FakeMorphSnapshot(id="snapshot-runtime")
+    builder = FakeMorphInstance(id="morphvm-builder", runtime_snapshot=runtime_snapshot)
+    client = FakeMorphClient(build_snapshot=build_snapshot, builder=builder)
+    operations = RecordingMorphCloudOperations(client_factory=lambda: client)
+
+    snapshot = operations.build_runtime_snapshot(
+        dockerfile_path=task_dir / "environment" / "Dockerfile",
+        context_dir=task_dir,
+        project_src_dir=project_src_dir,
+        runtime_packages=("pydantic>=2.11,<2.12",),
+    )
+
+    assert snapshot is runtime_snapshot
+    assert builder.stopped is True
+    assert build_snapshot.deleted is True
+    assert client.started_snapshot_ids == ["snapshot-build"]
+    assert builder.snapshot_metadata == {"aec-bench-role": "runtime"}
+    assert operations.events[0] == "prepare:morphvm-builder"
+
+
+def test_morph_cloud_operations_deletes_build_snapshot_when_builder_start_fails(tmp_path: Path) -> None:
+    task_dir = tmp_path / "task"
+    project_src_dir = tmp_path / "src" / "aec_bench"
+    (task_dir / "environment").mkdir(parents=True)
+    project_src_dir.mkdir(parents=True)
+    (task_dir / "environment" / "Dockerfile").write_text("FROM python:3.13-slim\n", encoding="utf-8")
+    (project_src_dir / "__init__.py").write_text("", encoding="utf-8")
+
+    build_snapshot = FakeMorphSnapshot(id="snapshot-build")
+    client = FakeMorphClient(build_snapshot=build_snapshot, builder=FakeMorphInstance(), fail_start=True)
+    operations = RecordingMorphCloudOperations(client_factory=lambda: client)
+
+    with pytest.raises(RuntimeError, match="start failed"):
+        operations.build_runtime_snapshot(
+            dockerfile_path=task_dir / "environment" / "Dockerfile",
+            context_dir=task_dir,
+            project_src_dir=project_src_dir,
+            runtime_packages=("pydantic>=2.11,<2.12",),
+        )
+
+    assert build_snapshot.deleted is True
+
+
+def test_extract_archive_rejects_path_traversal(tmp_path: Path) -> None:
+    payload = io.BytesIO()
+    with tarfile.open(fileobj=payload, mode="w:gz") as archive:
+        content = b"escape\n"
+        member = tarfile.TarInfo("../escape.txt")
+        member.size = len(content)
+        archive.addfile(member, io.BytesIO(content))
+
+    with pytest.raises(RuntimeError, match="unsafe archive member"):
+        extract_archive(archive_bytes=payload.getvalue(), target_dir=tmp_path / "target")
+
+    assert not (tmp_path / "escape.txt").exists()
+
+
+@dataclass
+class FakeMorphExecResponse:
+    exit_code: int = 0
+    stdout: str = "ok\n"
+    stderr: str = ""
+
+
+@dataclass
+class FakeMorphSnapshot:
+    id: str
+    deleted: bool = False
+
+    def delete(self) -> None:
+        self.deleted = True
+
+
+@dataclass
+class FakeMorphInstance:
+    id: str = "morphvm-test"
+    runtime_snapshot: FakeMorphSnapshot | None = None
+    commands: list[tuple[str, int | None]] = field(default_factory=list)
+    uploads: list[tuple[str, str, bool, bytes]] = field(default_factory=list)
+    stopped: bool = False
+    snapshot_metadata: dict[str, str] | None = None
+
+    def wait_until_ready(self) -> None:
+        return None
+
+    def exec(self, command: str, timeout: int | None = None) -> FakeMorphExecResponse:
+        self.commands.append((command, timeout))
+        return FakeMorphExecResponse()
+
+    def upload(self, local_path: str, remote_path: str, recursive: bool = False) -> None:
+        self.uploads.append((local_path, remote_path, recursive, Path(local_path).read_bytes()))
+
+    def stop(self) -> None:
+        self.stopped = True
+
+    def snapshot(
+        self,
+        *,
+        digest: str | None = None,
+        metadata: dict[str, str] | None = None,
+        ttl_seconds: int | None = None,
+    ) -> FakeMorphSnapshot:
+        del digest, ttl_seconds
+        self.snapshot_metadata = metadata
+        if self.runtime_snapshot is None:
+            return FakeMorphSnapshot(id="snapshot-runtime")
+        return self.runtime_snapshot
+
+
+@dataclass
+class FakeSnapshotApi:
+    build_snapshot: FakeMorphSnapshot
+
+    def create(self, **kwargs: object) -> FakeMorphSnapshot:
+        del kwargs
+        return self.build_snapshot
+
+
+@dataclass
+class FakeInstanceApi:
+    builder: FakeMorphInstance
+    started_snapshot_ids: list[str]
+    fail_start: bool = False
+
+    def start(self, *, snapshot_id: str, **kwargs: object) -> FakeMorphInstance:
+        del kwargs
+        self.started_snapshot_ids.append(snapshot_id)
+        if self.fail_start:
+            msg = "start failed"
+            raise RuntimeError(msg)
+        return self.builder
+
+
+@dataclass
+class FakeMorphClient:
+    build_snapshot: FakeMorphSnapshot
+    builder: FakeMorphInstance
+    fail_start: bool = False
+    started_snapshot_ids: list[str] = field(default_factory=list)
+
+    @property
+    def snapshots(self) -> FakeSnapshotApi:
+        return FakeSnapshotApi(build_snapshot=self.build_snapshot)
+
+    @property
+    def instances(self) -> FakeInstanceApi:
+        return FakeInstanceApi(
+            builder=self.builder,
+            started_snapshot_ids=self.started_snapshot_ids,
+            fail_start=self.fail_start,
+        )
+
+
+@dataclass(frozen=True)
+class RecordingMorphCloudOperations(MorphCloudOperations):
+    events: list[str] = field(default_factory=list)
+
+    def _prepare_docker_host(self, instance: Any) -> None:
+        self.events.append(f"prepare:{instance.id}")
+
+    def upload_directory(self, *, instance: Any, local_path: Path, remote_path: str) -> None:
+        self.events.append(f"upload:{instance.id}:{local_path.name}:{remote_path}")
+
+    def write_instance_file(self, *, instance: Any, remote_path: str, content: bytes) -> None:
+        del content
+        self.events.append(f"write:{instance.id}:{remote_path}")
+
+    def _run_host_command(
+        self,
+        instance: Any,
+        command: str,
+        *,
+        check: bool = True,
+        command_timeout_seconds: int | None = None,
+    ) -> MorphCommandResult:
+        del check, command_timeout_seconds
+        self.events.append(f"command:{instance.id}:{command}")
+        return MorphCommandResult(exit_code=0, stdout="", stderr="")

--- a/tests/providers/test_morph_harbor.py
+++ b/tests/providers/test_morph_harbor.py
@@ -1,0 +1,258 @@
+# ABOUTME: Tests for the Morph-backed Harbor environment adapter.
+# ABOUTME: Verifies Harbor BaseEnvironment methods delegate to Morph provider operations.
+
+from __future__ import annotations
+
+import io
+import tarfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from harbor.models.task.config import EnvironmentConfig  # type: ignore[import-untyped]
+from harbor.models.trial.paths import TrialPaths  # type: ignore[import-untyped]
+
+from aec_bench.providers.morph_cloud import MorphCommandResult
+from aec_bench.providers.morph_harbor import MorphHarborEnvironment
+
+
+def test_morph_harbor_environment_starts_runtime_snapshot(tmp_path: Path) -> None:
+    environment_dir = _write_environment(tmp_path)
+    operations = FakeMorphHarborOperations()
+    env = MorphHarborEnvironment(
+        environment_dir=environment_dir,
+        environment_name="heat-load-alpha",
+        session_id="trial-001",
+        trial_paths=TrialPaths(tmp_path / "trial"),
+        task_env_config=_environment_config(),
+        operations=operations,
+        project_src_dir=tmp_path / "src" / "aec_bench",
+    )
+
+    _run(env.start(force_build=False))
+
+    assert operations.builds[0]["dockerfile_path"] == environment_dir / "Dockerfile"
+    assert operations.builds[0]["context_dir"] == environment_dir.parent
+    assert operations.started_snapshots == [operations.snapshot]
+    assert operations.started_containers == [
+        {"instance": operations.instance, "workspace_dir": "/workspace", "logs_dir": "/logs"}
+    ]
+
+
+def test_morph_harbor_environment_exec_returns_harbor_exec_result(tmp_path: Path) -> None:
+    environment_dir = _write_environment(tmp_path)
+    operations = FakeMorphHarborOperations()
+    env = MorphHarborEnvironment(
+        environment_dir=environment_dir,
+        environment_name="heat-load-alpha",
+        session_id="trial-001",
+        trial_paths=TrialPaths(tmp_path / "trial"),
+        task_env_config=_environment_config(),
+        operations=operations,
+    )
+    _run(env.start(force_build=False))
+
+    result = _run(env.exec("python3 --version", cwd="/workspace", env={"ABC": "123"}, timeout_sec=30))
+
+    assert result.return_code == 7
+    assert result.stdout == "hello\n"
+    assert result.stderr == "warn\n"
+    assert operations.commands[-1] == {
+        "instance": operations.instance,
+        "command": ("bash", "-lc", "python3 --version"),
+        "workdir": "/workspace",
+        "env": {"ABC": "123"},
+        "timeout_seconds": 30,
+    }
+
+
+def test_morph_harbor_environment_uploads_and_downloads_files(tmp_path: Path) -> None:
+    environment_dir = _write_environment(tmp_path)
+    operations = FakeMorphHarborOperations(files={"/workspace/output.md": b"answer\n"})
+    env = MorphHarborEnvironment(
+        environment_dir=environment_dir,
+        environment_name="heat-load-alpha",
+        session_id="trial-001",
+        trial_paths=TrialPaths(tmp_path / "trial"),
+        task_env_config=_environment_config(),
+        operations=operations,
+    )
+    local_file = tmp_path / "payload.txt"
+    local_file.write_text("payload\n", encoding="utf-8")
+    target_file = tmp_path / "downloaded.md"
+    _run(env.start(force_build=False))
+
+    _run(env.upload_file(local_file, "/workspace/payload.txt"))
+    _run(env.upload_dir(environment_dir.parent, "/workspace"))
+    _run(env.download_file("/workspace/output.md", target_file))
+
+    assert operations.writes[0] == {
+        "instance": operations.instance,
+        "remote_path": "/workspace/payload.txt",
+        "content": b"payload\n",
+    }
+    assert operations.uploads[0] == {
+        "instance": operations.instance,
+        "local_path": environment_dir.parent,
+        "remote_path": "/workspace",
+    }
+    assert target_file.read_bytes() == b"answer\n"
+
+
+def test_morph_harbor_environment_downloads_directories(tmp_path: Path) -> None:
+    environment_dir = _write_environment(tmp_path)
+    operations = FakeMorphHarborOperations(directories={"/logs/agent": _archive_bytes({"output.md": b"answer\n"})})
+    env = MorphHarborEnvironment(
+        environment_dir=environment_dir,
+        environment_name="heat-load-alpha",
+        session_id="trial-001",
+        trial_paths=TrialPaths(tmp_path / "trial"),
+        task_env_config=_environment_config(),
+        operations=operations,
+    )
+    target_dir = tmp_path / "agent"
+    _run(env.start(force_build=False))
+
+    _run(env.download_dir("/logs/agent", target_dir))
+
+    assert (target_dir / "output.md").read_bytes() == b"answer\n"
+
+
+def test_morph_harbor_environment_stop_tears_down_instance(tmp_path: Path) -> None:
+    environment_dir = _write_environment(tmp_path)
+    operations = FakeMorphHarborOperations()
+    env = MorphHarborEnvironment(
+        environment_dir=environment_dir,
+        environment_name="heat-load-alpha",
+        session_id="trial-001",
+        trial_paths=TrialPaths(tmp_path / "trial"),
+        task_env_config=_environment_config(),
+        operations=operations,
+    )
+    _run(env.start(force_build=False))
+
+    _run(env.stop(delete=True))
+
+    assert operations.stopped_instances == [operations.instance]
+
+
+def _write_environment(tmp_path: Path) -> Path:
+    task_dir = tmp_path / "task"
+    environment_dir = task_dir / "environment"
+    environment_dir.mkdir(parents=True)
+    (environment_dir / "Dockerfile").write_text("FROM python:3.13-slim\n", encoding="utf-8")
+    return environment_dir
+
+
+def _environment_config() -> EnvironmentConfig:
+    return EnvironmentConfig.model_construct(
+        build_timeout_sec=600.0,
+        docker_image=None,
+        cpus=1,
+        memory_mb=2048,
+        storage_mb=10240,
+        gpus=0,
+        gpu_types=None,
+        allow_internet=True,
+        mcp_servers=[],
+        memory=None,
+        storage=None,
+    )
+
+
+def _run(coro: Any) -> Any:
+    import asyncio
+
+    return asyncio.run(coro)
+
+
+def _archive_bytes(files: dict[str, bytes]) -> bytes:
+    payload = io.BytesIO()
+    with tarfile.open(fileobj=payload, mode="w:gz") as archive:
+        for name, content in sorted(files.items()):
+            member = tarfile.TarInfo(name)
+            member.size = len(content)
+            archive.addfile(member, io.BytesIO(content))
+    return payload.getvalue()
+
+
+@dataclass(frozen=True)
+class FakeMorphObject:
+    id: str
+
+
+@dataclass
+class FakeMorphHarborOperations:
+    files: dict[str, bytes] = field(default_factory=dict)
+    directories: dict[str, bytes] = field(default_factory=dict)
+    snapshot: FakeMorphObject = field(default_factory=lambda: FakeMorphObject(id="snapshot-001"))
+    instance: FakeMorphObject = field(default_factory=lambda: FakeMorphObject(id="instance-001"))
+    builds: list[dict[str, Any]] = field(default_factory=list)
+    started_snapshots: list[object] = field(default_factory=list)
+    started_containers: list[dict[str, Any]] = field(default_factory=list)
+    commands: list[dict[str, Any]] = field(default_factory=list)
+    writes: list[dict[str, Any]] = field(default_factory=list)
+    uploads: list[dict[str, Any]] = field(default_factory=list)
+    stopped_instances: list[object] = field(default_factory=list)
+
+    def build_runtime_snapshot(
+        self,
+        *,
+        dockerfile_path: Path,
+        context_dir: Path,
+        project_src_dir: Path,
+        runtime_packages: tuple[str, ...],
+    ) -> object:
+        self.builds.append(
+            {
+                "dockerfile_path": dockerfile_path,
+                "context_dir": context_dir,
+                "project_src_dir": project_src_dir,
+                "runtime_packages": runtime_packages,
+            }
+        )
+        return self.snapshot
+
+    def start_instance(self, *, snapshot: object) -> object:
+        self.started_snapshots.append(snapshot)
+        return self.instance
+
+    def start_trial_container(self, *, instance: object, workspace_dir: str, logs_dir: str) -> None:
+        self.started_containers.append({"instance": instance, "workspace_dir": workspace_dir, "logs_dir": logs_dir})
+
+    def run_container_command_result(
+        self,
+        *,
+        instance: object,
+        command: tuple[str, ...],
+        workdir: str | None = None,
+        env: dict[str, str] | None = None,
+        timeout_seconds: int | None = None,
+    ) -> MorphCommandResult:
+        self.commands.append(
+            {
+                "instance": instance,
+                "command": command,
+                "workdir": workdir,
+                "env": env,
+                "timeout_seconds": timeout_seconds,
+            }
+        )
+        return MorphCommandResult(exit_code=7, stdout="hello\n", stderr="warn\n")
+
+    def write_instance_file(self, *, instance: object, remote_path: str, content: bytes) -> None:
+        self.writes.append({"instance": instance, "remote_path": remote_path, "content": content})
+
+    def upload_directory(self, *, instance: object, local_path: Path, remote_path: str) -> None:
+        self.uploads.append({"instance": instance, "local_path": local_path, "remote_path": remote_path})
+
+    def read_container_file(self, *, instance: object, remote_path: str) -> bytes | None:
+        del instance
+        return self.files.get(remote_path)
+
+    def read_container_directory_archive(self, *, instance: object, remote_path: str) -> bytes | None:
+        del instance
+        return self.directories.get(remote_path)
+
+    def stop_instance(self, *, instance: object) -> None:
+        self.stopped_instances.append(instance)

--- a/tests/web/test_triage_page.py
+++ b/tests/web/test_triage_page.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from fastapi.testclient import TestClient
 
 from aec_bench.contracts.evaluation_result import EvaluationResult, ValidityCheck
-from aec_bench.contracts.trial_record import AgentReference, TaskReference
+from aec_bench.contracts.trial_record import AgentReference, EnvironmentSnapshot, TaskReference
 from aec_bench.ledger.writer import write_trial_record
 from aec_bench.web.app import create_app
 from tests.support.trial_record_factories import make_trial_record
@@ -37,6 +37,33 @@ def test_triage_api_returns_json(tmp_path: Path) -> None:
     assert "filters" in data
     assert "experiments" in data
     assert "models" in data
+
+
+def test_triage_api_includes_compute_backend(tmp_path: Path) -> None:
+    """Trial rows expose the execution backend recorded in the ledger."""
+    ledger = tmp_path / "ledger"
+    ledger.mkdir()
+    tasks = tmp_path / "tasks"
+    tasks.mkdir()
+    write_trial_record(
+        ledger_root=ledger,
+        record=make_trial_record(
+            experiment_id="exp-01",
+            trial_id="trial-morph",
+            environment=EnvironmentSnapshot(
+                runtime_image="ghcr.io/example/task-image:latest",
+                compute_backend="morph",
+                tool_versions={"codes_search": "abc123"},
+            ),
+        ),
+    )
+    client = TestClient(create_app(ledger_root=ledger, tasks_root=tasks))
+
+    resp = client.get("/api/triage?experiment=exp-01")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["trials"][0]["compute_backend"] == "morph"
 
 
 def test_triage_api_filters_by_experiment(tmp_path: Path) -> None:

--- a/tests/web/test_viewer.py
+++ b/tests/web/test_viewer.py
@@ -31,7 +31,7 @@ def _make_client_with_trial(tmp_path: Path) -> TestClient:
     return TestClient(create_app(ledger_root=ledger, tasks_root=tasks))
 
 
-def _write_trajectory_jsonl(path: Path, entries: list[dict]) -> None:
+def _write_trajectory_jsonl(path: Path, entries: list[dict[str, object]]) -> None:
     """Write a trajectory JSONL file with version header and entry dicts."""
     lines = [json.dumps({"format": "aec-bench-trajectory", "version": 1})]
     for entry in entries:
@@ -303,11 +303,16 @@ def test_viewer_api_meta_returns_json(tmp_path: Path) -> None:
         ],
     )
 
-    from aec_bench.contracts.trial_record import OutputRecord
+    from aec_bench.contracts.trial_record import EnvironmentSnapshot, OutputRecord
 
     record = make_trial_record(
         experiment_id="experiment-001",
         trial_id="trial-001",
+        environment=EnvironmentSnapshot(
+            runtime_image="ghcr.io/example/task-image:latest",
+            compute_backend="morph",
+            tool_versions={"codes_search": "abc123"},
+        ),
         outputs=OutputRecord(
             raw_output_path=str(traj_dir / "output.jsonl"),
             trajectory_path=str(traj_path),
@@ -327,6 +332,7 @@ def test_viewer_api_meta_returns_json(tmp_path: Path) -> None:
     assert "reward_class" in data
     assert "artefacts" in data
     assert "has_trajectory" in data
+    assert data["compute_backend"] == "morph"
 
 
 def test_viewer_api_meta_404_for_missing_trial(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -18,6 +18,7 @@ dependencies = [
     { name = "httpx" },
     { name = "jinja2" },
     { name = "modal" },
+    { name = "morphcloud" },
     { name = "pdfplumber" },
     { name = "polars" },
     { name = "pydantic" },
@@ -67,6 +68,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28,<1" },
     { name = "jinja2", specifier = ">=3.1,<4" },
     { name = "modal", specifier = ">=1.3,<2" },
+    { name = "morphcloud", specifier = ">=0.1.111" },
     { name = "pdfplumber", specifier = ">=0.11.9" },
     { name = "polars", specifier = ">=1.30,<2" },
     { name = "pydantic", specifier = ">=2.11,<3" },
@@ -338,6 +340,72 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/af/98/00d3dd826d46959ad8e32af2dbb2398868fd9fd0683c26e56d0789bd0e68/authlib-1.6.9.tar.gz", hash = "sha256:d8f2421e7e5980cc1ddb4e32d3f5fa659cfaf60d8eaf3281ebed192e4ab74f04", size = 165134 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/53/23/b65f568ed0c22f1efacb744d2db1a33c8068f384b8c9b482b52ebdbc3ef6/authlib-1.6.9-py2.py3-none-any.whl", hash = "sha256:f08b4c14e08f0861dc18a32357b33fbcfd2ea86cfe3fe149484b4d764c4a0ac3", size = 244197 },
+]
+
+[[package]]
+name = "bcrypt"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/36/3329e2518d70ad8e2e5817d5a4cac6bba05a47767ec416c7d020a965f408/bcrypt-5.0.0.tar.gz", hash = "sha256:f748f7c2d6fd375cc93d3fba7ef4a9e3a092421b8dbf34d8d4dc06be9492dfdd", size = 25386 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/85/3e65e01985fddf25b64ca67275bb5bdb4040bd1a53b66d355c6c37c8a680/bcrypt-5.0.0-cp313-cp313t-macosx_10_12_universal2.whl", hash = "sha256:f3c08197f3039bec79cee59a606d62b96b16669cff3949f21e74796b6e3cd2be", size = 481806 },
+    { url = "https://files.pythonhosted.org/packages/44/dc/01eb79f12b177017a726cbf78330eb0eb442fae0e7b3dfd84ea2849552f3/bcrypt-5.0.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:200af71bc25f22006f4069060c88ed36f8aa4ff7f53e67ff04d2ab3f1e79a5b2", size = 268626 },
+    { url = "https://files.pythonhosted.org/packages/8c/cf/e82388ad5959c40d6afd94fb4743cc077129d45b952d46bdc3180310e2df/bcrypt-5.0.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:baade0a5657654c2984468efb7d6c110db87ea63ef5a4b54732e7e337253e44f", size = 271853 },
+    { url = "https://files.pythonhosted.org/packages/ec/86/7134b9dae7cf0efa85671651341f6afa695857fae172615e960fb6a466fa/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:c58b56cdfb03202b3bcc9fd8daee8e8e9b6d7e3163aa97c631dfcfcc24d36c86", size = 269793 },
+    { url = "https://files.pythonhosted.org/packages/cc/82/6296688ac1b9e503d034e7d0614d56e80c5d1a08402ff856a4549cb59207/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4bfd2a34de661f34d0bda43c3e4e79df586e4716ef401fe31ea39d69d581ef23", size = 289930 },
+    { url = "https://files.pythonhosted.org/packages/d1/18/884a44aa47f2a3b88dd09bc05a1e40b57878ecd111d17e5bba6f09f8bb77/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:ed2e1365e31fc73f1825fa830f1c8f8917ca1b3ca6185773b349c20fd606cec2", size = 272194 },
+    { url = "https://files.pythonhosted.org/packages/0e/8f/371a3ab33c6982070b674f1788e05b656cfbf5685894acbfef0c65483a59/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_aarch64.whl", hash = "sha256:83e787d7a84dbbfba6f250dd7a5efd689e935f03dd83b0f919d39349e1f23f83", size = 269381 },
+    { url = "https://files.pythonhosted.org/packages/b1/34/7e4e6abb7a8778db6422e88b1f06eb07c47682313997ee8a8f9352e5a6f1/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_x86_64.whl", hash = "sha256:137c5156524328a24b9fac1cb5db0ba618bc97d11970b39184c1d87dc4bf1746", size = 271750 },
+    { url = "https://files.pythonhosted.org/packages/c0/1b/54f416be2499bd72123c70d98d36c6cd61a4e33d9b89562c22481c81bb30/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:38cac74101777a6a7d3b3e3cfefa57089b5ada650dce2baf0cbdd9d65db22a9e", size = 303757 },
+    { url = "https://files.pythonhosted.org/packages/13/62/062c24c7bcf9d2826a1a843d0d605c65a755bc98002923d01fd61270705a/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:d8d65b564ec849643d9f7ea05c6d9f0cd7ca23bdd4ac0c2dbef1104ab504543d", size = 306740 },
+    { url = "https://files.pythonhosted.org/packages/d5/c8/1fdbfc8c0f20875b6b4020f3c7dc447b8de60aa0be5faaf009d24242aec9/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:741449132f64b3524e95cd30e5cd3343006ce146088f074f31ab26b94e6c75ba", size = 334197 },
+    { url = "https://files.pythonhosted.org/packages/a6/c1/8b84545382d75bef226fbc6588af0f7b7d095f7cd6a670b42a86243183cd/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:212139484ab3207b1f0c00633d3be92fef3c5f0af17cad155679d03ff2ee1e41", size = 352974 },
+    { url = "https://files.pythonhosted.org/packages/10/a6/ffb49d4254ed085e62e3e5dd05982b4393e32fe1e49bb1130186617c29cd/bcrypt-5.0.0-cp313-cp313t-win32.whl", hash = "sha256:9d52ed507c2488eddd6a95bccee4e808d3234fa78dd370e24bac65a21212b861", size = 148498 },
+    { url = "https://files.pythonhosted.org/packages/48/a9/259559edc85258b6d5fc5471a62a3299a6aa37a6611a169756bf4689323c/bcrypt-5.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f6984a24db30548fd39a44360532898c33528b74aedf81c26cf29c51ee47057e", size = 145853 },
+    { url = "https://files.pythonhosted.org/packages/2d/df/9714173403c7e8b245acf8e4be8876aac64a209d1b392af457c79e60492e/bcrypt-5.0.0-cp313-cp313t-win_arm64.whl", hash = "sha256:9fffdb387abe6aa775af36ef16f55e318dcda4194ddbf82007a6f21da29de8f5", size = 139626 },
+    { url = "https://files.pythonhosted.org/packages/f8/14/c18006f91816606a4abe294ccc5d1e6f0e42304df5a33710e9e8e95416e1/bcrypt-5.0.0-cp314-cp314t-macosx_10_12_universal2.whl", hash = "sha256:4870a52610537037adb382444fefd3706d96d663ac44cbb2f37e3919dca3d7ef", size = 481862 },
+    { url = "https://files.pythonhosted.org/packages/67/49/dd074d831f00e589537e07a0725cf0e220d1f0d5d8e85ad5bbff251c45aa/bcrypt-5.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48f753100931605686f74e27a7b49238122aa761a9aefe9373265b8b7aa43ea4", size = 268544 },
+    { url = "https://files.pythonhosted.org/packages/f5/91/50ccba088b8c474545b034a1424d05195d9fcbaaf802ab8bfe2be5a4e0d7/bcrypt-5.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f70aadb7a809305226daedf75d90379c397b094755a710d7014b8b117df1ebbf", size = 271787 },
+    { url = "https://files.pythonhosted.org/packages/aa/e7/d7dba133e02abcda3b52087a7eea8c0d4f64d3e593b4fffc10c31b7061f3/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:744d3c6b164caa658adcb72cb8cc9ad9b4b75c7db507ab4bc2480474a51989da", size = 269753 },
+    { url = "https://files.pythonhosted.org/packages/33/fc/5b145673c4b8d01018307b5c2c1fc87a6f5a436f0ad56607aee389de8ee3/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a28bc05039bdf3289d757f49d616ab3efe8cf40d8e8001ccdd621cd4f98f4fc9", size = 289587 },
+    { url = "https://files.pythonhosted.org/packages/27/d7/1ff22703ec6d4f90e62f1a5654b8867ef96bafb8e8102c2288333e1a6ca6/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:7f277a4b3390ab4bebe597800a90da0edae882c6196d3038a73adf446c4f969f", size = 272178 },
+    { url = "https://files.pythonhosted.org/packages/c8/88/815b6d558a1e4d40ece04a2f84865b0fef233513bd85fd0e40c294272d62/bcrypt-5.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:79cfa161eda8d2ddf29acad370356b47f02387153b11d46042e93a0a95127493", size = 269295 },
+    { url = "https://files.pythonhosted.org/packages/51/8c/e0db387c79ab4931fc89827d37608c31cc57b6edc08ccd2386139028dc0d/bcrypt-5.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a5393eae5722bcef046a990b84dff02b954904c36a194f6cfc817d7dca6c6f0b", size = 271700 },
+    { url = "https://files.pythonhosted.org/packages/06/83/1570edddd150f572dbe9fc00f6203a89fc7d4226821f67328a85c330f239/bcrypt-5.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f4c94dec1b5ab5d522750cb059bb9409ea8872d4494fd152b53cca99f1ddd8c", size = 334034 },
+    { url = "https://files.pythonhosted.org/packages/c9/f2/ea64e51a65e56ae7a8a4ec236c2bfbdd4b23008abd50ac33fbb2d1d15424/bcrypt-5.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0cae4cb350934dfd74c020525eeae0a5f79257e8a201c0c176f4b84fdbf2a4b4", size = 352766 },
+    { url = "https://files.pythonhosted.org/packages/d7/d4/1a388d21ee66876f27d1a1f41287897d0c0f1712ef97d395d708ba93004c/bcrypt-5.0.0-cp314-cp314t-win32.whl", hash = "sha256:b17366316c654e1ad0306a6858e189fc835eca39f7eb2cafd6aaca8ce0c40a2e", size = 152449 },
+    { url = "https://files.pythonhosted.org/packages/3f/61/3291c2243ae0229e5bca5d19f4032cecad5dfb05a2557169d3a69dc0ba91/bcrypt-5.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:92864f54fb48b4c718fc92a32825d0e42265a627f956bc0361fe869f1adc3e7d", size = 149310 },
+    { url = "https://files.pythonhosted.org/packages/3e/89/4b01c52ae0c1a681d4021e5dd3e45b111a8fb47254a274fa9a378d8d834b/bcrypt-5.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dd19cf5184a90c873009244586396a6a884d591a5323f0e8a5922560718d4993", size = 143761 },
+    { url = "https://files.pythonhosted.org/packages/84/29/6237f151fbfe295fe3e074ecc6d44228faa1e842a81f6d34a02937ee1736/bcrypt-5.0.0-cp38-abi3-macosx_10_12_universal2.whl", hash = "sha256:fc746432b951e92b58317af8e0ca746efe93e66555f1b40888865ef5bf56446b", size = 494553 },
+    { url = "https://files.pythonhosted.org/packages/45/b6/4c1205dde5e464ea3bd88e8742e19f899c16fa8916fb8510a851fae985b5/bcrypt-5.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c2388ca94ffee269b6038d48747f4ce8df0ffbea43f31abfa18ac72f0218effb", size = 275009 },
+    { url = "https://files.pythonhosted.org/packages/3b/71/427945e6ead72ccffe77894b2655b695ccf14ae1866cd977e185d606dd2f/bcrypt-5.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:560ddb6ec730386e7b3b26b8b4c88197aaed924430e7b74666a586ac997249ef", size = 278029 },
+    { url = "https://files.pythonhosted.org/packages/17/72/c344825e3b83c5389a369c8a8e58ffe1480b8a699f46c127c34580c4666b/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d79e5c65dcc9af213594d6f7f1fa2c98ad3fc10431e7aa53c176b441943efbdd", size = 275907 },
+    { url = "https://files.pythonhosted.org/packages/0b/7e/d4e47d2df1641a36d1212e5c0514f5291e1a956a7749f1e595c07a972038/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2b732e7d388fa22d48920baa267ba5d97cca38070b69c0e2d37087b381c681fd", size = 296500 },
+    { url = "https://files.pythonhosted.org/packages/0f/c3/0ae57a68be2039287ec28bc463b82e4b8dc23f9d12c0be331f4782e19108/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0c8e093ea2532601a6f686edbc2c6b2ec24131ff5c52f7610dd64fa4553b5464", size = 278412 },
+    { url = "https://files.pythonhosted.org/packages/45/2b/77424511adb11e6a99e3a00dcc7745034bee89036ad7d7e255a7e47be7d8/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5b1589f4839a0899c146e8892efe320c0fa096568abd9b95593efac50a87cb75", size = 275486 },
+    { url = "https://files.pythonhosted.org/packages/43/0a/405c753f6158e0f3f14b00b462d8bca31296f7ecfc8fc8bc7919c0c7d73a/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:89042e61b5e808b67daf24a434d89bab164d4de1746b37a8d173b6b14f3db9ff", size = 277940 },
+    { url = "https://files.pythonhosted.org/packages/62/83/b3efc285d4aadc1fa83db385ec64dcfa1707e890eb42f03b127d66ac1b7b/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:e3cf5b2560c7b5a142286f69bde914494b6d8f901aaa71e453078388a50881c4", size = 310776 },
+    { url = "https://files.pythonhosted.org/packages/95/7d/47ee337dacecde6d234890fe929936cb03ebc4c3a7460854bbd9c97780b8/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:f632fd56fc4e61564f78b46a2269153122db34988e78b6be8b32d28507b7eaeb", size = 312922 },
+    { url = "https://files.pythonhosted.org/packages/d6/3a/43d494dfb728f55f4e1cf8fd435d50c16a2d75493225b54c8d06122523c6/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:801cad5ccb6b87d1b430f183269b94c24f248dddbbc5c1f78b6ed231743e001c", size = 341367 },
+    { url = "https://files.pythonhosted.org/packages/55/ab/a0727a4547e383e2e22a630e0f908113db37904f58719dc48d4622139b5c/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3cf67a804fc66fc217e6914a5635000259fbbbb12e78a99488e4d5ba445a71eb", size = 359187 },
+    { url = "https://files.pythonhosted.org/packages/1b/bb/461f352fdca663524b4643d8b09e8435b4990f17fbf4fea6bc2a90aa0cc7/bcrypt-5.0.0-cp38-abi3-win32.whl", hash = "sha256:3abeb543874b2c0524ff40c57a4e14e5d3a66ff33fb423529c88f180fd756538", size = 153752 },
+    { url = "https://files.pythonhosted.org/packages/41/aa/4190e60921927b7056820291f56fc57d00d04757c8b316b2d3c0d1d6da2c/bcrypt-5.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:35a77ec55b541e5e583eb3436ffbbf53b0ffa1fa16ca6782279daf95d146dcd9", size = 150881 },
+    { url = "https://files.pythonhosted.org/packages/54/12/cd77221719d0b39ac0b55dbd39358db1cd1246e0282e104366ebbfb8266a/bcrypt-5.0.0-cp38-abi3-win_arm64.whl", hash = "sha256:cde08734f12c6a4e28dc6755cd11d3bdfea608d93d958fffbe95a7026ebe4980", size = 144931 },
+    { url = "https://files.pythonhosted.org/packages/5d/ba/2af136406e1c3839aea9ecadc2f6be2bcd1eff255bd451dd39bcf302c47a/bcrypt-5.0.0-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:0c418ca99fd47e9c59a301744d63328f17798b5947b0f791e9af3c1c499c2d0a", size = 495313 },
+    { url = "https://files.pythonhosted.org/packages/ac/ee/2f4985dbad090ace5ad1f7dd8ff94477fe089b5fab2040bd784a3d5f187b/bcrypt-5.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddb4e1500f6efdd402218ffe34d040a1196c072e07929b9820f363a1fd1f4191", size = 275290 },
+    { url = "https://files.pythonhosted.org/packages/e4/6e/b77ade812672d15cf50842e167eead80ac3514f3beacac8902915417f8b7/bcrypt-5.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7aeef54b60ceddb6f30ee3db090351ecf0d40ec6e2abf41430997407a46d2254", size = 278253 },
+    { url = "https://files.pythonhosted.org/packages/36/c4/ed00ed32f1040f7990dac7115f82273e3c03da1e1a1587a778d8cea496d8/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f0ce778135f60799d89c9693b9b398819d15f1921ba15fe719acb3178215a7db", size = 276084 },
+    { url = "https://files.pythonhosted.org/packages/e7/c4/fa6e16145e145e87f1fa351bbd54b429354fd72145cd3d4e0c5157cf4c70/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a71f70ee269671460b37a449f5ff26982a6f2ba493b3eabdd687b4bf35f875ac", size = 297185 },
+    { url = "https://files.pythonhosted.org/packages/24/b4/11f8a31d8b67cca3371e046db49baa7c0594d71eb40ac8121e2fc0888db0/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f8429e1c410b4073944f03bd778a9e066e7fad723564a52ff91841d278dfc822", size = 278656 },
+    { url = "https://files.pythonhosted.org/packages/ac/31/79f11865f8078e192847d2cb526e3fa27c200933c982c5b2869720fa5fce/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:edfcdcedd0d0f05850c52ba3127b1fce70b9f89e0fe5ff16517df7e81fa3cbb8", size = 275662 },
+    { url = "https://files.pythonhosted.org/packages/d4/8d/5e43d9584b3b3591a6f9b68f755a4da879a59712981ef5ad2a0ac1379f7a/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:611f0a17aa4a25a69362dcc299fda5c8a3d4f160e2abb3831041feb77393a14a", size = 278240 },
+    { url = "https://files.pythonhosted.org/packages/89/48/44590e3fc158620f680a978aafe8f87a4c4320da81ed11552f0323aa9a57/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:db99dca3b1fdc3db87d7c57eac0c82281242d1eabf19dcb8a6b10eb29a2e72d1", size = 311152 },
+    { url = "https://files.pythonhosted.org/packages/5f/85/e4fbfc46f14f47b0d20493669a625da5827d07e8a88ee460af6cd9768b44/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:5feebf85a9cefda32966d8171f5db7e3ba964b77fdfe31919622256f80f9cf42", size = 313284 },
+    { url = "https://files.pythonhosted.org/packages/25/ae/479f81d3f4594456a01ea2f05b132a519eff9ab5768a70430fa1132384b1/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3ca8a166b1140436e058298a34d88032ab62f15aae1c598580333dc21d27ef10", size = 341643 },
+    { url = "https://files.pythonhosted.org/packages/df/d2/36a086dee1473b14276cd6ea7f61aef3b2648710b5d7f1c9e032c29b859f/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:61afc381250c3182d9078551e3ac3a41da14154fbff647ddf52a769f588c4172", size = 359698 },
+    { url = "https://files.pythonhosted.org/packages/c0/f6/688d2cd64bfd0b14d805ddb8a565e11ca1fb0fd6817175d58b10052b6d88/bcrypt-5.0.0-cp39-abi3-win32.whl", hash = "sha256:64d7ce196203e468c457c37ec22390f1a61c85c6f0b8160fd752940ccfb3a683", size = 153725 },
+    { url = "https://files.pythonhosted.org/packages/9f/b9/9d9a641194a730bda138b3dfe53f584d61c58cd5230e37566e83ec2ffa0d/bcrypt-5.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:64ee8434b0da054d830fa8e89e1c8bf30061d539044a39524ff7dec90481e5c2", size = 150912 },
+    { url = "https://files.pythonhosted.org/packages/27/44/d2ef5e87509158ad2187f4dd0852df80695bb1ee0cfe0a684727b01a69e0/bcrypt-5.0.0-cp39-abi3-win_arm64.whl", hash = "sha256:f2347d3534e76bf50bca5500989d6c1d05ed64b440408057a37673282c654927", size = 144953 },
 ]
 
 [[package]]
@@ -1636,6 +1704,15 @@ wheels = [
 ]
 
 [[package]]
+name = "invoke"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/227c48c5fe47fa178ccf1fda8f047d16c97ba926567b661e9ce2045c600c/invoke-3.0.3.tar.gz", hash = "sha256:437b6a622223824380bfb4e64f612711a6b648c795f565efc8625af66fb57f0c", size = 343419 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/de/bbc12563bbf979618d17625a4e753ff7a078523e28d870d3626daa97261a/invoke-3.0.3-py3-none-any.whl", hash = "sha256:f11327165e5cbb89b2ad1d88d3292b5113332c43b8553b494da435d6ec6f5053", size = 160958 },
+]
+
+[[package]]
 name = "jaraco-classes"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2373,6 +2450,32 @@ wheels = [
 ]
 
 [[package]]
+name = "morphcloud"
+version = "0.1.111"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anthropic" },
+    { name = "click" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "paramiko" },
+    { name = "pathspec" },
+    { name = "prompt-toolkit" },
+    { name = "psutil" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "toml" },
+    { name = "tqdm" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/df/4883d1467ab1d5a865ecea88e3f6b743b7fd1b47a25c2c9990cdc4574a2d/morphcloud-0.1.111.tar.gz", hash = "sha256:6cbaa1395493395a94a53352158e80426ce0c33d763f717f3f2422b668f63951", size = 214452 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/96/7e3f4419cfecc234bea28d863558619bd87de809908154f6b296e1853ee7/morphcloud-0.1.111-py3-none-any.whl", hash = "sha256:0ff8260bdd0afcfc46e426ce4b78aab178f93006d4a92b9483640a5f209caceb", size = 229247 },
+]
+
+[[package]]
 name = "mpmath"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2940,6 +3043,21 @@ wheels = [
 ]
 
 [[package]]
+name = "paramiko"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bcrypt" },
+    { name = "cryptography" },
+    { name = "invoke" },
+    { name = "pynacl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/93/dcc25d52f49022ae6175d15e6bd751f1acc99b98bc61fc55e5155a7be2e7/paramiko-5.0.0.tar.gz", hash = "sha256:36763b5b95c2a0dcfdf1abc48e48156ee425b21efe2f0e787c2dd5a95c0e5e79", size = 1548586 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/5b/eadf6d45de38d30ab603f49393b6cd2cbe7e233af8cf90197e32782b68a9/paramiko-5.0.0-py3-none-any.whl", hash = "sha256:b7044611c30140d9a75261653210e2002977b71a0497ff3ba0d98d7edbf62f7c", size = 208919 },
+]
+
+[[package]]
 name = "pathable"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3228,6 +3346,34 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/f5/65d838092fd01c44d16037953fd4c2cc851e783de9b8f02b27ec4ffd906f/protobuf-6.33.5-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:8afa18e1d6d20af15b417e728e9f60f3aa108ee76f23c3b2c07a2c3b546d3afd", size = 339411 },
     { url = "https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0", size = 323465 },
     { url = "https://files.pythonhosted.org/packages/57/bf/2086963c69bdac3d7cff1cc7ff79b8ce5ea0bec6797a017e1be338a46248/protobuf-6.33.5-py3-none-any.whl", hash = "sha256:69915a973dd0f60f31a08b8318b73eab2bd6a392c79184b3612226b0a3f8ec02", size = 170687 },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595 },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082 },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476 },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062 },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893 },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589 },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664 },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087 },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383 },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210 },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228 },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284 },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090 },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859 },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560 },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997 },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972 },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266 },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737 },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617 },
 ]
 
 [[package]]
@@ -3585,6 +3731,41 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/fd/f1ebe24fcd31aaea8b85b3a7ac4c3fc96e20388be5466ace27c9a3c546d9/pymupdf-1.27.2.2-cp310-abi3-win32.whl", hash = "sha256:0b8e924433b7e0bd46be820899300259235997d5a747638471fb2762baa8ee30", size = 18008861 },
     { url = "https://files.pythonhosted.org/packages/a8/b6/2a9a8556000199bbf80a5915dcd15d550d1e5288894316445c54726aaf53/pymupdf-1.27.2.2-cp310-abi3-win_amd64.whl", hash = "sha256:09bb53f9486ccb5297030cbc2dbdae845ba1c3c5126e96eb2d16c4f118de0b5b", size = 19238032 },
     { url = "https://files.pythonhosted.org/packages/c2/c6/e3e11c42f09b9c34ec332c0f37b817671b59ef4001895b854f0494092105/pymupdf-1.27.2.2-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:6cebfbbdfd219ebdebf4d8e3914624b2e3d3a844c43f4f76935822dd9b13cc12", size = 24985299 },
+]
+
+[[package]]
+name = "pynacl"
+version = "1.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/9a/4019b524b03a13438637b11538c82781a5eda427394380381af8f04f467a/pynacl-1.6.2.tar.gz", hash = "sha256:018494d6d696ae03c7e656e5e74cdfd8ea1326962cc401bcf018f1ed8436811c", size = 3511692 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/79/0e3c34dc3c4671f67d251c07aa8eb100916f250ee470df230b0ab89551b4/pynacl-1.6.2-cp314-cp314t-macosx_10_10_universal2.whl", hash = "sha256:622d7b07cc5c02c666795792931b50c91f3ce3c2649762efb1ef0d5684c81594", size = 390064 },
+    { url = "https://files.pythonhosted.org/packages/eb/1c/23a26e931736e13b16483795c8a6b2f641bf6a3d5238c22b070a5112722c/pynacl-1.6.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d071c6a9a4c94d79eb665db4ce5cedc537faf74f2355e4d502591d850d3913c0", size = 809370 },
+    { url = "https://files.pythonhosted.org/packages/87/74/8d4b718f8a22aea9e8dcc8b95deb76d4aae380e2f5b570cc70b5fd0a852d/pynacl-1.6.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe9847ca47d287af41e82be1dd5e23023d3c31a951da134121ab02e42ac218c9", size = 1408304 },
+    { url = "https://files.pythonhosted.org/packages/fd/73/be4fdd3a6a87fe8a4553380c2b47fbd1f7f58292eb820902f5c8ac7de7b0/pynacl-1.6.2-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04316d1fc625d860b6c162fff704eb8426b1a8bcd3abacea11142cbd99a6b574", size = 844871 },
+    { url = "https://files.pythonhosted.org/packages/55/ad/6efc57ab75ee4422e96b5f2697d51bbcf6cdcc091e66310df91fbdc144a8/pynacl-1.6.2-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44081faff368d6c5553ccf55322ef2819abb40e25afaec7e740f159f74813634", size = 1446356 },
+    { url = "https://files.pythonhosted.org/packages/78/b7/928ee9c4779caa0a915844311ab9fb5f99585621c5d6e4574538a17dca07/pynacl-1.6.2-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:a9f9932d8d2811ce1a8ffa79dcbdf3970e7355b5c8eb0c1a881a57e7f7d96e88", size = 826814 },
+    { url = "https://files.pythonhosted.org/packages/f7/a9/1bdba746a2be20f8809fee75c10e3159d75864ef69c6b0dd168fc60e485d/pynacl-1.6.2-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:bc4a36b28dd72fb4845e5d8f9760610588a96d5a51f01d84d8c6ff9849968c14", size = 1411742 },
+    { url = "https://files.pythonhosted.org/packages/f3/2f/5e7ea8d85f9f3ea5b6b87db1d8388daa3587eed181bdeb0306816fdbbe79/pynacl-1.6.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3bffb6d0f6becacb6526f8f42adfb5efb26337056ee0831fb9a7044d1a964444", size = 801714 },
+    { url = "https://files.pythonhosted.org/packages/06/ea/43fe2f7eab5f200e40fb10d305bf6f87ea31b3bbc83443eac37cd34a9e1e/pynacl-1.6.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2fef529ef3ee487ad8113d287a593fa26f48ee3620d92ecc6f1d09ea38e0709b", size = 1372257 },
+    { url = "https://files.pythonhosted.org/packages/4d/54/c9ea116412788629b1347e415f72195c25eb2f3809b2d3e7b25f5c79f13a/pynacl-1.6.2-cp314-cp314t-win32.whl", hash = "sha256:a84bf1c20339d06dc0c85d9aea9637a24f718f375d861b2668b2f9f96fa51145", size = 231319 },
+    { url = "https://files.pythonhosted.org/packages/ce/04/64e9d76646abac2dccf904fccba352a86e7d172647557f35b9fe2a5ee4a1/pynacl-1.6.2-cp314-cp314t-win_amd64.whl", hash = "sha256:320ef68a41c87547c91a8b58903c9caa641ab01e8512ce291085b5fe2fcb7590", size = 244044 },
+    { url = "https://files.pythonhosted.org/packages/33/33/7873dc161c6a06f43cda13dec67b6fe152cb2f982581151956fa5e5cdb47/pynacl-1.6.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d29bfe37e20e015a7d8b23cfc8bd6aa7909c92a1b8f41ee416bbb3e79ef182b2", size = 188740 },
+    { url = "https://files.pythonhosted.org/packages/be/7b/4845bbf88e94586ec47a432da4e9107e3fc3ce37eb412b1398630a37f7dd/pynacl-1.6.2-cp38-abi3-macosx_10_10_universal2.whl", hash = "sha256:c949ea47e4206af7c8f604b8278093b674f7c79ed0d4719cc836902bf4517465", size = 388458 },
+    { url = "https://files.pythonhosted.org/packages/1e/b4/e927e0653ba63b02a4ca5b4d852a8d1d678afbf69b3dbf9c4d0785ac905c/pynacl-1.6.2-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8845c0631c0be43abdd865511c41eab235e0be69c81dc66a50911594198679b0", size = 800020 },
+    { url = "https://files.pythonhosted.org/packages/7f/81/d60984052df5c97b1d24365bc1e30024379b42c4edcd79d2436b1b9806f2/pynacl-1.6.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22de65bb9010a725b0dac248f353bb072969c94fa8d6b1f34b87d7953cf7bbe4", size = 1399174 },
+    { url = "https://files.pythonhosted.org/packages/68/f7/322f2f9915c4ef27d140101dd0ed26b479f7e6f5f183590fd32dfc48c4d3/pynacl-1.6.2-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46065496ab748469cdd999246d17e301b2c24ae2fdf739132e580a0e94c94a87", size = 835085 },
+    { url = "https://files.pythonhosted.org/packages/3e/d0/f301f83ac8dbe53442c5a43f6a39016f94f754d7a9815a875b65e218a307/pynacl-1.6.2-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a66d6fb6ae7661c58995f9c6435bda2b1e68b54b598a6a10247bfcdadac996c", size = 1437614 },
+    { url = "https://files.pythonhosted.org/packages/c4/58/fc6e649762b029315325ace1a8c6be66125e42f67416d3dbd47b69563d61/pynacl-1.6.2-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:26bfcd00dcf2cf160f122186af731ae30ab120c18e8375684ec2670dccd28130", size = 818251 },
+    { url = "https://files.pythonhosted.org/packages/c9/a8/b917096b1accc9acd878819a49d3d84875731a41eb665f6ebc826b1af99e/pynacl-1.6.2-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c8a231e36ec2cab018c4ad4358c386e36eede0319a0c41fed24f840b1dac59f6", size = 1402859 },
+    { url = "https://files.pythonhosted.org/packages/85/42/fe60b5f4473e12c72f977548e4028156f4d340b884c635ec6b063fe7e9a5/pynacl-1.6.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:68be3a09455743ff9505491220b64440ced8973fe930f270c8e07ccfa25b1f9e", size = 791926 },
+    { url = "https://files.pythonhosted.org/packages/fa/f9/e40e318c604259301cc091a2a63f237d9e7b424c4851cafaea4ea7c4834e/pynacl-1.6.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b097553b380236d51ed11356c953bf8ce36a29a3e596e934ecabe76c985a577", size = 1363101 },
+    { url = "https://files.pythonhosted.org/packages/48/47/e761c254f410c023a469284a9bc210933e18588ca87706ae93002c05114c/pynacl-1.6.2-cp38-abi3-win32.whl", hash = "sha256:5811c72b473b2f38f7e2a3dc4f8642e3a3e9b5e7317266e4ced1fba85cae41aa", size = 227421 },
+    { url = "https://files.pythonhosted.org/packages/41/ad/334600e8cacc7d86587fe5f565480fde569dfb487389c8e1be56ac21d8ac/pynacl-1.6.2-cp38-abi3-win_amd64.whl", hash = "sha256:62985f233210dee6548c223301b6c25440852e13d59a8b81490203c3227c5ba0", size = 239754 },
+    { url = "https://files.pythonhosted.org/packages/29/7d/5945b5af29534641820d3bd7b00962abbbdfee84ec7e19f0d5b3175f9a31/pynacl-1.6.2-cp38-abi3-win_arm64.whl", hash = "sha256:834a43af110f743a754448463e8fd61259cd4ab5bbedcf70f9dabad1d28a394c", size = 184801 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add Morph Cloud provider operations and a Harbor BaseEnvironment adapter
- route aec-bench run --backend morph through Harbor while preserving direct Morph runner support for smoke/evolution paths
- update CLI/API docs and result import contracts for Morph-backed Harbor runs

## Validation
- uv run ruff check on focused Morph/Harbor/API surface
- uv run ruff format --check on focused Morph/Harbor/API surface
- uv run mypy on focused Morph/Harbor/API surface
- uv run pytest focused Morph/Harbor/API/web slice
- uv run pytest -q
- live Morph Harbor smoke returned morph-harbor-ok

## Notes
- full repo Ruff still reports pre-existing lint/format issues in scripts and generated task files outside this PR scope
- frontend npm test is blocked by existing localStorage test-state leakage in runs page tests; Python web tests passed