### PR TITLE
Add lifecycle semantic transition metrics

### DIFF
--- a/docs/meta-harness-guide.md
+++ b/docs/meta-harness-guide.md
@@ -29,6 +29,7 @@ The important invariant is that agents propose and harness-owned code applies or
 - `aec_bench.meta_harness.model_runner` parses model endpoints and runs structured PydanticAI intake, world, review, and operation stages.
 - `aec_bench.meta_harness.evidence_lifecycle` owns staged evidence release, immutable checkpoint submissions, revisits, branches, and durable attempt lineage.
 - `aec_bench.meta_harness.evidence_lifecycle_local` runs one lifecycle through either a persistent model conversation or fresh checkpoint contexts.
+- `aec_bench.meta_harness.evidence_lifecycle_metrics` compares task-extracted semantic atoms across checkpoints without changing verifier reward.
 - `aec_bench.meta_harness.evidence_lifecycle_experiment` binds code, package, model configuration, prompts, tools, trajectories, metrics, and verification into an indexed experiment record.
 
 ## Evidence Lifecycles
@@ -59,12 +60,31 @@ aec-bench meta-harness lifecycle-run-local \
 Every local invocation writes root-level latest views plus an immutable experiment record:
 
 - `experiment-manifest.json` binds the repository commit and dirty digest, package and verifier hashes, exact model/configuration records, prompts, tool schema, visibility, and output hashes;
-- `metrics.json` normalizes checkpoint and whole-run timing, requests, tool calls, reads, revisits, retries, failures, tokens, and estimated cost;
+- `metrics.json` normalizes checkpoint and whole-run timing, requests, tool calls, reads, revisits, retries, failures, tokens, and estimated cost, and carries semantic-transition diagnostics when the task verifier provides them;
 - `verification.json` preserves the typed lifecycle verifier result;
 - `experiments/<experiment-id>/` preserves the canonical record for each failed, interrupted, resumed, or completed invocation;
 - `experiment-index.jsonl` is append-only and points to each canonical manifest by hash.
 
 This apparatus is an adaptation microscope for fixed-model behavior under staged evidence. Checkpoint progression is ordered and submission-gated; semantic verification occurs over the accumulated lifecycle. It does **not** yet provide action-conditioned evidence transitions, cross-run learner updates, demonstrated transfer, or continual learning.
+
+### Semantic transition diagnostics
+
+Semantic diagnostics are deliberately separate from verifier gates and reward. The task-specific verifier projects each cumulative submission into stable semantic atom IDs; the shared metric function compares those atoms across the declared checkpoint order. Equivalent reference lists are canonicalized as sets before comparison.
+
+The output reports explicit support counts and rates:
+
+- `initial.accuracy` is the fraction of initial semantic atoms that match the expected initial state;
+- `acquisition` is expected changes that move from the correct prior value to the correct new value, divided by all expected changes;
+- `update_precision` is actual changes that end in the expected current value, divided by all actual changes;
+- `update_recall` is expected changes whose current value is correct, divided by all expected changes;
+- `retention` is previously correct, expected-stable atoms that remain correct, divided by all previously correct, expected-stable atoms;
+- `interference` is the complementary count and rate of those prior-correct stable atoms that become incorrect.
+
+An atom that anticipates a future value can receive current-state correctness later, but it does not receive acquisition credit because its prior value was already wrong. A correction to an earlier model mistake can count as a precise update, but it is not evidence-driven acquisition. Rates are `null` when their denominator is zero; zero opportunity is never reported as perfect performance.
+
+SSC-03 currently extracts matrix states, run/report/claim transitions, readiness, stable finding and request identity/state, and accepted-decision status/supersession lineage. Free-form prose and evidence-reference fields with multiple verifier-approved formulations are excluded from exact atom comparison; their existing verifier gates remain authoritative.
+
+These diagnostics are persisted in `verification.json` and copied to `metrics.json` as `semantic_transition`. They are hash-bound by the existing experiment manifest. They do not alter checkpoint progression, model-visible feedback, gate scores, pass/fail, or reward.
 
 ## CLI
 

--- a/src/aec_bench/meta_harness/evidence_lifecycle.py
+++ b/src/aec_bench/meta_harness/evidence_lifecycle.py
@@ -553,7 +553,8 @@ def validate_lifecycle_verification(
         if isinstance(payload, LifecycleVerificationResult)
         else LifecycleVerificationResult.model_validate(payload)
     )
