### PR TITLE
Add controlled SSC-03 lifecycle variants

### DIFF
--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -135,6 +135,10 @@ Python enforcement direction:
 - represent revision of an earlier submission as a derived branch;
 - persist attempts, interruptions, failures, resumes, revisits, and visibility policy;
 - bind every local invocation to an immutable experiment manifest and append-only index entry.
+- derive public semantic variants from validated task-specific event contracts rather than arbitrary file patches;
+- keep host-side variant identity and lineage hash-bound without leaking it into model-visible evidence;
+- refuse non-empty lifecycle materialization targets and validate variant identity against package content before verification or indexing;
+- keep true holdout evidence outside public variant registries and committed packages.
 
 ---
 

--- a/docs/meta-harness-guide.md
+++ b/docs/meta-harness-guide.md
@@ -48,6 +48,37 @@ Two additional fresh-context policies define later ablations without deleting au
 
 The host workspace tool enforces visibility. All released evidence, archived submissions, trajectories, and conversations remain on disk for audit regardless of the model-visible policy.
 
+### Controlled SSC-03 variants
+
+SSC-03 exposes a small public calibration family through a task-specific event contract. Every variant starts from the same stale-manifest packet and keeps the same three checkpoint IDs. The host selects the event sequence at materialization; callers cannot patch arbitrary files or supply expected answers.
+
+| Variant | Response event | Closeout event | Intended pressure |
+| --- | --- | --- | --- |
+| `staged_full_correction` | corrected manifest, rerun, and report | propagated memo | canonical acquisition and closeout |
+| `semantic_no_op_release` | unregistered administrative runtime notice | complete corrected chain | retention under irrelevant evidence |
+| `response_assertion_only` | unregistered correction assertion without artifacts | complete corrected chain | assertion is not closure evidence |
+| `memo_closeout_missing` | corrected manifest, rerun, and report | memo assertion without memo | unresolved evidence must remain not ready |
+
+List or materialize the public variants through the existing task-world surface:
+
+```bash
+aec-bench --json task composite-template list-lifecycle-variants \
+  drainage-model-evidence-lifecycle-review
+
+aec-bench --json task composite-template materialize-lifecycle \
+  drainage-model-evidence-lifecycle-review \
+  --variant response_assertion_only \
+  --output lifecycle-package
+```
+
+Omitting `--variant` selects `staged_full_correction` and preserves the canonical agent-visible instructions and release bytes. Materialization requires an empty output directory so evidence from an earlier package cannot survive into another variant. The validated variant identity and existing adaptation lineage are stored in `hidden/variant.json`; the package hash, lifecycle experiment manifest, and append-only experiment index bind that identity. Variant IDs are not written into model-visible instructions or releases.
+
+Runtime notices are model-visible observations, but they are explicitly not registered project sources and are not added to cumulative `evidence_refs`. This keeps the no-op checkpoint semantically unchanged while still testing whether the reviewer invents an engineering update from irrelevant prose.
+
+Packages materialized before variant identity was introduced do not contain `hidden/variant.json` and are intentionally rejected rather than assigned an inferred label. Rematerialize them from the registered template; the default variant preserves the earlier canonical model-visible bytes.
+
+These committed variants are public calibration cases, not private holdouts. True holdout evidence must remain structurally separate and outside the public repository.
+
 ```bash
 aec-bench meta-harness lifecycle-run-local \
   --package lifecycle-package \

--- a/src/aec_bench/cli/commands/task_world_templates.py
+++ b/src/aec_bench/cli/commands/task_world_templates.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 import time
 from pathlib import Path
 
@@ -10,6 +11,7 @@ import typer
 
 from aec_bench.cli.output import emit, print_table
 from aec_bench.task_world_templates.catalogue import get_template, list_templates
+from aec_bench.task_world_templates.lifecycles import lifecycle_variant_ids
 from aec_bench.task_world_templates.materializer import (
     materialize_template_example,
     materialize_template_lifecycle,
@@ -82,12 +84,13 @@ def verify_example_command(
 def materialize_lifecycle_command(
     template_id: str = typer.Argument(..., help="Composite task-world template id"),
     output: Path = typer.Option(..., "--output", "-o", help="Directory where the lifecycle package is written"),
+    variant: str | None = typer.Option(None, "--variant", help="Registered semantic lifecycle variant id"),
 ) -> None:
     """Materialize a registered staged evidence-lifecycle package."""
     start = time.monotonic()
     try:
         template = get_template(template_id)
-        package_dir = materialize_template_lifecycle(template, output)
+        package_dir = materialize_template_lifecycle(template, output, variant_id=variant)
     except (KeyError, ValueError) as exc:
         emit("task composite-template materialize-lifecycle", None, errors=[str(exc)], start_time=start)
         return
@@ -98,7 +101,26 @@ def materialize_lifecycle_command(
             "template_id": template.template_id,
             "package_dir": str(package_dir),
             "checkpoint_count": len(template.evidence_lifecycle.checkpoints),
+            "variant_id": _materialized_variant_id(package_dir),
         },
+        start_time=start,
+    )
+
+
+@app.command("list-lifecycle-variants")
+def list_lifecycle_variants_command(
+    template_id: str = typer.Argument(..., help="Composite task-world template id"),
+) -> None:
+    """List public semantic variants registered for one lifecycle template."""
+    start = time.monotonic()
+    try:
+        variants = lifecycle_variant_ids(template_id)
+    except KeyError as exc:
+        emit("task composite-template list-lifecycle-variants", None, errors=[str(exc)], start_time=start)
+        return
+    emit(
+        "task composite-template list-lifecycle-variants",
+        {"template_id": template_id, "variants": list(variants)},
         start_time=start,
     )
 
@@ -112,6 +134,14 @@ def verify_lifecycle_command(
     start = time.monotonic()
     result = verify_template_lifecycle(package_dir, run_dir)
     emit("task composite-template verify-lifecycle", result, start_time=start)
+
+
+def _materialized_variant_id(package_dir: Path) -> str | None:
+    path = package_dir / "hidden" / "variant.json"
+    if not path.is_file():
+        return None
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return str(payload["variant_id"])
 
 
 def _render_templates(data: dict[str, object]) -> None:

--- a/src/aec_bench/meta_harness/evidence_lifecycle_experiment.py
+++ b/src/aec_bench/meta_harness/evidence_lifecycle_experiment.py
@@ -18,8 +18,10 @@ from pydantic import Field, NonNegativeFloat, NonNegativeInt
 from aec_bench.contracts.pricing import estimate_cost_usd
 from aec_bench.contracts.trajectory import read_trajectory
 from aec_bench.contracts.validators import NonEmptyStr, StrictModel
+from aec_bench.meta_harness.evidence_lifecycle import read_evidence_lifecycle_state
 from aec_bench.meta_harness.evidence_lifecycle_metrics import LifecycleSemanticMetrics
 from aec_bench.meta_harness.ledger import read_ledger
+from aec_bench.task_world_templates.lifecycles import lifecycle_package_variant
 
 
 class LifecycleExperimentMetrics(StrictModel):
@@ -72,6 +74,8 @@ def record_lifecycle_experiment(
     metrics_path = run / "metrics.json"
     manifest_path = run / "experiment-manifest.json"
     selected_index = index_path or run.parent / "experiment-index.jsonl"
+    variant = _package_variant(package)
+    read_evidence_lifecycle_state(package, run)
     _write_json(verification_path, verification)
 
     metrics = _build_metrics(run, agent, verification)
@@ -85,17 +89,20 @@ def record_lifecycle_experiment(
     state = _read_json(run / "state.json")
     experiment_id = f"lifecycle-{datetime.now(UTC).strftime('%Y%m%dT%H%M%S%fZ')}-{uuid.uuid4().hex[:12]}"
     output_hashes = _run_artifact_hashes(run)
+    lifecycle_manifest = {
+        "lifecycle_id": state["lifecycle_id"],
+        "world_id": state["world_id"],
+        "spec_sha256": state["lifecycle_spec_sha256"],
+        "package_sha256": state["package_sha256"],
+        "package_files": _tree_hashes(package),
+    }
+    if variant is not None:
+        lifecycle_manifest["variant"] = variant
     manifest = LifecycleExperimentManifest(
         experiment_id=experiment_id,
         created_at=datetime.now(UTC).isoformat(),
         repository=repository,
-        lifecycle={
-            "lifecycle_id": state["lifecycle_id"],
-            "world_id": state["world_id"],
-            "spec_sha256": state["lifecycle_spec_sha256"],
-            "package_sha256": state["package_sha256"],
-            "package_files": _tree_hashes(package),
-        },
+        lifecycle=lifecycle_manifest,
         verifier=_callable_provenance(verifier),
         model={
             "requested_model": agent["model"],
@@ -149,6 +156,9 @@ def record_lifecycle_experiment(
         "manifest_path": str(canonical_manifest),
         "manifest_sha256": manifest_sha256,
     }
+    if variant is not None:
+        index_entry["variant_id"] = variant["variant_id"]
+        index_entry["adaptation"] = variant["adaptation"]
     _append_jsonl(selected_index, index_entry)
     return {
         "experiment_id": experiment_id,
@@ -286,6 +296,10 @@ def _provider_environment() -> dict[str, str]:
         "AZURE_OPENAI_API_DEPLOYMENT_NAME_LM",
     )
     return {name: value for name in allowed if (value := os.getenv(name))}
+
+
+def _package_variant(package_dir: Path) -> dict[str, Any] | None:
+    return lifecycle_package_variant(package_dir)
 
 
 def _run_artifact_hashes(run_dir: Path) -> dict[str, str]:

--- a/src/aec_bench/task_world_templates/lifecycles/__init__.py
+++ b/src/aec_bench/task_world_templates/lifecycles/__init__.py
@@ -3,10 +3,12 @@
 
 from __future__ import annotations
 
+import json
+from collections.abc import Callable
 from dataclasses import dataclass
 from importlib import import_module
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from aec_bench.meta_harness.evidence_lifecycle import validate_lifecycle_verification
 from aec_bench.task_world_templates.contracts import CompositeTaskWorldTemplate, EvidenceLifecycleSpec
@@ -18,6 +20,9 @@ class LifecycleTemplateRegistration:
     module_name: str
     materializer_name: str
     verifier_name: str
+    variant_module_name: str | None = None
+    variant_ids_name: str | None = None
+    variant_metadata_name: str | None = None
 
 
 _LIFECYCLES = {
@@ -28,6 +33,9 @@ _LIFECYCLES = {
             module_name="aec_bench.task_world_templates.lifecycles.ssc03_drainage_model",
             materializer_name="materialize_ssc03_evidence_lifecycle",
             verifier_name="verify_ssc03_evidence_lifecycle",
+            variant_module_name="aec_bench.task_world_templates.lifecycles.ssc03_drainage_variants",
+            variant_ids_name="list_ssc03_lifecycle_variant_ids",
+            variant_metadata_name="validated_ssc03_package_variant",
         )
     ]
 }
@@ -38,16 +46,51 @@ def registered_lifecycle_template_ids() -> set[str]:
     return set(_LIFECYCLES)
 
 
+def lifecycle_variant_ids(template_id: str) -> tuple[str, ...]:
+    """Return declared materialization variants without exposing hidden task answers."""
+    registration = _entry(template_id)
+    if registration.variant_ids_name is None:
+        return ()
+    module = import_module(registration.variant_module_name or registration.module_name)
+    return tuple(getattr(module, registration.variant_ids_name)())
+
+
+def lifecycle_package_variant(package_dir: Path) -> dict[str, Any] | None:
+    """Validate and return task-owned variant metadata when a package declares it."""
+    template_path = Path(package_dir) / "template.json"
+    if not template_path.is_file():
+        return None
+    payload = json.loads(template_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or not isinstance(payload.get("template_id"), str):
+        raise ValueError(f"invalid lifecycle package template identity: {template_path}")
+    try:
+        registration = _entry(payload["template_id"])
+    except KeyError:
+        return None
+    if registration.variant_metadata_name is None:
+        return None
+    validator = getattr(import_module(registration.module_name), registration.variant_metadata_name)
+    return cast(dict[str, Any], validator(Path(package_dir)))
+
+
 def materialize_lifecycle_template(
     template: CompositeTaskWorldTemplate,
     output_dir: Path,
+    *,
+    variant_id: str | None = None,
 ) -> Path:
     """Dispatch lifecycle materialisation from the exact validated template contract."""
     if template.evidence_lifecycle is None:
         raise ValueError(f"template {template.template_id!r} does not define an evidence lifecycle")
     registration = _entry(template.template_id)
-    materializer = getattr(import_module(registration.module_name), registration.materializer_name)
-    return materializer(Path(output_dir), template=template)
+    materializer = cast(
+        Callable[..., Path], getattr(import_module(registration.module_name), registration.materializer_name)
+    )
+    if registration.variant_ids_name is None:
+        if variant_id is not None:
+            raise ValueError(f"lifecycle template {template.template_id!r} does not support variants")
+        return materializer(Path(output_dir), template=template)
+    return materializer(Path(output_dir), template=template, variant_id=variant_id)
 
 
 def verify_lifecycle_template(package_dir: Path, run_dir: Path) -> dict[str, Any]:

--- a/src/aec_bench/task_world_templates/lifecycles/ssc03_drainage_model.py
+++ b/src/aec_bench/task_world_templates/lifecycles/ssc03_drainage_model.py
@@ -13,6 +13,12 @@ from aec_bench.meta_harness.evidence_lifecycle import load_validated_lifecycle_s
 from aec_bench.meta_harness.evidence_lifecycle_metrics import score_semantic_transitions
 from aec_bench.task_world_templates.catalogue import get_template
 from aec_bench.task_world_templates.contracts import CompositeTaskWorldTemplate
+from aec_bench.task_world_templates.lifecycles.ssc03_drainage_variants import (
+    Ssc03LifecycleVariantContent,
+    Ssc03LifecycleVariantSpec,
+    compile_ssc03_lifecycle_variant,
+    validate_ssc03_lifecycle_variant_payload,
+)
 
 CHECKPOINT_IDS = ("initial_review", "response_review", "closeout_review")
 GATE_IDS = (
@@ -31,6 +37,7 @@ def materialize_ssc03_evidence_lifecycle(
     output_dir: Path,
     *,
     template: CompositeTaskWorldTemplate | None = None,
+    variant_id: str | None = None,
 ) -> Path:
     """Write the runnable three-release SSC-03 lifecycle package."""
     output = Path(output_dir)
@@ -39,6 +46,9 @@ def materialize_ssc03_evidence_lifecycle(
         raise ValueError(f"unexpected SSC-03 lifecycle template: {template.template_id}")
     if template.evidence_lifecycle is None:
         raise ValueError("SSC-03 lifecycle template is missing its evidence_lifecycle contract")
+    if output.exists() and (not output.is_dir() or any(output.iterdir())):
+        raise ValueError(f"output directory must be empty: {output}")
+    variant, content = _compile_variant_content(variant_id)
 
     _write_json(output / "template.json", template.model_dump(mode="json"))
     _write_json(output / "world.json", template.compile_task_world_payload())
@@ -50,21 +60,15 @@ def materialize_ssc03_evidence_lifecycle(
         path = output / "instructions" / f"{checkpoint_id}.md"
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(instruction, encoding="utf-8")
-    for checkpoint_id, files in _releases().items():
-        for relative_path, content in files.items():
+    for checkpoint_id, files in content.releases.items():
+        for relative_path, file_content in files.items():
             path = output / "releases" / checkpoint_id / relative_path
             path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(content, encoding="utf-8")
+            path.write_text(file_content, encoding="utf-8")
 
-    _write_json(output / "hidden" / "gold-submissions.json", _gold_submissions())
-    _write_json(
-        output / "hidden" / "verifier-config.json",
-        {
-            "allowed_evidence_refs": _allowed_evidence_refs(),
-            "decision_evidence_policy": _decision_evidence_policy(),
-            "closure_request_policy": _closure_request_policy(),
-        },
-    )
+    _write_json(output / "hidden" / "variant.json", variant.model_dump(mode="json"))
+    _write_json(output / "hidden" / "gold-submissions.json", content.gold_submissions)
+    _write_json(output / "hidden" / "verifier-config.json", content.verifier_config)
     return output
 
 
@@ -72,6 +76,7 @@ def verify_ssc03_evidence_lifecycle(package_dir: Path, run_dir: Path) -> dict[st
     """Grade checkpoint state and continuity without requiring exact review prose."""
     package = Path(package_dir)
     run = Path(run_dir)
+    validated_ssc03_package_variant(package)
     expected = _read_json(package / "hidden" / "gold-submissions.json")
     config = _read_json(package / "hidden" / "verifier-config.json")
     actual = load_validated_lifecycle_submissions(package, run)
@@ -102,6 +107,53 @@ def verify_ssc03_evidence_lifecycle(package_dir: Path, run_dir: Path) -> dict[st
         "gates": gates,
         "semantic_metrics": semantic_metrics.model_dump(mode="json"),
     }
+
+
+def validated_ssc03_package_variant(package_dir: Path) -> dict[str, Any]:
+    """Return typed variant provenance after checking it against materialized content."""
+    package = Path(package_dir)
+    try:
+        variant = validate_ssc03_lifecycle_variant_payload(_read_json(package / "hidden" / "variant.json"))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        raise ValueError("invalid or missing SSC-03 package variant identity") from exc
+    expected_variant, expected_content = _compile_variant_content(variant.variant_id)
+    actual_content = Ssc03LifecycleVariantContent(
+        releases=_read_release_tree(package),
+        gold_submissions=_read_json(package / "hidden" / "gold-submissions.json"),
+        verifier_config=_read_json(package / "hidden" / "verifier-config.json"),
+    )
+    if variant != expected_variant or actual_content != expected_content:
+        raise ValueError("variant identity does not match materialized package content")
+    return variant.model_dump(mode="json")
+
+
+def _compile_variant_content(
+    variant_id: str | None,
+) -> tuple[Ssc03LifecycleVariantSpec, Ssc03LifecycleVariantContent]:
+    return compile_ssc03_lifecycle_variant(
+        variant_id,
+        seed=Ssc03LifecycleVariantContent(
+            releases=_releases(),
+            gold_submissions=_gold_submissions(),
+            verifier_config={
+                "allowed_evidence_refs": _allowed_evidence_refs(),
+                "decision_evidence_policy": _decision_evidence_policy(),
+                "closure_request_policy": _closure_request_policy(),
+            },
+        ),
+    )
+
+
+def _read_release_tree(package_dir: Path) -> dict[str, dict[str, str]]:
+    releases: dict[str, dict[str, str]] = {}
+    root = package_dir / "releases"
+    for path in sorted(item for item in root.rglob("*") if item.is_file()):
+        relative = path.relative_to(root)
+        if len(relative.parts) < 2:
+            raise ValueError(f"release file must be nested below a checkpoint: {relative}")
+        checkpoint_id, *file_parts = relative.parts
+        releases.setdefault(checkpoint_id, {})["/".join(file_parts)] = path.read_text(encoding="utf-8")
+    return releases
 
 
 def _checkpoint_contract_gate(expected: dict[str, Any], actual: dict[str, Any]) -> dict[str, Any]:

--- a/src/aec_bench/task_world_templates/lifecycles/ssc03_drainage_variants.py
+++ b/src/aec_bench/task_world_templates/lifecycles/ssc03_drainage_variants.py
@@ -1,0 +1,537 @@
+# ABOUTME: Defines controlled semantic event sequences for SSC-03 evidence-lifecycle variants.
+# ABOUTME: Derives public calibration packages from one canonical task-specific lifecycle seed.
+
+from __future__ import annotations
+
+import copy
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, Literal
+
+from pydantic import field_validator, model_validator
+
+from aec_bench.contracts.adaptation import AdaptationCandidate, DerivationStep
+from aec_bench.contracts.validators import NonEmptyStr, StrictModel
+
+SSC03_LIFECYCLE_FAMILY_ID = "ssc03.drainage-model-evidence-lifecycle"
+SSC03_LIFECYCLE_TEMPLATE_ID = "drainage-model-evidence-lifecycle-review"
+DEFAULT_SSC03_LIFECYCLE_VARIANT_ID = "staged_full_correction"
+_CHECKPOINT_IDS = ("initial_review", "response_review", "closeout_review")
+
+
+class Ssc03EvidenceEvent(StrEnum):
+    SEMANTIC_NO_OP = "semantic_no_op"
+    ASSERT_INPUT_CORRECTION = "assert_input_correction"
+    RELEASE_CORRECTED_MODEL_CHAIN = "release_corrected_model_chain"
+    PROPAGATE_MEMO = "propagate_memo"
+    ASSERT_MEMO_CLOSURE = "assert_memo_closure"
+
+
+class Ssc03CheckpointVariantSpec(StrictModel):
+    checkpoint_id: Literal["initial_review", "response_review", "closeout_review"]
+    events: tuple[Ssc03EvidenceEvent, ...] = ()
+
+    @field_validator("events")
+    @classmethod
+    def validate_unique_events(cls, events: tuple[Ssc03EvidenceEvent, ...]) -> tuple[Ssc03EvidenceEvent, ...]:
+        if len(events) != len(set(events)):
+            raise ValueError("checkpoint events must be unique")
+        return events
+
+
+class Ssc03LifecycleVariantSpec(StrictModel):
+    schema_version: Literal["1"] = "1"
+    variant_id: NonEmptyStr
+    summary: NonEmptyStr
+    visibility: Literal["public"] = "public"
+    adaptation: AdaptationCandidate
+    checkpoints: tuple[Ssc03CheckpointVariantSpec, ...]
+
+    @field_validator("variant_id")
+    @classmethod
+    def validate_safe_variant_id(cls, variant_id: str) -> str:
+        if re.fullmatch(r"[a-z0-9]+(?:_[a-z0-9]+)*", variant_id) is None:
+            raise ValueError("variant_id must contain lowercase letters, digits, and single underscores")
+        return variant_id
+
+    @model_validator(mode="after")
+    def validate_identity_and_event_sequence(self) -> Ssc03LifecycleVariantSpec:
+        checkpoint_ids = tuple(checkpoint.checkpoint_id for checkpoint in self.checkpoints)
+        if checkpoint_ids != _CHECKPOINT_IDS:
+            raise ValueError("checkpoints must use the SSC-03 lifecycle order")
+        if self.adaptation.family_id != SSC03_LIFECYCLE_FAMILY_ID:
+            raise ValueError("adaptation family must match the SSC-03 lifecycle family")
+        if self.adaptation.seed_task_id != SSC03_LIFECYCLE_TEMPLATE_ID:
+            raise ValueError("adaptation seed task must match the SSC-03 lifecycle template")
+        if self.adaptation.variation != {"change_topology": self.variant_id}:
+            raise ValueError("adaptation variation must identify the lifecycle variant")
+
+        response_events = self.checkpoints[1].events
+        if len(response_events) != 1:
+            raise ValueError("response_review must declare exactly one controlled event")
+        closeout_events = self.checkpoints[2].events
+        supported_closeout_events = {
+            (Ssc03EvidenceEvent.PROPAGATE_MEMO,),
+            (Ssc03EvidenceEvent.ASSERT_MEMO_CLOSURE,),
+            (
+                Ssc03EvidenceEvent.RELEASE_CORRECTED_MODEL_CHAIN,
+                Ssc03EvidenceEvent.PROPAGATE_MEMO,
+            ),
+        }
+        if closeout_events not in supported_closeout_events:
+            raise ValueError("closeout_review event combination is not supported")
+
+        corrected_model_chain = False
+        for checkpoint in self.checkpoints:
+            for event in checkpoint.events:
+                _validate_event_checkpoint(event, checkpoint.checkpoint_id)
+                if event is Ssc03EvidenceEvent.RELEASE_CORRECTED_MODEL_CHAIN:
+                    if corrected_model_chain:
+                        raise ValueError("corrected model chain may be released only once")
+                    corrected_model_chain = True
+                elif event in {Ssc03EvidenceEvent.PROPAGATE_MEMO, Ssc03EvidenceEvent.ASSERT_MEMO_CLOSURE}:
+                    if not corrected_model_chain:
+                        raise ValueError("memo propagation requires a corrected model chain")
+        return self
+
+
+@dataclass(frozen=True)
+class Ssc03LifecycleVariantContent:
+    releases: dict[str, dict[str, str]]
+    gold_submissions: dict[str, dict[str, Any]]
+    verifier_config: dict[str, Any]
+
+
+def list_ssc03_lifecycle_variant_ids() -> tuple[str, ...]:
+    """Return stable public SSC-03 variant IDs in lexical order."""
+    return tuple(sorted(_VARIANTS))
+
+
+def get_ssc03_lifecycle_variant(variant_id: str) -> Ssc03LifecycleVariantSpec:
+    """Resolve one validated public SSC-03 lifecycle variant."""
+    try:
+        return _VARIANTS[variant_id].model_copy(deep=True)
+    except KeyError as exc:
+        known = ", ".join(list_ssc03_lifecycle_variant_ids())
+        raise KeyError(f"Unknown SSC-03 lifecycle variant {variant_id!r}. Known: {known}") from exc
+
+
+def validate_ssc03_lifecycle_variant_payload(payload: Any) -> Ssc03LifecycleVariantSpec:
+    """Validate serialized variant identity against the immutable public registry."""
+    candidate = Ssc03LifecycleVariantSpec.model_validate(payload)
+    registered = get_ssc03_lifecycle_variant(candidate.variant_id)
+    if candidate != registered:
+        raise ValueError("variant contract does not match its registered SSC-03 specification")
+    return candidate
+
+
+def compile_ssc03_lifecycle_variant(
+    variant_id: str | None,
+    *,
+    seed: Ssc03LifecycleVariantContent,
+) -> tuple[Ssc03LifecycleVariantSpec, Ssc03LifecycleVariantContent]:
+    """Derive one controlled package from the canonical SSC-03 lifecycle seed."""
+    selected_id = variant_id or DEFAULT_SSC03_LIFECYCLE_VARIANT_ID
+    spec = get_ssc03_lifecycle_variant(selected_id)
+    builders: dict[
+        tuple[tuple[Ssc03EvidenceEvent, ...], tuple[Ssc03EvidenceEvent, ...]],
+        Callable[[Ssc03LifecycleVariantContent], Ssc03LifecycleVariantContent],
+    ] = {
+        (
+            (Ssc03EvidenceEvent.RELEASE_CORRECTED_MODEL_CHAIN,),
+            (Ssc03EvidenceEvent.PROPAGATE_MEMO,),
+        ): _canonical_content,
+        (
+            (Ssc03EvidenceEvent.SEMANTIC_NO_OP,),
+            (
+                Ssc03EvidenceEvent.RELEASE_CORRECTED_MODEL_CHAIN,
+                Ssc03EvidenceEvent.PROPAGATE_MEMO,
+            ),
+        ): _semantic_no_op_content,
+        (
+            (Ssc03EvidenceEvent.ASSERT_INPUT_CORRECTION,),
+            (
+                Ssc03EvidenceEvent.RELEASE_CORRECTED_MODEL_CHAIN,
+                Ssc03EvidenceEvent.PROPAGATE_MEMO,
+            ),
+        ): _response_assertion_content,
+        (
+            (Ssc03EvidenceEvent.RELEASE_CORRECTED_MODEL_CHAIN,),
+            (Ssc03EvidenceEvent.ASSERT_MEMO_CLOSURE,),
+        ): _memo_closeout_missing_content,
+    }
+    event_topology = (spec.checkpoints[1].events, spec.checkpoints[2].events)
+    content = builders[event_topology](seed)
+    verifier_config = copy.deepcopy(content.verifier_config)
+    verifier_config["allowed_evidence_refs"] = {
+        checkpoint_id: list(content.gold_submissions[checkpoint_id]["evidence_refs"])
+        for checkpoint_id in _CHECKPOINT_IDS
+    }
+    return spec, Ssc03LifecycleVariantContent(
+        releases=content.releases,
+        gold_submissions=content.gold_submissions,
+        verifier_config=verifier_config,
+    )
+
+
+def _validate_event_checkpoint(event: Ssc03EvidenceEvent, checkpoint_id: str) -> None:
+    allowed = {
+        "initial_review": set(),
+        "response_review": {
+            Ssc03EvidenceEvent.SEMANTIC_NO_OP,
+            Ssc03EvidenceEvent.ASSERT_INPUT_CORRECTION,
+            Ssc03EvidenceEvent.RELEASE_CORRECTED_MODEL_CHAIN,
+        },
+        "closeout_review": {
+            Ssc03EvidenceEvent.RELEASE_CORRECTED_MODEL_CHAIN,
+            Ssc03EvidenceEvent.PROPAGATE_MEMO,
+            Ssc03EvidenceEvent.ASSERT_MEMO_CLOSURE,
+        },
+    }
+    if event not in allowed[checkpoint_id]:
+        raise ValueError(f"event {event.value!r} is not valid at {checkpoint_id}")
+
+
+def _variant(
+    variant_id: str,
+    summary: str,
+    *,
+    response_events: tuple[Ssc03EvidenceEvent, ...],
+    closeout_events: tuple[Ssc03EvidenceEvent, ...],
+) -> Ssc03LifecycleVariantSpec:
+    lineage = (
+        []
+        if variant_id == DEFAULT_SSC03_LIFECYCLE_VARIANT_ID
+        else [
+            DerivationStep(
+                axis="change_topology",
+                parent_value=DEFAULT_SSC03_LIFECYCLE_VARIANT_ID,
+                value=variant_id,
+            )
+        ]
+    )
+    return Ssc03LifecycleVariantSpec(
+        variant_id=variant_id,
+        summary=summary,
+        adaptation=AdaptationCandidate(
+            family_id=SSC03_LIFECYCLE_FAMILY_ID,
+            seed_task_id=SSC03_LIFECYCLE_TEMPLATE_ID,
+            variation_key=f"change_topology={variant_id}",
+            variation={"change_topology": variant_id},
+            derivation_lineage=lineage,
+        ),
+        checkpoints=(
+            Ssc03CheckpointVariantSpec(checkpoint_id="initial_review"),
+            Ssc03CheckpointVariantSpec(checkpoint_id="response_review", events=response_events),
+            Ssc03CheckpointVariantSpec(checkpoint_id="closeout_review", events=closeout_events),
+        ),
+    )
+
+
+def _canonical_content(seed: Ssc03LifecycleVariantContent) -> Ssc03LifecycleVariantContent:
+    return copy.deepcopy(seed)
+
+
+def _semantic_no_op_content(seed: Ssc03LifecycleVariantContent) -> Ssc03LifecycleVariantContent:
+    content = copy.deepcopy(seed)
+    initial = content.gold_submissions["initial_review"]
+    response = _unchanged_response(initial)
+    closeout = _single_release_closeout(content.gold_submissions, response)
+    content.releases["response_review"] = {"administrative-note.md": _SEMANTIC_NO_OP_NOTE}
+    content.releases["closeout_review"] = _direct_closeout_release(seed)
+    _configure_direct_closeout_policy(content.verifier_config)
+    return Ssc03LifecycleVariantContent(
+        releases=content.releases,
+        gold_submissions={
+            "initial_review": initial,
+            "response_review": response,
+            "closeout_review": closeout,
+        },
+        verifier_config=content.verifier_config,
+    )
+
+
+def _response_assertion_content(seed: Ssc03LifecycleVariantContent) -> Ssc03LifecycleVariantContent:
+    content = copy.deepcopy(seed)
+    initial = content.gold_submissions["initial_review"]
+    response = _unchanged_response(initial)
+    closeout = _single_release_closeout(content.gold_submissions, response)
+    content.releases["response_review"] = {"response-assertion.md": _INPUT_CORRECTION_ASSERTION}
+    content.releases["closeout_review"] = _direct_closeout_release(seed)
+    _configure_direct_closeout_policy(content.verifier_config)
+    return Ssc03LifecycleVariantContent(
+        releases=content.releases,
+        gold_submissions={
+            "initial_review": initial,
+            "response_review": response,
+            "closeout_review": closeout,
+        },
+        verifier_config=content.verifier_config,
+    )
+
+
+def _memo_closeout_missing_content(seed: Ssc03LifecycleVariantContent) -> Ssc03LifecycleVariantContent:
+    content = copy.deepcopy(seed)
+    response = content.gold_submissions["response_review"]
+    closeout = copy.deepcopy(response)
+    closeout["checkpoint_id"] = "closeout_review"
+    closeout["evidence_refs"] = list(response["evidence_refs"]) + [
+        "REG-03 Rev G",
+        "RESP-03-CLOSEOUT-01 Rev A",
+    ]
+    closeout["accepted_decisions"] = _register_only_closeout_decisions(
+        response["accepted_decisions"],
+        content.gold_submissions["closeout_review"]["accepted_decisions"],
+    )
+    content.releases["closeout_review"] = {
+        "document-register-rev-g.md": _MEMO_PENDING_REGISTER,
+        "comment-response.md": _MEMO_CLOSURE_ASSERTION,
+    }
+    content.gold_submissions["closeout_review"] = closeout
+    return content
+
+
+def _unchanged_response(initial: dict[str, Any]) -> dict[str, Any]:
+    response = copy.deepcopy(initial)
+    response["checkpoint_id"] = "response_review"
+    return response
+
+
+def _direct_closeout_release(seed: Ssc03LifecycleVariantContent) -> dict[str, str]:
+    release = {
+        **copy.deepcopy(seed.releases["closeout_review"]),
+        **copy.deepcopy(seed.releases["response_review"]),
+    }
+    release["comment-response.md"] = _DIRECT_CLOSEOUT_RESPONSE
+    return release
+
+
+def _configure_direct_closeout_policy(config: dict[str, Any]) -> None:
+    config["decision_evidence_policy"]["D-PRV01-002"] = {
+        "required": ["REG-03 Rev G"],
+        "allowed": ["REG-03 Rev G"],
+    }
+
+
+def _single_release_closeout(
+    canonical_gold: dict[str, dict[str, Any]],
+    response: dict[str, Any],
+) -> dict[str, Any]:
+    canonical_initial = canonical_gold["initial_review"]
+    canonical_response = canonical_gold["response_review"]
+    canonical_closeout = canonical_gold["closeout_review"]
+    response_additions = [
+        reference
+        for reference in canonical_response["evidence_refs"]
+        if reference not in canonical_initial["evidence_refs"]
+    ]
+    closeout_additions = [
+        reference
+        for reference in canonical_closeout["evidence_refs"]
+        if reference not in canonical_response["evidence_refs"]
+    ]
+    closeout = copy.deepcopy(canonical_closeout)
+    closeout["evidence_refs"] = list(response["evidence_refs"]) + response_additions + closeout_additions
+    closeout["findings"] = [
+        {
+            "finding_id": "F-PRV03-001",
+            "item": "PRV-03",
+            "status": "closed",
+            "opened_at": "initial_review",
+            "closed_at": "closeout_review",
+            "closure_evidence": ["MANIFEST-03-042 Rev B"],
+        }
+    ]
+    closeout["closure_evidence_requests"] = [
+        {
+            "request_id": "CER-001",
+            "finding_id": "F-PRV03-001",
+            "status": "closed",
+            "required_evidence": ["current manifest citing CATCH-03-BASIS-01 Rev D"],
+            "response_refs": ["MANIFEST-03-042 Rev B"],
+        }
+    ]
+    closeout["accepted_decisions"] = _direct_closeout_decisions(canonical_initial["accepted_decisions"])
+    return closeout
+
+
+def _direct_closeout_decisions(initial: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    decisions = copy.deepcopy(initial)
+    by_id = {decision["decision_id"]: decision for decision in decisions}
+    by_id["D-PRV01-001"].update(
+        {
+            "status": "superseded",
+            "superseded_by": "D-PRV01-002",
+            "supersession_reason": "REG-03 Rev G registers the combined correction and closeout release.",
+        }
+    )
+    by_id["D-PRV04-001"].update(
+        {
+            "status": "superseded",
+            "superseded_by": "D-PRV04-002",
+            "supersession_reason": "RUN-03-043 and REPORT-03-043 replace the reviewed run/report object.",
+        }
+    )
+    by_id["D-PRV05-001"].update(
+        {
+            "status": "superseded",
+            "superseded_by": "D-PRV05-002",
+            "supersession_reason": "MANIFEST-03-042 Rev B replaces the reviewed scenario-propagation object.",
+        }
+    )
+    by_id["D-PRV06-001"].update(
+        {
+            "status": "superseded",
+            "superseded_by": "D-PRV06-002",
+            "supersession_reason": "MEMO-03-DESIGN-01 Rev E propagates the replacement run/report object.",
+        }
+    )
+    decisions.extend(
+        [
+            {
+                "decision_id": "D-PRV01-002",
+                "item": "PRV-01",
+                "status": "accepted",
+                "basis_refs": ["REG-03 Rev G"],
+            },
+            {
+                "decision_id": "D-PRV03-001",
+                "item": "PRV-03",
+                "status": "accepted",
+                "basis_refs": [
+                    "MANIFEST-03-042 Rev B",
+                    "CATCH-03-BASIS-01 Rev D",
+                    "RAIN-03-BASIS-01 Rev C",
+                ],
+            },
+            {
+                "decision_id": "D-PRV04-002",
+                "item": "PRV-04",
+                "status": "accepted",
+                "basis_refs": ["RUN-03-REGISTER-01 Rev F", "REPORT-03-043 Rev A"],
+            },
+            {
+                "decision_id": "D-PRV05-002",
+                "item": "PRV-05",
+                "status": "accepted",
+                "basis_refs": ["RAIN-03-BASIS-01 Rev C", "MANIFEST-03-042 Rev B"],
+            },
+            {
+                "decision_id": "D-PRV06-002",
+                "item": "PRV-06",
+                "status": "accepted",
+                "basis_refs": ["MEMO-03-DESIGN-01 Rev E", "REPORT-03-043 Rev A"],
+            },
+        ]
+    )
+    return decisions
+
+
+def _register_only_closeout_decisions(
+    response: list[dict[str, Any]],
+    canonical_closeout: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    decisions = copy.deepcopy(response)
+    by_id = {decision["decision_id"]: decision for decision in decisions}
+    by_id["D-PRV01-002"].update(
+        {
+            "status": "superseded",
+            "superseded_by": "D-PRV01-003",
+            "supersession_reason": (
+                "REG-03 Rev G records the closeout assertion while the required memo remains absent."
+            ),
+        }
+    )
+    canonical_by_id = {decision["decision_id"]: decision for decision in canonical_closeout}
+    decisions.append(copy.deepcopy(canonical_by_id["D-PRV01-003"]))
+    return decisions
+
+
+_VARIANTS = {
+    spec.variant_id: spec
+    for spec in (
+        _variant(
+            "staged_full_correction",
+            "A corrected manifest and rerun arrive at response, followed by the propagated design memo at closeout.",
+            response_events=(Ssc03EvidenceEvent.RELEASE_CORRECTED_MODEL_CHAIN,),
+            closeout_events=(Ssc03EvidenceEvent.PROPAGATE_MEMO,),
+        ),
+        _variant(
+            "semantic_no_op_release",
+            "An unrelated administrative note arrives before the full corrected chain is released at closeout.",
+            response_events=(Ssc03EvidenceEvent.SEMANTIC_NO_OP,),
+            closeout_events=(
+                Ssc03EvidenceEvent.RELEASE_CORRECTED_MODEL_CHAIN,
+                Ssc03EvidenceEvent.PROPAGATE_MEMO,
+            ),
+        ),
+        _variant(
+            "response_assertion_only",
+            "A response asserts correction without artifacts; the complete corrected chain arrives at closeout.",
+            response_events=(Ssc03EvidenceEvent.ASSERT_INPUT_CORRECTION,),
+            closeout_events=(
+                Ssc03EvidenceEvent.RELEASE_CORRECTED_MODEL_CHAIN,
+                Ssc03EvidenceEvent.PROPAGATE_MEMO,
+            ),
+        ),
+        _variant(
+            "memo_closeout_missing",
+            "The rerun is corrected, but closeout asserts memo propagation without supplying the revised memo.",
+            response_events=(Ssc03EvidenceEvent.RELEASE_CORRECTED_MODEL_CHAIN,),
+            closeout_events=(Ssc03EvidenceEvent.ASSERT_MEMO_CLOSURE,),
+        ),
+    )
+}
+
+
+_SEMANTIC_NO_OP_NOTE = """# Administrative Runtime Notice
+
+This notice is not a registered project source.
+
+The document-control filing location has changed. No model input, run, report, memo, or governing revision changes.
+"""
+
+_INPUT_CORRECTION_ASSERTION = """# Model Custodian Runtime Assertion
+
+This assertion is not a registered project source.
+
+The model custodian states that the catchment input has been corrected and the model rerun. The revised manifest,
+run register, and report are not included in this release and must not be assumed.
+"""
+
+_DIRECT_CLOSEOUT_RESPONSE = """# Combined Correction and Closeout Response
+
+Source: RESP-03-CLOSEOUT-01 Rev A
+
+Finding F-PRV03-001 is nominated for closure against MANIFEST-03-042 Rev B. The corrected manifest, rerun, report,
+and propagated design memo are supplied together in this release. The reviewer must independently check the full
+chain before closing the finding or accepting issue readiness.
+"""
+
+_MEMO_PENDING_REGISTER = """# Closeout Document Register
+
+Register: REG-03 Rev G
+Supersedes: REG-03 Rev F
+
+| Document | Revision | Status |
+|---|---|---|
+| CATCH-03-BASIS-01 | Rev D | current |
+| RAIN-03-BASIS-01 | Rev C | current |
+| MANIFEST-03-042 | Rev B | current submission |
+| RUN-03-REGISTER-01 | Rev F | current |
+| REPORT-03-043 | Rev A | current submission |
+| MEMO-03-DESIGN-01 | Rev D | current; revision pending |
+| CRIT-SSC03-001 | Rev C | governing criteria |
+| COMMENT-03-REGISTER-01 | Rev A | current |
+| RESP-03-CLOSEOUT-01 | Rev A | current response assertion |
+"""
+
+_MEMO_CLOSURE_ASSERTION = """# Closeout Comment Response
+
+Source: RESP-03-CLOSEOUT-01 Rev A
+
+The design custodian states that MEMO-03-DESIGN-01 Rev E propagates RUN-03-043 and REPORT-03-043 Rev A. The revised
+memo is not included in this release, so the assertion alone is not closure evidence.
+"""

--- a/src/aec_bench/task_world_templates/materializer.py
+++ b/src/aec_bench/task_world_templates/materializer.py
@@ -103,12 +103,17 @@ def materialize_template_id_example(template_id: str, output_dir: Path) -> Path:
     return materialize_template_example(get_template(template_id), output_dir)
 
 
-def materialize_template_lifecycle(template: CompositeTaskWorldTemplate, output_dir: Path) -> Path:
+def materialize_template_lifecycle(
+    template: CompositeTaskWorldTemplate,
+    output_dir: Path,
+    *,
+    variant_id: str | None = None,
+) -> Path:
     """Materialize a registered evidence lifecycle for one composite template."""
     template = CompositeTaskWorldTemplate.model_validate(template.model_dump(mode="json"))
     if template.evidence_lifecycle is None:
         raise ValueError(f"template {template.template_id!r} does not define an evidence lifecycle")
-    return materialize_lifecycle_template(template, output_dir)
+    return materialize_lifecycle_template(template, output_dir, variant_id=variant_id)
 
 
 def verify_template_lifecycle(package_dir: Path, run_dir: Path) -> dict[str, Any]:

--- a/tests/cli/test_task_world_templates.py
+++ b/tests/cli/test_task_world_templates.py
@@ -102,5 +102,72 @@ def test_task_composite_template_lifecycle_commands_materialize_and_verify(tmp_p
 
     assert verified.exit_code == 0, verified.output
     assert json.loads(materialized.output)["data"]["checkpoint_count"] == 3
+    assert json.loads(materialized.output)["data"]["variant_id"] == "staged_full_correction"
     assert json.loads(verified.output)["data"]["overall"] == "pass"
     assert json.loads(verified.output)["data"]["reward"] == 1.0
+
+
+def test_task_composite_template_lifecycle_variant_commands_list_and_materialize(tmp_path: Path) -> None:
+    listed = runner.invoke(
+        app,
+        [
+            "--json",
+            "task",
+            "composite-template",
+            "list-lifecycle-variants",
+            "drainage-model-evidence-lifecycle-review",
+        ],
+    )
+    package = tmp_path / "response-assertion"
+    materialized = runner.invoke(
+        app,
+        [
+            "--json",
+            "task",
+            "composite-template",
+            "materialize-lifecycle",
+            "drainage-model-evidence-lifecycle-review",
+            "--variant",
+            "response_assertion_only",
+            "--output",
+            str(package),
+        ],
+    )
+
+    assert listed.exit_code == 0, listed.output
+    assert materialized.exit_code == 0, materialized.output
+    listed_data = json.loads(listed.output)["data"]
+    materialized_data = json.loads(materialized.output)["data"]
+    assert listed_data["variants"] == [
+        "memo_closeout_missing",
+        "response_assertion_only",
+        "semantic_no_op_release",
+        "staged_full_correction",
+    ]
+    assert materialized_data["variant_id"] == "response_assertion_only"
+    assert json.loads((package / "hidden" / "variant.json").read_text(encoding="utf-8"))["variant_id"] == (
+        "response_assertion_only"
+    )
+
+
+def test_task_composite_template_materialize_lifecycle_rejects_unknown_variant(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "--json",
+            "task",
+            "composite-template",
+            "materialize-lifecycle",
+            "drainage-model-evidence-lifecycle-review",
+            "--variant",
+            "not-a-variant",
+            "--output",
+            str(tmp_path / "package"),
+        ],
+    )
+
+    envelope = json.loads(result.output)
+    assert result.exit_code == 1
+    assert envelope["status"] == "error"
+    assert "not-a-variant" in envelope["errors"][0]
+    assert "staged_full_correction" in envelope["errors"][0]

--- a/tests/task_world_templates/test_ssc03_evidence_lifecycle.py
+++ b/tests/task_world_templates/test_ssc03_evidence_lifecycle.py
@@ -628,6 +628,11 @@ def test_persistent_session_runner_closes_actual_three_checkpoint_contract(tmp_p
     experiment_id = task_run["evidence"]["experiment"]["experiment_id"]
     canonical_metrics = _load_json(run_dir / "experiments" / experiment_id / "metrics.json")
     assert canonical_metrics["semantic_transition"] == metrics["semantic_transition"]
+    manifest = _load_json(run_dir / "experiment-manifest.json")
+    assert manifest["lifecycle"]["variant"]["variant_id"] == "staged_full_correction"
+    index_entry = json.loads((tmp_path / "experiment-index.jsonl").read_text(encoding="utf-8").splitlines()[0])
+    assert index_entry["variant_id"] == "staged_full_correction"
+    assert index_entry["adaptation"]["variation"] == {"change_topology": "staged_full_correction"}
 
 
 def test_branch_from_response_can_complete_and_verify_independently(tmp_path: Path) -> None:

--- a/tests/task_world_templates/test_ssc03_evidence_lifecycle_variants.py
+++ b/tests/task_world_templates/test_ssc03_evidence_lifecycle_variants.py
@@ -1,0 +1,552 @@
+# ABOUTME: Tests controlled semantic variants of the SSC-03 evidence lifecycle.
+# ABOUTME: Covers variant contracts, deterministic packages, topology state, leakage, and verification.
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from aec_bench.meta_harness.evidence_lifecycle import EvidenceLifecycleError, run_evidence_lifecycle
+from aec_bench.meta_harness.evidence_lifecycle_experiment import record_lifecycle_experiment
+from aec_bench.task_world_templates.catalogue import get_template
+from aec_bench.task_world_templates.lifecycles import lifecycle_package_variant
+from aec_bench.task_world_templates.lifecycles.ssc03_drainage_model import verify_ssc03_evidence_lifecycle
+from aec_bench.task_world_templates.lifecycles.ssc03_drainage_variants import (
+    DEFAULT_SSC03_LIFECYCLE_VARIANT_ID,
+    Ssc03EvidenceEvent,
+    Ssc03LifecycleVariantSpec,
+    get_ssc03_lifecycle_variant,
+    list_ssc03_lifecycle_variant_ids,
+)
+from aec_bench.task_world_templates.materializer import materialize_template_lifecycle
+
+EXPECTED_VARIANTS = (
+    "memo_closeout_missing",
+    "response_assertion_only",
+    "semantic_no_op_release",
+    "staged_full_correction",
+)
+CHECKPOINT_IDS = ("initial_review", "response_review", "closeout_review")
+
+
+def test_ssc03_variant_registry_is_explicit_and_has_canonical_default() -> None:
+    assert DEFAULT_SSC03_LIFECYCLE_VARIANT_ID == "staged_full_correction"
+    assert list_ssc03_lifecycle_variant_ids() == EXPECTED_VARIANTS
+
+    for variant_id in EXPECTED_VARIANTS:
+        spec = get_ssc03_lifecycle_variant(variant_id)
+        assert spec.variant_id == variant_id
+        assert spec.adaptation.variation == {"change_topology": variant_id}
+        assert spec.adaptation.seed_task_id == "drainage-model-evidence-lifecycle-review"
+        assert spec.visibility == "public"
+
+
+def test_ssc03_variant_registry_returns_defensive_copies() -> None:
+    first = get_ssc03_lifecycle_variant(DEFAULT_SSC03_LIFECYCLE_VARIANT_ID)
+    first.summary = "caller-local mutation"
+
+    second = get_ssc03_lifecycle_variant(DEFAULT_SSC03_LIFECYCLE_VARIANT_ID)
+    assert second.summary != first.summary
+
+
+def test_ssc03_variant_registry_rejects_unknown_id_with_known_choices() -> None:
+    with pytest.raises(KeyError, match="memo_closeout_missing.*staged_full_correction"):
+        get_ssc03_lifecycle_variant("not-a-variant")
+
+
+def test_ssc03_variant_contract_rejects_checkpoint_reordering() -> None:
+    payload = get_ssc03_lifecycle_variant(DEFAULT_SSC03_LIFECYCLE_VARIANT_ID).model_dump(mode="json")
+    payload["checkpoints"] = list(reversed(payload["checkpoints"]))
+
+    with pytest.raises(ValidationError, match="checkpoints must use the SSC-03 lifecycle order"):
+        Ssc03LifecycleVariantSpec.model_validate(payload)
+
+
+def test_ssc03_variant_contract_rejects_memo_propagation_without_corrected_model_chain() -> None:
+    payload = get_ssc03_lifecycle_variant(DEFAULT_SSC03_LIFECYCLE_VARIANT_ID).model_dump(mode="json")
+    payload["checkpoints"][1]["events"] = [Ssc03EvidenceEvent.SEMANTIC_NO_OP.value]
+
+    with pytest.raises(ValidationError, match="memo propagation requires a corrected model chain"):
+        Ssc03LifecycleVariantSpec.model_validate(payload)
+
+
+def test_ssc03_variant_contract_rejects_contradictory_response_events() -> None:
+    payload = get_ssc03_lifecycle_variant(DEFAULT_SSC03_LIFECYCLE_VARIANT_ID).model_dump(mode="json")
+    payload["checkpoints"][1]["events"] = [
+        Ssc03EvidenceEvent.SEMANTIC_NO_OP.value,
+        Ssc03EvidenceEvent.RELEASE_CORRECTED_MODEL_CHAIN.value,
+    ]
+
+    with pytest.raises(ValidationError, match="response_review must declare exactly one controlled event"):
+        Ssc03LifecycleVariantSpec.model_validate(payload)
+
+
+def test_ssc03_variant_contract_rejects_competing_closeout_events() -> None:
+    payload = get_ssc03_lifecycle_variant(DEFAULT_SSC03_LIFECYCLE_VARIANT_ID).model_dump(mode="json")
+    payload["checkpoints"][2]["events"] = [
+        Ssc03EvidenceEvent.PROPAGATE_MEMO.value,
+        Ssc03EvidenceEvent.ASSERT_MEMO_CLOSURE.value,
+    ]
+
+    with pytest.raises(ValidationError, match="closeout_review event combination is not supported"):
+        Ssc03LifecycleVariantSpec.model_validate(payload)
+
+
+def test_default_variant_preserves_pr11_agent_visible_package_bytes(tmp_path: Path) -> None:
+    package = materialize_template_lifecycle(
+        get_template("drainage-model-evidence-lifecycle-review"),
+        tmp_path / "package",
+    )
+
+    assert _visible_tree_hash(package) == "5a69cd443d15bc0037607020b34228f344e7b8ed30398bfdf17a9eacd78105d8"
+    assert _load_json(package / "hidden" / "variant.json")["variant_id"] == DEFAULT_SSC03_LIFECYCLE_VARIANT_ID
+
+
+def test_rematerializing_into_non_empty_package_is_rejected_without_mutation(tmp_path: Path) -> None:
+    template = get_template("drainage-model-evidence-lifecycle-review")
+    package = materialize_template_lifecycle(
+        template,
+        tmp_path / "package",
+        variant_id=DEFAULT_SSC03_LIFECYCLE_VARIANT_ID,
+    )
+    original = _package_files(package)
+
+    with pytest.raises(ValueError, match="output directory must be empty"):
+        materialize_template_lifecycle(template, package, variant_id="memo_closeout_missing")
+
+    assert _package_files(package) == original
+    assert (package / "releases" / "closeout_review" / "drainage-design-memo-rev-e.md").is_file()
+
+
+@pytest.mark.parametrize("variant_id", EXPECTED_VARIANTS)
+def test_ssc03_variants_materialize_deterministically_and_golden_state_verifies(
+    tmp_path: Path,
+    variant_id: str,
+) -> None:
+    template = get_template("drainage-model-evidence-lifecycle-review")
+    first = materialize_template_lifecycle(template, tmp_path / "first", variant_id=variant_id)
+    second = materialize_template_lifecycle(template, tmp_path / "second", variant_id=variant_id)
+
+    assert _package_files(first) == _package_files(second)
+    assert _load_json(first / "hidden" / "variant.json")["variant_id"] == variant_id
+    run_dir = _run_gold(first, tmp_path / "run")
+    result = verify_ssc03_evidence_lifecycle(first, run_dir)
+    assert result["overall"] == "pass"
+    assert result["reward"] == 1.0
+    assert result["semantic_metrics"]["initial"]["accuracy"] == 1.0
+    assert result["semantic_metrics"]["aggregate"]["retention"] == 1.0
+
+
+@pytest.mark.parametrize(
+    ("variant_id", "expected_failures", "expected_readiness"),
+    [
+        ("staged_full_correction", ("PRV-03", "PRV-06", None), "ready_to_issue"),
+        ("semantic_no_op_release", ("PRV-03", "PRV-03", None), "ready_to_issue"),
+        ("response_assertion_only", ("PRV-03", "PRV-03", None), "ready_to_issue"),
+        ("memo_closeout_missing", ("PRV-03", "PRV-06", "PRV-06"), "not_ready_to_issue"),
+    ],
+)
+def test_ssc03_variant_gold_encodes_declared_change_topology(
+    tmp_path: Path,
+    variant_id: str,
+    expected_failures: tuple[str | None, ...],
+    expected_readiness: str,
+) -> None:
+    package = materialize_template_lifecycle(
+        get_template("drainage-model-evidence-lifecycle-review"),
+        tmp_path / variant_id,
+        variant_id=variant_id,
+    )
+    gold = _load_json(package / "hidden" / "gold-submissions.json")
+
+    for checkpoint_id, failing_item in zip(
+        ("initial_review", "response_review", "closeout_review"),
+        expected_failures,
+        strict=True,
+    ):
+        failed = [item for item, status in gold[checkpoint_id]["review_matrix"].items() if status == "fail"]
+        assert failed == ([] if failing_item is None else [failing_item])
+    assert gold["closeout_review"]["readiness_decision"] == expected_readiness
+
+
+@pytest.mark.parametrize("variant_id", EXPECTED_VARIANTS)
+def test_rendered_sources_independently_support_variant_gold(tmp_path: Path, variant_id: str) -> None:
+    package = materialize_template_lifecycle(
+        get_template("drainage-model-evidence-lifecycle-review"),
+        tmp_path / variant_id,
+        variant_id=variant_id,
+    )
+    gold = _load_json(package / "hidden" / "gold-submissions.json")
+
+    for checkpoint_index, checkpoint_id in enumerate(CHECKPOINT_IDS):
+        source_text = _cumulative_release_text(package, checkpoint_index)
+        manifest_is_current = all(
+            fact in source_text
+            for fact in (
+                "Source: MANIFEST-03-042 Rev B",
+                "Catchment basis: CATCH-03-BASIS-01 Rev D",
+            )
+        )
+        rerun_is_traceable = all(
+            fact in source_text
+            for fact in (
+                "RUN-03-043 uses MANIFEST-03-042 Rev B",
+                "Source: REPORT-03-043 Rev A",
+                "Run: RUN-03-043",
+            )
+        )
+        memo_is_propagated = all(
+            fact in source_text
+            for fact in (
+                "Source: MEMO-03-DESIGN-01 Rev E",
+                "Cited run: RUN-03-043",
+                "Cited report: REPORT-03-043 Rev A",
+            )
+        )
+        corrected_chain = manifest_is_current and rerun_is_traceable
+        expected_failure = "PRV-03" if not corrected_chain else ("PRV-06" if not memo_is_propagated else None)
+        actual_failures = [item for item, status in gold[checkpoint_id]["review_matrix"].items() if status == "fail"]
+
+        assert actual_failures == ([] if expected_failure is None else [expected_failure])
+        assert gold[checkpoint_id]["transition_decision"] == {
+            "model_run": "governing" if corrected_chain else "non_governing",
+            "model_report": "governing" if corrected_chain else "non_governing",
+            "design_claim": "supported" if corrected_chain and memo_is_propagated else "unsupported",
+        }
+        for evidence_ref in gold[checkpoint_id]["evidence_refs"]:
+            assert evidence_ref in source_text
+
+
+def test_assertion_variants_do_not_treat_assertions_as_closure_evidence(tmp_path: Path) -> None:
+    template = get_template("drainage-model-evidence-lifecycle-review")
+    response_assertion = materialize_template_lifecycle(
+        template,
+        tmp_path / "response-assertion",
+        variant_id="response_assertion_only",
+    )
+    memo_assertion = materialize_template_lifecycle(
+        template,
+        tmp_path / "memo-assertion",
+        variant_id="memo_closeout_missing",
+    )
+    response_gold = _load_json(response_assertion / "hidden" / "gold-submissions.json")
+    memo_gold = _load_json(memo_assertion / "hidden" / "gold-submissions.json")
+
+    assert response_gold["response_review"]["findings"][0]["status"] == "open"
+    assert response_gold["response_review"]["closure_evidence_requests"][0]["response_refs"] == []
+    assert memo_gold["closeout_review"]["findings"][-1]["status"] == "open"
+    assert memo_gold["closeout_review"]["closure_evidence_requests"][-1]["response_refs"] == []
+    assert not (memo_assertion / "releases" / "closeout_review" / "drainage-design-memo-rev-e.md").exists()
+
+
+@pytest.mark.parametrize("variant_id", ["semantic_no_op_release", "response_assertion_only"])
+def test_deferred_correction_sources_only_name_findings_present_in_gold(tmp_path: Path, variant_id: str) -> None:
+    package = materialize_template_lifecycle(
+        get_template("drainage-model-evidence-lifecycle-review"),
+        tmp_path / variant_id,
+        variant_id=variant_id,
+    )
+    source_finding_ids = {
+        match
+        for path in (package / "releases").rglob("*.md")
+        for match in re.findall(r"F-PRV\d{2}-\d{3}", path.read_text(encoding="utf-8"))
+    }
+    gold = _load_json(package / "hidden" / "gold-submissions.json")
+    cumulative_finding_ids = {
+        finding["finding_id"] for checkpoint in gold.values() for finding in checkpoint["findings"]
+    }
+
+    assert source_finding_ids <= cumulative_finding_ids
+    assert "F-PRV06-001" not in source_finding_ids
+
+
+@pytest.mark.parametrize("variant_id", ["semantic_no_op_release", "response_assertion_only"])
+def test_direct_closeout_decision_ids_and_lineage_follow_actual_topology(tmp_path: Path, variant_id: str) -> None:
+    package = materialize_template_lifecycle(
+        get_template("drainage-model-evidence-lifecycle-review"),
+        tmp_path / variant_id,
+        variant_id=variant_id,
+    )
+    gold = _load_json(package / "hidden" / "gold-submissions.json")
+    closeout = {decision["decision_id"]: decision for decision in gold["closeout_review"]["accepted_decisions"]}
+
+    assert "D-PRV01-003" not in closeout
+    assert closeout["D-PRV01-001"]["superseded_by"] == "D-PRV01-002"
+    assert closeout["D-PRV01-002"] == {
+        "basis_refs": ["REG-03 Rev G"],
+        "decision_id": "D-PRV01-002",
+        "item": "PRV-01",
+        "status": "accepted",
+    }
+    assert closeout["D-PRV06-001"]["superseded_by"] == "D-PRV06-002"
+    assert "not yet propagated" not in closeout["D-PRV06-001"]["supersession_reason"]
+
+
+@pytest.mark.parametrize("variant_id", ["semantic_no_op_release", "response_assertion_only"])
+def test_non_evidence_response_events_preserve_engineering_state(tmp_path: Path, variant_id: str) -> None:
+    package = materialize_template_lifecycle(
+        get_template("drainage-model-evidence-lifecycle-review"),
+        tmp_path / variant_id,
+        variant_id=variant_id,
+    )
+    gold = _load_json(package / "hidden" / "gold-submissions.json")
+    initial = gold["initial_review"]
+    response = gold["response_review"]
+
+    for field in (
+        "evidence_refs",
+        "review_matrix",
+        "transition_decision",
+        "findings",
+        "closure_evidence_requests",
+        "accepted_decisions",
+        "readiness_decision",
+    ):
+        assert response[field] == initial[field]
+
+    result = verify_ssc03_evidence_lifecycle(package, _run_gold(package, tmp_path / "run"))
+    initial_to_response = result["semantic_metrics"]["transitions"][0]
+    assert initial_to_response["expected_update_count"] == 0
+    assert initial_to_response["acquisition"] is None
+    assert initial_to_response["retention"] == 1.0
+
+
+def test_verifier_rejects_variant_identity_that_does_not_match_package_topology(tmp_path: Path) -> None:
+    package = materialize_template_lifecycle(
+        get_template("drainage-model-evidence-lifecycle-review"),
+        tmp_path / "package",
+        variant_id="memo_closeout_missing",
+    )
+    run_dir = _run_gold(package, tmp_path / "run")
+    claimed = get_ssc03_lifecycle_variant("staged_full_correction").model_dump(mode="json")
+    _write_json(package / "hidden" / "variant.json", claimed)
+
+    with pytest.raises(ValueError, match="variant identity does not match materialized package content"):
+        verify_ssc03_evidence_lifecycle(package, run_dir)
+
+
+@pytest.mark.parametrize("failure_kind", ["missing", "malformed"])
+def test_verifier_rejects_missing_or_malformed_variant_identity(tmp_path: Path, failure_kind: str) -> None:
+    package = materialize_template_lifecycle(
+        get_template("drainage-model-evidence-lifecycle-review"),
+        tmp_path / "package",
+    )
+    variant_path = package / "hidden" / "variant.json"
+    if failure_kind == "missing":
+        variant_path.unlink()
+    else:
+        _write_json(variant_path, {"variant_id": DEFAULT_SSC03_LIFECYCLE_VARIANT_ID})
+
+    with pytest.raises(ValueError, match="invalid or missing SSC-03 package variant identity"):
+        verify_ssc03_evidence_lifecycle(package, tmp_path / "unused-run")
+
+
+def test_non_default_variant_is_recorded_in_manifest_and_index(tmp_path: Path) -> None:
+    package = materialize_template_lifecycle(
+        get_template("drainage-model-evidence-lifecycle-review"),
+        tmp_path / "package",
+        variant_id="response_assertion_only",
+    )
+    run_dir = _run_gold(package, tmp_path / "run")
+    verification = verify_ssc03_evidence_lifecycle(package, run_dir)
+    index_path = tmp_path / "experiment-index.jsonl"
+    record = record_lifecycle_experiment(
+        package_dir=package,
+        run_dir=run_dir,
+        agent=_experiment_agent(),
+        verifier=verify_ssc03_evidence_lifecycle,
+        verification=verification,
+        tool_schema=[],
+        repository_dir=Path(__file__).resolve().parents[2],
+        index_path=index_path,
+    )
+
+    manifest = _load_json(Path(record["manifest"]))
+    index_entry = json.loads(index_path.read_text(encoding="utf-8").splitlines()[0])
+    assert lifecycle_package_variant(package)["variant_id"] == "response_assertion_only"
+    assert manifest["lifecycle"]["variant"]["variant_id"] == "response_assertion_only"
+    assert index_entry["variant_id"] == "response_assertion_only"
+    assert index_entry["adaptation"]["variation"] == {"change_topology": "response_assertion_only"}
+
+
+def test_mismatched_variant_identity_cannot_enter_experiment_index(tmp_path: Path) -> None:
+    package = materialize_template_lifecycle(
+        get_template("drainage-model-evidence-lifecycle-review"),
+        tmp_path / "package",
+        variant_id="memo_closeout_missing",
+    )
+    run_dir = _run_gold(package, tmp_path / "run")
+    verification = verify_ssc03_evidence_lifecycle(package, run_dir)
+    _write_json(
+        package / "hidden" / "variant.json",
+        get_ssc03_lifecycle_variant("staged_full_correction").model_dump(mode="json"),
+    )
+    index_path = tmp_path / "experiment-index.jsonl"
+
+    with pytest.raises(ValueError, match="variant identity does not match materialized package content"):
+        record_lifecycle_experiment(
+            package_dir=package,
+            run_dir=run_dir,
+            agent=_experiment_agent(),
+            verifier=verify_ssc03_evidence_lifecycle,
+            verification=verification,
+            tool_schema=[],
+            repository_dir=Path(__file__).resolve().parents[2],
+            index_path=index_path,
+        )
+
+    assert not index_path.exists()
+    assert not (run_dir / "experiment-manifest.json").exists()
+    assert not (run_dir / "metrics.json").exists()
+
+
+def test_valid_package_from_another_variant_cannot_be_paired_with_run(tmp_path: Path) -> None:
+    template = get_template("drainage-model-evidence-lifecycle-review")
+    run_package = materialize_template_lifecycle(
+        template,
+        tmp_path / "run-package",
+        variant_id="memo_closeout_missing",
+    )
+    supplied_package = materialize_template_lifecycle(
+        template,
+        tmp_path / "supplied-package",
+        variant_id="response_assertion_only",
+    )
+    run_dir = _run_gold(run_package, tmp_path / "run")
+    verification = verify_ssc03_evidence_lifecycle(run_package, run_dir)
+    index_path = tmp_path / "experiment-index.jsonl"
+
+    with pytest.raises(EvidenceLifecycleError, match="package does not match lifecycle run"):
+        record_lifecycle_experiment(
+            package_dir=supplied_package,
+            run_dir=run_dir,
+            agent=_experiment_agent(),
+            verifier=verify_ssc03_evidence_lifecycle,
+            verification=verification,
+            tool_schema=[],
+            repository_dir=Path(__file__).resolve().parents[2],
+            index_path=index_path,
+        )
+
+    assert not index_path.exists()
+    assert not (run_dir / "experiment-manifest.json").exists()
+    assert not (run_dir / "metrics.json").exists()
+    assert not (run_dir / "experiments").exists()
+
+
+def test_prepared_workspace_never_contains_hidden_variant_metadata(tmp_path: Path) -> None:
+    package = materialize_template_lifecycle(
+        get_template("drainage-model-evidence-lifecycle-review"),
+        tmp_path / "package",
+        variant_id="response_assertion_only",
+    )
+    _run_gold(package, tmp_path / "run")
+    workspace = tmp_path / "run" / "workspace"
+
+    assert not (workspace / "hidden").exists()
+    visible_text = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in workspace.rglob("*")
+        if path.is_file() and path.suffix in {".json", ".md"}
+    )
+    assert "response_assertion_only" not in visible_text
+
+
+def test_variant_packages_have_distinct_host_side_hashes(tmp_path: Path) -> None:
+    template = get_template("drainage-model-evidence-lifecycle-review")
+    digests = {
+        hashlib.sha256(
+            b"".join(
+                relative.encode() + b"\0" + content
+                for relative, content in _package_files(
+                    materialize_template_lifecycle(template, tmp_path / variant_id, variant_id=variant_id)
+                ).items()
+            )
+        ).hexdigest()
+        for variant_id in EXPECTED_VARIANTS
+    }
+
+    assert len(digests) == len(EXPECTED_VARIANTS)
+
+
+@pytest.mark.parametrize("variant_id", EXPECTED_VARIANTS)
+def test_variant_identity_is_hidden_from_agent_visible_files(tmp_path: Path, variant_id: str) -> None:
+    package = materialize_template_lifecycle(
+        get_template("drainage-model-evidence-lifecycle-review"),
+        tmp_path / variant_id,
+        variant_id=variant_id,
+    )
+
+    visible_text = "\n".join(
+        path.read_text(encoding="utf-8")
+        for root in (package / "instructions", package / "releases")
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    )
+    assert variant_id not in visible_text
+
+
+def _run_gold(package: Path, run_dir: Path) -> Path:
+    gold = _load_json(package / "hidden" / "gold-submissions.json")
+
+    def resolve(context: dict) -> dict:
+        _write_json(Path(context["submission_path"]), gold[context["checkpoint_id"]])
+        return {"status": "completed"}
+
+    run_evidence_lifecycle(package, run_dir, episode_resolver=resolve)
+    return run_dir
+
+
+def _visible_tree_hash(package: Path) -> str:
+    lines = []
+    for root_name in ("instructions", "releases"):
+        root = package / root_name
+        for path in sorted(item for item in root.rglob("*") if item.is_file()):
+            digest = hashlib.sha256(path.read_bytes()).hexdigest()
+            lines.append(f"{digest}  {path.relative_to(package)}\n")
+    return hashlib.sha256("".join(lines).encode()).hexdigest()
+
+
+def _cumulative_release_text(package: Path, checkpoint_index: int) -> str:
+    return "\n".join(
+        path.read_text(encoding="utf-8")
+        for checkpoint_id in CHECKPOINT_IDS[: checkpoint_index + 1]
+        for path in sorted((package / "releases" / checkpoint_id).rglob("*"))
+        if path.is_file()
+    )
+
+
+def _package_files(package: Path) -> dict[str, bytes]:
+    return {str(path.relative_to(package)): path.read_bytes() for path in sorted(package.rglob("*")) if path.is_file()}
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _experiment_agent() -> dict:
+    return {
+        "model": "test-model",
+        "adapter": "in_process",
+        "execution_mode": "persistent_session",
+        "memory_visibility_policy": "persistent_context",
+        "max_turns_per_session": 1,
+        "status": "completed",
+        "sessions": [],
+        "totals": {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+        },
+    }


### PR DESCRIPTION
## Summary

Add a controlled public SSC-03 lifecycle family that exercises semantic retention, unsupported assertions, delayed correction, and unresolved closeout without changing the generic lifecycle state machine.

This is a stacked draft PR. Its base is `feat/ssc03-semantic-transition-metrics` (PR #11); after that PR merges, this branch can be rebased or retargeted to `main`.

## What changed

- Added a strict task-specific SSC-03 event contract and four public variants:
  - `staged_full_correction`
  - `semantic_no_op_release`
  - `response_assertion_only`
  - `memo_closeout_missing`
- Compiled package content from validated response/closeout event topology rather than accepting arbitrary file or gold-state patches.
- Preserved the canonical variant's model-visible instructions and release bytes.
- Added CLI discovery and selection:
  - `list-lifecycle-variants`
  - `materialize-lifecycle --variant ...`
- Bound variant identity and existing adaptation lineage into:
  - `hidden/variant.json`
  - the package hash
  - lifecycle experiment manifests
  - append-only experiment index entries
- Validated registered identity against the exact release tree, gold submissions, and verifier policy before verification or experiment recording.
- Validated that the supplied package is the package that produced the supplied run before writing any experiment artifacts.
- Rejected non-empty materialization targets so files from one variant cannot survive into another.
- Kept unregistered runtime notices out of cumulative project-source `evidence_refs`.
- Documented public-calibration, private-holdout, migration, and non-claim boundaries.

## Review hardening included

Independent contract review found and this branch fixes:

- stale evidence surviving cross-variant rematerialization;
- a deferred-closeout source naming a finding absent from gold;
- non-contiguous direct-closeout decision IDs and incorrect supersession prose;
- descriptive event metadata that did not originally drive compilation;
- mutable registry objects and untyped/mismatched variant identity;
- false experiment provenance from pairing a valid run with a different valid package.

## Contract boundaries

- These are committed public calibration variants, not private holdouts.
- Evidence release remains ordered and host-controlled.
- Runtime notices are observations, not registered project evidence.
- The task verifier remains scoring authority; semantic metrics do not replace reward.
- No sweep orchestration, provider calls, result interpretation, transfer intervention, RL export, action-conditioned evidence request, online weight update, or continual-learning claim is added here.
- Packages materialized before `hidden/variant.json` existed must be rematerialized; labels are not inferred.

## Validation

- `uv run pytest -q`
  - 5,176 passed
  - 20 skipped
  - 5 pre-existing warnings
- Focused lifecycle/metrics/CLI suite: 150 passed
- `uv run ruff format --check src/ tests/`
- `uv run ruff check src/ tests/`
- strict mypy over all changed source modules
- `git diff --cached --check`
- independent re-review: no remaining blockers

## Reviewer path

1. Read the event and variant contracts in `ssc03_drainage_variants.py`.
2. Check package identity/content validation in `ssc03_drainage_model.py`.
3. Check package/run validation before experiment writes in `evidence_lifecycle_experiment.py`.
4. Review the source-to-gold, rematerialization, identity mismatch, cross-package provenance, visibility, CLI, and manifest/index tests.
