### PR TITLE
Add maritime discipline with IACS-CSR principal-particulars tasks (L, L_LL, C_B)

### DIFF
--- a/docs/maritime-contributing.md
+++ b/docs/maritime-contributing.md
@@ -1,0 +1,149 @@
+# Maritime (IACS CSR / Class-Society) Task Contribution Guide
+
+A practical checklist for adding maritime benchmark tasks (IACS Common
+Structural Rules, class-society notations, and similar rulebook-driven
+calculations) without drifting from aec-bench's quality bar. It does not
+replace [`docs/tasks-guide.md`](tasks-guide.md), [`docs/INVARIANTS.md`](INVARIANTS.md),
+or the `/add-task`, `/create-template`, `/hardening-pass`, `/domain-check`
+skills — it cross-references them for the maritime-specific pitfalls.
+
+---
+
+## 1. Sourcing rule (non-negotiable)
+
+Every equation, coefficient, and table value must be **transcribed from the
+actual IACS CSR PDF**, not reconstructed from memory or from a web summary.
+
+- Pin the edition in every reference: currently **CSR-H, 01 JUL 2025**. Any
+  clause citation that doesn't carry an edition date is incomplete.
+- Cite the full clause path: `Part / Chapter / Section / §` (e.g.
+  `Pt 1 Ch 1 Sec 4 §3.1.1`), plus the PDF page number where practical.
+- `pdftotext -layout` frequently garbles fractions, subscripts, and
+  multi-line formulas in class-society PDFs. **If a formula looks garbled
+  or ambiguous after text extraction, render that PDF page to an image and
+  read it visually before writing any code.** Do not guess at a coefficient
+  because the text extraction was unclear.
+- Never reconstruct a coefficient, table value, or clamp bound "from
+  engineering judgement" or recollection of similar rules (e.g. IACS UR,
+  class NKs, or other societies' rules). If you can't find it verbatim in
+  the pinned edition, the task is not ready.
+
+This rule exists because an earlier unsourced maritime task attempt was
+discarded for exactly this reason — treat it as load-bearing, not
+bureaucratic.
+
+---
+
+## 2. Terminology
+
+Use the rulebook's own symbols and subscripts verbatim — don't rename them
+to look more "Pythonic":
+
+- `L` (Rule length), `L_LL` (freeboard length), `L_PP` (length between
+  perpendiculars), `L0`, `L1`, `L2` (regime-specific lengths), `B` (breadth),
+  `D` (depth), `T` (draught), `T_SC` (scantling draught), `Δ` (displacement),
+  `C_B` (block coefficient), `V` (speed), etc.
+- Rule length is capital `L`, not `l` or `RuleLength`.
+- Match output keys to the rule's own notation where practical — e.g. the
+  Rule length output key is `rule_length_L_m`, not `rule_length` or `L_m`.
+- If the rulebook only describes a quantity in prose (no symbol given),
+  name the param/output from that prose, in the same style used elsewhere
+  in the template (e.g. `stem_to_rudder_stock_distance_m`,
+  `extreme_length_on_waterline_at_TSC_m`).
+
+---
+
+## 3. Rules-compliant artifact checklist
+
+Full field-level rules live in
+[`src/aec_bench/init/skill_data/create-template/references/template-contract.md`](../src/aec_bench/init/skill_data/create-template/references/template-contract.md).
+Summary for maritime tasks specifically:
+
+- [ ] **Seed** — `seeds/maritime/<task-id>/source_task.json`, conforming to
+      `seeds/seed_schema.json` (see
+      [`add-task/references/seed-schema.md`](../src/aec_bench/init/skill_data/add-task/references/seed-schema.md)).
+      `status: "proposed"`, structured `inputs`/`outputs`, `reference_details`
+      with the verbatim clause quote, ≥2 worked examples computed by hand
+      (or independently) from the PDF, `feasibility` block.
+- [ ] **Template `engine.py`** — pure function, **stdlib only** (no
+      third-party imports), two ABOUTME header lines, `_validate_inputs()`
+      raising `ValueError` for physically impossible inputs, **every
+      returned output wrapped in `round(x, 2)`**. Categorical/enum params
+      (e.g. `has_rudder_stock`) arrive from the generator as **strings**
+      (`"true"` / `"false"`), never real booleans — normalize them inside
+      the engine (see `_normalize_has_rudder_stock` in
+      `src/aec_bench/templates/builtin/maritime/rule_length/engine.py` for
+      the pattern). Do not assume Python truthiness on the raw param.
+- [ ] **`params.toml`** — `[meta]` with pinned `standards`; `[params.*]`
+      using `min`/`max` (never `min_value`/`max_value`); `[outputs.*]` with
+      `tolerance`; `[archetypes.*]` with **flat** min/max ranges (not
+      nested under a `params` sub-table) plus `site_contexts`;
+      `[difficulty.*]` for easy/medium/hard. Enum `values` are always
+      strings, even when they look boolean or numeric.
+- [ ] **`instruction.md`** — Jinja2 template; guard every hideable param
+      with `{% if <param> is defined %}`; the JSON output block's keys
+      must exactly match the keys returned by `compute()`; ends with an
+      instruction to write the solution to `/workspace/output.md`.
+- [ ] **Instance(s)** under `tasks/maritime/<task-id>/<instance-name>/`:
+      `task.toml`, a fully-resolved `instruction.md` (no `{{`/`{%` left,
+      no placeholders), `tests/verify.py` (self-contained, tolerance-based),
+      `tests/test.sh`, `tests/fixtures/golden_pass.md` and
+      `golden_fail.md`, `environment/Dockerfile`, optionally
+      `solution/solve.py`.
+- [ ] Lifecycle starts at `proposed` (see promotion criteria in
+      [`tasks-guide.md`](tasks-guide.md#lifecycle-and-visibility)).
+- [ ] **Clean-instance rule**: at least 1 clean instance per 3 total
+      instances of the task type (an instance with no true issues that
+      still requires schema-valid output — tests false-positive
+      resistance).
+
+---
+
+## 4. Verification (the step that catches generation bugs)
+
+Static reading of `engine.py`/`params.toml` is not enough — the generator's
+categorical and hidden-param code paths only run when you actually generate
+instances. Run all of these, in order:
+
+1. `uv run aec-bench generate validate-template <template_dir>` — structural
+   validation of the template files.
+2. `uv run aec-bench generate task <name> --instances N` — **run this for
+   real, not just with `--dry-run`.** `--dry-run` skips codepaths that
+   resolve enum/categorical values and hidden-param substitution; only a
+   real generation run exercises them end-to-end.
+3. The engine's unit test (e.g. `tests/templates/test_<name>_engine.py`) —
+   assert `compute()` against the seed's worked examples.
+4. The instance verifier against both golden fixtures:
+   `tests/fixtures/golden_pass.md` must score as passing,
+   `tests/fixtures/golden_fail.md` must score as failing.
+5. `/hardening-pass` on the template (and again on each instance) —
+   catches formula drift, unrealistic archetype ranges, and tolerance
+   miscalibration.
+6. `/domain-check` — confirms the new files respect the dependency
+   directions and invariants in `docs/INVARIANTS.md` (e.g. templates stay
+   pure computation, no upward imports).
+
+---
+
+## 5. Discipline registration
+
+`maritime` must already be present everywhere the discipline enum is
+duplicated: `SeedSource` (contracts), `LibraryEntryBase` (contracts), and
+`seeds/seed_schema.json`. The introspection guard test
+`tests/contracts/test_discipline_consistency.py` enforces this — it must
+stay green. If you're the first to add a maritime task and the test fails,
+that's a signal the discipline needs registering upstream, not that the
+test is wrong.
+
+---
+
+## 6. Commits / PR
+
+- Use conventional commit prefixes: `feat:` for a new task/template,
+  `fix:` for a correction to an existing one, `docs:` for guide-only
+  changes, `test:` for test-only additions.
+- Keep the seed, template, and instance changes in separate, reviewable
+  commits where practical.
+- If you only have pull (read-only) access to the main repository, fork
+  it and open a pull request from your fork rather than pushing a branch
+  directly.

--- a/seeds/maritime/block-coefficient/source_task.json
+++ b/seeds/maritime/block-coefficient/source_task.json
@@ -1,0 +1,79 @@
+{
+  "status": "proposed",
+  "seed_origin": "expert",
+  "created_by": "const.koutsakis",
+  "source": {
+    "discipline": "maritime",
+    "task_id": "block-coefficient",
+    "task_name": "Block coefficient C_B",
+    "description": "Calculate the IACS Common Structural Rules (CSR-H) block coefficient C_B at the scantling draught T_SC: C_B = Delta / (1.025 x L x B x T_SC), where Delta is the moulded displacement of the ship at draught T_SC (in tonnes), L is the Rule length (m), B is the moulded breadth (m), and T_SC is the scantling draught (m).",
+    "inputs": [
+      {"name": "moulded_displacement_t", "type": "float", "unit": "t"},
+      {"name": "rule_length_L_m", "type": "float", "unit": "m"},
+      {"name": "moulded_breadth_B_m", "type": "float", "unit": "m"},
+      {"name": "scantling_draught_TSC_m", "type": "float", "unit": "m"}
+    ],
+    "outputs": [
+      {"name": "block_coefficient_CB", "type": "float", "unit": "dimensionless"}
+    ],
+    "standards": ["IACS Common Structural Rules (CSR-H), 01 JUL 2025, Pt 1 Ch 1 Sec 4, §3.1.8"],
+    "reference_details": [
+      "IACS CSR-H, 01 JUL 2025, Pt 1 Ch 1 Sec 4, §3.1.8, p.48: \"C_B, the block coefficient at the draught, T_SC is defined in the following equation: C_B = Delta / (1.025 . L . B . T_SC)\" where Delta = moulded displacement of the ship at draught T_SC (in tonnes); L = rule length (m); B = moulded breadth (m); T_SC = scantling draught (m)."
+    ],
+    "complexity": "low",
+    "worked_examples": [
+      {
+        "description": "Capesize bulk carrier: moulded displacement 180,000 t at rule length 280 m, breadth 45 m, scantling draught 18 m.",
+        "inputs": {
+          "moulded_displacement_t": 180000.0,
+          "rule_length_L_m": 280.0,
+          "moulded_breadth_B_m": 45.0,
+          "scantling_draught_TSC_m": 18.0
+        },
+        "outputs": {
+          "block_coefficient_CB": 0.77
+        }
+      },
+      {
+        "description": "VLCC (Very Large Crude Carrier): moulded displacement 366,000 t at rule length 330 m, breadth 60 m, scantling draught 22 m.",
+        "inputs": {
+          "moulded_displacement_t": 366000.0,
+          "rule_length_L_m": 330.0,
+          "moulded_breadth_B_m": 60.0,
+          "scantling_draught_TSC_m": 22.0
+        },
+        "outputs": {
+          "block_coefficient_CB": 0.82
+        }
+      },
+      {
+        "description": "Large container ship: moulded displacement 125,000 t at rule length 310 m, breadth 45 m, scantling draught 13.5 m — finer-formed hull, so a noticeably lower C_B than the bulk carrier and tanker examples.",
+        "inputs": {
+          "moulded_displacement_t": 125000.0,
+          "rule_length_L_m": 310.0,
+          "moulded_breadth_B_m": 45.0,
+          "scantling_draught_TSC_m": 13.5
+        },
+        "outputs": {
+          "block_coefficient_CB": 0.65
+        }
+      }
+    ],
+    "edge_cases": [
+      "Full-form ships (bulk carriers, tankers) have C_B in the region of 0.80-0.85; fine-formed ships (container ships) have C_B typically in the region of 0.60-0.70 — the same closed-form equation covers both regimes without any branching.",
+      "C_B must remain a positive value less than 1.0 for physically realistic ships; a computed value at or above 1.0 signals inconsistent input dimensions (e.g. a displacement too large for the given L, B, T_SC) rather than a valid design point.",
+      "All four inputs (Delta, L, B, T_SC) must be strictly positive; a non-positive value for any of them makes the ratio meaningless and should be rejected."
+    ]
+  },
+  "feasibility": {
+    "parameterisable": true,
+    "criteria": {
+      "closed_form": true,
+      "deterministic": true,
+      "parameterisable_inputs": true,
+      "numeric_outputs": true,
+      "single_compute": true
+    },
+    "notes": "Single closed-form ratio of four positive scalars (Delta, L, B, T_SC) with a fixed seawater-density constant. No branching, iteration, or table lookups required."
+  }
+}

--- a/seeds/maritime/freeboard-length/source_task.json
+++ b/seeds/maritime/freeboard-length/source_task.json
@@ -1,0 +1,75 @@
+{
+  "status": "proposed",
+  "seed_origin": "expert",
+  "created_by": "const.koutsakis",
+  "source": {
+    "discipline": "maritime",
+    "task_id": "freeboard-length",
+    "task_name": "Freeboard length L_LL",
+    "description": "Calculate the IACS Common Structural Rules (CSR-H) Freeboard length L_LL: 96% of the total length on a waterline at 85% of the least moulded depth measured from the top of the keel, or the length from the fore side of the stem to the axis of the rudder stock on that waterline, whichever is greater. For ships without a rudder stock (e.g. those fitted with azimuth thrusters), L_LL is taken as 96% of the waterline at 85% of the least moulded depth.",
+    "inputs": [
+      {"name": "total_length_on_85pct_depth_waterline_m", "type": "float", "unit": "m"},
+      {"name": "stem_to_rudder_stock_axis_distance_m", "type": "float", "unit": "m"},
+      {"name": "has_rudder_stock", "type": "categorical", "values": ["true", "false"]}
+    ],
+    "outputs": [
+      {"name": "freeboard_length_LLL_m", "type": "float", "unit": "m"}
+    ],
+    "standards": ["IACS Common Structural Rules (CSR-H), 01 JUL 2025, Pt 1 Ch 1 Sec 4, §3.1.2"],
+    "reference_details": [
+      "IACS CSR-H, 01 JUL 2025, Pt 1 Ch 1 Sec 4, §3.1.2, p.47: \"The freeboard length L_LL, in m, is to be taken as 96% of the total length on a waterline at 85% of the least moulded depth measured from the top of the keel, or as the length from the fore side of the stem to the axis of the rudder stock on that waterline, if that be greater. For ships without a rudder stock, the length L_LL is to be taken as 96% of the waterline at 85% of the least moulded depth.\""
+    ],
+    "complexity": "low",
+    "worked_examples": [
+      {
+        "description": "Panamax bulk carrier where the measured stem-to-rudder-stock-axis distance exceeds 96% of the 85%-depth waterline length, so it governs (the greater-of picks the measured distance).",
+        "inputs": {
+          "total_length_on_85pct_depth_waterline_m": 225.0,
+          "stem_to_rudder_stock_axis_distance_m": 220.0,
+          "has_rudder_stock": "true"
+        },
+        "outputs": {
+          "freeboard_length_LLL_m": 220.0
+        }
+      },
+      {
+        "description": "General cargo ship where the measured stem-to-rudder-stock-axis distance is below 96% of the 85%-depth waterline length, so 96% of the waterline length governs instead (the greater-of flips relative to the previous example).",
+        "inputs": {
+          "total_length_on_85pct_depth_waterline_m": 180.0,
+          "stem_to_rudder_stock_axis_distance_m": 170.0,
+          "has_rudder_stock": "true"
+        },
+        "outputs": {
+          "freeboard_length_LLL_m": 172.8
+        }
+      },
+      {
+        "description": "Offshore support vessel fitted with azimuth thrusters and no rudder stock; L_LL is taken directly as 96% of the 85%-depth waterline length, and the stem-to-rudder-stock-axis distance input does not apply.",
+        "inputs": {
+          "total_length_on_85pct_depth_waterline_m": 200.0,
+          "has_rudder_stock": "false"
+        },
+        "outputs": {
+          "freeboard_length_LLL_m": 192.0
+        }
+      }
+    ],
+    "edge_cases": [
+      "Measured stem-to-rudder-stock-axis distance greater than 96% of the 85%-depth waterline length: that measured distance governs L_LL (see worked example 1).",
+      "Measured stem-to-rudder-stock-axis distance less than 96% of the 85%-depth waterline length: 96% of the waterline length governs L_LL instead (see worked example 2).",
+      "No rudder stock (e.g. azimuth-thruster vessels): L_LL is taken directly as 96% of the 85%-depth waterline length; the stem-to-rudder-stock-axis distance input does not apply (see worked example 3).",
+      "Concave stem contours: the freeboard length calculation has a special-case treatment in the rules for ships with unusual (concave) stem contours; this is out of scope for this closed-form task, which assumes a conventional stem contour."
+    ]
+  },
+  "feasibility": {
+    "parameterisable": true,
+    "criteria": {
+      "closed_form": true,
+      "deterministic": true,
+      "parameterisable_inputs": true,
+      "numeric_outputs": true,
+      "single_compute": true
+    },
+    "notes": "Single greater-of formula (max of 96% of a given waterline length and a measured stem-to-rudder-stock-axis distance), one categorical branch for the no-rudder-stock case. No iteration or table lookups required."
+  }
+}

--- a/seeds/maritime/rule-length/source_task.json
+++ b/seeds/maritime/rule-length/source_task.json
@@ -1,0 +1,75 @@
+{
+  "status": "proposed",
+  "seed_origin": "expert",
+  "created_by": "const.koutsakis",
+  "source": {
+    "discipline": "maritime",
+    "task_id": "rule-length",
+    "task_name": "Rule length L",
+    "description": "Calculate the IACS Common Structural Rules (CSR-H) Rule length L: the distance, in metres, measured on the waterline at the scantling draught T_SC from the forward side of the stem to the centre (axis) of the rudder stock, clamped so it is not less than 96% and not more than 97% of the extreme length on the waterline at T_SC. For ships without a rudder stock (e.g. those fitted with azimuth thrusters), L is taken equal to 97% of the extreme length on the waterline at T_SC.",
+    "inputs": [
+      {"name": "extreme_length_on_waterline_at_TSC_m", "type": "float", "unit": "m"},
+      {"name": "stem_to_rudder_stock_distance_m", "type": "float", "unit": "m"},
+      {"name": "has_rudder_stock", "type": "categorical", "values": ["true", "false"]}
+    ],
+    "outputs": [
+      {"name": "rule_length_L_m", "type": "float", "unit": "m"}
+    ],
+    "standards": ["IACS Common Structural Rules (CSR-H), 01 JUL 2025, Pt 1 Ch 1 Sec 4, §3.1.1"],
+    "reference_details": [
+      "IACS CSR-H, 01 JUL 2025, Pt 1 Ch 1 Sec 4, §3.1.1, p.47: \"The Rule length L is the distance, in m, measured on the waterline at the scantling draught T_SC from the forward side of the stem to the centre of the rudder stock. L is to be not less than 96% and need not exceed 97% of the extreme length on the waterline at the scantling draught T_SC. In ships without rudder stock (e.g. ships fitted with azimuth thrusters), the Rule length L is to be taken equal to 97% of the extreme length on the waterline at the scantling draught T_SC. In ships with unusual stem or stern arrangements, the Rule length is considered on a case-by-case basis.\""
+    ],
+    "complexity": "low",
+    "worked_examples": [
+      {
+        "description": "Panamax bulk carrier where the measured stem-to-rudder-stock distance falls below the 96% lower bound, so the clamp bites and L is set to 96% of the extreme waterline length.",
+        "inputs": {
+          "extreme_length_on_waterline_at_TSC_m": 229.0,
+          "stem_to_rudder_stock_distance_m": 215.0,
+          "has_rudder_stock": "true"
+        },
+        "outputs": {
+          "rule_length_L_m": 219.84
+        }
+      },
+      {
+        "description": "Offshore support vessel fitted with azimuth thrusters and no rudder stock; L is taken as 97% of the extreme waterline length directly.",
+        "inputs": {
+          "extreme_length_on_waterline_at_TSC_m": 200.0,
+          "has_rudder_stock": "false"
+        },
+        "outputs": {
+          "rule_length_L_m": 194.0
+        }
+      },
+      {
+        "description": "General cargo ship where the measured stem-to-rudder-stock distance already lies within the 96%-97% band, so no clamping is applied and L equals the measured distance.",
+        "inputs": {
+          "extreme_length_on_waterline_at_TSC_m": 180.0,
+          "stem_to_rudder_stock_distance_m": 173.5,
+          "has_rudder_stock": "true"
+        },
+        "outputs": {
+          "rule_length_L_m": 173.5
+        }
+      }
+    ],
+    "edge_cases": [
+      "Measured stem-to-rudder-stock distance below 96% of the extreme waterline length: L is clamped up to the 96% lower bound (see worked example 1).",
+      "Measured stem-to-rudder-stock distance above 97% of the extreme waterline length: L is clamped down to the 97% upper cap.",
+      "No rudder stock (e.g. azimuth-thruster vessels): L is taken directly as 97% of the extreme waterline length; the stem-to-rudder-stock distance input does not apply.",
+      "Unusual stem or stern arrangements: the Rule length is determined on a case-by-case basis by the classification society and is out of scope for this closed-form task."
+    ]
+  },
+  "feasibility": {
+    "parameterisable": true,
+    "criteria": {
+      "closed_form": true,
+      "deterministic": true,
+      "parameterisable_inputs": true,
+      "numeric_outputs": true,
+      "single_compute": true
+    },
+    "notes": "Single clamp formula (min/max of a measured distance against two fractions of a given length), one categorical branch for the no-rudder-stock case. No iteration or table lookups required."
+  }
+}

--- a/seeds/seed_schema.json
+++ b/seeds/seed_schema.json
@@ -108,7 +108,7 @@
       "properties": {
         "discipline": {
           "type": "string",
-          "enum": ["civil", "electrical", "ground", "mechanical", "structural"]
+          "enum": ["civil", "electrical", "ground", "maritime", "mechanical", "structural"]
         },
         "task_id": { "type": "string" },
         "task_name": { "type": "string" },

--- a/src/aec_bench/contracts/library_catalogue.py
+++ b/src/aec_bench/contracts/library_catalogue.py
@@ -34,7 +34,9 @@ class LibraryEntryBase(StrictModel):
     """Fields shared by both TemplateEntry and SeedEntry."""
 
     task_id: str
-    discipline: Literal["civil", "electrical", "ground", "mechanical", "structural"]
+    # NOTE: this value set is duplicated across seed_task.py, library_catalogue.py, and
+    # seeds/seed_schema.json. Follow-up: unify into one canonical Discipline source.
+    discipline: Literal["civil", "electrical", "ground", "maritime", "mechanical", "structural"]
     category: str
     category_label: str | None = None
     standards: list[str] = Field(default_factory=list)

--- a/src/aec_bench/contracts/seed_task.py
+++ b/src/aec_bench/contracts/seed_task.py
@@ -29,7 +29,9 @@ class SeedSource(BaseModel):
 
     model_config = ConfigDict(extra="ignore")
 
-    discipline: Literal["civil", "electrical", "ground", "mechanical", "structural"]
+    # NOTE: this value set is duplicated across seed_task.py, library_catalogue.py, and
+    # seeds/seed_schema.json. Follow-up: unify into one canonical Discipline source.
+    discipline: Literal["civil", "electrical", "ground", "maritime", "mechanical", "structural"]
     task_id: NonEmptyStr
     task_name: NonEmptyStr
     description: NonEmptyStr

--- a/src/aec_bench/init/skill_data/add-task/SKILL.md
+++ b/src/aec_bench/init/skill_data/add-task/SKILL.md
@@ -35,7 +35,7 @@ Read `references/seed-schema.md` to understand the full field list.
 Ask follow-up questions for any fields not yet captured. Ask one or two questions at a time — keep it conversational, not like filling out a form.
 
 **Core fields (must collect all):**
-- **Discipline**: one of civil, electrical, ground, mechanical, structural
+- **Discipline**: one of civil, electrical, ground, maritime, mechanical, structural
 - **Task ID**: suggest a hyphenated slug derived from the task name (e.g., "Cable Sizing for Long Runs" → `cable-sizing-long-runs`)
 - **Task name**: human-readable name
 - **Description**: one paragraph explaining what the task tests

--- a/src/aec_bench/init/skill_data/add-task/references/seed-schema.md
+++ b/src/aec_bench/init/skill_data/add-task/references/seed-schema.md
@@ -26,7 +26,7 @@ imported from legacy inventories). Both are valid.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `discipline` | `enum` | One of: `civil`, `electrical`, `ground`, `mechanical`, `structural`. |
+| `discipline` | `enum` | One of: `civil`, `electrical`, `ground`, `maritime`, `mechanical`, `structural`. |
 | `task_id` | `string` | Kebab-case unique identifier (e.g. `"cable-sizing-long-runs"`). |
 | `task_name` | `string` | Human-readable title (e.g. `"Cable Sizing for Long Runs"`). |
 | `description` | `string` | One or two sentences explaining what the task calculates or evaluates. |

--- a/src/aec_bench/init/skill_data/configure-experiment/references/manifest-schema.md
+++ b/src/aec_bench/init/skill_data/configure-experiment/references/manifest-schema.md
@@ -21,7 +21,7 @@ Controls which tasks are included in the experiment.
 | `dataset` | string | No | null | Versioned dataset selector, as `name` or `name@version`. |
 | `include_patterns` | list[string] | No | [] | Glob patterns matching task paths (e.g., `electrical/*`, `ground/terzaghi-*`). |
 | `exclude_patterns` | list[string] | No | [] | Inverse patterns — tasks matching these are removed. |
-| `domains` | list[string] | No | [] | Discipline filter. Values come from the task directory structure (e.g., `civil`, `electrical`, `ground`, `mechanical`, `structural`). Empty means all domains. |
+| `domains` | list[string] | No | [] | Discipline filter. Values come from the task directory structure (e.g., `civil`, `electrical`, `ground`, `maritime`, `mechanical`, `structural`). Empty means all domains. |
 | `difficulties` | list[string] | No | [] | Difficulty filter: `easy`, `medium`, `hard`. Empty means all difficulties. |
 
 **Note:** The contract also has a `lifecycle_filter` field, but it is not currently consumed by the scheduler. Do not include it in generated YAML.

--- a/src/aec_bench/tasks/loader.py
+++ b/src/aec_bench/tasks/loader.py
@@ -24,7 +24,17 @@ class LoadError(Exception):
     pass
 
 
-KNOWN_DOMAINS = {"electrical", "mechanical", "structural", "architectural", "plumbing", "civil"}
+# "architectural" and "plumbing" are unverified/tracked-debt — no known task instances use them.
+KNOWN_DOMAINS = {
+    "civil",
+    "electrical",
+    "ground",
+    "maritime",
+    "mechanical",
+    "structural",
+    "architectural",
+    "plumbing",
+}
 WORKSPACE_OUTPUT_PATH_RE: Final[str] = r"/workspace/[A-Za-z0-9._/-]+"
 
 

--- a/src/aec_bench/templates/builtin/maritime/__init__.py
+++ b/src/aec_bench/templates/builtin/maritime/__init__.py
@@ -1,0 +1,2 @@
+# ABOUTME: Maritime engineering templates package.
+# ABOUTME: Contains ship classification and structural rule calculation templates (rule length, etc.).

--- a/src/aec_bench/templates/builtin/maritime/block_coefficient/__init__.py
+++ b/src/aec_bench/templates/builtin/maritime/block_coefficient/__init__.py
@@ -1,0 +1,2 @@
+# ABOUTME: IACS CSR-H Block coefficient (C_B) calculation template.
+# ABOUTME: Implements Pt 1 Ch 1 Sec 4 §3.1.8 of the 01 JUL 2025 edition.

--- a/src/aec_bench/templates/builtin/maritime/block_coefficient/engine.py
+++ b/src/aec_bench/templates/builtin/maritime/block_coefficient/engine.py
@@ -1,0 +1,61 @@
+# ABOUTME: IACS CSR-H Block coefficient (C_B) computation engine.
+# ABOUTME: Applies the displacement/(1.025*L*B*T_SC) ratio of Pt 1 Ch 1 Sec 4 §3.1.8.
+
+# CSR-H 01 JUL 2025 Pt 1 Ch 1 Sec 4 §3.1.8: seawater density used in the block
+# coefficient definition, C_B = Delta / (1.025 * L * B * T_SC).
+SEAWATER_DENSITY_T_M3 = 1.025
+
+
+def _validate_inputs(
+    moulded_displacement_t: float,
+    rule_length_L_m: float,
+    moulded_breadth_B_m: float,
+    scantling_draught_TSC_m: float,
+) -> None:
+    """Raise ValueError for invalid input parameters."""
+    if moulded_displacement_t <= 0:
+        msg = "moulded_displacement_t must be > 0"
+        raise ValueError(msg)
+    if rule_length_L_m <= 0:
+        msg = "rule_length_L_m must be > 0"
+        raise ValueError(msg)
+    if moulded_breadth_B_m <= 0:
+        msg = "moulded_breadth_B_m must be > 0"
+        raise ValueError(msg)
+    if scantling_draught_TSC_m <= 0:
+        msg = "scantling_draught_TSC_m must be > 0"
+        raise ValueError(msg)
+
+
+def compute(
+    moulded_displacement_t: float,
+    rule_length_L_m: float,
+    moulded_breadth_B_m: float,
+    scantling_draught_TSC_m: float,
+) -> dict[str, float]:
+    """Compute the IACS CSR-H Block coefficient C_B per Pt 1 Ch 1 Sec 4 §3.1.8.
+
+    C_B is the block coefficient at the scantling draught T_SC:
+
+        C_B = Delta / (1.025 * L * B * T_SC)
+
+    where Delta is the moulded displacement of the ship at draught T_SC (in tonnes),
+    L is the Rule length (m), B is the moulded breadth (m), and T_SC is the
+    scantling draught (m).
+
+    Returns a dict with key: block_coefficient_CB.
+    """
+    _validate_inputs(
+        moulded_displacement_t,
+        rule_length_L_m,
+        moulded_breadth_B_m,
+        scantling_draught_TSC_m,
+    )
+
+    block_coefficient_cb = moulded_displacement_t / (
+        SEAWATER_DENSITY_T_M3 * rule_length_L_m * moulded_breadth_B_m * scantling_draught_TSC_m
+    )
+
+    return {
+        "block_coefficient_CB": round(block_coefficient_cb, 2),
+    }

--- a/src/aec_bench/templates/builtin/maritime/block_coefficient/instruction.md
+++ b/src/aec_bench/templates/builtin/maritime/block_coefficient/instruction.md
@@ -1,0 +1,65 @@
+You are a senior naval architect specializing in classification society rule compliance.
+
+## Problem
+
+Calculate the IACS Block coefficient C_B for a ship under the Harmonised Common Structural Rules (CSR-H).
+
+## Given
+
+| Parameter | Value | Unit |
+|-----------|-------|------|
+{% if moulded_displacement_t is defined %}
+| Moulded displacement at T_SC (Delta) | {{ moulded_displacement_t }} | t |
+{% endif %}
+| Rule length (L) | {{ rule_length_L_m }} | m |
+| Moulded breadth (B) | {{ moulded_breadth_B_m }} | m |
+| Scantling draught (T_SC) | {{ scantling_draught_TSC_m }} | m |
+{% if archetype_description is defined %}
+
+### Vessel Context
+
+{{ archetype_description }}
+{% endif %}
+
+{% if tool_available %}
+## Available Tool
+
+A Block coefficient calculation tool is available at `/workspace/{{ meta.name }}_calc.py`. Run it with:
+
+```bash
+python3 /workspace/{{ meta.name }}_calc.py --help
+```
+
+You may use this tool to verify your calculations or compute values directly.
+{% endif %}
+
+## Required
+
+Calculate the following:
+
+1. Block coefficient C_B (dimensionless)
+
+## Applicable Standards
+
+- IACS Harmonised Common Structural Rules (CSR-H), edition 01 JUL 2025, Pt 1 Ch 1 Sec 4 §3.1.8
+
+## Constraints
+
+- No internet access is available. Work from engineering knowledge and the provided tool.
+- Quote from Pt 1 Ch 1 Sec 4 §3.1.8: "C_B, the block coefficient at the draught, T_SC is defined in the following equation: C_B = Delta / (1.025 x L x B x T_SC)" where Delta is the moulded displacement of the ship at draught T_SC (in tonnes), L is the Rule length (m), B is the moulded breadth (m), and T_SC is the scantling draught (m).
+- Use a seawater density of 1.025 t/m^3, per the formula above.
+{% if moulded_displacement_t is not defined %}
+- The moulded displacement is not given directly — infer an appropriate value from the vessel description above.
+{% endif %}
+
+## Output Format
+
+Show your step-by-step working in Markdown, including formulas and intermediate calculations. At the end of your solution, include a JSON block with your final answer in exactly this format:
+
+```json
+{
+  "block_coefficient_CB": <numeric_value>
+}
+```
+
+Write your complete solution to `/workspace/output.md`.

--- a/src/aec_bench/templates/builtin/maritime/block_coefficient/params.toml
+++ b/src/aec_bench/templates/builtin/maritime/block_coefficient/params.toml
@@ -1,0 +1,91 @@
+[meta]
+name = "block-coefficient"
+description = "IACS CSR-H Block coefficient C_B at the scantling draught T_SC"
+long_description = "Calculates the block coefficient C_B used throughout the IACS Harmonised Common Structural Rules for Bulk Carriers and Oil Tankers (CSR-H): C_B = Delta / (1.025 x L x B x T_SC), where Delta is the moulded displacement of the ship at draught T_SC (tonnes), L is the Rule length (m), B is the moulded breadth (m), and T_SC is the scantling draught (m). C_B is a fundamental principal-particulars quantity used throughout CSR-H scantling assessments."
+discipline = "maritime"
+category = "principal-particulars"
+standards = ["IACS CSR-H (Common Structural Rules) 01 JUL 2025, Pt 1 Ch 1 Sec 4, §3.1.8"]
+tags = ["maritime", "csr-h", "iacs", "block-coefficient", "principal-particulars", "deterministic"]
+tool_mode = "with-tool"
+
+[params.moulded_displacement_t]
+type = "float"
+unit = "t"
+description = "Moulded displacement of the ship at the scantling draught T_SC (Delta)"
+min = 15000.0
+max = 400000.0
+derivable_from = "archetype"
+
+[params.rule_length_L_m]
+type = "float"
+unit = "m"
+description = "Rule length L"
+min = 130.0
+max = 340.0
+
+[params.moulded_breadth_B_m]
+type = "float"
+unit = "m"
+description = "Moulded breadth B"
+min = 20.0
+max = 65.0
+
+[params.scantling_draught_TSC_m]
+type = "float"
+unit = "m"
+description = "Scantling draught T_SC"
+min = 8.0
+max = 24.0
+
+[outputs.block_coefficient_CB]
+description = "Block coefficient C_B (dimensionless)"
+tolerance = 0.03
+
+[archetypes.capesize_bulk_carrier]
+description = "Capesize bulk carrier with a moulded displacement of approximately 190,000 tonnes at the scantling draught"
+moulded_displacement_t = {min = 186200.0, max = 193800.0}
+rule_length_L_m = {min = 274.0, max = 286.0}
+moulded_breadth_B_m = {min = 44.0, max = 46.0}
+scantling_draught_TSC_m = {min = 17.6, max = 18.4}
+site_contexts = ["capesize-iron-ore-run", "capesize-coal-run"]
+
+[archetypes.vlcc_tanker]
+description = "VLCC (Very Large Crude Carrier) with a moulded displacement of approximately 366,000 tonnes at the scantling draught"
+moulded_displacement_t = {min = 358000.0, max = 374000.0}
+rule_length_L_m = {min = 323.0, max = 337.0}
+moulded_breadth_B_m = {min = 58.8, max = 61.2}
+scantling_draught_TSC_m = {min = 21.5, max = 22.5}
+site_contexts = ["arabian-gulf-crude-export", "west-africa-crude-export"]
+
+[archetypes.container_ship]
+description = "Large container ship with a moulded displacement of approximately 125,000 tonnes at the scantling draught"
+moulded_displacement_t = {min = 118000.0, max = 132000.0}
+rule_length_L_m = {min = 295.0, max = 325.0}
+moulded_breadth_B_m = {min = 43.0, max = 47.0}
+scantling_draught_TSC_m = {min = 12.8, max = 14.2}
+site_contexts = ["asia-europe-trade-lane", "transpacific-trade-lane"]
+
+[archetypes.general_cargo]
+description = "General cargo ship with a moulded displacement of approximately 23,500 tonnes at the scantling draught"
+moulded_displacement_t = {min = 22800.0, max = 24200.0}
+rule_length_L_m = {min = 145.0, max = 155.0}
+moulded_breadth_B_m = {min = 22.3, max = 23.7}
+scantling_draught_TSC_m = {min = 8.7, max = 9.3}
+site_contexts = ["short-sea-general-cargo", "coastal-breakbulk-trade"]
+
+[difficulty.easy]
+description = "All parameters given for a large, conventional bulker or tanker"
+visibility = "all_given"
+archetypes = ["capesize_bulk_carrier", "vlcc_tanker"]
+
+[difficulty.medium]
+description = "All parameters given across the full range of ship types"
+visibility = "all_given"
+archetypes = ["capesize_bulk_carrier", "vlcc_tanker", "container_ship", "general_cargo"]
+
+[difficulty.hard]
+description = "Moulded displacement hidden; agent must infer it from the vessel description"
+visibility = "partial"
+hidden_params = ["moulded_displacement_t"]
+replacement_text = "The vessel is a {{ archetype.description }} ({{ archetype.site_context }})"
+archetypes = ["capesize_bulk_carrier", "vlcc_tanker", "container_ship", "general_cargo"]

--- a/src/aec_bench/templates/builtin/maritime/freeboard_length/__init__.py
+++ b/src/aec_bench/templates/builtin/maritime/freeboard_length/__init__.py
@@ -1,0 +1,2 @@
+# ABOUTME: IACS CSR-H Freeboard length (L_LL) calculation template.
+# ABOUTME: Implements Pt 1 Ch 1 Sec 4 §3.1.2 of the 01 JUL 2025 edition.

--- a/src/aec_bench/templates/builtin/maritime/freeboard_length/engine.py
+++ b/src/aec_bench/templates/builtin/maritime/freeboard_length/engine.py
@@ -1,0 +1,91 @@
+# ABOUTME: IACS CSR-H Freeboard length (L_LL) computation engine.
+# ABOUTME: Applies the greater-of 96%-waterline / stem-to-rudder-stock rule of Pt 1 Ch 1 Sec 4 §3.1.2.
+
+# CSR-H 01 JUL 2025 Pt 1 Ch 1 Sec 4 §3.1.2:
+# "The freeboard length L_LL, in m, is to be taken as 96% of the total length on a
+# waterline at 85% of the least moulded depth measured from the top of the keel, or as
+# the length from the fore side of the stem to the axis of the rudder stock on that
+# waterline, if that be greater. For ships without a rudder stock, the length L_LL is
+# to be taken as 96% of the waterline at 85% of the least moulded depth."
+FREEBOARD_FRACTION = 0.96
+
+# Sentinel default for stem_to_rudder_stock_axis_distance_m when the ship has no rudder
+# stock (e.g. azimuth thruster vessels) and the parameter is not applicable.
+_NO_RUDDER_STOCK_SENTINEL = None
+
+
+def _normalize_has_rudder_stock(has_rudder_stock: bool | str) -> bool:
+    """Normalize has_rudder_stock to a real bool.
+
+    params.toml declares has_rudder_stock as an enum with values ["true", "false"]
+    (bool is not a valid param type), so the generator passes it as a string. Direct
+    or test callers may still pass a real bool. Accept both.
+    """
+    if isinstance(has_rudder_stock, bool):
+        return has_rudder_stock
+    normalized = has_rudder_stock.strip().lower()
+    if normalized == "true":
+        return True
+    if normalized == "false":
+        return False
+    msg = f"has_rudder_stock must be 'true' or 'false', got {has_rudder_stock!r}"
+    raise ValueError(msg)
+
+
+def _validate_inputs(
+    total_length_on_85pct_depth_waterline_m: float,
+    has_rudder_stock: bool,
+    stem_to_rudder_stock_axis_distance_m: float | None,
+) -> None:
+    """Raise ValueError for invalid input parameters."""
+    if total_length_on_85pct_depth_waterline_m <= 0:
+        msg = "total_length_on_85pct_depth_waterline_m must be > 0"
+        raise ValueError(msg)
+    if has_rudder_stock:
+        if stem_to_rudder_stock_axis_distance_m is None:
+            msg = "stem_to_rudder_stock_axis_distance_m is required when has_rudder_stock is True"
+            raise ValueError(msg)
+        if stem_to_rudder_stock_axis_distance_m <= 0:
+            msg = "stem_to_rudder_stock_axis_distance_m must be > 0"
+            raise ValueError(msg)
+        if stem_to_rudder_stock_axis_distance_m > total_length_on_85pct_depth_waterline_m:
+            msg = "stem_to_rudder_stock_axis_distance_m must be <= total_length_on_85pct_depth_waterline_m"
+            raise ValueError(msg)
+
+
+def compute(
+    total_length_on_85pct_depth_waterline_m: float,
+    has_rudder_stock: bool | str,
+    stem_to_rudder_stock_axis_distance_m: float | None = _NO_RUDDER_STOCK_SENTINEL,
+) -> dict[str, float]:
+    """Compute the IACS CSR-H Freeboard length L_LL per Pt 1 Ch 1 Sec 4 §3.1.2.
+
+    L_LL is taken as 96% of the total length on a waterline at 85% of the least
+    moulded depth measured from the top of the keel, or as the length from the fore
+    side of the stem to the axis of the rudder stock on that waterline, whichever is
+    greater. Ships without a rudder stock (e.g. fitted with azimuth thrusters) take
+    L_LL equal to 96% of the waterline length directly.
+
+    Returns a dict with key: freeboard_length_LLL_m.
+    """
+    has_rudder_stock = _normalize_has_rudder_stock(has_rudder_stock)
+
+    _validate_inputs(
+        total_length_on_85pct_depth_waterline_m,
+        has_rudder_stock,
+        stem_to_rudder_stock_axis_distance_m,
+    )
+
+    waterline_fraction = FREEBOARD_FRACTION * total_length_on_85pct_depth_waterline_m
+
+    if has_rudder_stock:
+        # _validate_inputs guarantees the measured distance is present and positive here;
+        # assert narrows float | None -> float for the type checker.
+        assert stem_to_rudder_stock_axis_distance_m is not None
+        freeboard_length_lll = max(waterline_fraction, stem_to_rudder_stock_axis_distance_m)
+    else:
+        freeboard_length_lll = waterline_fraction
+
+    return {
+        "freeboard_length_LLL_m": round(freeboard_length_lll, 2),
+    }

--- a/src/aec_bench/templates/builtin/maritime/freeboard_length/instruction.md
+++ b/src/aec_bench/templates/builtin/maritime/freeboard_length/instruction.md
@@ -1,0 +1,65 @@
+You are a senior naval architect specializing in classification society rule compliance.
+
+## Problem
+
+Calculate the IACS Freeboard length L_LL for a ship under the Harmonised Common Structural Rules (CSR-H).
+
+## Given
+
+| Parameter | Value | Unit |
+|-----------|-------|------|
+| Total length on a waterline at 85% of the least moulded depth | {{ total_length_on_85pct_depth_waterline_m }} | m |
+{% if has_rudder_stock is defined %}
+| Has rudder stock | {{ has_rudder_stock }} | - |
+{% endif %}
+{% if stem_to_rudder_stock_axis_distance_m is defined %}
+| Length from the fore side of the stem to the axis of the rudder stock, on that waterline | {{ stem_to_rudder_stock_axis_distance_m }} | m |
+{% endif %}
+{% if archetype_description is defined %}
+
+### Vessel Context
+
+{{ archetype_description }}
+{% endif %}
+
+{% if tool_available %}
+## Available Tool
+
+A Freeboard length calculation tool is available at `/workspace/{{ meta.name }}_calc.py`. Run it with:
+
+```bash
+python3 /workspace/{{ meta.name }}_calc.py --help
+```
+
+You may use this tool to verify your calculations or compute values directly.
+{% endif %}
+
+## Required
+
+Calculate the following:
+
+1. Freeboard length L_LL (m)
+
+## Applicable Standards
+
+- IACS Harmonised Common Structural Rules (CSR-H), edition 01 JUL 2025, Pt 1 Ch 1 Sec 4 §3.1.2
+
+## Constraints
+
+- No internet access is available. Work from engineering knowledge and the provided tool.
+- Quote from Pt 1 Ch 1 Sec 4 §3.1.2: "The freeboard length L_LL, in m, is to be taken as 96% of the total length on a waterline at 85% of the least moulded depth measured from the top of the keel, or as the length from the fore side of the stem to the axis of the rudder stock on that waterline, if that be greater. For ships without a rudder stock, the length L_LL is to be taken as 96% of the waterline at 85% of the least moulded depth."
+- If the ship has a rudder stock, L_LL is the GREATER of (a) 96% of the total length on the 85%-depth waterline and (b) the measured length from the fore side of the stem to the axis of the rudder stock on that waterline.
+- If the ship has no rudder stock (e.g. azimuth thrusters), L_LL = 96% of the total length on the 85%-depth waterline.
+- Ships with unusual (concave) stem contours are out of scope for this calculation — assume a conventional stem contour unless stated otherwise.
+
+## Output Format
+
+Show your step-by-step working in Markdown, including formulas and intermediate calculations. At the end of your solution, include a JSON block with your final answer in exactly this format:
+
+```json
+{
+  "freeboard_length_LLL_m": <numeric_value>
+}
+```
+
+Write your complete solution to `/workspace/output.md`.

--- a/src/aec_bench/templates/builtin/maritime/freeboard_length/params.toml
+++ b/src/aec_bench/templates/builtin/maritime/freeboard_length/params.toml
@@ -1,0 +1,73 @@
+[meta]
+name = "freeboard-length"
+description = "IACS CSR-H Freeboard length L_LL, the greater of 96% of the waterline length or the stem-to-rudder-stock distance"
+long_description = "Calculates the Freeboard length L_LL used throughout the IACS Harmonised Common Structural Rules for Bulk Carriers and Oil Tankers (CSR-H). L_LL is taken as 96% of the total length on a waterline at 85% of the least moulded depth measured from the top of the keel, or as the length from the fore side of the stem to the axis of the rudder stock on that waterline, whichever is greater. Ships without a rudder stock (e.g. fitted with azimuth thrusters) take L_LL equal to 96% of the waterline length directly. This is a principal-particulars quantity used for freeboard and stability assessment under CSR-H."
+discipline = "maritime"
+category = "principal-particulars"
+standards = ["IACS CSR-H (Common Structural Rules) 01 JUL 2025, Pt 1 Ch 1 Sec 4, §3.1.2"]
+tags = ["maritime", "csr-h", "iacs", "freeboard-length", "principal-particulars", "deterministic"]
+tool_mode = "with-tool"
+
+[params.total_length_on_85pct_depth_waterline_m]
+type = "float"
+unit = "m"
+description = "Total length on a waterline at 85% of the least moulded depth, measured from the top of the keel"
+min = 90.0
+max = 450.0
+
+[params.has_rudder_stock]
+type = "enum"
+description = "Whether the ship has a rudder stock (false for ships fitted with azimuth thrusters and similar)"
+values = ["true", "false"]
+
+[params.stem_to_rudder_stock_axis_distance_m]
+type = "float"
+unit = "m"
+description = "Length from the fore side of the stem to the axis of the rudder stock, on the 85%-depth waterline"
+min = 85.0
+max = 440.0
+optional = true
+
+[outputs.freeboard_length_LLL_m]
+description = "Freeboard length L_LL (m)"
+tolerance = 0.005
+
+[archetypes.conventional_rudder_ship]
+description = "Conventional single-screw ship with a rudder stock and moderate stern overhang"
+total_length_on_85pct_depth_waterline_m = {min = 220.0, max = 300.0}
+stem_to_rudder_stock_axis_distance_m = {min = 140.0, max = 210.0}
+site_contexts = ["bulk-carrier-panamax", "product-tanker-mr", "general-cargo-handysize"]
+
+[archetypes.long_stern_rudder_ship]
+description = "Rudder-stock ship with a long counter/cruiser stern, where the rudder stock axis sits well aft, beyond 96% of the waterline length"
+total_length_on_85pct_depth_waterline_m = {min = 200.0, max = 205.0}
+stem_to_rudder_stock_axis_distance_m = {min = 197.0, max = 199.5}
+site_contexts = ["chemical-tanker-cruiser-stern", "general-cargo-long-counter-stern", "livestock-carrier-cruiser-stern"]
+
+[archetypes.azimuth_thruster_ship]
+description = "Ship fitted with azimuth thrusters and no rudder stock"
+total_length_on_85pct_depth_waterline_m = {min = 100.0, max = 250.0}
+site_contexts = ["shuttle-tanker-dp", "offshore-support-vessel", "harbour-tug-azimuth"]
+
+[difficulty.easy]
+description = "Rudder stock ship where the measured stem-to-rudder-stock-axis distance governs (exceeds 96% of the waterline length)"
+visibility = "all_given"
+archetypes = ["long_stern_rudder_ship"]
+has_rudder_stock = ["true"]
+governing_term = ["stem_to_rudder_stock_distance"]
+
+[difficulty.medium]
+description = "Rudder stock ship where 96% of the waterline length governs (the measured distance is smaller, so the greater-of flips)"
+visibility = "all_given"
+archetypes = ["conventional_rudder_ship"]
+has_rudder_stock = ["true"]
+governing_term = ["waterline_fraction"]
+
+[difficulty.hard]
+description = "has_rudder_stock hidden; agent must infer the azimuth-thruster case from the vessel description"
+visibility = "partial"
+hidden_params = ["has_rudder_stock", "stem_to_rudder_stock_axis_distance_m"]
+replacement_text = "The vessel is a {{ archetype.description }} ({{ archetype.site_context }})"
+archetypes = ["azimuth_thruster_ship"]
+has_rudder_stock = ["false"]
+governing_term = ["no_rudder_stock"]

--- a/src/aec_bench/templates/builtin/maritime/rule_length/__init__.py
+++ b/src/aec_bench/templates/builtin/maritime/rule_length/__init__.py
@@ -1,0 +1,2 @@
+# ABOUTME: IACS CSR-H Rule length (L) calculation template.
+# ABOUTME: Implements Pt 1 Ch 1 Sec 4 §3.1.1 of the 01 JUL 2025 edition.

--- a/src/aec_bench/templates/builtin/maritime/rule_length/engine.py
+++ b/src/aec_bench/templates/builtin/maritime/rule_length/engine.py
@@ -1,0 +1,72 @@
+# ABOUTME: IACS CSR-H Rule length (L) computation engine.
+# ABOUTME: Applies the 96%/97% extreme-waterline-length clamp of Pt 1 Ch 1 Sec 4 §3.1.1.
+
+# CSR-H 01 JUL 2025 Pt 1 Ch 1 Sec 4 §3.1.1:
+# "L is to be not less than 96% and need not exceed 97% of the extreme length on the
+# waterline at the scantling draught T_SC."
+LOWER_BOUND_FRACTION = 0.96
+
+# CSR-H 01 JUL 2025 Pt 1 Ch 1 Sec 4 §3.1.1: upper cap on the Rule length L, see above.
+UPPER_BOUND_FRACTION = 0.97
+
+# Sentinel default for stem_to_rudder_stock_distance_m when the ship has no rudder
+# stock (e.g. azimuth thruster vessels) and the parameter is not applicable.
+_NO_RUDDER_STOCK_SENTINEL = None
+
+
+def _validate_inputs(
+    extreme_length_on_waterline_at_TSC_m: float,
+    has_rudder_stock: bool,
+    stem_to_rudder_stock_distance_m: float | None,
+) -> None:
+    """Raise ValueError for invalid input parameters."""
+    if extreme_length_on_waterline_at_TSC_m <= 0:
+        msg = "extreme_length_on_waterline_at_TSC_m must be > 0"
+        raise ValueError(msg)
+    if has_rudder_stock:
+        if stem_to_rudder_stock_distance_m is None:
+            msg = "stem_to_rudder_stock_distance_m is required when has_rudder_stock is True"
+            raise ValueError(msg)
+        if stem_to_rudder_stock_distance_m <= 0:
+            msg = "stem_to_rudder_stock_distance_m must be > 0"
+            raise ValueError(msg)
+        if stem_to_rudder_stock_distance_m > extreme_length_on_waterline_at_TSC_m:
+            msg = "stem_to_rudder_stock_distance_m must be <= extreme_length_on_waterline_at_TSC_m"
+            raise ValueError(msg)
+
+
+def compute(
+    extreme_length_on_waterline_at_TSC_m: float,
+    has_rudder_stock: bool,
+    stem_to_rudder_stock_distance_m: float | None = _NO_RUDDER_STOCK_SENTINEL,
+) -> dict[str, float]:
+    """Compute the IACS CSR-H Rule length L per Pt 1 Ch 1 Sec 4 §3.1.1.
+
+    L is the distance, in m, measured on the waterline at the scantling draught T_SC
+    from the forward side of the stem to the centre of the rudder stock, clamped to
+    lie between 96% and 97% of the extreme length on the waterline at T_SC. Ships
+    without a rudder stock (e.g. fitted with azimuth thrusters) take L equal to 97%
+    of the extreme length.
+
+    Returns a dict with key: rule_length_L_m.
+    """
+    _validate_inputs(
+        extreme_length_on_waterline_at_TSC_m,
+        has_rudder_stock,
+        stem_to_rudder_stock_distance_m,
+    )
+
+    lower_bound = LOWER_BOUND_FRACTION * extreme_length_on_waterline_at_TSC_m
+    upper_bound = UPPER_BOUND_FRACTION * extreme_length_on_waterline_at_TSC_m
+
+    if has_rudder_stock:
+        # _validate_inputs guarantees the measured distance is present and positive here;
+        # assert narrows float | None -> float for the type checker.
+        assert stem_to_rudder_stock_distance_m is not None
+        rule_length_l = min(max(stem_to_rudder_stock_distance_m, lower_bound), upper_bound)
+    else:
+        rule_length_l = upper_bound
+
+    return {
+        "rule_length_L_m": round(rule_length_l, 3),
+    }

--- a/src/aec_bench/templates/builtin/maritime/rule_length/engine.py
+++ b/src/aec_bench/templates/builtin/maritime/rule_length/engine.py
@@ -14,6 +14,24 @@ UPPER_BOUND_FRACTION = 0.97
 _NO_RUDDER_STOCK_SENTINEL = None
 
 
+def _normalize_has_rudder_stock(has_rudder_stock: bool | str) -> bool:
+    """Normalize has_rudder_stock to a real bool.
+
+    params.toml declares has_rudder_stock as an enum with values ["true", "false"]
+    (bool is not a valid param type), so the generator passes it as a string. Direct
+    or test callers may still pass a real bool. Accept both.
+    """
+    if isinstance(has_rudder_stock, bool):
+        return has_rudder_stock
+    normalized = has_rudder_stock.strip().lower()
+    if normalized == "true":
+        return True
+    if normalized == "false":
+        return False
+    msg = f"has_rudder_stock must be 'true' or 'false', got {has_rudder_stock!r}"
+    raise ValueError(msg)
+
+
 def _validate_inputs(
     extreme_length_on_waterline_at_TSC_m: float,
     has_rudder_stock: bool,
@@ -37,7 +55,7 @@ def _validate_inputs(
 
 def compute(
     extreme_length_on_waterline_at_TSC_m: float,
-    has_rudder_stock: bool,
+    has_rudder_stock: bool | str,
     stem_to_rudder_stock_distance_m: float | None = _NO_RUDDER_STOCK_SENTINEL,
 ) -> dict[str, float]:
     """Compute the IACS CSR-H Rule length L per Pt 1 Ch 1 Sec 4 §3.1.1.
@@ -50,6 +68,8 @@ def compute(
 
     Returns a dict with key: rule_length_L_m.
     """
+    has_rudder_stock = _normalize_has_rudder_stock(has_rudder_stock)
+
     _validate_inputs(
         extreme_length_on_waterline_at_TSC_m,
         has_rudder_stock,
@@ -68,5 +88,5 @@ def compute(
         rule_length_l = upper_bound
 
     return {
-        "rule_length_L_m": round(rule_length_l, 3),
+        "rule_length_L_m": round(rule_length_l, 2),
     }

--- a/src/aec_bench/templates/builtin/maritime/rule_length/instruction.md
+++ b/src/aec_bench/templates/builtin/maritime/rule_length/instruction.md
@@ -1,0 +1,65 @@
+You are a senior naval architect specializing in classification society rule compliance.
+
+## Problem
+
+Calculate the IACS Rule length L for a ship under the Harmonised Common Structural Rules (CSR-H).
+
+## Given
+
+| Parameter | Value | Unit |
+|-----------|-------|------|
+| Extreme length on the waterline at T_SC | {{ extreme_length_on_waterline_at_TSC_m }} | m |
+{% if has_rudder_stock is defined %}
+| Has rudder stock | {{ has_rudder_stock }} | - |
+{% endif %}
+{% if stem_to_rudder_stock_distance_m is defined %}
+| Distance from stem to rudder stock centre, on the waterline at T_SC | {{ stem_to_rudder_stock_distance_m }} | m |
+{% endif %}
+{% if archetype_description is defined %}
+
+### Vessel Context
+
+{{ archetype_description }}
+{% endif %}
+
+{% if tool_available %}
+## Available Tool
+
+A Rule length calculation tool is available at `/workspace/{{ meta.name }}_calc.py`. Run it with:
+
+```bash
+python3 /workspace/{{ meta.name }}_calc.py --help
+```
+
+You may use this tool to verify your calculations or compute values directly.
+{% endif %}
+
+## Required
+
+Calculate the following:
+
+1. Rule length L (m)
+
+## Applicable Standards
+
+- IACS Harmonised Common Structural Rules (CSR-H), edition 01 JUL 2025, Pt 1 Ch 1 Sec 4 §3.1.1
+
+## Constraints
+
+- No internet access is available. Work from engineering knowledge and the provided tool.
+- Quote from Pt 1 Ch 1 Sec 4 §3.1.1: "The Rule length L is the distance, in m, measured on the waterline at the scantling draught T_SC from the forward side of the stem to the centre of the rudder stock. L is to be not less than 96% and need not exceed 97% of the extreme length on the waterline at the scantling draught T_SC. In ships without rudder stock (e.g. ships fitted with azimuth thrusters), the Rule length L is to be taken equal to 97% of the extreme length on the waterline at the scantling draught T_SC. In ships with unusual stem or stern arrangements, the Rule length is considered on a case-by-case basis."
+- If the ship has a rudder stock, clamp the measured stem-to-rudder-stock distance to the range [0.96 x extreme length, 0.97 x extreme length].
+- If the ship has no rudder stock (e.g. azimuth thrusters), L = 0.97 x extreme length on the waterline at T_SC.
+- Ships with unusual stem or stern arrangements are out of scope for this calculation — assume conventional arrangements unless stated otherwise.
+
+## Output Format
+
+Show your step-by-step working in Markdown, including formulas and intermediate calculations. At the end of your solution, include a JSON block with your final answer in exactly this format:
+
+```json
+{
+  "rule_length_L_m": <numeric_value>
+}
+```
+
+Write your complete solution to `/workspace/output.md`.

--- a/src/aec_bench/templates/builtin/maritime/rule_length/params.toml
+++ b/src/aec_bench/templates/builtin/maritime/rule_length/params.toml
@@ -1,0 +1,66 @@
+[meta]
+name = "rule-length"
+description = "IACS CSR-H Rule length L, clamped between 96% and 97% of extreme waterline length"
+long_description = "Calculates the Rule length L used throughout the IACS Harmonised Common Structural Rules for Bulk Carriers and Oil Tankers (CSR-H). L is the distance, in m, measured on the waterline at the scantling draught T_SC from the forward side of the stem to the centre of the rudder stock, and is clamped to lie between 96% and 97% of the extreme length on the waterline at T_SC. Ships without a rudder stock (e.g. fitted with azimuth thrusters) take L equal to 97% of the extreme length. This is the first principal-particulars quantity computed for any CSR-H scantling assessment."
+discipline = "maritime"
+category = "principal-particulars"
+standards = ["IACS CSR-H (Common Structural Rules) 01 JUL 2025, Pt 1 Ch 1 Sec 4"]
+tags = ["maritime", "csr-h", "iacs", "rule-length", "principal-particulars", "deterministic"]
+tool_mode = "with-tool"
+
+[params.extreme_length_on_waterline_at_TSC_m]
+type = "float"
+unit = "m"
+description = "Extreme length on the waterline at the scantling draught T_SC"
+min = 90.0
+max = 450.0
+
+[params.has_rudder_stock]
+type = "enum"
+description = "Whether the ship has a rudder stock (false for ships fitted with azimuth thrusters and similar)"
+values = ["true", "false"]
+
+[params.stem_to_rudder_stock_distance_m]
+type = "float"
+unit = "m"
+description = "Distance measured on the waterline at T_SC from the forward side of the stem to the centre of the rudder stock"
+min = 85.0
+max = 440.0
+optional = true
+
+[outputs.rule_length_L_m]
+description = "Rule length L (m)"
+tolerance = 0.005
+
+[archetypes.conventional_rudder_ship]
+description = "Conventional single-screw ship with a rudder stock"
+extreme_length_on_waterline_at_TSC_m = {min = 150.0, max = 300.0}
+site_contexts = ["bulk-carrier-panamax", "product-tanker-mr", "general-cargo-handysize"]
+
+[archetypes.azimuth_thruster_ship]
+description = "Ship fitted with azimuth thrusters and no rudder stock"
+extreme_length_on_waterline_at_TSC_m = {min = 100.0, max = 250.0}
+site_contexts = ["shuttle-tanker-dp", "offshore-support-vessel", "harbour-tug-azimuth"]
+
+[difficulty.easy]
+description = "Rudder stock ship with measured distance between the 96%/97% bounds"
+visibility = "all_given"
+archetypes = ["conventional_rudder_ship"]
+has_rudder_stock = ["true"]
+clamp_regime = ["within_bounds"]
+
+[difficulty.medium]
+description = "Rudder stock ship where the measured distance falls outside the 96%/97% band, so the clamp bites"
+visibility = "all_given"
+archetypes = ["conventional_rudder_ship"]
+has_rudder_stock = ["true"]
+clamp_regime = ["lower_bound_bites", "upper_bound_bites"]
+
+[difficulty.hard]
+description = "has_rudder_stock hidden; agent must infer the azimuth-thruster case from the vessel description"
+visibility = "partial"
+hidden_params = ["has_rudder_stock", "stem_to_rudder_stock_distance_m"]
+replacement_text = "The vessel is a {{ archetype.description }} ({{ archetype.site_context }})"
+archetypes = ["azimuth_thruster_ship"]
+has_rudder_stock = ["false"]
+clamp_regime = ["no_rudder_stock"]

--- a/src/aec_bench/templates/builtin/maritime/rule_length/params.toml
+++ b/src/aec_bench/templates/builtin/maritime/rule_length/params.toml
@@ -32,9 +32,31 @@ optional = true
 description = "Rule length L (m)"
 tolerance = 0.005
 
-[archetypes.conventional_rudder_ship]
-description = "Conventional single-screw ship with a rudder stock"
+[archetypes.conventional_within_bounds]
+description = "Conventional single-screw ship with a rudder stock; measured distance falls inside the 96%/97% band"
+# Narrow extreme-length range (max/min <= 0.97/0.96) so that, combined with the stem
+# range below, stem_to_rudder_stock_distance_m always lands strictly between
+# 0.96*extreme and 0.97*extreme (the within_bounds clamp regime) regardless of which
+# value is independently sampled from each range.
+extreme_length_on_waterline_at_TSC_m = {min = 200.0, max = 200.5}
+stem_to_rudder_stock_distance_m = {min = 192.6, max = 193.8}
+site_contexts = ["bulk-carrier-panamax", "product-tanker-mr", "general-cargo-handysize"]
+
+[archetypes.conventional_lower_bites]
+description = "Conventional single-screw ship with a rudder stock; measured distance is short, so the 96% lower bound bites"
 extreme_length_on_waterline_at_TSC_m = {min = 150.0, max = 300.0}
+# stem_max <= 0.96 * extreme_min (0.96 * 150 = 144) so stem < 0.96*extreme for every
+# sampled combination, regardless of the independently sampled extreme length.
+stem_to_rudder_stock_distance_m = {min = 80.0, max = 140.0}
+site_contexts = ["bulk-carrier-panamax", "product-tanker-mr", "general-cargo-handysize"]
+
+[archetypes.conventional_upper_bites]
+description = "Conventional single-screw ship with a rudder stock; measured distance is long, so the 97% upper bound bites"
+# Narrow extreme-length range (max/min <= 1/0.97) so that, combined with the stem
+# range below, stem_to_rudder_stock_distance_m always lands strictly above
+# 0.97*extreme yet no more than extreme itself (the upper_bound_bites clamp regime).
+extreme_length_on_waterline_at_TSC_m = {min = 220.0, max = 224.0}
+stem_to_rudder_stock_distance_m = {min = 217.5, max = 220.0}
 site_contexts = ["bulk-carrier-panamax", "product-tanker-mr", "general-cargo-handysize"]
 
 [archetypes.azimuth_thruster_ship]
@@ -45,14 +67,14 @@ site_contexts = ["shuttle-tanker-dp", "offshore-support-vessel", "harbour-tug-az
 [difficulty.easy]
 description = "Rudder stock ship with measured distance between the 96%/97% bounds"
 visibility = "all_given"
-archetypes = ["conventional_rudder_ship"]
+archetypes = ["conventional_within_bounds"]
 has_rudder_stock = ["true"]
 clamp_regime = ["within_bounds"]
 
 [difficulty.medium]
 description = "Rudder stock ship where the measured distance falls outside the 96%/97% band, so the clamp bites"
 visibility = "all_given"
-archetypes = ["conventional_rudder_ship"]
+archetypes = ["conventional_lower_bites", "conventional_upper_bites"]
 has_rudder_stock = ["true"]
 clamp_regime = ["lower_bound_bites", "upper_bound_bites"]
 

--- a/src/aec_bench/tui/screens/library.py
+++ b/src/aec_bench/tui/screens/library.py
@@ -459,6 +459,7 @@ _DISCIPLINE_CYCLE: list[str] = [
     "civil",
     "electrical",
     "ground",
+    "maritime",
     "mechanical",
     "structural",
 ]

--- a/tasks/maritime/block-coefficient/capesize-bulk-carrier/environment/Dockerfile
+++ b/tasks/maritime/block-coefficient/capesize-bulk-carrier/environment/Dockerfile
@@ -1,0 +1,14 @@
+# ABOUTME: Auto-generated container for maritime — block-coefficient — capesize-bulk-carrier.
+# ABOUTME: Extensions: claude-cli. Regenerate with: aec-bench generate dockerfiles
+FROM --platform=linux/amd64 ubuntu:24.04
+
+RUN apt-get update && apt-get install -y \
+    bc \
+    curl \
+    procps \
+    python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://claude.ai/install.sh | bash
+
+WORKDIR /workspace

--- a/tasks/maritime/block-coefficient/capesize-bulk-carrier/instruction.md
+++ b/tasks/maritime/block-coefficient/capesize-bulk-carrier/instruction.md
@@ -1,0 +1,43 @@
+You are a senior naval architect specializing in classification society rule compliance.
+
+## Problem
+
+Calculate the IACS Block coefficient C_B for a Capesize bulk carrier under the Harmonised Common Structural Rules (CSR-H).
+
+## Vessel Details
+
+| Parameter | Value | Unit |
+|-----------|-------|------|
+| Vessel type | Capesize bulk carrier | - |
+| Moulded displacement at T_SC (Delta) | 180000.0 | t |
+| Rule length (L) | 280.0 | m |
+| Moulded breadth (B) | 45.0 | m |
+| Scantling draught (T_SC) | 18.0 | m |
+
+## Required
+
+Calculate the following:
+
+1. Block coefficient C_B (dimensionless)
+
+## Applicable Standards
+
+- IACS Harmonised Common Structural Rules (CSR-H), edition 01 JUL 2025, Pt 1 Ch 1 Sec 4 §3.1.8
+
+## Constraints
+
+- No internet access is available. Work from engineering knowledge only.
+- Quote from Pt 1 Ch 1 Sec 4 §3.1.8: "C_B, the block coefficient at the draught, T_SC is defined in the following equation: C_B = Delta / (1.025 x L x B x T_SC)" where Delta is the moulded displacement of the ship at draught T_SC (in tonnes), L is the Rule length (m), B is the moulded breadth (m), and T_SC is the scantling draught (m).
+- Use a seawater density of 1.025 t/m^3, per the formula above.
+
+## Output Format
+
+Show your step-by-step working in Markdown, including formulas and intermediate calculations. At the end of your solution, include a JSON block with your final answer in exactly this format:
+
+```json
+{
+  "block_coefficient_CB": <numeric_value>
+}
+```
+
+Write your complete solution to `/workspace/output.md`.

--- a/tasks/maritime/block-coefficient/capesize-bulk-carrier/solution/solve.py
+++ b/tasks/maritime/block-coefficient/capesize-bulk-carrier/solution/solve.py
@@ -1,0 +1,45 @@
+# ABOUTME: Reference solution for capesize-bulk-carrier Block coefficient calculation.
+# ABOUTME: Computes from first principles and writes output.md with JSON block.
+
+import json
+from pathlib import Path
+
+# Compute from first principles
+data = {
+    "vessel_type": "Capesize bulk carrier",
+    "moulded_displacement_t": 180000.0,
+    "rule_length_L_m": 280.0,
+    "moulded_breadth_B_m": 45.0,
+    "scantling_draught_TSC_m": 18.0,
+    "seawater_density_t_m3": 1.025,
+    "block_coefficient_CB": 0.77,
+}
+
+output_fields = {
+    "block_coefficient_CB": data["block_coefficient_CB"],
+}
+
+solution = f"""# Block Coefficient Calculation — Capesize Bulk Carrier
+
+## Vessel: Capesize bulk carrier
+
+Per IACS CSR-H (01 JUL 2025) Pt 1 Ch 1 Sec 4 §3.1.8, the block coefficient at
+the scantling draught is:
+
+C_B = Delta / (1.025 x L x B x T_SC)
+
+- Delta (moulded displacement) = 180,000 t
+- L (Rule length) = 280.0 m
+- B (moulded breadth) = 45.0 m
+- T_SC (scantling draught) = 18.0 m
+
+C_B = 180000 / (1.025 x 280.0 x 45.0 x 18.0)
+    = 180000 / 232470.0
+    = 0.7744 -> 0.77
+
+```json
+{json.dumps(output_fields, indent=2)}
+```
+"""
+
+Path("/workspace/output.md").write_text(solution)

--- a/tasks/maritime/block-coefficient/capesize-bulk-carrier/task.toml
+++ b/tasks/maritime/block-coefficient/capesize-bulk-carrier/task.toml
@@ -1,0 +1,20 @@
+version = "1.0"
+
+[metadata]
+difficulty = "easy"
+category = "reasoning"
+tags = ["maritime", "csr-h", "iacs", "block-coefficient", "principal-particulars", "deterministic"]
+
+[agent]
+timeout_sec = 600.0
+
+[verifier]
+timeout_sec = 120.0
+
+[environment]
+extensions = ["claude-cli"]
+build_timeout_sec = 600.0
+cpus = 1
+memory_mb = 2048
+storage_mb = 5120
+allow_internet = true

--- a/tasks/maritime/block-coefficient/capesize-bulk-carrier/tests/fixtures/golden_fail.md
+++ b/tasks/maritime/block-coefficient/capesize-bulk-carrier/tests/fixtures/golden_fail.md
@@ -1,0 +1,7 @@
+# Golden Fail Output
+
+```json
+{
+  "block_coefficient_CB": 0.0
+}
+```

--- a/tasks/maritime/block-coefficient/capesize-bulk-carrier/tests/fixtures/golden_pass.md
+++ b/tasks/maritime/block-coefficient/capesize-bulk-carrier/tests/fixtures/golden_pass.md
@@ -1,0 +1,7 @@
+# Golden Pass Output
+
+```json
+{
+  "block_coefficient_CB": 0.77
+}
+```

--- a/tasks/maritime/block-coefficient/capesize-bulk-carrier/tests/test.sh
+++ b/tasks/maritime/block-coefficient/capesize-bulk-carrier/tests/test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# ABOUTME: Thin wrapper that runs the Python verifier.
+# ABOUTME: Ensures reward.json is always written, even on crash.
+
+REWARD_FILE="/logs/verifier/reward.json"
+mkdir -p /logs/verifier
+trap 'if [ ! -f "$REWARD_FILE" ]; then echo "{\"reward\": 0.0}" > "$REWARD_FILE"; fi' EXIT
+python3 /tests/verify.py

--- a/tasks/maritime/block-coefficient/capesize-bulk-carrier/tests/verify.py
+++ b/tasks/maritime/block-coefficient/capesize-bulk-carrier/tests/verify.py
@@ -1,0 +1,121 @@
+# ABOUTME: Verifier for capesize-bulk-carrier Block coefficient calculation task.
+# ABOUTME: Computes ground truth from IACS CSR-H Pt 1 Ch 1 Sec 4 §3.1.8 and scores agent output.
+
+import argparse
+import json
+import math
+import re
+from pathlib import Path
+
+DEFAULT_OUTPUT_FILE = Path("/workspace/output.md")
+DEFAULT_REWARD_FILE = Path("/logs/verifier/reward.json")
+
+# ---- Input parameters (Capesize bulk carrier) ----
+MOULDED_DISPLACEMENT_T = 180000.0
+RULE_LENGTH_L_M = 280.0
+MOULDED_BREADTH_B_M = 45.0
+SCANTLING_DRAUGHT_TSC_M = 18.0
+
+# CSR-H 01 JUL 2025 Pt 1 Ch 1 Sec 4 §3.1.8
+SEAWATER_DENSITY_T_M3 = 1.025
+
+
+def write_reward(reward: float, details: dict[str, float], path: Path) -> None:
+    """Write reward JSON for Harbor, plus per-field details to a sibling file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"reward": round(reward, 2)}))
+    details_path = path.parent / "details.json"
+    details_path.write_text(json.dumps(details))
+
+
+def compute_ground_truth() -> dict[str, float]:
+    """Compute the expected Block coefficient C_B for this instance.
+
+    C_B = Delta / (1.025 x L x B x T_SC) = 180000 / (1.025 x 280 x 45 x 18) = 0.77.
+    """
+    block_coefficient_cb = MOULDED_DISPLACEMENT_T / (
+        SEAWATER_DENSITY_T_M3 * RULE_LENGTH_L_M * MOULDED_BREADTH_B_M * SCANTLING_DRAUGHT_TSC_M
+    )
+
+    return {
+        "block_coefficient_CB": round(block_coefficient_cb, 2),
+    }
+
+
+def extract_json_block(text: str) -> dict | None:
+    """Extract the last fenced JSON block from Markdown text."""
+    pattern = r"```json\s*\n(.*?)\n\s*```"
+    matches = re.findall(pattern, text, re.DOTALL)
+    if not matches:
+        return None
+    try:
+        return json.loads(matches[-1])
+    except json.JSONDecodeError:
+        return None
+
+
+def score_field(
+    expected: float,
+    actual_val: object,
+    rel_tol: float,
+) -> float:
+    """Score a single field: 1.0 if within tolerance, 0.0 otherwise."""
+    if actual_val is None:
+        return 0.0
+    try:
+        actual_float = float(actual_val)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 0.0
+    if math.isclose(actual_float, expected, rel_tol=rel_tol):
+        return 1.0
+    return 0.0
+
+
+def score_answers(
+    expected: dict[str, float],
+    actual: dict | None,
+) -> tuple[float, dict[str, float]]:
+    """Score each field and return overall reward + per-field details."""
+    tolerances: dict[str, float] = {
+        "block_coefficient_CB": 0.03,
+    }
+
+    if not actual:
+        details = {k: 0.0 for k in expected}
+        return 0.0, details
+
+    details: dict[str, float] = {}
+    for key, exp_val in expected.items():
+        act_val = actual.get(key)
+        tol = tolerances.get(key, 0.03)
+        details[key] = score_field(exp_val, act_val, tol)
+
+    total = len(expected)
+    reward = sum(details.values()) / total if total > 0 else 0.0
+    return round(reward, 2), details
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Verify capesize-bulk-carrier output")
+    parser.add_argument("--input", type=Path, default=DEFAULT_OUTPUT_FILE)
+    parser.add_argument("--output", type=Path, default=DEFAULT_REWARD_FILE)
+    args = parser.parse_args()
+
+    try:
+        if not args.input.exists() or args.input.stat().st_size == 0:
+            details = {k: 0.0 for k in compute_ground_truth()}
+            write_reward(0.0, details, args.output)
+            return
+
+        text = args.input.read_text()
+        expected = compute_ground_truth()
+        actual = extract_json_block(text)
+        reward, details = score_answers(expected, actual)
+        write_reward(reward, details, args.output)
+    except Exception:
+        details = {k: 0.0 for k in compute_ground_truth()}
+        write_reward(0.0, details, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/maritime/freeboard-length/general-cargo-waterline-governs/environment/Dockerfile
+++ b/tasks/maritime/freeboard-length/general-cargo-waterline-governs/environment/Dockerfile
@@ -1,0 +1,14 @@
+# ABOUTME: Auto-generated container for maritime — freeboard-length — general-cargo-waterline-governs.
+# ABOUTME: Extensions: claude-cli. Regenerate with: aec-bench generate dockerfiles
+FROM --platform=linux/amd64 ubuntu:24.04
+
+RUN apt-get update && apt-get install -y \
+    bc \
+    curl \
+    procps \
+    python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://claude.ai/install.sh | bash
+
+WORKDIR /workspace

--- a/tasks/maritime/freeboard-length/general-cargo-waterline-governs/instruction.md
+++ b/tasks/maritime/freeboard-length/general-cargo-waterline-governs/instruction.md
@@ -1,0 +1,43 @@
+You are a senior naval architect specializing in classification society rule compliance.
+
+## Problem
+
+Calculate the IACS Freeboard length L_LL for a general cargo ship under the Harmonised Common Structural Rules (CSR-H).
+
+## Vessel Details
+
+| Parameter | Value | Unit |
+|-----------|-------|------|
+| Vessel type | General cargo ship | - |
+| Total length on a waterline at 85% of the least moulded depth | 180.0 | m |
+| Has rudder stock | true | - |
+| Length from the fore side of the stem to the axis of the rudder stock, on that waterline | 170.0 | m |
+
+## Required
+
+Calculate the following:
+
+1. Freeboard length L_LL (m)
+
+## Applicable Standards
+
+- IACS Harmonised Common Structural Rules (CSR-H), edition 01 JUL 2025, Pt 1 Ch 1 Sec 4 §3.1.2
+
+## Constraints
+
+- No internet access is available. Work from engineering knowledge only.
+- Quote from Pt 1 Ch 1 Sec 4 §3.1.2: "The freeboard length L_LL, in m, is to be taken as 96% of the total length on a waterline at 85% of the least moulded depth measured from the top of the keel, or as the length from the fore side of the stem to the axis of the rudder stock on that waterline, if that be greater. For ships without a rudder stock, the length L_LL is to be taken as 96% of the waterline at 85% of the least moulded depth."
+- The vessel has a rudder stock, so L_LL is the GREATER of (a) 96% of the total length on the 85%-depth waterline and (b) the measured length from the fore side of the stem to the axis of the rudder stock on that waterline.
+- The vessel has a conventional stem contour — the concave-stem-contour special case does not apply here.
+
+## Output Format
+
+Show your step-by-step working in Markdown, including formulas and intermediate calculations. At the end of your solution, include a JSON block with your final answer in exactly this format:
+
+```json
+{
+  "freeboard_length_LLL_m": <numeric_value>
+}
+```
+
+Write your complete solution to `/workspace/output.md`.

--- a/tasks/maritime/freeboard-length/general-cargo-waterline-governs/solution/solve.py
+++ b/tasks/maritime/freeboard-length/general-cargo-waterline-governs/solution/solve.py
@@ -1,0 +1,40 @@
+# ABOUTME: Reference solution for general-cargo-waterline-governs Freeboard length calculation.
+# ABOUTME: Computes from first principles and writes output.md with JSON block.
+
+import json
+from pathlib import Path
+
+# Compute from first principles
+data = {
+    "vessel_type": "General cargo ship",
+    "total_length_on_85pct_depth_waterline_m": 180.0,
+    "has_rudder_stock": True,
+    "stem_to_rudder_stock_axis_distance_m": 170.0,
+    "waterline_fraction_m": 172.8,
+    "freeboard_length_LLL_m": 172.8,
+}
+
+output_fields = {
+    "freeboard_length_LLL_m": data["freeboard_length_LLL_m"],
+}
+
+solution = f"""# Freeboard Length Calculation — General Cargo Ship
+
+## Vessel: General cargo ship (total length 180.0 m on the 85%-depth waterline)
+
+Per IACS CSR-H (01 JUL 2025) Pt 1 Ch 1 Sec 4 §3.1.2, the Freeboard length L_LL is the
+greater of 96% of the total length on the 85%-depth waterline and the measured length
+from the fore side of the stem to the axis of the rudder stock on that waterline.
+
+- Waterline fraction = 0.96 x 180.0 = 172.8 m
+- Measured stem-to-rudder-stock-axis distance = 170.0 m
+
+Since the waterline fraction (172.8 m) is greater than the measured distance (170.0 m),
+the waterline fraction governs: L_LL = 172.8 m.
+
+```json
+{json.dumps(output_fields, indent=2)}
+```
+"""
+
+Path("/workspace/output.md").write_text(solution)

--- a/tasks/maritime/freeboard-length/general-cargo-waterline-governs/task.toml
+++ b/tasks/maritime/freeboard-length/general-cargo-waterline-governs/task.toml
@@ -1,0 +1,20 @@
+version = "1.0"
+
+[metadata]
+difficulty = "medium"
+category = "reasoning"
+tags = ["maritime", "csr-h", "iacs", "freeboard-length", "principal-particulars", "deterministic"]
+
+[agent]
+timeout_sec = 600.0
+
+[verifier]
+timeout_sec = 120.0
+
+[environment]
+extensions = ["claude-cli"]
+build_timeout_sec = 600.0
+cpus = 1
+memory_mb = 2048
+storage_mb = 5120
+allow_internet = true

--- a/tasks/maritime/freeboard-length/general-cargo-waterline-governs/tests/fixtures/golden_fail.md
+++ b/tasks/maritime/freeboard-length/general-cargo-waterline-governs/tests/fixtures/golden_fail.md
@@ -1,0 +1,7 @@
+# Golden Fail Output
+
+```json
+{
+  "freeboard_length_LLL_m": 0.0
+}
+```

--- a/tasks/maritime/freeboard-length/general-cargo-waterline-governs/tests/fixtures/golden_pass.md
+++ b/tasks/maritime/freeboard-length/general-cargo-waterline-governs/tests/fixtures/golden_pass.md
@@ -1,0 +1,7 @@
+# Golden Pass Output
+
+```json
+{
+  "freeboard_length_LLL_m": 172.8
+}
+```

--- a/tasks/maritime/freeboard-length/general-cargo-waterline-governs/tests/test.sh
+++ b/tasks/maritime/freeboard-length/general-cargo-waterline-governs/tests/test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# ABOUTME: Thin wrapper that runs the Python verifier.
+# ABOUTME: Ensures reward.json is always written, even on crash.
+
+REWARD_FILE="/logs/verifier/reward.json"
+mkdir -p /logs/verifier
+trap 'if [ ! -f "$REWARD_FILE" ]; then echo "{\"reward\": 0.0}" > "$REWARD_FILE"; fi' EXIT
+python3 /tests/verify.py

--- a/tasks/maritime/freeboard-length/general-cargo-waterline-governs/tests/verify.py
+++ b/tasks/maritime/freeboard-length/general-cargo-waterline-governs/tests/verify.py
@@ -1,0 +1,125 @@
+# ABOUTME: Verifier for general-cargo-waterline-governs Freeboard length calculation task.
+# ABOUTME: Computes ground truth from IACS CSR-H Pt 1 Ch 1 Sec 4 §3.1.2 and scores agent output.
+
+import argparse
+import json
+import math
+import re
+from pathlib import Path
+
+DEFAULT_OUTPUT_FILE = Path("/workspace/output.md")
+DEFAULT_REWARD_FILE = Path("/logs/verifier/reward.json")
+
+# ---- Input parameters (General cargo ship) ----
+TOTAL_LENGTH_ON_85PCT_DEPTH_WATERLINE_M = 180.0
+HAS_RUDDER_STOCK = True
+STEM_TO_RUDDER_STOCK_AXIS_DISTANCE_M = 170.0
+
+# CSR-H 01 JUL 2025 Pt 1 Ch 1 Sec 4 §3.1.2
+FREEBOARD_FRACTION = 0.96
+
+
+def write_reward(reward: float, details: dict[str, float], path: Path) -> None:
+    """Write reward JSON for Harbor, plus per-field details to a sibling file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"reward": round(reward, 2)}))
+    details_path = path.parent / "details.json"
+    details_path.write_text(json.dumps(details))
+
+
+def compute_ground_truth() -> dict[str, float]:
+    """Compute the expected Freeboard length L_LL for this instance.
+
+    Waterline fraction governs: 0.96 x total length (172.8 m) exceeds the measured
+    stem-to-rudder-stock-axis distance (170.0 m), so L_LL is taken as the waterline
+    fraction.
+    """
+    waterline_fraction = FREEBOARD_FRACTION * TOTAL_LENGTH_ON_85PCT_DEPTH_WATERLINE_M
+
+    if HAS_RUDDER_STOCK:
+        freeboard_length_lll = max(waterline_fraction, STEM_TO_RUDDER_STOCK_AXIS_DISTANCE_M)
+    else:
+        freeboard_length_lll = waterline_fraction
+
+    return {
+        "freeboard_length_LLL_m": round(freeboard_length_lll, 2),
+    }
+
+
+def extract_json_block(text: str) -> dict | None:
+    """Extract the last fenced JSON block from Markdown text."""
+    pattern = r"```json\s*\n(.*?)\n\s*```"
+    matches = re.findall(pattern, text, re.DOTALL)
+    if not matches:
+        return None
+    try:
+        return json.loads(matches[-1])
+    except json.JSONDecodeError:
+        return None
+
+
+def score_field(
+    expected: float,
+    actual_val: object,
+    rel_tol: float,
+) -> float:
+    """Score a single field: 1.0 if within tolerance, 0.0 otherwise."""
+    if actual_val is None:
+        return 0.0
+    try:
+        actual_float = float(actual_val)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 0.0
+    if math.isclose(actual_float, expected, rel_tol=rel_tol):
+        return 1.0
+    return 0.0
+
+
+def score_answers(
+    expected: dict[str, float],
+    actual: dict | None,
+) -> tuple[float, dict[str, float]]:
+    """Score each field and return overall reward + per-field details."""
+    tolerances: dict[str, float] = {
+        "freeboard_length_LLL_m": 0.005,
+    }
+
+    if not actual:
+        details = {k: 0.0 for k in expected}
+        return 0.0, details
+
+    details: dict[str, float] = {}
+    for key, exp_val in expected.items():
+        act_val = actual.get(key)
+        tol = tolerances.get(key, 0.03)
+        details[key] = score_field(exp_val, act_val, tol)
+
+    total = len(expected)
+    reward = sum(details.values()) / total if total > 0 else 0.0
+    return round(reward, 2), details
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Verify general-cargo-waterline-governs output")
+    parser.add_argument("--input", type=Path, default=DEFAULT_OUTPUT_FILE)
+    parser.add_argument("--output", type=Path, default=DEFAULT_REWARD_FILE)
+    args = parser.parse_args()
+
+    try:
+        if not args.input.exists() or args.input.stat().st_size == 0:
+            details = {k: 0.0 for k in compute_ground_truth()}
+            write_reward(0.0, details, args.output)
+            return
+
+        text = args.input.read_text()
+        expected = compute_ground_truth()
+        actual = extract_json_block(text)
+        reward, details = score_answers(expected, actual)
+        write_reward(reward, details, args.output)
+    except Exception:
+        details = {k: 0.0 for k in compute_ground_truth()}
+        write_reward(0.0, details, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/maritime/rule-length/bulk-carrier-lower-bound/environment/Dockerfile
+++ b/tasks/maritime/rule-length/bulk-carrier-lower-bound/environment/Dockerfile
@@ -1,0 +1,14 @@
+# ABOUTME: Auto-generated container for maritime — rule-length — bulk-carrier-lower-bound.
+# ABOUTME: Extensions: claude-cli. Regenerate with: aec-bench generate dockerfiles
+FROM --platform=linux/amd64 ubuntu:24.04
+
+RUN apt-get update && apt-get install -y \
+    bc \
+    curl \
+    procps \
+    python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://claude.ai/install.sh | bash
+
+WORKDIR /workspace

--- a/tasks/maritime/rule-length/bulk-carrier-lower-bound/instruction.md
+++ b/tasks/maritime/rule-length/bulk-carrier-lower-bound/instruction.md
@@ -1,0 +1,43 @@
+You are a senior naval architect specializing in classification society rule compliance.
+
+## Problem
+
+Calculate the IACS Rule length L for a Panamax bulk carrier under the Harmonised Common Structural Rules (CSR-H).
+
+## Vessel Details
+
+| Parameter | Value | Unit |
+|-----------|-------|------|
+| Vessel type | Panamax bulk carrier | - |
+| Extreme length on the waterline at T_SC | 229.0 | m |
+| Has rudder stock | true | - |
+| Distance from stem to rudder stock centre, on the waterline at T_SC | 215.0 | m |
+
+## Required
+
+Calculate the following:
+
+1. Rule length L (m)
+
+## Applicable Standards
+
+- IACS Harmonised Common Structural Rules (CSR-H), edition 01 JUL 2025, Pt 1 Ch 1 Sec 4 §3.1.1
+
+## Constraints
+
+- No internet access is available. Work from engineering knowledge only.
+- Quote from Pt 1 Ch 1 Sec 4 §3.1.1: "The Rule length L is the distance, in m, measured on the waterline at the scantling draught T_SC from the forward side of the stem to the centre of the rudder stock. L is to be not less than 96% and need not exceed 97% of the extreme length on the waterline at the scantling draught T_SC. In ships without rudder stock (e.g. ships fitted with azimuth thrusters), the Rule length L is to be taken equal to 97% of the extreme length on the waterline at the scantling draught T_SC. In ships with unusual stem or stern arrangements, the Rule length is considered on a case-by-case basis."
+- The vessel has a rudder stock, so clamp the measured stem-to-rudder-stock distance to the range [0.96 x extreme length, 0.97 x extreme length].
+- The vessel has conventional stem and stern arrangements — the unusual-arrangement case does not apply here.
+
+## Output Format
+
+Show your step-by-step working in Markdown, including formulas and intermediate calculations. At the end of your solution, include a JSON block with your final answer in exactly this format:
+
+```json
+{
+  "rule_length_L_m": <numeric_value>
+}
+```
+
+Write your complete solution to `/workspace/output.md`.

--- a/tasks/maritime/rule-length/bulk-carrier-lower-bound/solution/solve.py
+++ b/tasks/maritime/rule-length/bulk-carrier-lower-bound/solution/solve.py
@@ -1,0 +1,42 @@
+# ABOUTME: Reference solution for bulk-carrier-lower-bound Rule length calculation.
+# ABOUTME: Computes from first principles and writes output.md with JSON block.
+
+import json
+from pathlib import Path
+
+# Compute from first principles
+data = {
+    "vessel_type": "Panamax bulk carrier",
+    "extreme_length_on_waterline_at_TSC_m": 229.0,
+    "has_rudder_stock": True,
+    "stem_to_rudder_stock_distance_m": 215.0,
+    "lower_bound_m": 219.84,
+    "upper_bound_m": 222.13,
+    "rule_length_L_m": 219.84,
+}
+
+output_fields = {
+    "rule_length_L_m": data["rule_length_L_m"],
+}
+
+solution = f"""# Rule Length Calculation — Panamax Bulk Carrier
+
+## Vessel: Panamax bulk carrier (extreme length 229.0 m on waterline at T_SC)
+
+Per IACS CSR-H (01 JUL 2025) Pt 1 Ch 1 Sec 4 §3.1.1, the Rule length L is clamped
+to the range [0.96 x extreme length, 0.97 x extreme length] when a rudder stock
+is fitted.
+
+- Lower bound = 0.96 x 229.0 = 219.84 m
+- Upper bound = 0.97 x 229.0 = 222.13 m
+- Measured stem-to-rudder-stock distance = 215.0 m (below the lower bound)
+
+Since the measured distance (215.0 m) is less than the lower bound (219.84 m),
+the Rule length is clamped up to the lower bound: L = 219.84 m.
+
+```json
+{json.dumps(output_fields, indent=2)}
+```
+"""
+
+Path("/workspace/output.md").write_text(solution)

--- a/tasks/maritime/rule-length/bulk-carrier-lower-bound/task.toml
+++ b/tasks/maritime/rule-length/bulk-carrier-lower-bound/task.toml
@@ -1,0 +1,20 @@
+version = "1.0"
+
+[metadata]
+difficulty = "medium"
+category = "reasoning"
+tags = ["maritime", "csr-h", "iacs", "rule-length", "principal-particulars", "deterministic"]
+
+[agent]
+timeout_sec = 600.0
+
+[verifier]
+timeout_sec = 120.0
+
+[environment]
+extensions = ["claude-cli"]
+build_timeout_sec = 600.0
+cpus = 1
+memory_mb = 2048
+storage_mb = 5120
+allow_internet = true

--- a/tasks/maritime/rule-length/bulk-carrier-lower-bound/tests/fixtures/golden_fail.md
+++ b/tasks/maritime/rule-length/bulk-carrier-lower-bound/tests/fixtures/golden_fail.md
@@ -1,0 +1,7 @@
+# Golden Fail Output
+
+```json
+{
+  "rule_length_L_m": 0.0
+}
+```

--- a/tasks/maritime/rule-length/bulk-carrier-lower-bound/tests/fixtures/golden_pass.md
+++ b/tasks/maritime/rule-length/bulk-carrier-lower-bound/tests/fixtures/golden_pass.md
@@ -1,0 +1,7 @@
+# Golden Pass Output
+
+```json
+{
+  "rule_length_L_m": 219.84
+}
+```

--- a/tasks/maritime/rule-length/bulk-carrier-lower-bound/tests/test.sh
+++ b/tasks/maritime/rule-length/bulk-carrier-lower-bound/tests/test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# ABOUTME: Thin wrapper that runs the Python verifier.
+# ABOUTME: Ensures reward.json is always written, even on crash.
+
+REWARD_FILE="/logs/verifier/reward.json"
+mkdir -p /logs/verifier
+trap 'if [ ! -f "$REWARD_FILE" ]; then echo "{\"reward\": 0.0}" > "$REWARD_FILE"; fi' EXIT
+python3 /tests/verify.py

--- a/tasks/maritime/rule-length/bulk-carrier-lower-bound/tests/verify.py
+++ b/tasks/maritime/rule-length/bulk-carrier-lower-bound/tests/verify.py
@@ -1,0 +1,126 @@
+# ABOUTME: Verifier for bulk-carrier-lower-bound Rule length calculation task.
+# ABOUTME: Computes ground truth from IACS CSR-H Pt 1 Ch 1 Sec 4 §3.1.1 and scores agent output.
+
+import argparse
+import json
+import math
+import re
+from pathlib import Path
+
+DEFAULT_OUTPUT_FILE = Path("/workspace/output.md")
+DEFAULT_REWARD_FILE = Path("/logs/verifier/reward.json")
+
+# ---- Input parameters (Panamax bulk carrier) ----
+EXTREME_LENGTH_ON_WATERLINE_AT_TSC_M = 229.0
+HAS_RUDDER_STOCK = True
+STEM_TO_RUDDER_STOCK_DISTANCE_M = 215.0
+
+# CSR-H 01 JUL 2025 Pt 1 Ch 1 Sec 4 §3.1.1
+LOWER_BOUND_FRACTION = 0.96
+UPPER_BOUND_FRACTION = 0.97
+
+
+def write_reward(reward: float, details: dict[str, float], path: Path) -> None:
+    """Write reward JSON for Harbor, plus per-field details to a sibling file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"reward": round(reward, 2)}))
+    details_path = path.parent / "details.json"
+    details_path.write_text(json.dumps(details))
+
+
+def compute_ground_truth() -> dict[str, float]:
+    """Compute the expected Rule length L for this instance.
+
+    Lower bound bites: the measured stem-to-rudder-stock distance (215.0 m) is
+    below 0.96 x extreme length (219.84 m), so L is clamped up to the lower bound.
+    """
+    lower_bound = LOWER_BOUND_FRACTION * EXTREME_LENGTH_ON_WATERLINE_AT_TSC_M
+    upper_bound = UPPER_BOUND_FRACTION * EXTREME_LENGTH_ON_WATERLINE_AT_TSC_M
+
+    if HAS_RUDDER_STOCK:
+        rule_length_l = min(max(STEM_TO_RUDDER_STOCK_DISTANCE_M, lower_bound), upper_bound)
+    else:
+        rule_length_l = upper_bound
+
+    return {
+        "rule_length_L_m": round(rule_length_l, 3),
+    }
+
+
+def extract_json_block(text: str) -> dict | None:
+    """Extract the last fenced JSON block from Markdown text."""
+    pattern = r"```json\s*\n(.*?)\n\s*```"
+    matches = re.findall(pattern, text, re.DOTALL)
+    if not matches:
+        return None
+    try:
+        return json.loads(matches[-1])
+    except json.JSONDecodeError:
+        return None
+
+
+def score_field(
+    expected: float,
+    actual_val: object,
+    rel_tol: float,
+) -> float:
+    """Score a single field: 1.0 if within tolerance, 0.0 otherwise."""
+    if actual_val is None:
+        return 0.0
+    try:
+        actual_float = float(actual_val)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 0.0
+    if math.isclose(actual_float, expected, rel_tol=rel_tol):
+        return 1.0
+    return 0.0
+
+
+def score_answers(
+    expected: dict[str, float],
+    actual: dict | None,
+) -> tuple[float, dict[str, float]]:
+    """Score each field and return overall reward + per-field details."""
+    tolerances: dict[str, float] = {
+        "rule_length_L_m": 0.005,
+    }
+
+    if not actual:
+        details = {k: 0.0 for k in expected}
+        return 0.0, details
+
+    details: dict[str, float] = {}
+    for key, exp_val in expected.items():
+        act_val = actual.get(key)
+        tol = tolerances.get(key, 0.03)
+        details[key] = score_field(exp_val, act_val, tol)
+
+    total = len(expected)
+    reward = sum(details.values()) / total if total > 0 else 0.0
+    return round(reward, 2), details
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Verify bulk-carrier-lower-bound output")
+    parser.add_argument("--input", type=Path, default=DEFAULT_OUTPUT_FILE)
+    parser.add_argument("--output", type=Path, default=DEFAULT_REWARD_FILE)
+    args = parser.parse_args()
+
+    try:
+        if not args.input.exists() or args.input.stat().st_size == 0:
+            details = {k: 0.0 for k in compute_ground_truth()}
+            write_reward(0.0, details, args.output)
+            return
+
+        text = args.input.read_text()
+        expected = compute_ground_truth()
+        actual = extract_json_block(text)
+        reward, details = score_answers(expected, actual)
+        write_reward(reward, details, args.output)
+    except Exception:
+        details = {k: 0.0 for k in compute_ground_truth()}
+        write_reward(0.0, details, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/maritime/rule-length/bulk-carrier-lower-bound/tests/verify.py
+++ b/tasks/maritime/rule-length/bulk-carrier-lower-bound/tests/verify.py
@@ -43,7 +43,7 @@ def compute_ground_truth() -> dict[str, float]:
         rule_length_l = upper_bound
 
     return {
-        "rule_length_L_m": round(rule_length_l, 3),
+        "rule_length_L_m": round(rule_length_l, 2),
     }
 
 

--- a/tests/contracts/test_discipline_consistency.py
+++ b/tests/contracts/test_discipline_consistency.py
@@ -1,0 +1,50 @@
+# ABOUTME: Guards that the discipline value set stays in sync across all three seams
+# ABOUTME: that currently duplicate it: SeedSource, LibraryEntryBase, and seed_schema.json.
+
+import json
+import typing
+from pathlib import Path
+
+from aec_bench.contracts.library_catalogue import LibraryEntryBase
+from aec_bench.contracts.seed_task import SeedSource
+
+SCHEMA_PATH = Path(__file__).resolve().parents[2] / "seeds" / "seed_schema.json"
+
+
+def _seed_task_disciplines() -> frozenset[str]:
+    annotation = SeedSource.model_fields["discipline"].annotation
+    return frozenset(typing.get_args(annotation))
+
+
+def _library_catalogue_disciplines() -> frozenset[str]:
+    annotation = LibraryEntryBase.model_fields["discipline"].annotation
+    return frozenset(typing.get_args(annotation))
+
+
+def _seed_schema_disciplines() -> frozenset[str]:
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    enum = schema["$defs"]["source"]["properties"]["discipline"]["enum"]
+    return frozenset(enum)
+
+
+def test_discipline_sets_match_across_all_sites() -> None:
+    seed_task = _seed_task_disciplines()
+    library_catalogue = _library_catalogue_disciplines()
+    seed_schema = _seed_schema_disciplines()
+
+    assert seed_task == library_catalogue == seed_schema, (
+        "discipline value sets have drifted apart: "
+        f"seed_task.py={sorted(seed_task)!r}, "
+        f"library_catalogue.py={sorted(library_catalogue)!r}, "
+        f"seed_schema.json={sorted(seed_schema)!r}"
+    )
+
+
+def test_maritime_is_registered_everywhere() -> None:
+    seed_task = _seed_task_disciplines()
+    library_catalogue = _library_catalogue_disciplines()
+    seed_schema = _seed_schema_disciplines()
+
+    assert "maritime" in seed_task, "maritime missing from SeedSource.discipline"
+    assert "maritime" in library_catalogue, "maritime missing from LibraryEntryBase.discipline"
+    assert "maritime" in seed_schema, "maritime missing from seed_schema.json discipline enum"

--- a/tests/templates/test_block_coefficient_engine.py
+++ b/tests/templates/test_block_coefficient_engine.py
@@ -1,0 +1,232 @@
+# ABOUTME: Tests for the IACS CSR-H Block coefficient (C_B) engine compute function.
+# ABOUTME: Validates worked examples across ship types and input validation.
+
+from math import isclose
+from pathlib import Path
+
+import pytest
+
+TEMPLATE_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "aec_bench"
+    / "templates"
+    / "builtin"
+    / "maritime"
+    / "block_coefficient"
+)
+
+
+# --- Block coefficient computation tests ---
+
+
+def test_compute_capesize_bulk_carrier_worked_example() -> None:
+    """Capesize bulk carrier: Delta=180000 t, L=280 m, B=45 m, T_SC=18 m -> C_B=0.77."""
+    from aec_bench.templates.builtin.maritime.block_coefficient.engine import compute
+
+    result = compute(
+        moulded_displacement_t=180000.0,
+        rule_length_L_m=280.0,
+        moulded_breadth_B_m=45.0,
+        scantling_draught_TSC_m=18.0,
+    )
+
+    assert isclose(result["block_coefficient_CB"], 0.77, rel_tol=1e-9)
+
+
+def test_compute_vlcc_tanker_worked_example() -> None:
+    """VLCC tanker: Delta=366000 t, L=330 m, B=60 m, T_SC=22 m -> C_B=0.82."""
+    from aec_bench.templates.builtin.maritime.block_coefficient.engine import compute
+
+    result = compute(
+        moulded_displacement_t=366000.0,
+        rule_length_L_m=330.0,
+        moulded_breadth_B_m=60.0,
+        scantling_draught_TSC_m=22.0,
+    )
+
+    assert isclose(result["block_coefficient_CB"], 0.82, rel_tol=1e-9)
+
+
+def test_compute_container_ship_worked_example() -> None:
+    """Container ship: Delta=125000 t, L=310 m, B=45 m, T_SC=13.5 m -> C_B=0.65 (finer hull)."""
+    from aec_bench.templates.builtin.maritime.block_coefficient.engine import compute
+
+    result = compute(
+        moulded_displacement_t=125000.0,
+        rule_length_L_m=310.0,
+        moulded_breadth_B_m=45.0,
+        scantling_draught_TSC_m=13.5,
+    )
+
+    assert isclose(result["block_coefficient_CB"], 0.65, rel_tol=1e-9)
+
+
+def test_compute_general_cargo_worked_example() -> None:
+    """General cargo ship: Delta=23500 t, L=150 m, B=23 m, T_SC=9 m -> C_B=0.74."""
+    from aec_bench.templates.builtin.maritime.block_coefficient.engine import compute
+
+    result = compute(
+        moulded_displacement_t=23500.0,
+        rule_length_L_m=150.0,
+        moulded_breadth_B_m=23.0,
+        scantling_draught_TSC_m=9.0,
+    )
+
+    assert isclose(result["block_coefficient_CB"], 0.74, rel_tol=1e-9)
+
+
+def test_compute_returns_only_expected_key() -> None:
+    """Output dict has exactly the one scored key."""
+    from aec_bench.templates.builtin.maritime.block_coefficient.engine import compute
+
+    result = compute(
+        moulded_displacement_t=180000.0,
+        rule_length_L_m=280.0,
+        moulded_breadth_B_m=45.0,
+        scantling_draught_TSC_m=18.0,
+    )
+
+    assert set(result.keys()) == {"block_coefficient_CB"}
+
+
+def test_compute_is_pure() -> None:
+    """Same inputs produce identical outputs — function is deterministic and pure."""
+    from aec_bench.templates.builtin.maritime.block_coefficient.engine import compute
+
+    kwargs = {
+        "moulded_displacement_t": 190000.0,
+        "rule_length_L_m": 280.0,
+        "moulded_breadth_B_m": 45.0,
+        "scantling_draught_TSC_m": 18.0,
+    }
+
+    result_a = compute(**kwargs)
+    result_b = compute(**kwargs)
+
+    assert result_a == result_b
+
+
+# --- Validation tests ---
+
+
+def test_compute_rejects_non_positive_moulded_displacement() -> None:
+    """Non-positive moulded displacement raises ValueError."""
+    from aec_bench.templates.builtin.maritime.block_coefficient.engine import compute
+
+    with pytest.raises(ValueError, match="moulded_displacement_t"):
+        compute(
+            moulded_displacement_t=0.0,
+            rule_length_L_m=280.0,
+            moulded_breadth_B_m=45.0,
+            scantling_draught_TSC_m=18.0,
+        )
+
+
+def test_compute_rejects_negative_moulded_displacement() -> None:
+    """Negative moulded displacement raises ValueError."""
+    from aec_bench.templates.builtin.maritime.block_coefficient.engine import compute
+
+    with pytest.raises(ValueError, match="moulded_displacement_t"):
+        compute(
+            moulded_displacement_t=-1000.0,
+            rule_length_L_m=280.0,
+            moulded_breadth_B_m=45.0,
+            scantling_draught_TSC_m=18.0,
+        )
+
+
+def test_compute_rejects_non_positive_rule_length() -> None:
+    """Non-positive Rule length raises ValueError."""
+    from aec_bench.templates.builtin.maritime.block_coefficient.engine import compute
+
+    with pytest.raises(ValueError, match="rule_length_L_m"):
+        compute(
+            moulded_displacement_t=180000.0,
+            rule_length_L_m=0.0,
+            moulded_breadth_B_m=45.0,
+            scantling_draught_TSC_m=18.0,
+        )
+
+
+def test_compute_rejects_negative_rule_length() -> None:
+    """Negative Rule length raises ValueError."""
+    from aec_bench.templates.builtin.maritime.block_coefficient.engine import compute
+
+    with pytest.raises(ValueError, match="rule_length_L_m"):
+        compute(
+            moulded_displacement_t=180000.0,
+            rule_length_L_m=-280.0,
+            moulded_breadth_B_m=45.0,
+            scantling_draught_TSC_m=18.0,
+        )
+
+
+def test_compute_rejects_non_positive_moulded_breadth() -> None:
+    """Non-positive moulded breadth raises ValueError."""
+    from aec_bench.templates.builtin.maritime.block_coefficient.engine import compute
+
+    with pytest.raises(ValueError, match="moulded_breadth_B_m"):
+        compute(
+            moulded_displacement_t=180000.0,
+            rule_length_L_m=280.0,
+            moulded_breadth_B_m=0.0,
+            scantling_draught_TSC_m=18.0,
+        )
+
+
+def test_compute_rejects_negative_moulded_breadth() -> None:
+    """Negative moulded breadth raises ValueError."""
+    from aec_bench.templates.builtin.maritime.block_coefficient.engine import compute
+
+    with pytest.raises(ValueError, match="moulded_breadth_B_m"):
+        compute(
+            moulded_displacement_t=180000.0,
+            rule_length_L_m=280.0,
+            moulded_breadth_B_m=-45.0,
+            scantling_draught_TSC_m=18.0,
+        )
+
+
+def test_compute_rejects_non_positive_scantling_draught() -> None:
+    """Non-positive scantling draught raises ValueError."""
+    from aec_bench.templates.builtin.maritime.block_coefficient.engine import compute
+
+    with pytest.raises(ValueError, match="scantling_draught_TSC_m"):
+        compute(
+            moulded_displacement_t=180000.0,
+            rule_length_L_m=280.0,
+            moulded_breadth_B_m=45.0,
+            scantling_draught_TSC_m=0.0,
+        )
+
+
+def test_compute_rejects_negative_scantling_draught() -> None:
+    """Negative scantling draught raises ValueError."""
+    from aec_bench.templates.builtin.maritime.block_coefficient.engine import compute
+
+    with pytest.raises(ValueError, match="scantling_draught_TSC_m"):
+        compute(
+            moulded_displacement_t=180000.0,
+            rule_length_L_m=280.0,
+            moulded_breadth_B_m=45.0,
+            scantling_draught_TSC_m=-18.0,
+        )
+
+
+# --- params.toml loading test ---
+
+
+def test_params_toml_loads_into_template_config() -> None:
+    """params.toml is loadable by the registry and has correct structure."""
+    from aec_bench.templates.registry import load_template
+
+    config, _ = load_template(TEMPLATE_DIR)
+    assert config.meta.name == "block-coefficient"
+    assert config.meta.discipline == "maritime"
+    assert "moulded_displacement_t" in config.params
+    assert "block_coefficient_CB" in config.outputs
+    assert len(config.difficulty) >= 2
+    for preset in config.difficulty.values():
+        for arch_name in preset.archetypes:
+            assert arch_name in config.archetypes

--- a/tests/templates/test_freeboard_length_engine.py
+++ b/tests/templates/test_freeboard_length_engine.py
@@ -1,0 +1,210 @@
+# ABOUTME: Tests for the IACS CSR-H Freeboard length (L_LL) engine compute function.
+# ABOUTME: Validates the greater-of regime, the no-rudder-stock case, and input validation.
+
+from math import isclose
+from pathlib import Path
+
+import pytest
+
+TEMPLATE_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "aec_bench"
+    / "templates"
+    / "builtin"
+    / "maritime"
+    / "freeboard_length"
+)
+
+
+# --- Freeboard length computation tests ---
+
+
+def test_compute_stem_to_rudder_stock_distance_governs() -> None:
+    """Measured stem-to-rudder-stock-axis distance exceeds 96% of the waterline length,
+    so it governs the greater-of."""
+    from aec_bench.templates.builtin.maritime.freeboard_length.engine import compute
+
+    # total = 225.0 -> 0.96 x total = 216.0; measured = 220.0 exceeds it.
+    result = compute(
+        total_length_on_85pct_depth_waterline_m=225.0,
+        has_rudder_stock=True,
+        stem_to_rudder_stock_axis_distance_m=220.0,
+    )
+
+    assert isclose(result["freeboard_length_LLL_m"], 220.0, rel_tol=1e-9)
+
+
+def test_compute_waterline_fraction_governs() -> None:
+    """Measured stem-to-rudder-stock-axis distance is below 96% of the waterline length,
+    so 96% of the waterline length governs instead (the greater-of flips)."""
+    from aec_bench.templates.builtin.maritime.freeboard_length.engine import compute
+
+    # total = 180.0 -> 0.96 x total = 172.8; measured = 170.0 is below it.
+    result = compute(
+        total_length_on_85pct_depth_waterline_m=180.0,
+        has_rudder_stock=True,
+        stem_to_rudder_stock_axis_distance_m=170.0,
+    )
+
+    assert isclose(result["freeboard_length_LLL_m"], 172.8, rel_tol=1e-9)
+
+
+def test_compute_no_rudder_stock_returns_96_percent() -> None:
+    """Ships without a rudder stock (e.g. azimuth thrusters) take L_LL = 0.96 x total length."""
+    from aec_bench.templates.builtin.maritime.freeboard_length.engine import compute
+
+    result = compute(
+        total_length_on_85pct_depth_waterline_m=200.0,
+        has_rudder_stock=False,
+    )
+
+    assert isclose(result["freeboard_length_LLL_m"], 192.0, rel_tol=1e-9)
+
+
+def test_compute_accepts_string_false_for_has_rudder_stock() -> None:
+    """The generator passes has_rudder_stock as the string 'false' (params.toml enum values
+    are ["true", "false"] since bool is not a valid param type); this must behave identically
+    to the Python bool False."""
+    from aec_bench.templates.builtin.maritime.freeboard_length.engine import compute
+
+    result = compute(
+        total_length_on_85pct_depth_waterline_m=200.0,
+        has_rudder_stock="false",
+    )
+
+    assert isclose(result["freeboard_length_LLL_m"], 192.0, rel_tol=1e-9)
+
+
+def test_compute_accepts_string_true_for_has_rudder_stock() -> None:
+    """The generator passes has_rudder_stock as the string 'true'; the measured distance
+    below the waterline fraction must still let the waterline fraction govern."""
+    from aec_bench.templates.builtin.maritime.freeboard_length.engine import compute
+
+    result = compute(
+        total_length_on_85pct_depth_waterline_m=180.0,
+        has_rudder_stock="true",
+        stem_to_rudder_stock_axis_distance_m=170.0,
+    )
+
+    assert isclose(result["freeboard_length_LLL_m"], 172.8, rel_tol=1e-9)
+
+
+def test_compute_rejects_invalid_has_rudder_stock_string() -> None:
+    """A has_rudder_stock string other than 'true'/'false' raises ValueError."""
+    from aec_bench.templates.builtin.maritime.freeboard_length.engine import compute
+
+    with pytest.raises(ValueError, match="has_rudder_stock"):
+        compute(
+            total_length_on_85pct_depth_waterline_m=200.0,
+            has_rudder_stock="maybe",
+        )
+
+
+def test_compute_returns_only_expected_key() -> None:
+    """Output dict has exactly the one scored key."""
+    from aec_bench.templates.builtin.maritime.freeboard_length.engine import compute
+
+    result = compute(
+        total_length_on_85pct_depth_waterline_m=200.0,
+        has_rudder_stock=True,
+        stem_to_rudder_stock_axis_distance_m=195.0,
+    )
+
+    assert set(result.keys()) == {"freeboard_length_LLL_m"}
+
+
+def test_compute_is_pure() -> None:
+    """Same inputs produce identical outputs — function is deterministic and pure."""
+    from aec_bench.templates.builtin.maritime.freeboard_length.engine import compute
+
+    kwargs = {
+        "total_length_on_85pct_depth_waterline_m": 210.0,
+        "has_rudder_stock": True,
+        "stem_to_rudder_stock_axis_distance_m": 205.0,
+    }
+
+    result_a = compute(**kwargs)
+    result_b = compute(**kwargs)
+
+    assert result_a == result_b
+
+
+# --- Validation tests ---
+
+
+def test_compute_rejects_non_positive_total_length() -> None:
+    """Non-positive total length raises ValueError."""
+    from aec_bench.templates.builtin.maritime.freeboard_length.engine import compute
+
+    with pytest.raises(ValueError, match="total_length_on_85pct_depth_waterline_m"):
+        compute(
+            total_length_on_85pct_depth_waterline_m=0.0,
+            has_rudder_stock=True,
+            stem_to_rudder_stock_axis_distance_m=100.0,
+        )
+
+
+def test_compute_rejects_negative_total_length() -> None:
+    """Negative total length raises ValueError."""
+    from aec_bench.templates.builtin.maritime.freeboard_length.engine import compute
+
+    with pytest.raises(ValueError, match="total_length_on_85pct_depth_waterline_m"):
+        compute(
+            total_length_on_85pct_depth_waterline_m=-50.0,
+            has_rudder_stock=True,
+            stem_to_rudder_stock_axis_distance_m=40.0,
+        )
+
+
+def test_compute_rejects_non_positive_stem_to_rudder_stock_axis_distance() -> None:
+    """Non-positive measured distance raises ValueError when has_rudder_stock is True."""
+    from aec_bench.templates.builtin.maritime.freeboard_length.engine import compute
+
+    with pytest.raises(ValueError, match="stem_to_rudder_stock_axis_distance_m"):
+        compute(
+            total_length_on_85pct_depth_waterline_m=200.0,
+            has_rudder_stock=True,
+            stem_to_rudder_stock_axis_distance_m=0.0,
+        )
+
+
+def test_compute_rejects_measured_distance_exceeding_total_length() -> None:
+    """Measured distance greater than the total length raises ValueError."""
+    from aec_bench.templates.builtin.maritime.freeboard_length.engine import compute
+
+    with pytest.raises(ValueError, match="stem_to_rudder_stock_axis_distance_m"):
+        compute(
+            total_length_on_85pct_depth_waterline_m=200.0,
+            has_rudder_stock=True,
+            stem_to_rudder_stock_axis_distance_m=205.0,
+        )
+
+
+def test_compute_rejects_missing_stem_to_rudder_stock_axis_distance_when_has_rudder_stock() -> None:
+    """Omitting the measured distance when has_rudder_stock is True raises ValueError."""
+    from aec_bench.templates.builtin.maritime.freeboard_length.engine import compute
+
+    with pytest.raises(ValueError, match="stem_to_rudder_stock_axis_distance_m"):
+        compute(
+            total_length_on_85pct_depth_waterline_m=200.0,
+            has_rudder_stock=True,
+        )
+
+
+# --- params.toml loading test ---
+
+
+def test_params_toml_loads_into_template_config() -> None:
+    """params.toml is loadable by the registry and has correct structure."""
+    from aec_bench.templates.registry import load_template
+
+    config, _ = load_template(TEMPLATE_DIR)
+    assert config.meta.name == "freeboard-length"
+    assert config.meta.discipline == "maritime"
+    assert "total_length_on_85pct_depth_waterline_m" in config.params
+    assert "freeboard_length_LLL_m" in config.outputs
+    assert len(config.difficulty) >= 2
+    for preset in config.difficulty.values():
+        for arch_name in preset.archetypes:
+            assert arch_name in config.archetypes

--- a/tests/templates/test_freeboard_length_engine.py
+++ b/tests/templates/test_freeboard_length_engine.py
@@ -118,14 +118,16 @@ def test_compute_is_pure() -> None:
     """Same inputs produce identical outputs — function is deterministic and pure."""
     from aec_bench.templates.builtin.maritime.freeboard_length.engine import compute
 
-    kwargs = {
-        "total_length_on_85pct_depth_waterline_m": 210.0,
-        "has_rudder_stock": True,
-        "stem_to_rudder_stock_axis_distance_m": 205.0,
-    }
-
-    result_a = compute(**kwargs)
-    result_b = compute(**kwargs)
+    result_a = compute(
+        total_length_on_85pct_depth_waterline_m=210.0,
+        has_rudder_stock=True,
+        stem_to_rudder_stock_axis_distance_m=205.0,
+    )
+    result_b = compute(
+        total_length_on_85pct_depth_waterline_m=210.0,
+        has_rudder_stock=True,
+        stem_to_rudder_stock_axis_distance_m=205.0,
+    )
 
     assert result_a == result_b
 

--- a/tests/templates/test_rule_length_engine.py
+++ b/tests/templates/test_rule_length_engine.py
@@ -124,14 +124,16 @@ def test_compute_is_pure() -> None:
     """Same inputs produce identical outputs — function is deterministic and pure."""
     from aec_bench.templates.builtin.maritime.rule_length.engine import compute
 
-    kwargs = {
-        "extreme_length_on_waterline_at_TSC_m": 210.0,
-        "has_rudder_stock": True,
-        "stem_to_rudder_stock_distance_m": 195.0,
-    }
-
-    result_a = compute(**kwargs)
-    result_b = compute(**kwargs)
+    result_a = compute(
+        extreme_length_on_waterline_at_TSC_m=210.0,
+        has_rudder_stock=True,
+        stem_to_rudder_stock_distance_m=195.0,
+    )
+    result_b = compute(
+        extreme_length_on_waterline_at_TSC_m=210.0,
+        has_rudder_stock=True,
+        stem_to_rudder_stock_distance_m=195.0,
+    )
 
     assert result_a == result_b
 

--- a/tests/templates/test_rule_length_engine.py
+++ b/tests/templates/test_rule_length_engine.py
@@ -1,0 +1,177 @@
+# ABOUTME: Tests for the IACS CSR-H Rule length (L) engine compute function.
+# ABOUTME: Validates the 96%/97% clamp regimes, the no-rudder-stock case, and input validation.
+
+from math import isclose
+from pathlib import Path
+
+import pytest
+
+TEMPLATE_DIR = (
+    Path(__file__).resolve().parents[2] / "src" / "aec_bench" / "templates" / "builtin" / "maritime" / "rule_length"
+)
+
+
+# --- Rule length computation tests ---
+
+
+def test_compute_measured_distance_between_bounds_returns_measured() -> None:
+    """Measured distance within [0.96L, 0.97L] is used as-is (no clamp applied)."""
+    from aec_bench.templates.builtin.maritime.rule_length.engine import compute
+
+    # extreme = 200 m -> lower = 192.0, upper = 194.0; measured = 193.0 is inside.
+    result = compute(
+        extreme_length_on_waterline_at_TSC_m=200.0,
+        has_rudder_stock=True,
+        stem_to_rudder_stock_distance_m=193.0,
+    )
+
+    assert isclose(result["rule_length_L_m"], 193.0, rel_tol=1e-9)
+
+
+def test_compute_measured_distance_below_lower_bound_clamps_to_96_percent() -> None:
+    """Measured distance below 0.96 x extreme length is clamped up to the lower bound."""
+    from aec_bench.templates.builtin.maritime.rule_length.engine import compute
+
+    # extreme = 200 m -> lower = 192.0; measured = 180.0 is below lower bound.
+    result = compute(
+        extreme_length_on_waterline_at_TSC_m=200.0,
+        has_rudder_stock=True,
+        stem_to_rudder_stock_distance_m=180.0,
+    )
+
+    assert isclose(result["rule_length_L_m"], 192.0, rel_tol=1e-9)
+
+
+def test_compute_measured_distance_above_upper_bound_clamps_to_97_percent() -> None:
+    """Measured distance above 0.97 x extreme length is clamped down to the upper bound."""
+    from aec_bench.templates.builtin.maritime.rule_length.engine import compute
+
+    # extreme = 200 m -> upper = 194.0; measured = 199.0 exceeds upper bound.
+    result = compute(
+        extreme_length_on_waterline_at_TSC_m=200.0,
+        has_rudder_stock=True,
+        stem_to_rudder_stock_distance_m=199.0,
+    )
+
+    assert isclose(result["rule_length_L_m"], 194.0, rel_tol=1e-9)
+
+
+def test_compute_no_rudder_stock_returns_97_percent() -> None:
+    """Ships without a rudder stock (e.g. azimuth thrusters) take L = 0.97 x extreme length."""
+    from aec_bench.templates.builtin.maritime.rule_length.engine import compute
+
+    result = compute(
+        extreme_length_on_waterline_at_TSC_m=150.0,
+        has_rudder_stock=False,
+    )
+
+    assert isclose(result["rule_length_L_m"], 145.5, rel_tol=1e-9)
+
+
+def test_compute_returns_only_expected_key() -> None:
+    """Output dict has exactly the one scored key."""
+    from aec_bench.templates.builtin.maritime.rule_length.engine import compute
+
+    result = compute(
+        extreme_length_on_waterline_at_TSC_m=200.0,
+        has_rudder_stock=True,
+        stem_to_rudder_stock_distance_m=193.0,
+    )
+
+    assert set(result.keys()) == {"rule_length_L_m"}
+
+
+def test_compute_is_pure() -> None:
+    """Same inputs produce identical outputs — function is deterministic and pure."""
+    from aec_bench.templates.builtin.maritime.rule_length.engine import compute
+
+    kwargs = {
+        "extreme_length_on_waterline_at_TSC_m": 210.0,
+        "has_rudder_stock": True,
+        "stem_to_rudder_stock_distance_m": 195.0,
+    }
+
+    result_a = compute(**kwargs)
+    result_b = compute(**kwargs)
+
+    assert result_a == result_b
+
+
+# --- Validation tests ---
+
+
+def test_compute_rejects_non_positive_extreme_length() -> None:
+    """Non-positive extreme length raises ValueError."""
+    from aec_bench.templates.builtin.maritime.rule_length.engine import compute
+
+    with pytest.raises(ValueError, match="extreme_length_on_waterline_at_TSC_m"):
+        compute(
+            extreme_length_on_waterline_at_TSC_m=0.0,
+            has_rudder_stock=True,
+            stem_to_rudder_stock_distance_m=100.0,
+        )
+
+
+def test_compute_rejects_negative_extreme_length() -> None:
+    """Negative extreme length raises ValueError."""
+    from aec_bench.templates.builtin.maritime.rule_length.engine import compute
+
+    with pytest.raises(ValueError, match="extreme_length_on_waterline_at_TSC_m"):
+        compute(
+            extreme_length_on_waterline_at_TSC_m=-50.0,
+            has_rudder_stock=True,
+            stem_to_rudder_stock_distance_m=40.0,
+        )
+
+
+def test_compute_rejects_non_positive_stem_to_rudder_stock_distance() -> None:
+    """Non-positive measured distance raises ValueError when has_rudder_stock is True."""
+    from aec_bench.templates.builtin.maritime.rule_length.engine import compute
+
+    with pytest.raises(ValueError, match="stem_to_rudder_stock_distance_m"):
+        compute(
+            extreme_length_on_waterline_at_TSC_m=200.0,
+            has_rudder_stock=True,
+            stem_to_rudder_stock_distance_m=0.0,
+        )
+
+
+def test_compute_rejects_measured_distance_exceeding_extreme_length() -> None:
+    """Measured distance greater than the extreme length raises ValueError."""
+    from aec_bench.templates.builtin.maritime.rule_length.engine import compute
+
+    with pytest.raises(ValueError, match="stem_to_rudder_stock_distance_m"):
+        compute(
+            extreme_length_on_waterline_at_TSC_m=200.0,
+            has_rudder_stock=True,
+            stem_to_rudder_stock_distance_m=205.0,
+        )
+
+
+def test_compute_rejects_missing_stem_to_rudder_stock_distance_when_has_rudder_stock() -> None:
+    """Omitting the measured distance when has_rudder_stock is True raises ValueError."""
+    from aec_bench.templates.builtin.maritime.rule_length.engine import compute
+
+    with pytest.raises(ValueError, match="stem_to_rudder_stock_distance_m"):
+        compute(
+            extreme_length_on_waterline_at_TSC_m=200.0,
+            has_rudder_stock=True,
+        )
+
+
+# --- params.toml loading test ---
+
+
+def test_params_toml_loads_into_template_config() -> None:
+    """params.toml is loadable by the registry and has correct structure."""
+    from aec_bench.templates.registry import load_template
+
+    config, _ = load_template(TEMPLATE_DIR)
+    assert config.meta.name == "rule-length"
+    assert config.meta.discipline == "maritime"
+    assert "extreme_length_on_waterline_at_TSC_m" in config.params
+    assert "rule_length_L_m" in config.outputs
+    assert len(config.difficulty) >= 2
+    for preset in config.difficulty.values():
+        for arch_name in preset.archetypes:
+            assert arch_name in config.archetypes

--- a/tests/templates/test_rule_length_engine.py
+++ b/tests/templates/test_rule_length_engine.py
@@ -68,6 +68,45 @@ def test_compute_no_rudder_stock_returns_97_percent() -> None:
     assert isclose(result["rule_length_L_m"], 145.5, rel_tol=1e-9)
 
 
+def test_compute_accepts_string_false_for_has_rudder_stock() -> None:
+    """The generator passes has_rudder_stock as the string 'false' (params.toml enum values
+    are ["true", "false"] since bool is not a valid param type); this must behave identically
+    to the Python bool False."""
+    from aec_bench.templates.builtin.maritime.rule_length.engine import compute
+
+    result = compute(
+        extreme_length_on_waterline_at_TSC_m=200.0,
+        has_rudder_stock="false",
+    )
+
+    assert isclose(result["rule_length_L_m"], 194.0, rel_tol=1e-9)
+
+
+def test_compute_accepts_string_true_for_has_rudder_stock() -> None:
+    """The generator passes has_rudder_stock as the string 'true'; the measured distance
+    above the upper bound must still clamp down to 0.97 x extreme length."""
+    from aec_bench.templates.builtin.maritime.rule_length.engine import compute
+
+    result = compute(
+        extreme_length_on_waterline_at_TSC_m=200.0,
+        has_rudder_stock="true",
+        stem_to_rudder_stock_distance_m=199.0,
+    )
+
+    assert isclose(result["rule_length_L_m"], 194.0, rel_tol=1e-9)
+
+
+def test_compute_rejects_invalid_has_rudder_stock_string() -> None:
+    """A has_rudder_stock string other than 'true'/'false' raises ValueError."""
+    from aec_bench.templates.builtin.maritime.rule_length.engine import compute
+
+    with pytest.raises(ValueError, match="has_rudder_stock"):
+        compute(
+            extreme_length_on_waterline_at_TSC_m=200.0,
+            has_rudder_stock="maybe",
+        )
+
+
 def test_compute_returns_only_expected_key() -> None:
     """Output dict has exactly the one scored key."""
     from aec_bench.templates.builtin.maritime.rule_length.engine import compute


### PR DESCRIPTION
## Summary

Adds a new **`maritime`** engineering discipline and its first tasks: the computable **principal-particulars** quantities of the IACS Harmonised Common Structural Rules, each sourced verbatim from **CSR-H (01 JUL 2025), Part 1, Chapter 1, Section 4**.

Maritime classification calculations are a strong fit for aec-bench's feasibility criteria (closed-form, deterministic, single numeric output, standards-anchored), and there was previously no marine/maritime discipline.

## What's included

| Task | Clause | Formula |
|---|---|---|
| **Rule length L** | §3.1.1 | `min(max(measured, 0.96·L_ext), 0.97·L_ext)`; `0.97·L_ext` if no rudder stock |
| **Freeboard length L_LL** | §3.1.2 | `max(0.96·total, stem)` with rudder stock; `0.96·total` without |
| **Block coefficient C_B** | §3.1.8 | `Δ / (1.025 · L · B · T_SC)` |

Plus:
- **Discipline registration** across the three contract sites (`SeedSource`/`LibraryEntryBase` Literals + `seed_schema.json` enum), `KNOWN_DOMAINS`, the TUI discipline cycle, and skill docs — with an **introspection guard test** (`tests/contracts/test_discipline_consistency.py`) that fails if those sites ever drift. Also re-adds the erroneously-missing `ground` to `KNOWN_DOMAINS`.
- Each task ships a template (`engine.py`/`params.toml`/`instruction.md`), an expert **seed** (`seeds/maritime/...`), a generated **instance** with a self-contained verifier + golden pass/fail fixtures, and **engine unit tests**.
- **`docs/maritime-contributing.md`** — a contribution guide codifying the rules-compliant maritime authoring practice.

## Sourcing & quality

- **Every coefficient is transcribed verbatim from the CSR document with the edition pinned and the clause cited** — no values reconstructed from general knowledge. (The `0.96`/`0.97`, `1.025`, etc. are read directly from §3.1.1/§3.1.2/§3.1.8.)
- Terminology follows the rulebook (capital `L`, `L_LL`, `C_B`, `Δ`, `B`, `T_SC`; output keys embed the symbol).
- All engines: pure, stdlib-only, `_validate_inputs` raising `ValueError`, outputs rounded to 2 dp per `template-contract.md`.
- **Generation verified for real** (not just `--dry-run`): all three templates generate cleanly across seeds 1–12 (36/36 runs succeed). A pre-existing `rule_length` generation crash (`stem > extreme` for ~half of seeds) is fixed here by scoping archetype ranges.
- Verifiers discriminate (golden_pass → 1.0, golden_fail → 0.0); seeds validate against `seed_schema.json`; `ruff`/`mypy` clean on new files.
- All tasks `lifecycle = proposed`.

## Scope notes

- The other §3.1.3–3.1.7 quantities (B, D, draughts, Δ, V) are **definitions of measured/given inputs**, not closed-form tasks, so they are inputs here rather than separate entries.
- Follow-ups noted in-code: a canonical `Discipline` enum to remove the discipline-literal duplication, and `KNOWN_DOMAINS` cleanup of stale `architectural`/`plumbing`.

## Note on issue links

No `Closes #` references: this was authored by an external contributor without triage access to file labeled `ticket` issues on this repo. Task specs were recorded locally and are reflected in the commit messages and `docs/maritime-contributing.md`.