-    return result.model_dump(mode="json")
+    excluded = {"semantic_metrics"} if result.semantic_metrics is None else None
+    return result.model_dump(mode="json", exclude=excluded)
 
 
 def _initialize_state(

--- a/src/aec_bench/meta_harness/evidence_lifecycle_experiment.py
+++ b/src/aec_bench/meta_harness/evidence_lifecycle_experiment.py
@@ -18,6 +18,7 @@ from pydantic import Field, NonNegativeFloat, NonNegativeInt
 from aec_bench.contracts.pricing import estimate_cost_usd
 from aec_bench.contracts.trajectory import read_trajectory
 from aec_bench.contracts.validators import NonEmptyStr, StrictModel
+from aec_bench.meta_harness.evidence_lifecycle_metrics import LifecycleSemanticMetrics
 from aec_bench.meta_harness.ledger import read_ledger
 
 
@@ -37,6 +38,7 @@ class LifecycleExperimentMetrics(StrictModel):
     estimated_cost_usd: NonNegativeFloat | None = None
     checkpoint_seconds: dict[str, NonNegativeFloat] = Field(default_factory=dict)
     whole_run_seconds: NonNegativeFloat | None = None
+    semantic_transition: LifecycleSemanticMetrics | None = None
 
 
 class LifecycleExperimentManifest(StrictModel):
@@ -72,8 +74,11 @@ def record_lifecycle_experiment(
     selected_index = index_path or run.parent / "experiment-index.jsonl"
     _write_json(verification_path, verification)
 
-    metrics = _build_metrics(run, agent)
-    _write_json(metrics_path, metrics.model_dump(mode="json"))
+    metrics = _build_metrics(run, agent, verification)
+    metrics_payload = metrics.model_dump(mode="json")
+    if metrics.semantic_transition is None:
+        metrics_payload.pop("semantic_transition")
+    _write_json(metrics_path, metrics_payload)
     trajectories = sorted(run.glob("**/trajectory.jsonl"))
     prompts = _interaction_prompts(trajectories)
     repository = _repository_provenance(repository_dir or Path.cwd())
@@ -129,7 +134,7 @@ def record_lifecycle_experiment(
     canonical_metrics = experiment_dir / "metrics.json"
     canonical_manifest = experiment_dir / "experiment-manifest.json"
     _write_json(canonical_verification, verification)
-    _write_json(canonical_metrics, metrics.model_dump(mode="json"))
+    _write_json(canonical_metrics, metrics_payload)
     _write_json(canonical_manifest, manifest.model_dump(mode="json"))
     manifest_sha256 = _sha256(canonical_manifest)
     index_entry = {
@@ -156,7 +161,11 @@ def record_lifecycle_experiment(
     }
 
 
-def _build_metrics(run_dir: Path, agent: dict[str, Any]) -> LifecycleExperimentMetrics:
+def _build_metrics(
+    run_dir: Path,
+    agent: dict[str, Any],
+    verification: dict[str, Any],
+) -> LifecycleExperimentMetrics:
     trajectories = sorted(run_dir.glob("**/trajectory.jsonl"))
     entries = [entry for path in trajectories for entry in read_trajectory(path)]
     requests = sum(len({entry.step for entry in read_trajectory(path) if entry.step > 0}) for path in trajectories)
@@ -176,6 +185,8 @@ def _build_metrics(run_dir: Path, agent: dict[str, Any]) -> LifecycleExperimentM
         cache_read_tokens=int(totals["cache_read_tokens"]),
         cache_write_tokens=int(totals["cache_write_tokens"]),
     )
+    semantic_payload = verification.get("semantic_metrics")
+    semantic = LifecycleSemanticMetrics.model_validate(semantic_payload) if semantic_payload is not None else None
     return LifecycleExperimentMetrics(
         checkpoint_count=sum(checkpoint["status"] == "submitted" for checkpoint in state["checkpoint_runs"]),
         requests=requests,
@@ -191,6 +202,7 @@ def _build_metrics(run_dir: Path, agent: dict[str, Any]) -> LifecycleExperimentM
         estimated_cost_usd=cost,
         checkpoint_seconds=timing["checkpoint_seconds"],
         whole_run_seconds=timing["whole_run_seconds"],
+        semantic_transition=semantic,
     )
 
 

--- a/src/aec_bench/meta_harness/evidence_lifecycle_metrics.py
+++ b/src/aec_bench/meta_harness/evidence_lifecycle_metrics.py
@@ -1,0 +1,308 @@
+# ABOUTME: Computes reward-independent semantic transition diagnostics for evidence lifecycles.
+# ABOUTME: Separates expected state acquisition and retention from verifier gates and operational efficiency.
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any, Literal
+
+from pydantic import Field, model_validator
+
+from aec_bench.contracts.validators import NonEmptyStr, StrictModel
+
+_MISSING = object()
+
+
+class LifecycleSemanticStateAccuracy(StrictModel):
+    correct_atoms: int = Field(ge=0)
+    total_atoms: int = Field(ge=0)
+    accuracy: float | None = Field(default=None, ge=0.0, le=1.0)
+
+    @model_validator(mode="after")
+    def validate_support(self) -> LifecycleSemanticStateAccuracy:
+        if self.correct_atoms > self.total_atoms:
+            raise ValueError("correct_atoms cannot exceed total_atoms")
+        _validate_rate(self.accuracy, self.correct_atoms, self.total_atoms, "accuracy")
+        return self
+
+
+class LifecycleSemanticTransitionSummary(StrictModel):
+    expected_update_count: int = Field(ge=0)
+    actual_update_count: int = Field(ge=0)
+    aligned_update_count: int = Field(ge=0)
+    updated_to_expected_count: int = Field(ge=0)
+    acquired_update_count: int = Field(ge=0)
+    unsupported_update_count: int = Field(ge=0)
+    stable_correct_before_count: int = Field(ge=0)
+    retained_count: int = Field(ge=0)
+    interference_count: int = Field(ge=0)
+    acquisition: float | None = Field(default=None, ge=0.0, le=1.0)
+    update_precision: float | None = Field(default=None, ge=0.0, le=1.0)
+    update_recall: float | None = Field(default=None, ge=0.0, le=1.0)
+    update_f1: float | None = Field(default=None, ge=0.0, le=1.0)
+    retention: float | None = Field(default=None, ge=0.0, le=1.0)
+    interference: float | None = Field(default=None, ge=0.0, le=1.0)
+
+    @model_validator(mode="after")
+    def validate_counts_and_support(self) -> LifecycleSemanticTransitionSummary:
+        if self.aligned_update_count > self.actual_update_count:
+            raise ValueError("aligned_update_count cannot exceed actual_update_count")
+        if self.updated_to_expected_count > self.expected_update_count:
+            raise ValueError("updated_to_expected_count cannot exceed expected_update_count")
+        if self.acquired_update_count > self.updated_to_expected_count:
+            raise ValueError("acquired_update_count cannot exceed updated_to_expected_count")
+        if self.unsupported_update_count != self.actual_update_count - self.aligned_update_count:
+            raise ValueError("unsupported_update_count must equal actual updates minus aligned updates")
+        if self.retained_count + self.interference_count != self.stable_correct_before_count:
+            raise ValueError("retained and interference counts must partition stable prior-correct atoms")
+        _validate_rate(self.acquisition, self.acquired_update_count, self.expected_update_count, "acquisition")
+        _validate_rate(self.update_precision, self.aligned_update_count, self.actual_update_count, "update_precision")
+        _validate_rate(
+            self.update_recall,
+            self.updated_to_expected_count,
+            self.expected_update_count,
+            "update_recall",
+        )
+        expected_f1 = _f1(self.update_precision, self.update_recall)
+        if self.update_f1 != expected_f1:
+            raise ValueError("update_f1 must match update precision and recall")
+        _validate_rate(self.retention, self.retained_count, self.stable_correct_before_count, "retention")
+        _validate_rate(
+            self.interference,
+            self.interference_count,
+            self.stable_correct_before_count,
+            "interference",
+        )
+        return self
+
+
+class LifecycleSemanticTransitionMetrics(LifecycleSemanticTransitionSummary):
+    from_checkpoint_id: NonEmptyStr
+    to_checkpoint_id: NonEmptyStr
+
+
+class LifecycleSemanticMetrics(StrictModel):
+    schema_version: Literal["1"] = "1"
+    initial_checkpoint_id: NonEmptyStr
+    initial: LifecycleSemanticStateAccuracy
+    transitions: list[LifecycleSemanticTransitionMetrics]
+    aggregate: LifecycleSemanticTransitionSummary
+
+    @model_validator(mode="after")
+    def validate_transition_chain(self) -> LifecycleSemanticMetrics:
+        previous = self.initial_checkpoint_id
+        for transition in self.transitions:
+            if transition.from_checkpoint_id != previous:
+                raise ValueError("semantic transitions must form one contiguous checkpoint chain")
+            previous = transition.to_checkpoint_id
+        expected_aggregate = _aggregate(self.transitions)
+        if self.aggregate != expected_aggregate:
+            raise ValueError("semantic aggregate must equal the sum of its transitions")
+        return self
+
+
+def score_semantic_transitions(
+    *,
+    checkpoint_ids: Sequence[str],
+    expected: Mapping[str, Mapping[str, Any]],
+    actual: Mapping[str, Mapping[str, Any]],
+) -> LifecycleSemanticMetrics:
+    """Compare task-extracted semantic atoms across one ordered lifecycle."""
+    ordered = tuple(checkpoint_ids)
+    if not ordered:
+        raise ValueError("semantic transition scoring requires at least one checkpoint")
+    if len(set(ordered)) != len(ordered):
+        raise ValueError("semantic transition checkpoint ids must be unique")
+    missing_expected = [checkpoint_id for checkpoint_id in ordered if checkpoint_id not in expected]
+    missing_actual = [checkpoint_id for checkpoint_id in ordered if checkpoint_id not in actual]
+    if missing_expected:
+        raise ValueError(f"missing expected semantic checkpoints: {', '.join(missing_expected)}")
+    if missing_actual:
+        raise ValueError(f"missing actual semantic checkpoints: {', '.join(missing_actual)}")
+
+    expected_states = {checkpoint_id: _canonical_atoms(expected[checkpoint_id]) for checkpoint_id in ordered}
+    actual_states = {checkpoint_id: _canonical_atoms(actual[checkpoint_id]) for checkpoint_id in ordered}
+    initial = _state_accuracy(expected_states[ordered[0]], actual_states[ordered[0]])
+    transitions = [
+        _score_transition(
+            from_checkpoint_id=previous,
+            to_checkpoint_id=current,
+            expected_before=expected_states[previous],
+            expected_after=expected_states[current],
+            actual_before=actual_states[previous],
+            actual_after=actual_states[current],
+        )
+        for previous, current in zip(ordered, ordered[1:], strict=False)
+    ]
+    aggregate = _aggregate(transitions)
+    return LifecycleSemanticMetrics(
+        initial_checkpoint_id=ordered[0],
+        initial=initial,
+        transitions=transitions,
+        aggregate=aggregate,
+    )
+
+
+def _state_accuracy(expected: dict[str, Any], actual: dict[str, Any]) -> LifecycleSemanticStateAccuracy:
+    atom_ids = set(expected) | set(actual)
+    correct = sum(expected.get(atom_id, _MISSING) == actual.get(atom_id, _MISSING) for atom_id in atom_ids)
+    return LifecycleSemanticStateAccuracy(
+        correct_atoms=correct,
+        total_atoms=len(atom_ids),
+        accuracy=_rate(correct, len(atom_ids)),
+    )
+
+
+def _score_transition(
+    *,
+    from_checkpoint_id: str,
+    to_checkpoint_id: str,
+    expected_before: dict[str, Any],
+    expected_after: dict[str, Any],
+    actual_before: dict[str, Any],
+    actual_after: dict[str, Any],
+) -> LifecycleSemanticTransitionMetrics:
+    atom_ids = set(expected_before) | set(expected_after) | set(actual_before) | set(actual_after)
+    expected_updates = {
+        atom_id
+        for atom_id in atom_ids
+        if expected_before.get(atom_id, _MISSING) != expected_after.get(atom_id, _MISSING)
+    }
+    actual_updates = {
+        atom_id for atom_id in atom_ids if actual_before.get(atom_id, _MISSING) != actual_after.get(atom_id, _MISSING)
+    }
+    aligned_updates = {
+        atom_id
+        for atom_id in actual_updates
+        if actual_after.get(atom_id, _MISSING) == expected_after.get(atom_id, _MISSING)
+    }
+    updated_to_expected = {
+        atom_id
+        for atom_id in expected_updates
+        if actual_after.get(atom_id, _MISSING) == expected_after.get(atom_id, _MISSING)
+    }
+    acquired_updates = {
+        atom_id
+        for atom_id in updated_to_expected
+        if actual_before.get(atom_id, _MISSING) == expected_before.get(atom_id, _MISSING)
+    }
+    expected_stable = atom_ids - expected_updates
+    stable_correct_before = {
+        atom_id
+        for atom_id in expected_stable
+        if actual_before.get(atom_id, _MISSING) == expected_before.get(atom_id, _MISSING)
+    }
+    retained = {
+        atom_id
+        for atom_id in stable_correct_before
+        if actual_after.get(atom_id, _MISSING) == expected_after.get(atom_id, _MISSING)
+    }
+    summary = _transition_summary(
+        expected_update_count=len(expected_updates),
+        actual_update_count=len(actual_updates),
+        aligned_update_count=len(aligned_updates),
+        updated_to_expected_count=len(updated_to_expected),
+        acquired_update_count=len(acquired_updates),
+        stable_correct_before_count=len(stable_correct_before),
+        retained_count=len(retained),
+    )
+    return LifecycleSemanticTransitionMetrics(
+        from_checkpoint_id=from_checkpoint_id,
+        to_checkpoint_id=to_checkpoint_id,
+        **summary.model_dump(),
+    )
+
+
+def _aggregate(transitions: list[LifecycleSemanticTransitionMetrics]) -> LifecycleSemanticTransitionSummary:
+    return _transition_summary(
+        expected_update_count=sum(item.expected_update_count for item in transitions),
+        actual_update_count=sum(item.actual_update_count for item in transitions),
+        aligned_update_count=sum(item.aligned_update_count for item in transitions),
+        updated_to_expected_count=sum(item.updated_to_expected_count for item in transitions),
+        acquired_update_count=sum(item.acquired_update_count for item in transitions),
+        stable_correct_before_count=sum(item.stable_correct_before_count for item in transitions),
+        retained_count=sum(item.retained_count for item in transitions),
+    )
+
+
+def _transition_summary(
+    *,
+    expected_update_count: int,
+    actual_update_count: int,
+    aligned_update_count: int,
+    updated_to_expected_count: int,
+    acquired_update_count: int,
+    stable_correct_before_count: int,
+    retained_count: int,
+) -> LifecycleSemanticTransitionSummary:
+    precision = _rate(aligned_update_count, actual_update_count)
+    recall = _rate(updated_to_expected_count, expected_update_count)
+    return LifecycleSemanticTransitionSummary(
+        expected_update_count=expected_update_count,
+        actual_update_count=actual_update_count,
+        aligned_update_count=aligned_update_count,
+        updated_to_expected_count=updated_to_expected_count,
+        acquired_update_count=acquired_update_count,
+        unsupported_update_count=actual_update_count - aligned_update_count,
+        stable_correct_before_count=stable_correct_before_count,
+        retained_count=retained_count,
+        interference_count=stable_correct_before_count - retained_count,
+        acquisition=_rate(acquired_update_count, expected_update_count),
+        update_precision=precision,
+        update_recall=recall,
+        update_f1=_f1(precision, recall),
+        retention=_rate(retained_count, stable_correct_before_count),
+        interference=_rate(stable_correct_before_count - retained_count, stable_correct_before_count),
+    )
+
+
+def _canonical_atoms(atoms: Mapping[str, Any]) -> dict[str, Any]:
+    canonical: dict[str, Any] = {}
+    for atom_id, value in atoms.items():
+        if not isinstance(atom_id, str) or not atom_id.strip():
+            raise ValueError("semantic atom ids must be non-empty strings")
+        canonical[atom_id] = _canonical_value(value)
+    return canonical
+
+
+def _canonical_value(value: Any) -> Any:
+    if isinstance(value, list):
+        canonical = [_canonical_value(item) for item in value]
+        unique = {_sort_key(item): item for item in canonical}
+        return ("set", tuple(unique[key] for key in sorted(unique)))
+    if isinstance(value, dict):
+        return ("object", tuple(sorted((str(key), _canonical_value(item)) for key, item in value.items())))
+    if value is None:
+        return ("null", None)
+    if isinstance(value, bool):
+        return ("boolean", value)
+    if isinstance(value, int):
+        return ("integer", value)
+    if isinstance(value, float):
+        return ("number", value)
+    if isinstance(value, str):
+        return ("string", value)
+    return (type(value).__name__, repr(value))
+
+
+def _sort_key(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, default=repr)
+
+
+def _rate(numerator: int, denominator: int) -> float | None:
+    return None if denominator == 0 else round(numerator / denominator, 6)
+
+
+def _f1(precision: float | None, recall: float | None) -> float | None:
+    if precision is None or recall is None:
+        return None
+    if precision + recall == 0.0:
+        return 0.0
+    return round(2 * precision * recall / (precision + recall), 6)
+
+
+def _validate_rate(value: float | None, numerator: int, denominator: int, field_name: str) -> None:
+    expected = _rate(numerator, denominator)
+    if value != expected:
+        raise ValueError(f"{field_name} must match its numerator and denominator")

--- a/src/aec_bench/meta_harness/evidence_lifecycle_state.py
+++ b/src/aec_bench/meta_harness/evidence_lifecycle_state.py
@@ -1,5 +1,5 @@
 # ABOUTME: Defines durable runtime records for evidence-lifecycle runs and checkpoints.
-# ABOUTME: Models attempts, submissions, revisits, and recovery lineage independently of task content.
+# ABOUTME: Models recovery lineage and reward-independent semantic diagnostics independently of task content.
 
 from __future__ import annotations
 
@@ -9,6 +9,7 @@ from typing import Literal
 from pydantic import Field, PositiveInt, model_validator
 
 from aec_bench.contracts.validators import NonEmptyStr, StrictModel
+from aec_bench.meta_harness.evidence_lifecycle_metrics import LifecycleSemanticMetrics
 
 
 class LifecycleRunStatus(StrEnum):
@@ -168,6 +169,7 @@ class LifecycleVerificationResult(StrictModel):
     passed: bool
     reward: float = Field(ge=0.0, le=1.0)
     gates: dict[str, LifecycleGateResult] = Field(min_length=1)
+    semantic_metrics: LifecycleSemanticMetrics | None = None
 
     @model_validator(mode="after")
     def validate_outcome_consistency(self) -> LifecycleVerificationResult:

--- a/src/aec_bench/task_world_templates/lifecycles/ssc03_drainage_model.py
+++ b/src/aec_bench/task_world_templates/lifecycles/ssc03_drainage_model.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from aec_bench.meta_harness.evidence_lifecycle import load_validated_lifecycle_submissions
+from aec_bench.meta_harness.evidence_lifecycle_metrics import score_semantic_transitions
 from aec_bench.task_world_templates.catalogue import get_template
 from aec_bench.task_world_templates.contracts import CompositeTaskWorldTemplate
 
@@ -87,6 +88,11 @@ def verify_ssc03_evidence_lifecycle(package_dir: Path, run_dir: Path) -> dict[st
     }
     reward = round(sum(float(gate["score"]) for gate in gates.values()) / len(gates), 4)
     passed = all(bool(gate["passed"]) for gate in gates.values())
+    semantic_metrics = score_semantic_transitions(
+        checkpoint_ids=CHECKPOINT_IDS,
+        expected={checkpoint_id: _semantic_atoms(expected[checkpoint_id]) for checkpoint_id in CHECKPOINT_IDS},
+        actual={checkpoint_id: _semantic_atoms(actual[checkpoint_id]) for checkpoint_id in CHECKPOINT_IDS},
+    )
     return {
         "template_id": "drainage-model-evidence-lifecycle-review",
         "lifecycle_id": "ssc03.drainage-model-evidence-lifecycle",
@@ -94,6 +100,7 @@ def verify_ssc03_evidence_lifecycle(package_dir: Path, run_dir: Path) -> dict[st
         "passed": passed,
         "reward": reward,
         "gates": gates,
+        "semantic_metrics": semantic_metrics.model_dump(mode="json"),
     }
 
 
@@ -379,6 +386,68 @@ def _reference_set(value: Any) -> tuple[set[str], bool]:
     if not isinstance(value, list):
         return set(), True
     return {item for item in value if isinstance(item, str)}, any(not isinstance(item, str) for item in value)
+
+
+def _semantic_atoms(submission: dict[str, Any]) -> dict[str, Any]:
+    """Project one SSC-03 submission into stable, reward-independent state atoms."""
+    atoms: dict[str, Any] = {}
+    matrix = submission.get("review_matrix")
+    matrix = matrix if isinstance(matrix, dict) else {}
+    for index in range(1, 10):
+        item = f"PRV-0{index}"
+        atoms[f"review_matrix.{item}"] = matrix.get(item)
+
+    transition = submission.get("transition_decision")
+    transition = transition if isinstance(transition, dict) else {}
+    for field in ("model_run", "model_report", "design_claim"):
+        atoms[f"transition_decision.{field}"] = transition.get(field)
+    atoms["readiness_decision"] = submission.get("readiness_decision")
+
+    _record_atoms(
+        atoms,
+        collection_name="findings",
+        records=submission.get("findings"),
+        identity_key="finding_id",
+        scalar_fields=("item", "status", "opened_at", "closed_at"),
+    )
+    _record_atoms(
+        atoms,
+        collection_name="closure_evidence_requests",
+        records=submission.get("closure_evidence_requests"),
+        identity_key="request_id",
+        scalar_fields=("finding_id", "status"),
+    )
+    _record_atoms(
+        atoms,
+        collection_name="accepted_decisions",
+        records=submission.get("accepted_decisions"),
+        identity_key="decision_id",
+        scalar_fields=("item", "status", "superseded_by"),
+    )
+    return atoms
+
+
+def _record_atoms(
+    atoms: dict[str, Any],
+    *,
+    collection_name: str,
+    records: Any,
+    identity_key: str,
+    scalar_fields: tuple[str, ...],
+) -> None:
+    if not isinstance(records, list):
+        atoms[f"{collection_name}.__identity_valid"] = False
+        return
+    identified = {
+        record[identity_key]: record
+        for record in records
+        if isinstance(record, dict) and isinstance(record.get(identity_key), str) and record[identity_key]
+    }
+    atoms[f"{collection_name}.__identity_valid"] = len(identified) == len(records)
+    for record_id, record in identified.items():
+        prefix = f"{collection_name}.{record_id}"
+        for field in scalar_fields:
+            atoms[f"{prefix}.{field}"] = record.get(field)
 
 
 def _instructions() -> dict[str, str]:

--- a/tests/meta_harness/test_evidence_lifecycle.py
+++ b/tests/meta_harness/test_evidence_lifecycle.py
@@ -137,6 +137,55 @@ def test_verification_contract_rejects_out_of_range_and_inconsistent_results() -
         )
 
 
+def test_verification_contract_preserves_legacy_shape_without_semantic_metrics() -> None:
+    result = validate_lifecycle_verification(
+        {
+            "lifecycle_id": "lifecycle.demo",
+            "overall": "pass",
+            "passed": True,
+            "reward": 1.0,
+            "gates": {"demo": {"passed": True, "score": 1.0, "failures": []}},
+        }
+    )
+
+    assert "semantic_metrics" not in result
+
+
+def test_verification_contract_rejects_inconsistent_semantic_metric_counts() -> None:
+    with pytest.raises(ValidationError, match="unsupported_update_count must equal"):
+        validate_lifecycle_verification(
+            {
+                "lifecycle_id": "lifecycle.demo",
+                "overall": "pass",
+                "passed": True,
+                "reward": 1.0,
+                "gates": {"demo": {"passed": True, "score": 1.0, "failures": []}},
+                "semantic_metrics": {
+                    "initial_checkpoint_id": "initial_review",
+                    "initial": {"correct_atoms": 1, "total_atoms": 1, "accuracy": 1.0},
+                    "transitions": [],
+                    "aggregate": {
+                        "expected_update_count": 0,
+                        "actual_update_count": 0,
+                        "aligned_update_count": 0,
+                        "updated_to_expected_count": 0,
+                        "acquired_update_count": 0,
+                        "unsupported_update_count": 1,
+                        "stable_correct_before_count": 0,
+                        "retained_count": 0,
+                        "interference_count": 0,
+                        "acquisition": None,
+                        "update_precision": None,
+                        "update_recall": None,
+                        "update_f1": None,
+                        "retention": None,
+                        "interference": None,
+                    },
+                },
+            }
+        )
+
+
 def test_session_id_uses_highest_existing_sequence(tmp_path: Path) -> None:
     sessions = tmp_path / "sessions"
     (sessions / "session-001").mkdir(parents=True)
@@ -957,6 +1006,32 @@ def test_local_run_records_complete_experiment_provenance_and_normalized_metrics
     assert len(index_entries) == 1
     assert index_entries[0]["experiment_id"] == manifest["experiment_id"]
     assert index_entries[0]["manifest_sha256"] == task_run["evidence"]["experiment"]["manifest_sha256"]
+
+
+def test_operational_metrics_preserve_nullable_legacy_fields_without_semantic_diagnostics(tmp_path: Path) -> None:
+    package = _write_package(tmp_path / "package")
+    run_dir = tmp_path / "run"
+
+    run_local_evidence_lifecycle_fresh_context(
+        package_dir=package,
+        run_dir=run_dir,
+        model="unpriced-test-model",
+        registry=_WritingRegistry(),
+        verifier=lambda _package, _run: {
+            "lifecycle_id": "lifecycle.demo",
+            "reward": 1.0,
+            "overall": "pass",
+            "passed": True,
+            "gates": {"continuity": {"passed": True, "score": 1.0, "failures": []}},
+        },
+    )
+
+    metrics = _load_json(run_dir / "metrics.json")
+
+    assert "semantic_transition" not in metrics
+    assert "estimated_cost_usd" in metrics
+    assert metrics["estimated_cost_usd"] is None
+    assert "whole_run_seconds" in metrics
 
 
 def test_lifecycle_control_tool_submits_and_releases_next_checkpoint(tmp_path: Path) -> None:

--- a/tests/meta_harness/test_evidence_lifecycle_metrics.py
+++ b/tests/meta_harness/test_evidence_lifecycle_metrics.py
@@ -1,0 +1,218 @@
+# ABOUTME: Tests reward-independent semantic transition metrics for staged evidence lifecycles.
+# ABOUTME: Covers acquisition, update precision and recall, retention, interference, and empty support.
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from aec_bench.meta_harness.evidence_lifecycle_metrics import (
+    LifecycleSemanticMetrics,
+    LifecycleSemanticStateAccuracy,
+    score_semantic_transitions,
+)
+
+
+def test_semantic_transition_metrics_score_exact_updates_and_retention() -> None:
+    expected = {
+        "initial_review": {"revision": "A", "stable": "accepted"},
+        "response_review": {"revision": "B", "stable": "accepted", "finding": "open"},
+        "closeout_review": {"revision": "B", "stable": "accepted", "finding": "closed"},
+    }
+
+    metrics = score_semantic_transitions(
+        checkpoint_ids=("initial_review", "response_review", "closeout_review"),
+        expected=expected,
+        actual=expected,
+    )
+
+    assert metrics.initial.correct_atoms == 2
+    assert metrics.initial.total_atoms == 2
+    assert metrics.initial.accuracy == 1.0
+    assert [transition.expected_update_count for transition in metrics.transitions] == [2, 1]
+    assert [transition.stable_correct_before_count for transition in metrics.transitions] == [1, 2]
+    assert metrics.aggregate.expected_update_count == 3
+    assert metrics.aggregate.actual_update_count == 3
+    assert metrics.aggregate.acquired_update_count == 3
+    assert metrics.aggregate.acquisition == 1.0
+    assert metrics.aggregate.update_precision == 1.0
+    assert metrics.aggregate.update_recall == 1.0
+    assert metrics.aggregate.update_f1 == 1.0
+    assert metrics.aggregate.retention == 1.0
+    assert metrics.aggregate.interference_count == 0
+
+
+def test_semantic_transition_metrics_localize_missed_and_unsupported_changes() -> None:
+    expected = {
+        "initial_review": {"changing": "old", "stable": "accepted"},
+        "response_review": {"changing": "new", "stable": "accepted"},
+    }
+    actual = {
+        "initial_review": {"changing": "old", "stable": "accepted"},
+        "response_review": {"changing": "old", "stable": "damaged"},
+    }
+
+    metrics = score_semantic_transitions(
+        checkpoint_ids=("initial_review", "response_review"),
+        expected=expected,
+        actual=actual,
+    )
+    transition = metrics.transitions[0]
+
+    assert transition.expected_update_count == 1
+    assert transition.actual_update_count == 1
+    assert transition.aligned_update_count == 0
+    assert transition.acquired_update_count == 0
+    assert transition.unsupported_update_count == 1
+    assert transition.update_precision == 0.0
+    assert transition.update_recall == 0.0
+    assert transition.update_f1 == 0.0
+    assert transition.stable_correct_before_count == 1
+    assert transition.retained_count == 0
+    assert transition.interference_count == 1
+    assert transition.retention == 0.0
+    assert transition.interference == 1.0
+
+
+def test_semantic_transition_metrics_do_not_credit_premature_state_as_acquisition() -> None:
+    expected = {
+        "initial_review": {"revision": "A", "stable": "accepted"},
+        "response_review": {"revision": "B", "stable": "accepted"},
+    }
+    actual = {
+        "initial_review": {"revision": "B", "stable": "accepted"},
+        "response_review": {"revision": "B", "stable": "accepted"},
+    }
+
+    metrics = score_semantic_transitions(
+        checkpoint_ids=("initial_review", "response_review"),
+        expected=expected,
+        actual=actual,
+    )
+    transition = metrics.transitions[0]
+
+    assert metrics.initial.accuracy == 0.5
+    assert transition.expected_update_count == 1
+    assert transition.actual_update_count == 0
+    assert transition.acquired_update_count == 0
+    assert transition.acquisition == 0.0
+    assert transition.update_recall == 1.0
+    assert transition.update_precision is None
+
+
+def test_semantic_transition_metrics_credit_recovery_without_calling_it_acquisition() -> None:
+    expected = {
+        "initial_review": {"changed_by_evidence": "old", "stable": "accepted"},
+        "response_review": {"changed_by_evidence": "new", "stable": "accepted"},
+    }
+    actual = {
+        "initial_review": {"changed_by_evidence": "old", "stable": "mistaken"},
+        "response_review": {"changed_by_evidence": "new", "stable": "accepted"},
+    }
+
+    metrics = score_semantic_transitions(
+        checkpoint_ids=("initial_review", "response_review"),
+        expected=expected,
+        actual=actual,
+    )
+    transition = metrics.transitions[0]
+
+    assert transition.actual_update_count == 2
+    assert transition.aligned_update_count == 2
+    assert transition.update_precision == 1.0
+    assert transition.acquired_update_count == 1
+    assert transition.acquisition == 1.0
+    assert transition.stable_correct_before_count == 0
+    assert transition.retention is None
+
+
+def test_semantic_transition_metrics_compare_reference_lists_as_sets() -> None:
+    expected = {
+        "initial_review": {"closure_refs": ["DOC-A", "DOC-B"]},
+        "response_review": {"closure_refs": ["DOC-A", "DOC-B", "DOC-C"]},
+    }
+    actual = {
+        "initial_review": {"closure_refs": ["DOC-B", "DOC-A", "DOC-A"]},
+        "response_review": {"closure_refs": ["DOC-C", "DOC-B", "DOC-A", "DOC-C"]},
+    }
+
+    metrics = score_semantic_transitions(
+        checkpoint_ids=("initial_review", "response_review"),
+        expected=expected,
+        actual=actual,
+    )
+
+    assert metrics.initial.accuracy == 1.0
+    assert metrics.transitions[0].acquisition == 1.0
+    assert metrics.transitions[0].update_precision == 1.0
+
+
+def test_semantic_transition_metrics_distinguish_boolean_and_integer_values() -> None:
+    expected = {"initial_review": {"state": True}}
+    actual = {"initial_review": {"state": 1}}
+
+    metrics = score_semantic_transitions(
+        checkpoint_ids=("initial_review",),
+        expected=expected,
+        actual=actual,
+    )
+
+    assert metrics.initial.accuracy == 0.0
+
+
+def test_semantic_metric_contract_rejects_rate_that_does_not_match_support() -> None:
+    with pytest.raises(ValidationError, match="accuracy must match"):
+        LifecycleSemanticStateAccuracy(correct_atoms=1, total_atoms=2, accuracy=1.0)
+
+
+def test_semantic_metric_contract_rejects_aggregate_that_does_not_match_transitions() -> None:
+    states = {
+        "initial_review": {"revision": "A"},
+        "response_review": {"revision": "B"},
+    }
+    payload = score_semantic_transitions(
+        checkpoint_ids=("initial_review", "response_review"),
+        expected=states,
+        actual=states,
+    ).model_dump(mode="json")
+    payload["aggregate"] = {
+        "expected_update_count": 0,
+        "actual_update_count": 0,
+        "aligned_update_count": 0,
+        "updated_to_expected_count": 0,
+        "acquired_update_count": 0,
+        "unsupported_update_count": 0,
+        "stable_correct_before_count": 0,
+        "retained_count": 0,
+        "interference_count": 0,
+        "acquisition": None,
+        "update_precision": None,
+        "update_recall": None,
+        "update_f1": None,
+        "retention": None,
+        "interference": None,
+    }
+
+    with pytest.raises(ValidationError, match="aggregate must equal"):
+        LifecycleSemanticMetrics.model_validate(payload)
+
+
+def test_semantic_transition_metrics_use_null_for_zero_opportunity_rates() -> None:
+    states = {"initial_review": {"stable": "accepted"}}
+
+    metrics = score_semantic_transitions(
+        checkpoint_ids=("initial_review",),
+        expected=states,
+        actual=states,
+    )
+
+    assert metrics.transitions == []
+    assert metrics.aggregate.expected_update_count == 0
+    assert metrics.aggregate.actual_update_count == 0
+    assert metrics.aggregate.stable_correct_before_count == 0
+    assert metrics.aggregate.acquisition is None
+    assert metrics.aggregate.update_precision is None
+    assert metrics.aggregate.update_recall is None
+    assert metrics.aggregate.update_f1 is None
+    assert metrics.aggregate.retention is None
+    assert metrics.aggregate.interference is None

--- a/tests/task_world_templates/test_ssc03_evidence_lifecycle.py
+++ b/tests/task_world_templates/test_ssc03_evidence_lifecycle.py
@@ -235,8 +235,33 @@ def test_golden_lifecycle_scores_one_without_bypassing_parent_agentic_review(tmp
 
     assert task_run["evidence"]["score"] == {"reward": 1.0, "passed": True}
     assert task_run["evidence"]["verification"]["overall"] == "pass"
+    semantic = task_run["evidence"]["verification"]["semantic_metrics"]
+    assert semantic["initial"]["accuracy"] == 1.0
+    assert semantic["aggregate"]["acquisition"] == 1.0
+    assert semantic["aggregate"]["update_precision"] == 1.0
+    assert semantic["aggregate"]["update_recall"] == 1.0
+    assert semantic["aggregate"]["retention"] == 1.0
+    assert semantic["aggregate"]["interference_count"] == 0
     assert {item["status"] for item in evaluation.closure_results} == {"certified"}
     assert evaluation.overall_status == "review_required"
+
+
+def test_semantic_metrics_separate_missed_acquisition_from_existing_gate_reward(tmp_path: Path) -> None:
+    def mutate(payload: dict) -> None:
+        payload["review_matrix"]["PRV-03"] = "fail"
+
+    package, run_dir = _run_with_mutation(tmp_path, "response_review", mutate)
+
+    result = verify_ssc03_evidence_lifecycle(package, run_dir)
+    semantic = result["semantic_metrics"]
+    initial_to_response = semantic["transitions"][0]
+
+    assert result["gates"]["checkpoint_contract"]["passed"] is False
+    assert initial_to_response["from_checkpoint_id"] == "initial_review"
+    assert initial_to_response["to_checkpoint_id"] == "response_review"
+    assert initial_to_response["acquired_update_count"] < initial_to_response["expected_update_count"]
+    assert initial_to_response["acquisition"] < 1.0
+    assert semantic["aggregate"]["update_recall"] < 1.0
 
 
 def test_verifier_localizes_premature_evidence_reference(tmp_path: Path) -> None:
@@ -293,6 +318,24 @@ def test_verifier_requires_closure_request_response_lineage(tmp_path: Path) -> N
     assert result["reward"] < 1.0
     assert result["gates"]["closure_evidence"]["passed"] is False
     assert "response_review:CER-001:response_refs" in result["gates"]["closure_evidence"]["failures"]
+
+
+def test_semantic_metrics_accept_verifier_valid_closure_reference_supersets(tmp_path: Path) -> None:
+    def mutate(payload: dict) -> None:
+        finding = next(item for item in payload["findings"] if item["finding_id"] == "F-PRV03-001")
+        finding["closure_evidence"].append("RUN-03-REGISTER-01 Rev F")
+        request = next(item for item in payload["closure_evidence_requests"] if item["request_id"] == "CER-001")
+        request["response_refs"].append("RUN-03-REGISTER-01 Rev F")
+
+    package, run_dir = _run_with_mutation(tmp_path, "response_review", mutate)
+
+    result = verify_ssc03_evidence_lifecycle(package, run_dir)
+
+    assert result["overall"] == "pass"
+    assert result["gates"]["closure_evidence"]["passed"] is True
+    assert result["semantic_metrics"]["aggregate"]["acquisition"] == 1.0
+    assert result["semantic_metrics"]["aggregate"]["update_precision"] == 1.0
+    assert result["semantic_metrics"]["aggregate"]["retention"] == 1.0
 
 
 def test_continuity_and_readiness_gates_score_single_errors_fractionally(tmp_path: Path) -> None:
@@ -580,6 +623,11 @@ def test_persistent_session_runner_closes_actual_three_checkpoint_contract(tmp_p
     assert task_run["evidence"]["lifecycle"]["status"] == "complete"
     assert task_run["evidence"]["score"] == {"reward": 1.0, "passed": True}
     assert task_run["evidence"]["verification"]["overall"] == "pass"
+    metrics = _load_json(run_dir / "metrics.json")
+    assert metrics["semantic_transition"]["aggregate"]["acquisition"] == 1.0
+    experiment_id = task_run["evidence"]["experiment"]["experiment_id"]
+    canonical_metrics = _load_json(run_dir / "experiments" / experiment_id / "metrics.json")
+    assert canonical_metrics["semantic_transition"] == metrics["semantic_transition"]
 
 
 def test_branch_from_response_can_complete_and_verify_independently(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add a typed, reward-independent semantic transition metric contract for evidence lifecycles
- separate initial-state accuracy, acquisition, update precision/recall/F1, retention, and interference
- project SSC-03 cumulative review submissions into stable semantic atom identities
- persist semantic diagnostics in `verification.json` and `metrics.json` under the existing experiment hash chain
- document exact metric support, zero-opportunity semantics, and the boundary from verifier reward

## Why

PR #10 made lifecycle execution reproducible and exposed four controlled memory-visibility policies, but its metrics were operational: requests, tool calls, reads, retries, tokens, cost, and timing. The verifier's mean gate reward could not distinguish whether a model acquired the expected new state, merely anticipated it, preserved unaffected state, or introduced interference.

This PR adds that measurement layer before introducing more semantic variants or model-sweep orchestration.

## Metric contract

The shared scorer consumes task-extracted semantic atoms in declared checkpoint order and reports explicit numerator, denominator, and rate fields.

- `initial.accuracy`: correct initial atoms / all initial atoms
- `acquisition`: expected changes that move from the correct prior value to the correct new value / expected changes
- `update_precision`: actual changes that end at the expected current value / actual changes
- `update_recall`: expected changes whose current value is correct / expected changes
- `update_f1`: harmonic mean of update precision and recall
- `retention`: prior-correct, expected-stable atoms that remain correct / prior-correct, expected-stable atoms
- `interference`: prior-correct, expected-stable atoms that become incorrect / the same stable support

Rates are `null` when their denominator is zero. Aggregate counts and rates must reconcile exactly with the persisted per-transition records. Reference-list values are canonicalized as sets, including duplicate removal, and scalar types remain distinct.

SSC-03 extracts matrix states, run/report/claim transitions, readiness, finding/request identity and state, and accepted-decision status/supersession lineage. Free-form prose and verifier-approved evidence-reference alternatives remain under the existing task gates rather than exact atom comparison.

## Boundaries

- no changes to model prompts or visible evidence
- no changes to checkpoint transitions or visibility policies
- no changes to verifier gates, pass/fail, or reward
- no scenario variants or sweep orchestration
- no action-conditioned interaction, training export, weight updates, or continual-learning claim

## Review hardening

An independent diff review identified and the final code fixes preserve:

- legacy nullable operational metric keys when semantic diagnostics are absent
- exact aggregate-to-transition reconciliation
- verifier-valid closure-reference supersets without false semantic penalties
- one identity-validity atom per record collection instead of double-weighting structural counts

## Validation

- `uv run pytest tests/meta_harness/test_evidence_lifecycle_metrics.py tests/meta_harness/test_evidence_lifecycle.py tests/task_world_templates/test_ssc03_evidence_lifecycle.py -q` (`105 passed`)
- `uv run pytest tests/ -q` (`5134 passed, 20 skipped`; five existing configuration/deprecation warnings)
- `uv run ruff format --check src/ tests/` (`1552 files already formatted`)
- `uv run ruff check src/ tests/` (`All checks passed`)
- strict mypy over all four changed lifecycle source modules (`Success: no issues found`)
- `git diff --check` passed

## Review focus

1. semantic metric definitions and zero-support behavior
2. aggregate and rate contract validation
3. SSC-03 atom projection boundaries
4. backward-compatible experiment artifact serialization
