### PR TITLE
SSC-03: Add lifecycle calibration experiment runner

### DIFF
--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -159,10 +159,28 @@ Required fields:
 Optional field:
 
 - `cost`
+- `adaptation`
+- `lifecycle_execution`
+- `lifecycle_provenance`
+
+Lifecycle records use typed session and provenance contracts. `lifecycle_execution` preserves mode, visibility policy, the per-session turn limit, requested and actual adapter identity, resolved model identity, usage, failures, checkpoint coverage, and hashed per-session artifacts. An actual adapter that differs from the requested condition is an unscored failed execution, never evidence for the requested adapter. Interrupted sessions whose provider-resolved model was never durably observed use the explicit `unresolved` value and force `completeness=partial`; the requested alias is never substituted as resolved provenance. `lifecycle_provenance` binds lifecycle/world identity, package/spec hashes, repository or installed-source content identity, runtime provider and realized dependency-byte identity, the registered task scorer and dispatcher chain, the canonical invocation manifest and sealed index entry, and the snapshotted ablation manifest and expanded plan.
+
+Lifecycle calibration manifests and plans carry a strict `study_design`: `descriptive_calibration`, per-session turn budgets, deterministic sequential plan order, no randomization, no counterbalancing, and `causal_effects_supported=false`. Evaluation artifacts must repeat this contract and expose the resource envelope beside outcomes. They must not promote group differences to causal effects while those controls remain absent.
 
 Key rule:
 
 - a `complete` record must contain enough provenance to support reproducibility claims.
+- a complete lifecycle record must reference hashed immutable output artifacts; paths back into a mutable working run are not sufficient.
+- lifecycle finalization must reconcile every session, token total, task revision, verification result, and artifact hash against the canonical invocation and its immutable snapshot before publication.
+- the planned runtime provider, sorted dependency distributions, and realized dependency-byte fingerprint must exactly match the canonical invocation before publication.
+- every submitted lifecycle checkpoint must resolve to exactly one final submitted attempt and a durable session owner.
+- every fresh-context session must own exactly one checkpoint; retries use distinct attempt-specific sessions.
+- attempt mode, session mode, visibility policy, actual adapter, and per-session turn limit must reconcile with the planned condition before reward attribution.
+- the per-invocation index seal is authoritative for crash recovery; the shared discovery index may be reconstructed from valid seals without changing invocation identity.
+- immutable snapshot recovery has authority over mutable source package/run aliases once the snapshot exists.
+- ledger publication is exclusive, fsync-durable through newly created ancestors, and atomic; an artifact snapshot left before record publication is recoverable without another model call.
+- session-result publication is atomic and fsync-durable; a torn result from a terminal persistent session is quarantined and replaced by an unresolved zero-reward failure only when its submitted ownership and complete trajectory validate.
+- malformed trajectory history is a conflict and is never truncated or inferred during recovery.
 
 ### EvaluationResult
 

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -138,6 +138,19 @@ Python enforcement direction:
 - derive public semantic variants from validated task-specific event contracts rather than arbitrary file patches;
 - keep host-side variant identity and lineage hash-bound without leaking it into model-visible evidence;
 - refuse non-empty lifecycle materialization targets and validate variant identity against package content before verification or indexing;
+- finalize lifecycle sweeps through one append-only core `TrialRecord` per planned invocation;
+- snapshot and hash lifecycle inputs and outputs under the ledger before claiming a complete record;
+- bind plan and trial identity to materialized package/spec hashes, the actual registered scorer, and the declared aec-bench source inventory;
+- bind each trial to the selected runtime provider and the realized bytes of its active dependency closure, then recapture and reconcile that fingerprint at invocation finalization;
+- retain each fresh or persistent attempt in its own session directory, including interrupted attempts with unresolved provider identity;
+- require every submitted checkpoint to have one final submitted attempt and durable session ownership before it can contribute reward;
+- require every fresh-context session to own exactly one checkpoint, with retries receiving distinct attempt-specific session directories;
+- reconcile attempt/session mode, visibility, per-session turn budget, and requested/actual adapter identity, and keep mismatches as explicit unscored failures;
+- derive cross-run lifecycle summaries from core ledger records and their snapshotted historical plan, never mutable run-directory scans or the current planner state;
+- give an existing immutable snapshot authority over later mutable source state;
+- publish session results, snapshots, and records atomically and fsync-durably through every new ancestor, and recover terminal-session crashes, artifact-only finalization, or a locked shared invocation index from durable evidence without rerunning the agent;
+- quarantine a torn terminal session result before publishing a conservative unresolved failure, but reject malformed trajectory history rather than silently truncating or reconstructing it;
+- persist the study design with each lifecycle calibration and never make causal claims beyond its budget and ordering controls;
 - keep true holdout evidence outside public variant registries and committed packages.
 
 ---

--- a/docs/examples/meta-harness/lifecycle-ablation.example.yaml
+++ b/docs/examples/meta-harness/lifecycle-ablation.example.yaml
@@ -1,0 +1,30 @@
+# Public calibration sweep for the SSC-03 staged evidence lifecycle.
+# Provider seeds and parallel execution are deliberately unsupported in this version.
+schema_version: "1"
+experiment_id: ssc03-public-calibration
+lifecycle_template_id: drainage-model-evidence-lifecycle-review
+study_design:
+  interpretation: descriptive_calibration
+  turn_budget_scope: per_session
+  execution_order: deterministic_sequential_plan_order
+  randomized: false
+  counterbalanced: false
+  causal_effects_supported: false
+variants:
+  - staged_full_correction
+  - semantic_no_op_release
+  - response_assertion_only
+  - memo_closeout_missing
+agents:
+  - name: tool-loop-model
+    adapter: tool_loop
+    model: claude-sonnet-4-6
+    parameters:
+      # Fresh SSC-03 conditions can open three sessions before retries; this is not a total-trial budget.
+      max_turns_per_session: 60
+repetitions: 1
+output_root: ../../../artifacts/ssc03-public-calibration
+ledger_root: ../../../ledger
+limits:
+  max_trials: 16
+  max_concurrency: 1

--- a/docs/meta-harness-guide.md
+++ b/docs/meta-harness-guide.md
@@ -79,6 +79,50 @@ Packages materialized before variant identity was introduced do not contain `hid
 
 These committed variants are public calibration cases, not private holdouts. True holdout evidence must remain structurally separate and outside the public repository.
 
+### Lifecycle ablation sweeps
+
+The lifecycle ablation runner expands one strict manifest across:
+
+```text
+public variant × valid execution/visibility condition × agent × repetition
+```
+
+The four valid conditions are the persistent conversation with `persistent_context`, plus fresh checkpoint contexts with `artifact_memory`, `raw_evidence_only`, or `current_release_only`. Invalid mode/policy combinations are rejected instead of entering a larger meaningless Cartesian product.
+
+This release is a **descriptive calibration sweep**, not a randomized causal ablation. Its required `study_design` contract records that the turn budget is per session, execution follows deterministic sequential plan order, trials are neither randomized nor counterbalanced, and causal effects are unsupported. Persistent trials normally use one session. Every fresh-context session owns exactly one checkpoint; a retry opens another attempt-specific session rather than reusing context across checkpoints. Total configured turn capacity is therefore not held constant. Group means locate hypotheses; they do not identify effects of context or memory policy.
+
+Preview an exact plan without materializing persistent packages, writing ledgers, or calling a provider:
+
+```bash
+aec-bench --json meta-harness lifecycle-ablation \
+  --config docs/examples/meta-harness/lifecycle-ablation.example.yaml \
+  --dry-run
+```
+
+The preview classifies every trial as `pending`, `resumable`, `finalizable`, `complete`, or `conflict` using the same persisted-manifest, package, deterministic gold/verifier smoke, runtime-lineage, snapshot, and record checks as execution. Planning and smoke validation materialize each missing variant only in temporary directories so task package/spec hashes can enter the trial identity without changing the requested output tree.
+
+Run or resume the same manifest by omitting `--dry-run`. Trial IDs are full SHA-256 identities over every experimental dimension, materialized task revision, registered scorer, and declared aec-bench source inventory. The runner persists the normalized manifest and expanded plan, rejects code, task, configuration, or storage-contract drift on resume, materializes each public variant once, and runs a deterministic package/gold/verifier smoke gate before any model call. Execution is deliberately sequential in this version.
+
+Each lifecycle invocation retains its task-owned manifest, metrics, verification, sessions, and checkpoint state. Finalization then:
+
+1. resolves the canonical invocation through its per-invocation sealed index entry, ignores abandoned dot-prefixed staging directories, validates every declared run artifact, package file, session, attempt owner, execution mode, visibility policy, per-session turn limit, requested and actual adapter identity, token total, verifier result, and plan field, and repairs a missing or truncated shared discovery index from canonical seals under an inter-process lock;
+2. snapshots only the hash-declared package/run files, canonical invocation and seal, normalized index entry, sweep manifest, and expanded plan under `ledger/<experiment>/_artifacts/<trial-id>/`;
+3. rebuilds and validates the record from staged immutable bytes rather than mutable working paths;
+4. fsyncs every staged file, directory, and newly created ancestor before atomically publishing the snapshot and one typed core `TrialRecord`; and
+5. recovers a validated snapshot left before record publication without calling the model again.
+
+The lifecycle invocation UUID is audit evidence, not a competing sweep identity. Cross-run discovery and resume use the current content-bound plan; historical aggregate evaluation uses the plan referenced by the immutable records themselves. Lifecycle summaries are persisted as `EvaluationArtifact`s and read only the ledger records and their hash-bound snapshots. Changing or deleting a mutable source run—or later changing planner code or Python versions—cannot redefine a finalized result.
+
+Provider failures are first-class zero-reward records with preserved sessions, costs, failure details, and artifacts. A returned adapter implementation that differs from the requested condition is recorded as an actual-adapter identity mismatch and remains an unscored failed execution; it cannot be credited to the planned adapter. Every submitted checkpoint must have one final submitted attempt and durable session ownership in the planned execution mode. Session results are atomically replaced and fsync-durable. A persistent session that crashes after submitting the final checkpoint but before returning an agent result is sealed from its durable attempts and validated trajectory with unresolved model/adapter identity, recorded as `interrupted_after_completion`, and finalized at zero reward without rebuilding an adapter. A torn terminal `agent_result.json` is retained as `agent_result.corrupt.json` before the conservative failure record is published; a malformed trajectory remains a conflict because the runner will not infer or truncate event history. A rerun never overwrites a finalized success or failure under the same trial ID. Fresh-context retries use attempt-specific directories; abandoned fresh or persistent sessions are sealed as interrupted without pretending that a requested model alias was a provider-resolved identity. A completed invocation—or immutable snapshot—that crashed before core record publication is imported without calling the model again, and a valid immutable snapshot cannot be vetoed by later mutable package or run corruption.
+
+Artifact finalization and execution success do not by themselves justify `completeness=complete`. A lifecycle record is complete only when it also carries typed, hash-bound sessions with observed resolved-model and adapter identity and comes from a clean Git repository snapshot whose commit and source inventory can reproduce the adapter, dispatcher, and registered task scorer. Git provenance is accepted only when the loaded `aec_bench` package is actually tracked by that repository; an ignored installation under another project's `.venv` cannot inherit the caller's commit, and tracked nonstandard package layouts are hashed from the package path that ownership validation actually resolved. Installed source uses a freshly recomputed `source-sha256:` identity over the package and installed distribution metadata so in-process source drift changes the plan. Such records remain `partial` because no retrievable repository revision was observed. Dirty-worktree or unresolved-session invocations likewise remain honest `partial` records while preserving the same immutable evidence.
+
+Every trial also binds a separate runtime-dependency provenance object: requested adapter, locally resolved provider family, sorted distribution identities, and a SHA-256 inventory of the current bytes in the `pydantic-ai-slim` base closure plus the selected provider extra and verifier dependencies. Explicit `provider:model` names use a declared provider-to-extra map and unknown provider prefixes fail closed; unprefixed replay/test identities retain the non-provider base closure. When multiple active distribution roots contain the same package, the first import-search path is authoritative. `RECORD` may enumerate files, but its recorded hashes are never trusted; the planner rereads realized bytes, resolves editable `direct_url.json` sources, and invalidates its per-file cache on filesystem identity, size, mtime, or ctime changes. The invocation recaptures this object after execution, finalization requires exact equality with the planned trial, and the typed `TrialRecord` preserves it. Dependency code drift therefore changes plan/trial identity before execution or becomes an explicit conflict if it occurs after planning.
+
+The manifest accepts only lifecycle controls that the current runner applies: `tool_loop` or `pydantic_ai`, plus a required positive `max_turns_per_session`. The explicit name prevents a per-session cap from being mistaken for a total-trial budget. Provider seeds, temperatures, custom clients, prompt overrides, parallel execution, private holdouts, transfer interventions, total-trial budget allocation, randomized or counterbalanced ordering, and automatic causal interpretation are intentionally deferred rather than silently ignored.
+
+The ledger-derived `EvaluationArtifact` repeats the hash-bound study design and reports each group's session count, configured turn capacity, requests, tool calls, tokens, reward, retention, and cost. It deliberately emits no pairwise effect, winner, or causal estimate. A future causal phase must define retry-aware total-trial budget allocation and randomized or counterbalanced execution before such comparisons are valid.
+
 ```bash
 aec-bench meta-harness lifecycle-run-local \
   --package lifecycle-package \
@@ -90,11 +134,11 @@ aec-bench meta-harness lifecycle-run-local \
 
 Every local invocation writes root-level latest views plus an immutable experiment record:
 
-- `experiment-manifest.json` binds the repository commit and dirty digest, package and verifier hashes, exact model/configuration records, prompts, tool schema, visibility, and output hashes;
+- `experiment-manifest.json` is a mutable latest-view alias; its canonical indexed copy binds repository commit, source inventory and dirty digest, package hashes, the scorer/dispatcher chain, execution environment, exact model/configuration records, prompts, tool schema, visibility, and every authoritative run-artifact hash;
 - `metrics.json` normalizes checkpoint and whole-run timing, requests, tool calls, reads, revisits, retries, failures, tokens, and estimated cost, and carries semantic-transition diagnostics when the task verifier provides them;
 - `verification.json` preserves the typed lifecycle verifier result;
-- `experiments/<experiment-id>/` preserves the canonical record for each failed, interrupted, resumed, or completed invocation;
-- `experiment-index.jsonl` is append-only and points to each canonical manifest by hash.
+- `experiments/<experiment-id>/` preserves the canonical record and its `index-entry.json` seal for each failed, interrupted, resumed, or completed invocation;
+- `experiment-index.jsonl` is the shared discovery view, points to each canonical manifest by hash, and is rebuilt under a file lock from valid per-invocation seals after an interrupted append so concurrent repairs cannot lose entries.
 
 This apparatus is an adaptation microscope for fixed-model behavior under staged evidence. Checkpoint progression is ordered and submission-gated; semantic verification occurs over the accumulated lifecycle. It does **not** yet provide action-conditioned evidence transitions, cross-run learner updates, demonstrated transfer, or continual learning.
 

--- a/src/aec_bench/cli/commands/meta_harness.py
+++ b/src/aec_bench/cli/commands/meta_harness.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 import typer
+import yaml  # type: ignore[import-untyped]
 
 from aec_bench.cli.output import emit, print_success
 from aec_bench.meta_harness.autonomy import AutonomyConfig, run_autonomous_process
@@ -19,6 +20,11 @@ from aec_bench.meta_harness.evidence_lifecycle import (
     read_evidence_lifecycle_state,
     revisit_evidence_checkpoint,
     submit_evidence_checkpoint,
+)
+from aec_bench.meta_harness.evidence_lifecycle_ablation import (
+    inspect_lifecycle_ablation_plan,
+    load_lifecycle_ablation_manifest,
+    run_lifecycle_ablation,
 )
 from aec_bench.meta_harness.evidence_lifecycle_local import (
     LifecycleVisibilityPolicy,
@@ -141,7 +147,7 @@ def lifecycle_run_local_command(
         help="Execution mode: persistent (one conversation) or fresh-context (one per checkpoint)",
     ),
     process_id: str = typer.Option("process.lifecycle", "--process-id", help="Parent meta-harness process id"),
-    max_turns: int = typer.Option(60, "--max-turns", min=1, help="Maximum model requests for the agent run"),
+    max_turns: int = typer.Option(60, "--max-turns", min=1, help="Maximum model requests per model session"),
     visibility_policy: str | None = typer.Option(
         None,
         "--visibility-policy",
@@ -192,6 +198,29 @@ def _lifecycle_visibility_policy(value: str) -> LifecycleVisibilityPolicy:
             f"visibility policy must be one of: {choices}",
             param_hint="--visibility-policy",
         ) from exc
+
+
+@app.command("lifecycle-ablation")
+def lifecycle_ablation_command(
+    config: Path = typer.Option(..., "--config", help="Lifecycle ablation YAML manifest"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Print the exact plan without writing or calling models"),
+) -> None:
+    """Plan or execute a typed, resumable evidence-lifecycle ablation sweep."""
+    start = time.monotonic()
+    command = "meta-harness lifecycle-ablation"
+    try:
+        manifest = load_lifecycle_ablation_manifest(config)
+        if dry_run:
+            result = {
+                "dry_run": True,
+                **inspect_lifecycle_ablation_plan(manifest),
+            }
+        else:
+            result = run_lifecycle_ablation(manifest).model_dump(mode="json")
+    except (OSError, ValueError, yaml.YAMLError) as exc:
+        emit(command, None, errors=[str(exc)], start_time=start)
+        return
+    emit(command, result, start_time=start)
 
 
 @app.command("logic-evaluate")

--- a/src/aec_bench/contracts/trial_record.py
+++ b/src/aec_bench/contracts/trial_record.py
@@ -3,12 +3,13 @@
 
 from datetime import datetime
 from enum import StrEnum
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import (
     Field,
     NonNegativeFloat,
     NonNegativeInt,
+    PositiveInt,
     field_validator,
     model_validator,
 )
@@ -47,6 +48,20 @@ class FileReference(StrictModel):
     source: str | None = None
 
 
+class ArtifactReference(StrictModel):
+    kind: NonEmptyStr
+    path: NonEmptyStr
+    sha256: NonEmptyStr
+    media_type: NonEmptyStr
+
+    @field_validator("sha256")
+    @classmethod
+    def validate_sha256(cls, value: str) -> str:
+        if len(value) != 64 or any(character not in "0123456789abcdef" for character in value):
+            raise ValueError("sha256 must contain 64 lowercase hexadecimal characters")
+        return value
+
+
 class InputRecord(StrictModel):
     instruction: NonEmptyStr
     system_prompt: str | None = None
@@ -59,6 +74,7 @@ class OutputRecord(StrictModel):
     conversation_path: str | None = None
     trajectory_path: str | None = None
     agent_result: dict[str, Any] | None = None
+    artifacts: list[ArtifactReference] | None = None
 
 
 class TimingRecord(StrictModel):
@@ -127,6 +143,126 @@ class AdaptationProvenance(StrictModel):
         return self
 
 
+class LifecycleSessionRecord(StrictModel):
+    session_id: NonEmptyStr
+    checkpoint_ids: list[NonEmptyStr] = Field(default_factory=list)
+    requested_adapter: NonEmptyStr | None = None
+    adapter: NonEmptyStr
+    resolved_model: NonEmptyStr
+    execution_mode: Literal["persistent_context", "fresh_context"] | None = None
+    memory_visibility_policy: (
+        Literal[
+            "persistent_context",
+            "artifact_memory",
+            "raw_evidence_only",
+            "current_release_only",
+        ]
+        | None
+    ) = None
+    configuration: dict[str, Any] = Field(default_factory=dict)
+    status: Literal["completed", "failed", "partial"]
+    input_tokens: NonNegativeInt = 0
+    output_tokens: NonNegativeInt = 0
+    cache_read_tokens: NonNegativeInt = 0
+    cache_write_tokens: NonNegativeInt = 0
+    failure_kind: str | None = None
+    provider_error: str | None = None
+    artifacts: list[ArtifactReference] = Field(default_factory=list)
+
+    @field_validator("checkpoint_ids")
+    @classmethod
+    def validate_checkpoint_ids(cls, value: list[str]) -> list[str]:
+        if len(value) != len(set(value)):
+            raise ValueError("session checkpoint ids must be unique")
+        return value
+
+
+class LifecycleExecutionRecord(StrictModel):
+    execution_mode: Literal["persistent_context", "fresh_context"]
+    memory_visibility_policy: Literal[
+        "persistent_context",
+        "artifact_memory",
+        "raw_evidence_only",
+        "current_release_only",
+    ]
+    max_turns_per_session: PositiveInt
+    status: Literal["completed", "failed", "partial"]
+    sessions: list[LifecycleSessionRecord] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_session_consistency(self) -> "LifecycleExecutionRecord":
+        if self.execution_mode == "persistent_context" and self.memory_visibility_policy != "persistent_context":
+            raise ValueError("persistent lifecycle execution requires persistent_context visibility")
+        if self.execution_mode == "fresh_context" and self.memory_visibility_policy == "persistent_context":
+            raise ValueError("fresh lifecycle execution cannot use persistent_context visibility")
+        resolved_models = {
+            session.resolved_model for session in self.sessions if session.resolved_model != "unresolved"
+        }
+        if len(resolved_models) > 1:
+            raise ValueError("resolved model must remain stable across lifecycle sessions")
+        if len({session.adapter for session in self.sessions if session.adapter != "unresolved"}) > 1:
+            raise ValueError("adapter must remain stable across lifecycle sessions")
+        session_ids = [session.session_id for session in self.sessions]
+        if len(session_ids) != len(set(session_ids)):
+            raise ValueError("lifecycle session ids must be unique")
+        if self.status == "completed" and (
+            not self.sessions or any(session.status != "completed" for session in self.sessions)
+        ):
+            raise ValueError("completed lifecycle execution requires completed sessions")
+        if any(
+            session.execution_mode is not None and session.execution_mode != self.execution_mode
+            for session in self.sessions
+        ):
+            raise ValueError("session execution mode must match lifecycle execution")
+        if any(
+            session.memory_visibility_policy is not None
+            and session.memory_visibility_policy != self.memory_visibility_policy
+            for session in self.sessions
+        ):
+            raise ValueError("session visibility policy must match lifecycle execution")
+        return self
+
+
+class LifecycleTrialProvenance(StrictModel):
+    lifecycle_id: NonEmptyStr
+    world_id: NonEmptyStr
+    spec_sha256: NonEmptyStr
+    package_sha256: NonEmptyStr
+    repository_commit: NonEmptyStr
+    repository_kind: Literal["git", "source_tree"] = "git"
+    repository_dirty: bool
+    repository_dirty_digest: NonEmptyStr
+    runtime_provider: NonEmptyStr
+    runtime_distributions: tuple[NonEmptyStr, ...]
+    runtime_dependency_sha256: NonEmptyStr
+    verifier_qualified_name: NonEmptyStr
+    verifier_source_sha256: NonEmptyStr
+    invocation_manifest: ArtifactReference
+    invocation_index: ArtifactReference | None = None
+    ablation_manifest: ArtifactReference | None = None
+    ablation_plan: ArtifactReference | None = None
+
+    @field_validator(
+        "spec_sha256",
+        "package_sha256",
+        "repository_dirty_digest",
+        "runtime_dependency_sha256",
+        "verifier_source_sha256",
+    )
+    @classmethod
+    def validate_hashes(cls, value: str) -> str:
+        return ArtifactReference.validate_sha256(value)
+
+    @field_validator("runtime_distributions")
+    @classmethod
+    def validate_runtime_distributions(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if not value:
+            raise ValueError("runtime dependency distributions are required")
+        if tuple(sorted(set(value))) != value:
+            raise ValueError("runtime dependency distributions must be sorted and unique")
+        return value
+
+
 class TrialRecord(StrictModel):
     trial_id: NonEmptyStr
     experiment_id: NonEmptyStr
@@ -141,6 +277,8 @@ class TrialRecord(StrictModel):
     timing: TimingRecord
     cost: CostRecord | None = None
     adaptation: AdaptationProvenance | None = None
+    lifecycle_execution: LifecycleExecutionRecord | None = None
+    lifecycle_provenance: LifecycleTrialProvenance | None = None
     completeness: Completeness
 
     @model_validator(mode="after")
@@ -153,7 +291,66 @@ class TrialRecord(StrictModel):
                 missing.append("environment.tool_versions")
             if self.inputs.input_files is None:
                 missing.append("inputs.input_files")
+            if self.lifecycle_execution is not None or self.lifecycle_provenance is not None:
+                if self.lifecycle_execution is None:
+                    missing.append("lifecycle_execution")
+                if self.lifecycle_provenance is None:
+                    missing.append("lifecycle_provenance")
+                if self.lifecycle_provenance is not None and self.lifecycle_provenance.repository_dirty:
+                    missing.append("lifecycle_provenance.clean_repository")
+                if self.lifecycle_provenance is not None:
+                    if self.lifecycle_provenance.invocation_index is None:
+                        missing.append("lifecycle_provenance.invocation_index")
+                    if self.lifecycle_provenance.ablation_manifest is None:
+                        missing.append("lifecycle_provenance.ablation_manifest")
+                    if self.lifecycle_provenance.ablation_plan is None:
+                        missing.append("lifecycle_provenance.ablation_plan")
+                if self.lifecycle_execution is not None and not self.lifecycle_execution.sessions:
+                    missing.append("lifecycle_execution.sessions")
+                if self.lifecycle_execution is not None and any(
+                    not session.artifacts for session in self.lifecycle_execution.sessions
+                ):
+                    missing.append("lifecycle_execution.sessions.artifacts")
+                if self.lifecycle_execution is not None and any(
+                    session.resolved_model == "unresolved" for session in self.lifecycle_execution.sessions
+                ):
+                    missing.append("lifecycle_execution.sessions.resolved_model")
+                if self.lifecycle_execution is not None and any(
+                    session.adapter == "unresolved" for session in self.lifecycle_execution.sessions
+                ):
+                    missing.append("lifecycle_execution.sessions.adapter")
+                if not self.outputs.artifacts:
+                    missing.append("outputs.artifacts")
             if missing:
                 msg = f"complete trial record missing provenance fields: {', '.join(missing)}"
                 raise ValueError(msg)
+        if (self.lifecycle_execution is None) != (self.lifecycle_provenance is None):
+            raise ValueError("lifecycle execution and provenance must be provided together")
+        if self.lifecycle_execution is not None:
+            resolved_models = {
+                session.resolved_model
+                for session in self.lifecycle_execution.sessions
+                if session.resolved_model != "unresolved"
+            }
+            adapters = {
+                session.adapter for session in self.lifecycle_execution.sessions if session.adapter != "unresolved"
+            }
+            if resolved_models and resolved_models != {self.agent.model}:
+                raise ValueError("agent model must match the lifecycle resolved model")
+            if adapters and adapters != {self.agent.adapter}:
+                raise ValueError("agent adapter must match lifecycle sessions")
+            if (
+                self.outputs.artifacts
+                and self.lifecycle_provenance is not None
+                and self.lifecycle_provenance.invocation_manifest not in self.outputs.artifacts
+            ):
+                raise ValueError("lifecycle invocation manifest must be included in output artifacts")
+            if self.outputs.artifacts and self.lifecycle_provenance is not None:
+                bound_artifacts = (
+                    self.lifecycle_provenance.invocation_index,
+                    self.lifecycle_provenance.ablation_manifest,
+                    self.lifecycle_provenance.ablation_plan,
+                )
+                if any(artifact is not None and artifact not in self.outputs.artifacts for artifact in bound_artifacts):
+                    raise ValueError("lifecycle sweep provenance must be included in output artifacts")
         return self

--- a/src/aec_bench/ledger/durability.py
+++ b/src/aec_bench/ledger/durability.py
@@ -1,0 +1,40 @@
+# ABOUTME: Provides fsync-aware filesystem primitives for immutable ledger publication.
+# ABOUTME: Makes newly created directories, staged trees, and parent entries power-loss durable.
+
+import os
+from pathlib import Path
+
+
+def mkdir_durable(path: Path) -> None:
+    """Create a directory tree and fsync every parent whose child entry changed."""
+    target = Path(path)
+    missing: list[Path] = []
+    cursor = target
+    while not cursor.exists():
+        missing.append(cursor)
+        cursor = cursor.parent
+    target.mkdir(parents=True, exist_ok=True)
+    for directory in reversed(missing):
+        fsync_directory(directory.parent)
+
+
+def fsync_tree(root: Path) -> None:
+    """Flush every regular file and directory in one staged publication tree."""
+    for path in sorted(item for item in Path(root).rglob("*") if item.is_file()):
+        descriptor = os.open(path, os.O_RDONLY)
+        try:
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+    directories = [Path(root), *(item for item in Path(root).rglob("*") if item.is_dir())]
+    for path in sorted(directories, key=lambda item: len(item.parts), reverse=True):
+        fsync_directory(path)
+
+
+def fsync_directory(path: Path) -> None:
+    """Flush one directory entry table."""
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)

--- a/src/aec_bench/ledger/writer.py
+++ b/src/aec_bench/ledger/writer.py
@@ -1,9 +1,12 @@
 # ABOUTME: Append-only TrialRecord persistence helpers for the Python ledger package.
 # ABOUTME: Writes one JSON record per trial and rejects duplicate trial IDs within an experiment.
 
+import os
+import uuid
 from pathlib import Path
 
 from aec_bench.contracts.trial_record import TrialRecord
+from aec_bench.ledger.durability import fsync_directory, mkdir_durable
 
 
 class DuplicateTrialRecordError(Exception):
@@ -12,12 +15,27 @@ class DuplicateTrialRecordError(Exception):
 
 def write_trial_record(*, ledger_root: Path, record: TrialRecord) -> Path:
     path = ledger_root / record.experiment_id / f"{record.trial_id}.json"
-    if path.exists():
-        raise DuplicateTrialRecordError(f"trial record already exists: {path}")
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(record.model_dump_json(indent=2), encoding="utf-8")
+    mkdir_durable(path.parent)
+    temporary = path.parent / f".{path.name}.{uuid.uuid4().hex}.tmp"
+    try:
+        _write_record_temp(temporary, record.model_dump_json(indent=2))
+        try:
+            os.link(temporary, path)
+        except FileExistsError as exc:
+            raise DuplicateTrialRecordError(f"trial record already exists: {path}") from exc
+        fsync_directory(path.parent)
+    finally:
+        temporary.unlink(missing_ok=True)
     return path
 
 
 def write_trial_records(*, ledger_root: Path, records: list[TrialRecord]) -> list[Path]:
     return [write_trial_record(ledger_root=ledger_root, record=record) for record in records]
+
+
+def _write_record_temp(path: Path, payload: str) -> None:
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+        handle.write(payload)
+        handle.flush()
+        os.fsync(handle.fileno())

--- a/src/aec_bench/meta_harness/evidence_lifecycle.py
+++ b/src/aec_bench/meta_harness/evidence_lifecycle.py
@@ -47,6 +47,18 @@ def load_evidence_lifecycle_spec(package_dir: Path) -> EvidenceLifecycleSpec:
     return EvidenceLifecycleSpec.model_validate(payload)
 
 
+def evidence_lifecycle_package_identity(package_dir: Path) -> dict[str, str]:
+    """Return the content-bound identity of one validated lifecycle package."""
+    package = Path(package_dir)
+    spec = load_evidence_lifecycle_spec(package)
+    return {
+        "lifecycle_id": spec.lifecycle_id,
+        "world_id": spec.world_id,
+        "spec_sha256": _spec_sha256(spec),
+        "package_sha256": _package_sha256(package),
+    }
+
+
 def prepare_evidence_checkpoint(package_dir: Path, run_dir: Path) -> dict[str, Any]:
     """Release exactly the next checkpoint into the persistent agent workspace."""
     package = Path(package_dir)

--- a/src/aec_bench/meta_harness/evidence_lifecycle_ablation.py
+++ b/src/aec_bench/meta_harness/evidence_lifecycle_ablation.py
@@ -1,0 +1,639 @@
+# ABOUTME: Orchestrates resumable model-by-variant evidence-lifecycle ablation experiments.
+# ABOUTME: Classifies persisted state, dispatches trials, and publishes immutable records and summaries.
+
+from __future__ import annotations
+
+import json
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, cast
+
+import yaml  # type: ignore[import-untyped]
+
+from aec_bench.contracts.trial_record import TrialRecord
+from aec_bench.meta_harness.evidence_lifecycle import (
+    evidence_lifecycle_package_identity,
+    read_evidence_lifecycle_state,
+    run_evidence_lifecycle,
+)
+from aec_bench.meta_harness.evidence_lifecycle_ablation_plan import (
+    LifecycleAblationCondition,
+    LifecycleAblationLimits,
+    LifecycleAblationManifest,
+    LifecycleAblationPlan,
+    LifecycleAblationRunResult,
+    LifecycleAblationStudyDesign,
+    LifecycleAblationTrial,
+    LifecycleExecutionMode,
+    build_lifecycle_ablation_plan,
+)
+from aec_bench.meta_harness.evidence_lifecycle_experiment import (
+    LifecycleExperimentSweepContext,
+)
+from aec_bench.meta_harness.evidence_lifecycle_local import (
+    recover_completed_persistent_lifecycle_session,
+    run_local_evidence_lifecycle_fresh_context,
+    run_local_evidence_lifecycle_session,
+    validate_completed_persistent_lifecycle_recovery,
+)
+from aec_bench.task_world_templates.catalogue import get_template
+from aec_bench.task_world_templates.lifecycles import (
+    lifecycle_package_variant,
+)
+from aec_bench.task_world_templates.materializer import (
+    materialize_template_lifecycle,
+    verify_template_lifecycle,
+)
+
+__all__ = [
+    "LifecycleAblationCondition",
+    "LifecycleAblationLimits",
+    "LifecycleAblationManifest",
+    "LifecycleAblationPlan",
+    "LifecycleAblationRunResult",
+    "LifecycleAblationStudyDesign",
+    "LifecycleAblationTrial",
+    "LifecycleExecutionMode",
+    "build_lifecycle_ablation_plan",
+    "inspect_lifecycle_ablation_plan",
+    "load_lifecycle_ablation_manifest",
+    "run_lifecycle_ablation",
+]
+
+LifecycleRegistryFactory = Callable[[LifecycleAblationTrial, Path, Path], Any]
+
+
+def load_lifecycle_ablation_manifest(path: Path) -> LifecycleAblationManifest:
+    """Load YAML and resolve sweep storage paths relative to the manifest file."""
+    source = Path(path)
+    payload = yaml.safe_load(source.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected lifecycle ablation YAML object: {source}")
+    manifest = LifecycleAblationManifest.model_validate(payload)
+    base = source.parent.resolve()
+
+    def resolve(raw: str) -> str:
+        candidate = Path(raw)
+        return str(candidate.resolve() if candidate.is_absolute() else (base / candidate).resolve())
+
+    normalized = manifest.model_dump(mode="json")
+    normalized["output_root"] = resolve(manifest.output_root)
+    normalized["ledger_root"] = resolve(manifest.ledger_root)
+    return LifecycleAblationManifest.model_validate(normalized)
+
+
+def inspect_lifecycle_ablation_plan(manifest: LifecycleAblationManifest) -> dict[str, Any]:
+    """Report deterministic trial status without creating files or invoking adapters."""
+    from aec_bench.meta_harness.evidence_lifecycle_trial_record import (
+        build_lifecycle_trial_record,
+        validate_lifecycle_ablation_snapshot,
+    )
+
+    plan = build_lifecycle_ablation_plan(manifest)
+    mutable_trials = [
+        trial
+        for trial in plan.trials
+        if not Path(trial.ledger_path).is_file()
+        and not (Path(manifest.ledger_root) / manifest.experiment_id / "_artifacts" / trial.trial_id).is_dir()
+    ]
+    contract_error: str | None = None
+    smoke_error: str | None = None
+    if mutable_trials:
+        try:
+            contract_error = _persisted_contract_error(
+                Path(manifest.output_root) / "manifest.json",
+                manifest.model_dump(mode="json"),
+                label="lifecycle ablation manifest",
+            ) or _persisted_contract_error(
+                Path(manifest.output_root) / "plan.json",
+                plan.model_dump(mode="json"),
+                label="lifecycle ablation plan",
+            )
+        except (OSError, ValueError) as exc:
+            contract_error = str(exc)
+        if contract_error is None:
+            smoke_error = _dry_run_smoke_error(manifest, plan)
+    statuses: list[dict[str, Any]] = []
+    for trial in plan.trials:
+        status = "pending"
+        reason: str | None = None
+        record_path = Path(trial.ledger_path)
+        package = Path(trial.package_dir)
+        run_dir = Path(trial.run_dir)
+        artifact_dir = Path(manifest.ledger_root) / manifest.experiment_id / "_artifacts" / trial.trial_id
+        if record_path.is_file():
+            try:
+                record = TrialRecord.model_validate_json(record_path.read_text(encoding="utf-8"))
+                _validate_existing_record(record, manifest, trial)
+            except (OSError, RuntimeError, ValueError) as exc:
+                status = "conflict"
+                reason = str(exc)
+            else:
+                status = "complete"
+        elif artifact_dir.is_dir():
+            try:
+                validate_lifecycle_ablation_snapshot(manifest, trial)
+            except (OSError, RuntimeError, ValueError) as exc:
+                status = "conflict"
+                reason = str(exc)
+            else:
+                status = "finalizable"
+        else:
+            reason = contract_error or smoke_error
+            if reason is None and package.exists():
+                try:
+                    _validate_variant_package(package, trial)
+                except (OSError, RuntimeError, ValueError) as exc:
+                    reason = str(exc)
+            if reason is not None:
+                status = "conflict"
+            elif _trial_has_finalizable_state(manifest, trial):
+                try:
+                    if (run_dir / "state.json").is_file():
+                        _validate_ablation_runtime_state(package, run_dir, trial)
+                    build_lifecycle_trial_record(
+                        manifest=manifest,
+                        trial=trial,
+                        package_dir=package,
+                        run_dir=run_dir,
+                    )
+                except (OSError, RuntimeError, ValueError) as exc:
+                    status = "conflict"
+                    reason = str(exc)
+                else:
+                    status = "finalizable"
+            elif (run_dir / "state.json").is_file():
+                try:
+                    _validate_ablation_runtime_state(package, run_dir, trial)
+                    state = read_evidence_lifecycle_state(package, run_dir)
+                    if (
+                        state["status"] == "complete"
+                        and trial.execution_mode is LifecycleExecutionMode.PERSISTENT_CONTEXT
+                    ):
+                        validate_completed_persistent_lifecycle_recovery(package, run_dir)
+                except (OSError, RuntimeError, ValueError) as exc:
+                    status = "conflict"
+                    reason = str(exc)
+                else:
+                    status = (
+                        "finalizable"
+                        if state["status"] == "complete"
+                        and trial.execution_mode is LifecycleExecutionMode.PERSISTENT_CONTEXT
+                        else "resumable"
+                    )
+        item = {
+            "trial_id": trial.trial_id,
+            "variant_id": trial.variant_id,
+            "agent_name": trial.agent.name,
+            "adapter": trial.agent.adapter,
+            "model": trial.agent.model,
+            "execution_mode": trial.execution_mode.value,
+            "memory_visibility_policy": trial.memory_visibility_policy.value,
+            "repetition": trial.repetition,
+            "package_dir": trial.package_dir,
+            "run_dir": trial.run_dir,
+            "ledger_path": trial.ledger_path,
+            "status": status,
+        }
+        if reason is not None:
+            item["reason"] = reason
+        statuses.append(item)
+    return {
+        "plan": plan.model_dump(mode="json"),
+        "trial_statuses": statuses,
+    }
+
+
+def run_lifecycle_ablation(
+    manifest: LifecycleAblationManifest,
+    *,
+    registry_factory: LifecycleRegistryFactory | None = None,
+) -> LifecycleAblationRunResult:
+    """Execute or resume a sequential sweep and finalize each invocation once."""
+    from aec_bench.meta_harness.evidence_lifecycle_trial_record import finalize_lifecycle_trial_record
+
+    plan = build_lifecycle_ablation_plan(manifest)
+    output_root = Path(manifest.output_root)
+
+    executed = 0
+    imported_orphans = 0
+    skipped = 0
+    failed = 0
+    trial_ids = [trial.trial_id for trial in plan.trials]
+    record_paths_by_trial: dict[str, str] = {}
+    remaining: list[LifecycleAblationTrial] = []
+    for trial in plan.trials:
+        record_path = Path(trial.ledger_path)
+        if record_path.is_file():
+            record = TrialRecord.model_validate_json(record_path.read_text(encoding="utf-8"))
+            _validate_existing_record(record, manifest, trial)
+            skipped += 1
+            record_paths_by_trial[trial.trial_id] = str(record_path)
+            continue
+        artifact_dir = Path(manifest.ledger_root) / manifest.experiment_id / "_artifacts" / trial.trial_id
+        if artifact_dir.is_dir():
+            finalized = finalize_lifecycle_trial_record(
+                manifest=manifest,
+                trial=trial,
+                package_dir=Path(trial.package_dir),
+                run_dir=Path(trial.run_dir),
+            )
+            imported_orphans += 1
+            record_paths_by_trial[trial.trial_id] = str(finalized)
+            record = TrialRecord.model_validate_json(finalized.read_text(encoding="utf-8"))
+            failed += int(_record_execution_failed(record))
+            continue
+        remaining.append(trial)
+
+    if remaining:
+        _write_or_validate_json(
+            output_root / "manifest.json",
+            manifest.model_dump(mode="json"),
+            label="lifecycle ablation manifest",
+        )
+        _write_or_validate_json(
+            output_root / "plan.json",
+            plan.model_dump(mode="json"),
+            label="lifecycle ablation plan",
+        )
+
+    planned_by_variant = {trial.variant_id: trial for trial in remaining}
+    packages = {
+        variant_id: _ensure_variant_package(manifest, planned_by_variant[variant_id])
+        for variant_id in sorted(planned_by_variant)
+    }
+    if packages:
+        _smoke_lifecycle_packages(packages)
+
+    for trial in remaining:
+        package = packages[trial.variant_id]
+        run_dir = Path(trial.run_dir)
+        if (run_dir / "state.json").is_file():
+            _validate_ablation_runtime_state(package, run_dir, trial)
+
+        if _trial_has_finalizable_state(manifest, trial):
+            finalized = finalize_lifecycle_trial_record(
+                manifest=manifest,
+                trial=trial,
+                package_dir=package,
+                run_dir=run_dir,
+            )
+            imported_orphans += 1
+            record_paths_by_trial[trial.trial_id] = str(finalized)
+            record = TrialRecord.model_validate_json(finalized.read_text(encoding="utf-8"))
+            failed += int(_record_execution_failed(record))
+            continue
+
+        sweep_context = LifecycleExperimentSweepContext(
+            sweep_experiment_id=manifest.experiment_id,
+            planned_trial_id=trial.trial_id,
+            plan_sha256=plan.plan_sha256,
+            condition_id=f"{trial.execution_mode.value}__{trial.memory_visibility_policy.value}",
+            repetition=trial.repetition,
+        )
+        max_turns = trial.max_turns_per_session
+        state = read_evidence_lifecycle_state(package, run_dir) if (run_dir / "state.json").is_file() else None
+        if (
+            state is not None
+            and state["status"] == "complete"
+            and trial.execution_mode is LifecycleExecutionMode.PERSISTENT_CONTEXT
+        ):
+            recover_completed_persistent_lifecycle_session(
+                package_dir=package,
+                run_dir=run_dir,
+                model=trial.agent.model,
+                verifier=verify_template_lifecycle,
+                adapter_kind=trial.agent.adapter,
+                max_turns=max_turns,
+                process_id=f"process.lifecycle.{trial.trial_id}",
+                visibility_policy=trial.memory_visibility_policy,
+                sweep_context=sweep_context,
+                repository_dir=Path(__file__).resolve().parent,
+            )
+            finalized = finalize_lifecycle_trial_record(
+                manifest=manifest,
+                trial=trial,
+                package_dir=package,
+                run_dir=run_dir,
+            )
+            imported_orphans += 1
+            record_paths_by_trial[trial.trial_id] = str(finalized)
+            record = TrialRecord.model_validate_json(finalized.read_text(encoding="utf-8"))
+            failed += int(_record_execution_failed(record))
+            continue
+
+        registry = registry_factory(trial, package, run_dir) if registry_factory is not None else None
+        try:
+            if trial.execution_mode is LifecycleExecutionMode.PERSISTENT_CONTEXT:
+                run_local_evidence_lifecycle_session(
+                    package_dir=package,
+                    run_dir=run_dir,
+                    model=trial.agent.model,
+                    verifier=verify_template_lifecycle,
+                    adapter_kind=trial.agent.adapter,
+                    max_turns=max_turns,
+                    process_id=f"process.lifecycle.{trial.trial_id}",
+                    registry=registry,
+                    visibility_policy=trial.memory_visibility_policy,
+                    sweep_context=sweep_context,
+                    repository_dir=Path(__file__).resolve().parent,
+                    require_adapter_identity_match=True,
+                )
+            else:
+                run_local_evidence_lifecycle_fresh_context(
+                    package_dir=package,
+                    run_dir=run_dir,
+                    model=trial.agent.model,
+                    verifier=verify_template_lifecycle,
+                    adapter_kind=trial.agent.adapter,
+                    max_turns=max_turns,
+                    process_id=f"process.lifecycle.{trial.trial_id}",
+                    registry=registry,
+                    visibility_policy=trial.memory_visibility_policy,
+                    sweep_context=sweep_context,
+                    repository_dir=Path(__file__).resolve().parent,
+                    require_adapter_identity_match=True,
+                )
+        except Exception:
+            if not (run_dir / "experiment-manifest.json").is_file():
+                raise
+        executed += 1
+        finalized = finalize_lifecycle_trial_record(
+            manifest=manifest,
+            trial=trial,
+            package_dir=package,
+            run_dir=run_dir,
+        )
+        record_paths_by_trial[trial.trial_id] = str(finalized)
+        record = TrialRecord.model_validate_json(finalized.read_text(encoding="utf-8"))
+        failed += int(_record_execution_failed(record))
+
+    from aec_bench.meta_harness.evidence_lifecycle_evaluation import write_lifecycle_ablation_evaluation
+
+    summary_path = write_lifecycle_ablation_evaluation(manifest)
+    record_paths = [record_paths_by_trial[trial_id] for trial_id in trial_ids]
+    return LifecycleAblationRunResult(
+        experiment_id=manifest.experiment_id,
+        plan_sha256=plan.plan_sha256,
+        run_root=manifest.output_root,
+        ledger_root=manifest.ledger_root,
+        planned_trials=plan.trial_count,
+        executed_trials=executed,
+        imported_orphans=imported_orphans,
+        skipped_trials=skipped,
+        failed_trials=failed,
+        trial_ids=trial_ids,
+        record_paths=record_paths,
+        summary_path=str(summary_path),
+    )
+
+
+def _ensure_variant_package(manifest: LifecycleAblationManifest, trial: LifecycleAblationTrial) -> Path:
+    variant_id = trial.variant_id
+    package = Path(manifest.output_root) / "packages" / variant_id
+    if not package.exists():
+        materialize_template_lifecycle(
+            get_template(manifest.lifecycle_template_id),
+            package,
+            variant_id=variant_id,
+        )
+    _validate_variant_package(package, trial)
+    return package
+
+
+def _validate_variant_package(package: Path, trial: LifecycleAblationTrial) -> None:
+    variant_id = trial.variant_id
+    identity = lifecycle_package_variant(package)
+    if identity is None or identity.get("variant_id") != variant_id:
+        raise ValueError(f"materialized lifecycle package does not match planned variant {variant_id!r}")
+    package_identity = evidence_lifecycle_package_identity(package)
+    expected_identity = {
+        "lifecycle_id": trial.lifecycle_id,
+        "world_id": trial.world_id,
+        "spec_sha256": trial.spec_sha256,
+        "package_sha256": trial.package_sha256,
+    }
+    if package_identity != expected_identity:
+        raise ValueError("variant identity does not match materialized package content")
+
+
+def _smoke_lifecycle_packages(packages: dict[str, Path]) -> None:
+    with tempfile.TemporaryDirectory(prefix="aec-bench-lifecycle-smoke-") as temporary:
+        smoke_root = Path(temporary)
+        for variant_id, package in sorted(packages.items()):
+            gold_path = package / "hidden" / "gold-submissions.json"
+            if not gold_path.is_file():
+                raise ValueError(f"lifecycle package lacks deterministic smoke submissions: {variant_id}")
+            gold = _read_json(gold_path)
+
+            run_dir = smoke_root / variant_id
+            run_evidence_lifecycle(
+                package,
+                run_dir,
+                episode_resolver=_gold_smoke_resolver(gold),
+            )
+            verification = verify_template_lifecycle(package, run_dir)
+            if not verification.get("passed") or float(verification.get("reward", 0.0)) != 1.0:
+                raise ValueError(f"lifecycle package failed deterministic smoke verification: {variant_id}")
+
+
+def _dry_run_smoke_error(
+    manifest: LifecycleAblationManifest,
+    plan: LifecycleAblationPlan,
+) -> str | None:
+    try:
+        with tempfile.TemporaryDirectory(prefix="aec-bench-lifecycle-inspect-") as temporary:
+            temporary_root = Path(temporary)
+            trials_by_variant = {trial.variant_id: trial for trial in plan.trials}
+            packages: dict[str, Path] = {}
+            for variant_id in sorted(manifest.variants):
+                planned = Path(trials_by_variant[variant_id].package_dir)
+                if planned.exists():
+                    packages[variant_id] = planned
+                    continue
+                packages[variant_id] = materialize_template_lifecycle(
+                    get_template(manifest.lifecycle_template_id),
+                    temporary_root / variant_id,
+                    variant_id=variant_id,
+                )
+            _smoke_lifecycle_packages(packages)
+    except (OSError, RuntimeError, ValueError) as exc:
+        return str(exc)
+    return None
+
+
+def _validate_ablation_runtime_state(
+    package: Path,
+    run_dir: Path,
+    trial: LifecycleAblationTrial,
+) -> None:
+    state = read_evidence_lifecycle_state(package, run_dir)
+    checkpoint_runs = state.get("checkpoint_runs")
+    if not isinstance(checkpoint_runs, list):
+        raise ValueError("lifecycle state checkpoint_runs are malformed")
+    session_attempts: dict[str, list[str]] = {}
+    for checkpoint in checkpoint_runs:
+        if not isinstance(checkpoint, dict):
+            raise ValueError("lifecycle checkpoint state is malformed")
+        checkpoint_id = str(checkpoint.get("checkpoint_id") or "")
+        attempts = checkpoint.get("attempts")
+        if not isinstance(attempts, list):
+            raise ValueError(f"lifecycle checkpoint attempts are malformed: {checkpoint_id}")
+        for attempt in attempts:
+            if not isinstance(attempt, dict):
+                raise ValueError(f"lifecycle checkpoint attempt is malformed: {checkpoint_id}")
+            if attempt.get("execution_mode") != trial.execution_mode.value:
+                raise ValueError(f"attempt execution mode does not match planned trial: {checkpoint_id}")
+            session_id = str(attempt.get("session_id") or "")
+            session_attempts.setdefault(session_id, []).append(checkpoint_id)
+        if checkpoint.get("status") != "submitted":
+            continue
+        if not attempts:
+            raise ValueError(f"submitted checkpoint has no adapter attempt owner: {checkpoint_id}")
+        submitted = [attempt for attempt in attempts if attempt.get("status") == "submitted"]
+        if len(submitted) != 1 or attempts[-1] != submitted[0]:
+            raise ValueError(f"submitted checkpoint has ambiguous adapter attempt ownership: {checkpoint_id}")
+
+    if trial.execution_mode is LifecycleExecutionMode.FRESH_CONTEXT and any(
+        len(checkpoint_ids) != 1 for checkpoint_ids in session_attempts.values()
+    ):
+        raise ValueError("fresh session must own exactly one checkpoint attempt")
+
+    for path in sorted(run_dir.glob("**/agent_result.json")):
+        if "experiments" in path.relative_to(run_dir).parts:
+            continue
+        try:
+            payload = _read_json(path)
+        except (OSError, ValueError) as exc:
+            relative = path.relative_to(run_dir)
+            session_id = relative.parts[1] if len(relative.parts) == 3 else ""
+            session_attempt_statuses = [
+                str(attempt.get("status") or "")
+                for checkpoint in checkpoint_runs
+                for attempt in checkpoint.get("attempts", [])
+                if isinstance(attempt, dict) and attempt.get("session_id") == session_id
+            ]
+            terminal_persistent_result = (
+                path.is_file()
+                and trial.execution_mode is LifecycleExecutionMode.PERSISTENT_CONTEXT
+                and state.get("status") == "complete"
+                and relative.parts == ("sessions", session_id, "agent_result.json")
+                and bool(session_attempt_statuses)
+                and all(status == "submitted" for status in session_attempt_statuses)
+            )
+            if not terminal_persistent_result:
+                raise ValueError(f"lifecycle session result is malformed: {path}") from exc
+            validate_completed_persistent_lifecycle_recovery(package, run_dir)
+            continue
+        if payload.get("model") != trial.agent.model:
+            raise ValueError(f"lifecycle session requested model does not match planned trial: {path}")
+        if payload.get("adapter") != trial.agent.adapter:
+            raise ValueError(f"lifecycle session requested adapter does not match planned trial: {path}")
+        if payload.get("max_turns") != trial.max_turns_per_session:
+            raise ValueError(f"lifecycle session turn limit does not match planned trial: {path}")
+        expected_session_mode = (
+            "persistent" if trial.execution_mode is LifecycleExecutionMode.PERSISTENT_CONTEXT else "fresh"
+        )
+        if payload.get("session_mode") != expected_session_mode:
+            raise ValueError(f"session execution mode does not match planned trial: {path}")
+        if payload.get("memory_visibility_policy") != trial.memory_visibility_policy.value:
+            raise ValueError(f"session visibility policy does not match planned trial: {path}")
+        relative = path.relative_to(run_dir)
+        session_id = str(payload.get("session_id") or "")
+        if expected_session_mode == "persistent" and relative.parts[:2] != ("sessions", session_id):
+            raise ValueError(f"persistent session artifact path does not match planned trial: {path}")
+        if expected_session_mode == "fresh" and (
+            len(relative.parts) < 4 or relative.parts[0] != "episodes" or relative.parts[2] != session_id
+        ):
+            raise ValueError(f"fresh session artifact path does not match planned trial: {path}")
+        resolved_adapter = payload.get("adapter_name")
+        if not isinstance(resolved_adapter, str) or not resolved_adapter:
+            raise ValueError(f"lifecycle session resolved adapter is missing: {path}")
+        allowed_mismatch = payload.get("status") == "failed" and (
+            payload.get("failure_kind") == "adapter_identity_mismatch"
+            or (
+                resolved_adapter == "unresolved"
+                and payload.get("failure_kind") in {"interrupted", "interrupted_after_completion"}
+            )
+        )
+        if resolved_adapter != trial.agent.adapter and not allowed_mismatch:
+            raise ValueError(f"lifecycle session resolved adapter does not match planned trial: {path}")
+
+
+def _write_or_validate_json(path: Path, payload: dict[str, Any], *, label: str) -> None:
+    if path.is_file():
+        if _read_json(path) != payload:
+            raise ValueError(f"{label} conflicts with the persisted sweep contract")
+        return
+    if path.exists():
+        raise ValueError(f"{label} path is not a file: {path}")
+    temporary = path.with_suffix(f"{path.suffix}.tmp")
+    _write_json(temporary, payload)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary.replace(path)
+
+
+def _persisted_contract_error(path: Path, payload: dict[str, Any], *, label: str) -> str | None:
+    if path.is_file():
+        if _read_json(path) != payload:
+            return f"{label} conflicts with the persisted sweep contract"
+        return None
+    if path.exists():
+        return f"{label} path is not a file: {path}"
+    return None
+
+
+def _gold_smoke_resolver(
+    gold: dict[str, Any],
+) -> Callable[[dict[str, Any]], dict[str, str]]:
+    def resolve(context: dict[str, Any]) -> dict[str, str]:
+        submission = Path(context["submission_path"])
+        _write_json(
+            submission,
+            cast(dict[str, Any], gold[context["checkpoint_id"]]),
+        )
+        return {"status": "completed"}
+
+    return resolve
+
+
+def _trial_has_finalizable_state(
+    manifest: LifecycleAblationManifest,
+    trial: LifecycleAblationTrial,
+) -> bool:
+    artifact_dir = Path(manifest.ledger_root) / manifest.experiment_id / "_artifacts" / trial.trial_id
+    canonical_invocations = Path(trial.run_dir) / "experiments"
+    return artifact_dir.is_dir() or any(
+        not path.parent.name.startswith(".") for path in canonical_invocations.glob("*/experiment-manifest.json")
+    )
+
+
+def _validate_existing_record(
+    record: TrialRecord,
+    manifest: LifecycleAblationManifest,
+    trial: LifecycleAblationTrial,
+) -> None:
+    from aec_bench.meta_harness.evidence_lifecycle_trial_record import validate_lifecycle_ablation_record
+
+    validate_lifecycle_ablation_record(record, manifest, trial)
+
+
+def _record_execution_failed(record: TrialRecord) -> bool:
+    return (
+        record.lifecycle_execution is None
+        or record.lifecycle_execution.status != "completed"
+        or not record.evaluation.validity.verifier_completed
+    )
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return cast(dict[str, Any], payload)
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/src/aec_bench/meta_harness/evidence_lifecycle_ablation_plan.py
+++ b/src/aec_bench/meta_harness/evidence_lifecycle_ablation_plan.py
@@ -1,0 +1,443 @@
+# ABOUTME: Defines immutable contracts and content-bound planning for lifecycle ablation sweeps.
+# ABOUTME: Keeps plan identity independent from execution, finalization, and summary orchestration.
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import re
+import tempfile
+from enum import StrEnum
+from pathlib import Path
+from typing import Literal
+
+from pydantic import (
+    Field,
+    NonNegativeFloat,
+    NonNegativeInt,
+    PositiveInt,
+    field_validator,
+    model_validator,
+)
+
+from aec_bench.contracts.experiment_manifest import AgentConfig
+from aec_bench.contracts.trial_record import AdaptationProvenance, ArtifactReference
+from aec_bench.contracts.validators import NonEmptyStr, StrictModel
+from aec_bench.meta_harness.evidence_lifecycle import evidence_lifecycle_package_identity
+from aec_bench.meta_harness.evidence_lifecycle_experiment import (
+    repository_provenance,
+    runtime_dependency_provenance,
+)
+from aec_bench.meta_harness.evidence_lifecycle_local import (
+    LifecycleVisibilityPolicy,
+    run_local_evidence_lifecycle_fresh_context,
+)
+from aec_bench.task_world_templates.catalogue import get_template
+from aec_bench.task_world_templates.lifecycles import (
+    lifecycle_variant_ids,
+    lifecycle_variant_metadata,
+    registered_lifecycle_verifier,
+)
+from aec_bench.task_world_templates.materializer import (
+    materialize_template_lifecycle,
+    verify_template_lifecycle,
+)
+
+
+class LifecycleExecutionMode(StrEnum):
+    PERSISTENT_CONTEXT = "persistent_context"
+    FRESH_CONTEXT = "fresh_context"
+
+
+class LifecycleAblationCondition(StrictModel):
+    execution_mode: LifecycleExecutionMode
+    memory_visibility_policy: LifecycleVisibilityPolicy
+
+    @model_validator(mode="after")
+    def validate_mode_policy_pair(self) -> LifecycleAblationCondition:
+        if (
+            self.execution_mode is LifecycleExecutionMode.PERSISTENT_CONTEXT
+            and self.memory_visibility_policy is not LifecycleVisibilityPolicy.PERSISTENT_CONTEXT
+        ):
+            raise ValueError("persistent_context execution requires persistent_context visibility")
+        if (
+            self.execution_mode is LifecycleExecutionMode.FRESH_CONTEXT
+            and self.memory_visibility_policy is LifecycleVisibilityPolicy.PERSISTENT_CONTEXT
+        ):
+            raise ValueError("fresh_context execution cannot use persistent_context visibility")
+        return self
+
+
+def _default_conditions() -> tuple[LifecycleAblationCondition, ...]:
+    return (
+        LifecycleAblationCondition(
+            execution_mode=LifecycleExecutionMode.PERSISTENT_CONTEXT,
+            memory_visibility_policy=LifecycleVisibilityPolicy.PERSISTENT_CONTEXT,
+        ),
+        LifecycleAblationCondition(
+            execution_mode=LifecycleExecutionMode.FRESH_CONTEXT,
+            memory_visibility_policy=LifecycleVisibilityPolicy.ARTIFACT_MEMORY,
+        ),
+        LifecycleAblationCondition(
+            execution_mode=LifecycleExecutionMode.FRESH_CONTEXT,
+            memory_visibility_policy=LifecycleVisibilityPolicy.RAW_EVIDENCE_ONLY,
+        ),
+        LifecycleAblationCondition(
+            execution_mode=LifecycleExecutionMode.FRESH_CONTEXT,
+            memory_visibility_policy=LifecycleVisibilityPolicy.CURRENT_RELEASE_ONLY,
+        ),
+    )
+
+
+class LifecycleAblationLimits(StrictModel):
+    max_trials: PositiveInt
+    max_concurrency: Literal[1] = 1
+    max_estimated_cost_usd: NonNegativeFloat | None = None
+
+
+class LifecycleAblationStudyDesign(StrictModel):
+    interpretation: Literal["descriptive_calibration"]
+    turn_budget_scope: Literal["per_session"]
+    execution_order: Literal["deterministic_sequential_plan_order"]
+    randomized: Literal[False]
+    counterbalanced: Literal[False]
+    causal_effects_supported: Literal[False]
+
+
+class LifecycleAblationManifest(StrictModel):
+    schema_version: Literal["1"] = "1"
+    experiment_id: NonEmptyStr
+    lifecycle_template_id: NonEmptyStr
+    variants: tuple[NonEmptyStr, ...]
+    agents: tuple[AgentConfig, ...]
+    study_design: LifecycleAblationStudyDesign
+    conditions: tuple[LifecycleAblationCondition, ...] = Field(default_factory=_default_conditions)
+    repetitions: PositiveInt = 1
+    output_root: NonEmptyStr
+    ledger_root: NonEmptyStr
+    limits: LifecycleAblationLimits
+    estimated_cost_per_trial_usd: NonNegativeFloat | None = None
+
+    @field_validator("experiment_id")
+    @classmethod
+    def validate_safe_experiment_id(cls, value: str) -> str:
+        if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", value) is None:
+            raise ValueError("experiment_id must be safe for use as a directory name")
+        return value
+
+    @field_validator("variants")
+    @classmethod
+    def validate_variants(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if not value:
+            raise ValueError("variants must not be empty")
+        if len(value) != len(set(value)):
+            raise ValueError("variant ids must be unique")
+        return value
+
+    @field_validator("agents")
+    @classmethod
+    def validate_agents(cls, value: tuple[AgentConfig, ...]) -> tuple[AgentConfig, ...]:
+        if not value:
+            raise ValueError("agents must not be empty")
+        names = [agent.name for agent in value]
+        if len(names) != len(set(names)):
+            raise ValueError("agent names must be unique")
+        for agent in value:
+            if agent.adapter not in {"tool_loop", "pydantic_ai"}:
+                raise ValueError("lifecycle ablations require tool_loop or pydantic_ai adapters")
+            if agent.client is not None:
+                raise ValueError("lifecycle ablations do not yet accept custom client configuration")
+            if agent.system_prompt_file is not None:
+                raise ValueError("lifecycle ablations use the lifecycle-owned system prompt")
+            unknown_parameters = sorted(set(agent.parameters) - {"max_turns_per_session"})
+            if unknown_parameters:
+                raise ValueError(
+                    "unsupported lifecycle agent parameters: "
+                    f"{', '.join(unknown_parameters)}; use max_turns_per_session because total trial budgets "
+                    "are not controlled"
+                )
+            max_turns = agent.parameters.get("max_turns_per_session")
+            if max_turns is None:
+                raise ValueError("lifecycle agent max_turns_per_session is required")
+            if not isinstance(max_turns, int) or isinstance(max_turns, bool) or max_turns < 1:
+                raise ValueError("lifecycle agent max_turns_per_session must be a positive integer")
+        return value
+
+    @field_validator("conditions")
+    @classmethod
+    def validate_conditions(
+        cls,
+        value: tuple[LifecycleAblationCondition, ...],
+    ) -> tuple[LifecycleAblationCondition, ...]:
+        if not value:
+            raise ValueError("conditions must not be empty")
+        identities = [(condition.execution_mode, condition.memory_visibility_policy) for condition in value]
+        if len(identities) != len(set(identities)):
+            raise ValueError("ablation conditions must be unique")
+        return value
+
+    @model_validator(mode="after")
+    def validate_cost_limit(self) -> LifecycleAblationManifest:
+        if self.limits.max_estimated_cost_usd is not None and self.estimated_cost_per_trial_usd is None:
+            raise ValueError("estimated_cost_per_trial_usd is required when a cost limit is set")
+        return self
+
+
+class LifecycleRuntimeProvenance(StrictModel):
+    adapter: Literal["tool_loop", "pydantic_ai"]
+    provider: NonEmptyStr
+    distributions: tuple[NonEmptyStr, ...]
+    dependency_inventory_sha256: NonEmptyStr
+
+    @field_validator("dependency_inventory_sha256")
+    @classmethod
+    def validate_hash(cls, value: str) -> str:
+        return ArtifactReference.validate_sha256(value)
+
+    @model_validator(mode="after")
+    def validate_distributions(self) -> LifecycleRuntimeProvenance:
+        if not self.distributions:
+            raise ValueError("runtime provenance requires dependency distributions")
+        if tuple(sorted(set(self.distributions))) != self.distributions:
+            raise ValueError("runtime provenance distributions must be sorted and unique")
+        return self
+
+
+class LifecycleAblationTrial(StrictModel):
+    trial_id: NonEmptyStr
+    variant_id: NonEmptyStr
+    adaptation: AdaptationProvenance
+    lifecycle_id: NonEmptyStr
+    world_id: NonEmptyStr
+    spec_sha256: NonEmptyStr
+    package_sha256: NonEmptyStr
+    agent: AgentConfig
+    runtime_provenance: LifecycleRuntimeProvenance
+    max_turns_per_session: PositiveInt
+    execution_mode: LifecycleExecutionMode
+    memory_visibility_policy: LifecycleVisibilityPolicy
+    repetition: PositiveInt
+    package_dir: NonEmptyStr
+    run_dir: NonEmptyStr
+    ledger_path: NonEmptyStr
+
+    @field_validator("spec_sha256", "package_sha256")
+    @classmethod
+    def validate_hashes(cls, value: str) -> str:
+        return ArtifactReference.validate_sha256(value)
+
+
+class LifecycleAblationCodeProvenance(StrictModel):
+    repository_commit: NonEmptyStr
+    source_inventory_sha256: NonEmptyStr
+    planner_source_sha256: NonEmptyStr
+    lifecycle_runtime_source_sha256: NonEmptyStr
+    local_runner_source_sha256: NonEmptyStr
+    trial_importer_source_sha256: NonEmptyStr
+    verifier_entrypoint_qualified_name: NonEmptyStr
+    verifier_entrypoint_source_sha256: NonEmptyStr
+    verifier_qualified_name: NonEmptyStr
+    verifier_source_sha256: NonEmptyStr
+
+    @field_validator(
+        "planner_source_sha256",
+        "lifecycle_runtime_source_sha256",
+        "local_runner_source_sha256",
+        "trial_importer_source_sha256",
+        "source_inventory_sha256",
+        "verifier_entrypoint_source_sha256",
+        "verifier_source_sha256",
+    )
+    @classmethod
+    def validate_hashes(cls, value: str) -> str:
+        return ArtifactReference.validate_sha256(value)
+
+
+class LifecycleAblationPlan(StrictModel):
+    schema_version: Literal["1"] = "1"
+    experiment_id: NonEmptyStr
+    manifest_sha256: NonEmptyStr
+    plan_sha256: NonEmptyStr
+    study_design: LifecycleAblationStudyDesign
+    code_provenance: LifecycleAblationCodeProvenance
+    trial_count: NonNegativeInt
+    planned_estimated_cost_usd: NonNegativeFloat | None = None
+    trials: tuple[LifecycleAblationTrial, ...]
+
+    @model_validator(mode="after")
+    def validate_trial_count(self) -> LifecycleAblationPlan:
+        if self.trial_count != len(self.trials):
+            raise ValueError("trial_count must equal the number of planned trials")
+        expected = _canonical_sha256(self.model_dump(mode="json", exclude={"plan_sha256"}))
+        if self.plan_sha256 != expected:
+            raise ValueError("plan_sha256 must bind the canonical expanded lifecycle plan")
+        return self
+
+
+class LifecycleAblationRunResult(StrictModel):
+    schema_version: Literal["1"] = "1"
+    experiment_id: NonEmptyStr
+    plan_sha256: NonEmptyStr
+    run_root: NonEmptyStr
+    ledger_root: NonEmptyStr
+    planned_trials: NonNegativeInt
+    executed_trials: NonNegativeInt
+    imported_orphans: NonNegativeInt
+    skipped_trials: NonNegativeInt
+    failed_trials: NonNegativeInt
+    trial_ids: list[NonEmptyStr]
+    record_paths: list[NonEmptyStr]
+    summary_path: NonEmptyStr
+
+
+def build_lifecycle_ablation_plan(manifest: LifecycleAblationManifest) -> LifecycleAblationPlan:
+    """Expand a validated manifest into stable identities without provider calls."""
+    manifest = LifecycleAblationManifest.model_validate(manifest.model_dump(mode="json"))
+    try:
+        known_variants = set(lifecycle_variant_ids(manifest.lifecycle_template_id))
+    except KeyError as exc:
+        raise ValueError(f"unknown lifecycle template: {manifest.lifecycle_template_id}") from exc
+    unknown = sorted(set(manifest.variants) - known_variants)
+    if unknown:
+        raise ValueError(f"unknown lifecycle variants for {manifest.lifecycle_template_id}: {', '.join(unknown)}")
+    adaptations = {
+        variant_id: AdaptationProvenance.model_validate(
+            lifecycle_variant_metadata(manifest.lifecycle_template_id, variant_id)["adaptation"]
+        )
+        for variant_id in manifest.variants
+    }
+    code_provenance = _ablation_code_provenance(manifest.lifecycle_template_id)
+    runtime_provenance = {
+        (agent.adapter, agent.model): LifecycleRuntimeProvenance.model_validate(
+            runtime_dependency_provenance(
+                adapter_kind=agent.adapter,
+                model_name=agent.model,
+            )
+        )
+        for agent in manifest.agents
+    }
+    package_identities: dict[str, dict[str, str]] = {}
+    with tempfile.TemporaryDirectory(prefix="aec-bench-lifecycle-plan-") as temporary:
+        package_root = Path(temporary)
+        template = get_template(manifest.lifecycle_template_id)
+        for variant_id in sorted(manifest.variants):
+            package = materialize_template_lifecycle(
+                template,
+                package_root / variant_id,
+                variant_id=variant_id,
+            )
+            package_identities[variant_id] = evidence_lifecycle_package_identity(package)
+
+    manifest_sha256 = _canonical_sha256(manifest.model_dump(mode="json"))
+    trials: list[LifecycleAblationTrial] = []
+    for variant_id in sorted(manifest.variants):
+        for agent in sorted(manifest.agents, key=lambda item: (item.name, item.adapter, item.model)):
+            for condition in sorted(
+                manifest.conditions,
+                key=lambda item: (item.execution_mode.value, item.memory_visibility_policy.value),
+            ):
+                for repetition_index in range(manifest.repetitions):
+                    identity = {
+                        "experiment_id": manifest.experiment_id,
+                        "lifecycle_template_id": manifest.lifecycle_template_id,
+                        "variant_id": variant_id,
+                        "adaptation": adaptations[variant_id].model_dump(mode="json"),
+                        "code_provenance": code_provenance.model_dump(mode="json"),
+                        "study_design": manifest.study_design.model_dump(mode="json"),
+                        **package_identities[variant_id],
+                        "agent": agent.model_dump(mode="json"),
+                        "runtime_provenance": runtime_provenance[(agent.adapter, agent.model)].model_dump(mode="json"),
+                        "execution_mode": condition.execution_mode.value,
+                        "memory_visibility_policy": condition.memory_visibility_policy.value,
+                        "repetition": repetition_index + 1,
+                    }
+                    trial_id = f"trial-{_canonical_sha256(identity)}"
+                    trials.append(
+                        LifecycleAblationTrial(
+                            trial_id=trial_id,
+                            variant_id=variant_id,
+                            adaptation=adaptations[variant_id],
+                            **package_identities[variant_id],
+                            agent=agent,
+                            runtime_provenance=runtime_provenance[(agent.adapter, agent.model)],
+                            max_turns_per_session=int(agent.parameters["max_turns_per_session"]),
+                            execution_mode=condition.execution_mode,
+                            memory_visibility_policy=condition.memory_visibility_policy,
+                            repetition=repetition_index + 1,
+                            package_dir=str(Path(manifest.output_root) / "packages" / variant_id),
+                            run_dir=str(Path(manifest.output_root) / "trials" / trial_id),
+                            ledger_path=str(Path(manifest.ledger_root) / manifest.experiment_id / f"{trial_id}.json"),
+                        )
+                    )
+
+    if len({trial.trial_id for trial in trials}) != len(trials):
+        raise ValueError("planned lifecycle trial identities are not unique")
+    trial_count = len(trials)
+    if trial_count > manifest.limits.max_trials:
+        raise ValueError(f"planned trial count {trial_count} exceeds max_trials {manifest.limits.max_trials}")
+    planned_cost = (
+        float(manifest.estimated_cost_per_trial_usd) * trial_count
+        if manifest.estimated_cost_per_trial_usd is not None
+        else None
+    )
+    if (
+        planned_cost is not None
+        and manifest.limits.max_estimated_cost_usd is not None
+        and planned_cost > manifest.limits.max_estimated_cost_usd
+    ):
+        raise ValueError(
+            f"planned estimated cost {planned_cost} exceeds limit {manifest.limits.max_estimated_cost_usd}"
+        )
+    plan_payload = {
+        "schema_version": "1",
+        "experiment_id": manifest.experiment_id,
+        "manifest_sha256": manifest_sha256,
+        "study_design": manifest.study_design.model_dump(mode="json"),
+        "code_provenance": code_provenance.model_dump(mode="json"),
+        "trial_count": trial_count,
+        "planned_estimated_cost_usd": planned_cost,
+        "trials": [trial.model_dump(mode="json") for trial in trials],
+    }
+    return LifecycleAblationPlan.model_validate(
+        {
+            **plan_payload,
+            "plan_sha256": _canonical_sha256(plan_payload),
+        }
+    )
+
+
+def _canonical_sha256(payload: object) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _ablation_code_provenance(template_id: str) -> LifecycleAblationCodeProvenance:
+    planner_path = Path(__file__).resolve()
+    lifecycle_runtime_path = planner_path.with_name("evidence_lifecycle.py")
+    local_runner_path = Path(inspect.getsourcefile(run_local_evidence_lifecycle_fresh_context) or "")
+    importer_path = planner_path.with_name("evidence_lifecycle_trial_record.py")
+    verifier_entrypoint_path = Path(inspect.getsourcefile(verify_template_lifecycle) or "")
+    verifier = registered_lifecycle_verifier(template_id)
+    verifier_path = Path(inspect.getsourcefile(verifier) or "")
+    paths = {
+        "planner_source_sha256": planner_path,
+        "lifecycle_runtime_source_sha256": lifecycle_runtime_path,
+        "local_runner_source_sha256": local_runner_path,
+        "trial_importer_source_sha256": importer_path,
+        "verifier_entrypoint_source_sha256": verifier_entrypoint_path,
+        "verifier_source_sha256": verifier_path,
+    }
+    missing = [str(path) for path in paths.values() if not path.is_file()]
+    if missing:
+        raise ValueError(f"lifecycle ablation source provenance is unavailable: {', '.join(missing)}")
+    repository = repository_provenance(planner_path.parent)
+    return LifecycleAblationCodeProvenance(
+        **{name: hashlib.sha256(path.read_bytes()).hexdigest() for name, path in paths.items()},
+        repository_commit=str(repository["commit"]),
+        source_inventory_sha256=str(repository["source_inventory_sha256"]),
+        verifier_entrypoint_qualified_name=(
+            f"{verify_template_lifecycle.__module__}.{verify_template_lifecycle.__qualname__}"
+        ),
+        verifier_qualified_name=f"{verifier.__module__}.{verifier.__qualname__}",
+    )

--- a/src/aec_bench/meta_harness/evidence_lifecycle_evaluation.py
+++ b/src/aec_bench/meta_harness/evidence_lifecycle_evaluation.py
@@ -1,0 +1,314 @@
+# ABOUTME: Builds lifecycle-ablation summaries exclusively from append-only core TrialRecords.
+# ABOUTME: Keeps sweep-specific evaluation beside its meta-harness plan and immutable snapshot boundary.
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import defaultdict
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from aec_bench.contracts.trial_record import ArtifactReference, TrialRecord
+from aec_bench.evaluation.artifact import (
+    EvaluationArtifact,
+    EvaluationFilters,
+    write_evaluation_artifact,
+)
+from aec_bench.meta_harness.evidence_lifecycle_ablation_plan import (
+    LifecycleAblationManifest,
+    LifecycleAblationPlan,
+    LifecycleAblationTrial,
+    build_lifecycle_ablation_plan,
+)
+from aec_bench.meta_harness.evidence_lifecycle_trial_record import (
+    validate_historical_lifecycle_ablation_record,
+)
+
+
+def build_lifecycle_ablation_evaluation(
+    manifest: LifecycleAblationManifest,
+) -> EvaluationArtifact:
+    """Build one deterministic summary from the experiment's core ledger records."""
+    paths = _trial_record_paths(manifest)
+    if paths:
+        first = TrialRecord.model_validate_json(paths[0].read_text(encoding="utf-8"))
+        historical_manifest, plan = _load_historical_sweep_contract(manifest, first)
+    else:
+        historical_manifest = manifest
+        plan = build_lifecycle_ablation_plan(manifest)
+    planned = {trial.trial_id: trial for trial in plan.trials}
+    records = _read_validated_records(historical_manifest, plan, planned, paths)
+
+    completed = sum(_record_completed(record) for record in records)
+    failed = len(records) - completed
+    passed = sum(record.evaluation.reward >= 1.0 for record in records)
+    rewards = [record.evaluation.reward for record in records]
+    summary = {
+        "study_design": plan.study_design.model_dump(mode="json"),
+        "planned_trials": plan.trial_count,
+        "invocation_records": len(records),
+        "completed_trials": completed,
+        "failed_trials": failed,
+        "passed_trials": passed,
+        "mean_reward": _mean(rewards),
+        "total_cost_usd": sum(record.cost.estimated_cost_usd or 0.0 for record in records if record.cost is not None),
+        "groups": _group_records(records, planned),
+    }
+    record_digest = hashlib.sha256(
+        json.dumps(
+            [record.model_dump(mode="json") for record in sorted(records, key=lambda item: item.trial_id)],
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    timestamp = max((record.timestamp for record in records), default=datetime.fromtimestamp(0, tz=UTC))
+    return EvaluationArtifact(
+        evaluation_id=f"lifecycle-ablation-{record_digest}",
+        experiment_id=manifest.experiment_id,
+        timestamp=timestamp,
+        filters=EvaluationFilters(),
+        summary=summary,
+        framework_version="1",
+    )
+
+
+def write_lifecycle_ablation_evaluation(manifest: LifecycleAblationManifest) -> Path:
+    """Persist the deterministic ledger-derived summary as an EvaluationArtifact."""
+    return write_evaluation_artifact(
+        Path(manifest.ledger_root),
+        build_lifecycle_ablation_evaluation(manifest),
+    )
+
+
+def _group_records(
+    records: list[TrialRecord],
+    planned: dict[str, LifecycleAblationTrial],
+) -> list[dict[str, Any]]:
+    grouped: dict[tuple[str, str, str, str, str, str], list[TrialRecord]] = defaultdict(list)
+    for record in records:
+        trial = planned[record.trial_id]
+        key = (
+            trial.agent.name,
+            trial.agent.adapter,
+            trial.agent.model,
+            trial.variant_id,
+            trial.execution_mode.value,
+            trial.memory_visibility_policy.value,
+        )
+        grouped[key].append(record)
+
+    result: list[dict[str, Any]] = []
+    for key, group in sorted(grouped.items()):
+        rewards = [record.evaluation.reward for record in group]
+        retentions = [retention for record in group if (retention := _retention(record)) is not None]
+        completed = sum(_record_completed(record) for record in group)
+        executions = [record.lifecycle_execution for record in group]
+        if any(execution is None for execution in executions):
+            raise ValueError("lifecycle calibration group contains a record without execution provenance")
+        turn_limits = {execution.max_turns_per_session for execution in executions if execution is not None}
+        if len(turn_limits) != 1:
+            raise ValueError("lifecycle calibration group mixes per-session turn limits")
+        max_turns_per_session = next(iter(turn_limits))
+        session_counts = [len(execution.sessions) for execution in executions if execution is not None]
+        configured_capacities = [max_turns_per_session * count for count in session_counts]
+        requests = [_operational_metric(record, "requests") for record in group]
+        tool_calls = [_operational_metric(record, "tool_calls") for record in group]
+        token_values = {
+            "input": [
+                record.cost.tokens_in if record.cost and record.cost.tokens_in is not None else 0 for record in group
+            ],
+            "output": [
+                record.cost.tokens_out if record.cost and record.cost.tokens_out is not None else 0 for record in group
+            ],
+            "cache_read": [
+                record.cost.cache_read_tokens if record.cost and record.cost.cache_read_tokens is not None else 0
+                for record in group
+            ],
+            "cache_write": [
+                record.cost.cache_write_tokens if record.cost and record.cost.cache_write_tokens is not None else 0
+                for record in group
+            ],
+        }
+        result.append(
+            {
+                "agent_name": key[0],
+                "adapter": key[1],
+                "requested_adapter": key[1],
+                "resolved_adapters": sorted(
+                    {
+                        session.adapter
+                        for execution in executions
+                        if execution is not None
+                        for session in execution.sessions
+                    }
+                ),
+                "requested_model": key[2],
+                "resolved_models": sorted(
+                    {
+                        session.resolved_model
+                        for execution in executions
+                        if execution is not None
+                        for session in execution.sessions
+                    }
+                ),
+                "variant_id": key[3],
+                "execution_mode": key[4],
+                "memory_visibility_policy": key[5],
+                "trials": len(group),
+                "completed": completed,
+                "failed": len(group) - completed,
+                "passed": sum(reward >= 1.0 for reward in rewards),
+                "mean_reward": _mean(rewards),
+                "mean_retention": _mean(retentions) if retentions else None,
+                "total_cost_usd": sum(
+                    record.cost.estimated_cost_usd or 0.0 for record in group if record.cost is not None
+                ),
+                "turn_budget_scope": "per_session",
+                "max_turns_per_session": max_turns_per_session,
+                "total_sessions": sum(session_counts),
+                "mean_sessions_per_trial": _mean(session_counts),
+                "total_configured_turn_capacity": sum(configured_capacities),
+                "mean_configured_turn_capacity": _mean(configured_capacities),
+                "total_requests": sum(requests),
+                "mean_requests": _mean(requests),
+                "total_tool_calls": sum(tool_calls),
+                "mean_tool_calls": _mean(tool_calls),
+                "total_input_tokens": sum(token_values["input"]),
+                "mean_input_tokens": _mean(token_values["input"]),
+                "total_output_tokens": sum(token_values["output"]),
+                "mean_output_tokens": _mean(token_values["output"]),
+                "total_cache_read_tokens": sum(token_values["cache_read"]),
+                "mean_cache_read_tokens": _mean(token_values["cache_read"]),
+                "total_cache_write_tokens": sum(token_values["cache_write"]),
+                "mean_cache_write_tokens": _mean(token_values["cache_write"]),
+            }
+        )
+    return result
+
+
+def _read_validated_records(
+    manifest: LifecycleAblationManifest,
+    plan: LifecycleAblationPlan,
+    planned: dict[str, LifecycleAblationTrial],
+    paths: list[Path],
+) -> list[TrialRecord]:
+    records: list[TrialRecord] = []
+    seen: set[str] = set()
+    for path in paths:
+        record = TrialRecord.model_validate_json(path.read_text(encoding="utf-8"))
+        trial = planned.get(record.trial_id)
+        if trial is None:
+            raise ValueError(f"ledger contains trial outside the ablation plan: {record.trial_id}")
+        if record.trial_id in seen:
+            raise ValueError(f"ledger contains duplicate planned trial id: {record.trial_id}")
+        if path.resolve() != Path(trial.ledger_path).resolve():
+            raise ValueError(f"TrialRecord is not stored at its canonical ledger path: {record.trial_id}")
+        validate_historical_lifecycle_ablation_record(record, manifest, plan, trial)
+        seen.add(record.trial_id)
+        records.append(record)
+    return records
+
+
+def _trial_record_paths(manifest: LifecycleAblationManifest) -> list[Path]:
+    experiment_root = Path(manifest.ledger_root) / manifest.experiment_id
+    if not experiment_root.exists():
+        return []
+    return sorted(
+        path
+        for path in experiment_root.rglob("*.json")
+        if not any(part.startswith("_") for part in path.relative_to(experiment_root).parts)
+    )
+
+
+def _load_historical_sweep_contract(
+    requested_manifest: LifecycleAblationManifest,
+    record: TrialRecord,
+) -> tuple[LifecycleAblationManifest, LifecycleAblationPlan]:
+    provenance = record.lifecycle_provenance
+    if provenance is None or provenance.ablation_manifest is None or provenance.ablation_plan is None:
+        raise ValueError("historical TrialRecord is missing snapshotted ablation contract references")
+    manifest_payload = _read_artifact_json(
+        Path(requested_manifest.ledger_root),
+        provenance.ablation_manifest,
+        expected_kind="lifecycle_ablation_manifest",
+    )
+    plan_payload = _read_artifact_json(
+        Path(requested_manifest.ledger_root),
+        provenance.ablation_plan,
+        expected_kind="lifecycle_ablation_plan",
+    )
+    historical_manifest = LifecycleAblationManifest.model_validate(manifest_payload)
+    plan = LifecycleAblationPlan.model_validate(plan_payload)
+    if historical_manifest != requested_manifest:
+        raise ValueError("requested ablation manifest does not match the snapshotted historical manifest")
+    manifest_sha256 = hashlib.sha256(
+        json.dumps(
+            historical_manifest.model_dump(mode="json"),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode("utf-8")
+    ).hexdigest()
+    if plan.experiment_id != historical_manifest.experiment_id or plan.manifest_sha256 != manifest_sha256:
+        raise ValueError("snapshotted historical plan does not bind the ablation manifest")
+    return historical_manifest, plan
+
+
+def _read_artifact_json(
+    ledger_root: Path,
+    artifact: ArtifactReference,
+    *,
+    expected_kind: str,
+) -> dict[str, Any]:
+    if artifact.kind != expected_kind:
+        raise ValueError(f"historical sweep artifact kind must be {expected_kind}")
+    root = ledger_root.resolve()
+    path = (ledger_root / artifact.path).resolve()
+    try:
+        path.relative_to(root)
+    except ValueError as exc:
+        raise ValueError("historical sweep artifact escapes the ledger root") from exc
+    if not path.is_file() or hashlib.sha256(path.read_bytes()).hexdigest() != artifact.sha256:
+        raise ValueError("historical sweep artifact hash does not match its TrialRecord")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("historical sweep artifact must contain a JSON object")
+    return payload
+
+
+def _retention(record: TrialRecord) -> float | None:
+    breakdown = record.evaluation.breakdown
+    if not isinstance(breakdown, dict):
+        return None
+    semantic = breakdown.get("semantic_transition")
+    if not isinstance(semantic, dict):
+        return None
+    aggregate = semantic.get("aggregate")
+    if not isinstance(aggregate, dict):
+        return None
+    value = aggregate.get("retention")
+    return float(value) if isinstance(value, int | float) and not isinstance(value, bool) else None
+
+
+def _record_completed(record: TrialRecord) -> bool:
+    return bool(
+        record.lifecycle_execution is not None
+        and record.lifecycle_execution.status == "completed"
+        and record.evaluation.validity.verifier_completed
+    )
+
+
+def _operational_metric(record: TrialRecord, name: str) -> int:
+    breakdown = record.evaluation.breakdown
+    operational = breakdown.get("operational_metrics") if isinstance(breakdown, dict) else None
+    value = operational.get(name) if isinstance(operational, dict) else None
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ValueError(f"lifecycle operational metric must be a non-negative integer: {name}")
+    return value
+
+
+def _mean(values: Sequence[float | int]) -> float:
+    return sum(values) / len(values) if values else 0.0

--- a/src/aec_bench/meta_harness/evidence_lifecycle_experiment.py
+++ b/src/aec_bench/meta_harness/evidence_lifecycle_experiment.py
@@ -3,25 +3,45 @@
 
 from __future__ import annotations
 
+import fcntl
 import hashlib
 import inspect
 import json
 import os
+import platform
+import re
+import shutil
 import subprocess
+import sys
 import uuid
+from collections import deque
 from datetime import UTC, datetime
+from importlib import metadata as importlib_metadata
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Literal, cast
+from urllib.parse import unquote, urlparse
 
-from pydantic import Field, NonNegativeFloat, NonNegativeInt
+from pydantic import Field, NonNegativeFloat, NonNegativeInt, PositiveInt
 
 from aec_bench.contracts.pricing import estimate_cost_usd
 from aec_bench.contracts.trajectory import read_trajectory
 from aec_bench.contracts.validators import NonEmptyStr, StrictModel
+from aec_bench.ledger.durability import (
+    fsync_directory as _fsync_directory,
+)
+from aec_bench.ledger.durability import (
+    fsync_tree as _fsync_tree,
+)
+from aec_bench.ledger.durability import (
+    mkdir_durable,
+)
 from aec_bench.meta_harness.evidence_lifecycle import read_evidence_lifecycle_state
 from aec_bench.meta_harness.evidence_lifecycle_metrics import LifecycleSemanticMetrics
 from aec_bench.meta_harness.ledger import read_ledger
-from aec_bench.task_world_templates.lifecycles import lifecycle_package_variant
+from aec_bench.task_world_templates.lifecycles import (
+    lifecycle_package_variant,
+    registered_lifecycle_verifier,
+)
 
 
 class LifecycleExperimentMetrics(StrictModel):
@@ -43,17 +63,54 @@ class LifecycleExperimentMetrics(StrictModel):
     semantic_transition: LifecycleSemanticMetrics | None = None
 
 
+class LifecycleExperimentSweepContext(StrictModel):
+    schema_version: Literal["1"] = "1"
+    sweep_experiment_id: NonEmptyStr
+    planned_trial_id: NonEmptyStr
+    plan_sha256: NonEmptyStr
+    condition_id: NonEmptyStr
+    repetition: PositiveInt
+
+
 class LifecycleExperimentManifest(StrictModel):
     schema_version: NonEmptyStr = "1"
     experiment_id: NonEmptyStr
     created_at: NonEmptyStr
     repository: dict[str, Any]
+    environment: dict[str, Any]
     lifecycle: dict[str, Any]
     verifier: dict[str, Any]
     model: dict[str, Any]
     execution: dict[str, Any]
     interaction: dict[str, Any]
     outputs: dict[str, Any]
+    sweep: LifecycleExperimentSweepContext | None = None
+
+
+_REALIZED_FILE_DIGESTS: dict[Path, tuple[tuple[int, int, int, int, int], str]] = {}
+_REQUIREMENT_PATTERN = re.compile(r"^\s*([A-Za-z0-9][A-Za-z0-9._-]*)(?:\[([^]]+)\])?")
+_EXTRA_MARKER_PATTERN = re.compile(r"\bextra\s*==\s*(['\"])([^'\"]+)\1")
+_OPENAI_COMPATIBLE_PROVIDERS = {
+    "alibaba",
+    "azure",
+    "cerebras",
+    "deepseek",
+    "fireworks",
+    "github",
+    "grok",
+    "heroku",
+    "litellm",
+    "moonshotai",
+    "nebius",
+    "ollama",
+    "openai",
+    "openai-chat",
+    "openai-responses",
+    "ovhcloud",
+    "sambanova",
+    "together",
+    "vercel",
+}
 
 
 def record_lifecycle_experiment(
@@ -66,6 +123,7 @@ def record_lifecycle_experiment(
     tool_schema: list[dict[str, Any]],
     repository_dir: Path | None = None,
     index_path: Path | None = None,
+    sweep_context: LifecycleExperimentSweepContext | None = None,
 ) -> dict[str, Any]:
     """Write one self-contained run record and append its immutable index entry."""
     package = Path(package_dir)
@@ -85,7 +143,11 @@ def record_lifecycle_experiment(
     _write_json(metrics_path, metrics_payload)
     trajectories = sorted(run.glob("**/trajectory.jsonl"))
     prompts = _interaction_prompts(trajectories)
-    repository = _repository_provenance(repository_dir or Path.cwd())
+    repository = repository_provenance(repository_dir or Path(__file__).resolve().parent)
+    runtime_provenance = runtime_dependency_provenance(
+        adapter_kind=str(agent["adapter"]),
+        model_name=str(agent["model"]),
+    )
     state = _read_json(run / "state.json")
     experiment_id = f"lifecycle-{datetime.now(UTC).strftime('%Y%m%dT%H%M%S%fZ')}-{uuid.uuid4().hex[:12]}"
     output_hashes = _run_artifact_hashes(run)
@@ -98,18 +160,42 @@ def record_lifecycle_experiment(
     }
     if variant is not None:
         lifecycle_manifest["variant"] = variant
+    verifier_entrypoint = _callable_provenance(verifier)
+    registered_verifier = verifier_entrypoint
+    template_path = package / "template.json"
+    if template_path.is_file():
+        template_id = _read_json(template_path).get("template_id")
+        if isinstance(template_id, str):
+            try:
+                registered_verifier = _callable_provenance(registered_lifecycle_verifier(template_id))
+            except KeyError:
+                pass
+    verifier_chain = [verifier_entrypoint]
+    if registered_verifier != verifier_entrypoint:
+        verifier_chain.append(registered_verifier)
     manifest = LifecycleExperimentManifest(
         experiment_id=experiment_id,
         created_at=datetime.now(UTC).isoformat(),
         repository=repository,
+        environment={
+            "python_version": platform.python_version(),
+            "platform": platform.platform(),
+            "runtime_provenance": runtime_provenance,
+        },
         lifecycle=lifecycle_manifest,
-        verifier=_callable_provenance(verifier),
+        verifier={
+            **registered_verifier,
+            "entrypoint": verifier_entrypoint,
+            "chain": verifier_chain,
+        },
         model={
             "requested_model": agent["model"],
             "resolved_models": sorted(
                 {str(session.get("resolved_model") or agent["model"]) for session in agent.get("sessions", [])}
             ),
             "adapter": agent["adapter"],
+            "requested_adapter": agent["adapter"],
+            "resolved_adapters": agent.get("resolved_adapters", []),
             "session_configurations": [
                 session.get("configuration_record", {}) for session in agent.get("sessions", [])
             ],
@@ -134,31 +220,47 @@ def record_lifecycle_experiment(
             "metrics.json": _sha256(metrics_path),
             "artifacts": output_hashes,
         },
+        sweep=sweep_context,
     )
     _write_json(manifest_path, manifest.model_dump(mode="json"))
+    _fsync_tree(run)
     experiment_dir = run / "experiments" / experiment_id
-    canonical_verification = experiment_dir / "verification.json"
-    canonical_metrics = experiment_dir / "metrics.json"
+    canonical_staging = experiment_dir.with_name(f".{experiment_id}.staging-{uuid.uuid4().hex}")
     canonical_manifest = experiment_dir / "experiment-manifest.json"
-    _write_json(canonical_verification, verification)
-    _write_json(canonical_metrics, metrics_payload)
-    _write_json(canonical_manifest, manifest.model_dump(mode="json"))
-    manifest_sha256 = _sha256(canonical_manifest)
-    index_entry = {
-        "experiment_id": experiment_id,
-        "created_at": manifest.created_at,
-        "repository_commit": repository["commit"],
-        "model": agent["model"],
-        "execution_mode": agent["execution_mode"],
-        "memory_visibility_policy": agent["memory_visibility_policy"],
-        "reward": verification["reward"],
-        "passed": verification["passed"],
-        "manifest_path": str(canonical_manifest),
-        "manifest_sha256": manifest_sha256,
-    }
-    if variant is not None:
-        index_entry["variant_id"] = variant["variant_id"]
-        index_entry["adaptation"] = variant["adaptation"]
+    mkdir_durable(experiment_dir.parent)
+    try:
+        staging_verification = canonical_staging / "verification.json"
+        staging_metrics = canonical_staging / "metrics.json"
+        staging_manifest = canonical_staging / "experiment-manifest.json"
+        _write_json(staging_verification, verification)
+        _write_json(staging_metrics, metrics_payload)
+        _write_json(staging_manifest, manifest.model_dump(mode="json"))
+        manifest_sha256 = _sha256(staging_manifest)
+        index_entry = {
+            "experiment_id": experiment_id,
+            "created_at": manifest.created_at,
+            "repository_commit": repository["commit"],
+            "model": agent["model"],
+            "execution_mode": agent["execution_mode"],
+            "memory_visibility_policy": agent["memory_visibility_policy"],
+            "reward": verification["reward"],
+            "passed": verification["passed"],
+            "manifest_path": str(canonical_manifest),
+            "manifest_sha256": manifest_sha256,
+        }
+        if variant is not None:
+            index_entry["variant_id"] = variant["variant_id"]
+            index_entry["adaptation"] = variant["adaptation"]
+        if sweep_context is not None:
+            index_entry["sweep"] = sweep_context.model_dump(mode="json")
+        _write_json(canonical_staging / "index-entry.json", index_entry)
+        _fsync_tree(canonical_staging)
+        canonical_staging.replace(experiment_dir)
+        _fsync_directory(experiment_dir.parent)
+    except Exception:
+        if canonical_staging.exists():
+            shutil.rmtree(canonical_staging)
+        raise
     _append_jsonl(selected_index, index_entry)
     return {
         "experiment_id": experiment_id,
@@ -257,9 +359,270 @@ def _interaction_prompts(trajectory_paths: list[Path]) -> dict[str, Any]:
     return {"system_prompts": system_prompts, "user_prompts": user_prompts}
 
 
-def _repository_provenance(repository_dir: Path) -> dict[str, Any]:
-    root = _git(repository_dir, "rev-parse", "--show-toplevel").decode().strip()
+def runtime_dependency_provenance(
+    *,
+    adapter_kind: str,
+    model_name: str,
+    search_paths: tuple[Path, ...] | None = None,
+) -> dict[str, Any]:
+    """Hash the realized runtime distributions used by one lifecycle condition."""
+    if adapter_kind not in {"in_process", "tool_loop", "pydantic_ai"}:
+        raise ValueError(f"unsupported lifecycle runtime adapter: {adapter_kind}")
+
+    provider = _resolve_runtime_provider(adapter_kind, model_name)
+    roots = tuple(Path(path).resolve() for path in (search_paths or _runtime_distribution_search_paths()))
+    if not roots:
+        raise ValueError("lifecycle runtime distribution search path is unavailable")
+    distributions: dict[str, importlib_metadata.Distribution] = {}
+    for root in roots:
+        for candidate_distribution in importlib_metadata.distributions(path=[str(root)]):
+            raw_name = candidate_distribution.metadata.get("Name")
+            if raw_name:
+                distributions.setdefault(_canonicalize_distribution_name(str(raw_name)), candidate_distribution)
+    selected = _runtime_distribution_closure(distributions, adapter_kind, provider)
+    digest = hashlib.sha256()
+    identities: list[str] = []
+    for name in sorted(selected):
+        distribution = distributions.get(name)
+        if distribution is None:
+            identity = f"{name}==missing"
+            identities.append(identity)
+            _update_inventory_digest(digest, f"distribution/{name}", identity.encode("utf-8"))
+            continue
+        identity = f"{name}=={distribution.version}"
+        identities.append(identity)
+        _update_inventory_digest(digest, f"distribution/{name}", identity.encode("utf-8"))
+        entries = _realized_distribution_entries(name, distribution)
+        if not entries:
+            raise ValueError(f"runtime distribution has no hashable realized files: {identity}")
+        for relative, file_sha256 in entries:
+            _update_inventory_digest(
+                digest,
+                f"distribution/{name}/{relative}",
+                bytes.fromhex(file_sha256),
+            )
+    return {
+        "adapter": adapter_kind,
+        "provider": provider,
+        "distributions": sorted(identities),
+        "dependency_inventory_sha256": digest.hexdigest(),
+    }
+
+
+def _runtime_distribution_search_paths() -> tuple[Path, ...]:
+    roots: list[Path] = []
+    for raw_path in sys.path:
+        candidate = Path(raw_path or os.getcwd()).resolve()
+        if not candidate.is_dir() or not any(candidate.glob("*.dist-info")):
+            continue
+        if candidate not in roots:
+            roots.append(candidate)
+    return tuple(roots)
+
+
+def _runtime_distribution_closure(
+    distributions: dict[str, importlib_metadata.Distribution],
+    adapter_kind: str,
+    provider: str,
+) -> dict[str, set[str]]:
+    if adapter_kind == "in_process":
+        seeds: dict[str, set[str]] = {"pydantic": set(), "pyyaml": set()}
+    else:
+        provider_extras, provider_distributions = _runtime_provider_dependencies(provider)
+        seeds = {
+            "httpx": set(),
+            "pydantic": set(),
+            "pydantic-ai": set(),
+            "pydantic-ai-slim": provider_extras,
+            "pyyaml": set(),
+        }
+        seeds.update({name: set() for name in provider_distributions})
+    queue = deque((_canonicalize_distribution_name(name), extras) for name, extras in seeds.items())
+    selected: dict[str, set[str]] = {}
+    while queue:
+        name, requested_extras = queue.popleft()
+        if name in selected and requested_extras <= selected[name]:
+            continue
+        active_extras = selected.setdefault(name, set())
+        active_extras.update(requested_extras)
+        distribution = distributions.get(name)
+        if distribution is None or name == "pydantic-ai":
+            continue
+        for raw_requirement in distribution.requires or ():
+            parsed = _parse_distribution_requirement(raw_requirement, active_extras)
+            if parsed is None:
+                continue
+            requirement_name, requirement_extras = parsed
+            queue.append((requirement_name, requirement_extras))
+    return selected
+
+
+def _resolve_runtime_provider(adapter_kind: str, model_name: str) -> str:
+    if adapter_kind == "in_process":
+        return "in_process"
+    from aec_bench.adapters.rlm.providers import resolve_pydantic_provider
+
+    provider = resolve_pydantic_provider(model_name)
+    if provider == "auto" and ":" in model_name:
+        provider = model_name.split(":", maxsplit=1)[0]
+    return "google-vertex" if provider == "vertexai" else provider
+
+
+def _runtime_provider_dependencies(provider: str) -> tuple[set[str], set[str]]:
+    selected = provider.removeprefix("gateway/")
+    selected = {
+        "chat": "openai",
+        "converse": "bedrock",
+        "gemini": "google-gla",
+        "responses": "openai",
+    }.get(selected, selected)
+    if selected == "auto":
+        return set(), set()
+    if selected in _OPENAI_COMPATIBLE_PROVIDERS:
+        return {"openai"}, {"openai"}
+    mapping: dict[str, tuple[set[str], set[str]]] = {
+        "anthropic": ({"anthropic"}, {"anthropic"}),
+        "bedrock": ({"bedrock"}, {"boto3", "botocore"}),
+        "cohere": ({"cohere"}, {"cohere"}),
+        "google-gla": ({"google"}, {"google-genai"}),
+        "google-vertex": ({"google", "vertexai"}, {"google-auth", "google-genai"}),
+        "groq": ({"groq"}, {"groq"}),
+        "huggingface": ({"huggingface"}, {"huggingface-hub"}),
+        "mistral": ({"mistral"}, {"mistralai"}),
+        "openrouter": ({"openrouter"}, {"openai"}),
+        "sentence-transformers": ({"sentence-transformers"}, {"sentence-transformers"}),
+        "voyageai": ({"voyageai"}, {"voyageai"}),
+        "xai": ({"xai"}, {"xai-sdk"}),
+    }
+    try:
+        return mapping[selected]
+    except KeyError as exc:
+        raise ValueError(f"unsupported lifecycle runtime provider dependency mapping: {provider}") from exc
+
+
+def _canonicalize_distribution_name(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _parse_distribution_requirement(raw_requirement: str, active_extras: set[str]) -> tuple[str, set[str]] | None:
+    requirement, separator, marker = raw_requirement.partition(";")
+    match = _REQUIREMENT_PATTERN.match(requirement)
+    if match is None:
+        raise ValueError(f"runtime distribution requirement is malformed: {raw_requirement}")
+    if separator and "extra" in marker:
+        marker_extras = {match.group(2) for match in _EXTRA_MARKER_PATTERN.finditer(marker)}
+        if not marker_extras:
+            raise ValueError(f"runtime distribution extra marker is unsupported: {raw_requirement}")
+        if not active_extras.intersection(marker_extras):
+            return None
+    extras = {extra.strip() for extra in (match.group(2) or "").split(",") if extra.strip()}
+    return _canonicalize_distribution_name(match.group(1)), extras
+
+
+def _realized_distribution_entries(
+    name: str,
+    distribution: importlib_metadata.Distribution,
+) -> list[tuple[str, str]]:
+    entries: dict[str, str] = {}
+    for package_path in distribution.files or ():
+        relative = package_path.as_posix()
+        if "__pycache__" in package_path.parts or package_path.suffix == ".pyc":
+            continue
+        path = Path(str(distribution.locate_file(package_path)))
+        if path.is_file():
+            entries[relative] = _realized_file_sha256(path)
+        else:
+            entries[relative] = hashlib.sha256(b"missing-realized-file").hexdigest()
+    if not entries:
+        for metadata_name in ("METADATA", "WHEEL", "entry_points.txt", "direct_url.json", "RECORD"):
+            content = distribution.read_text(metadata_name)
+            if content is not None:
+                entries[f"metadata/{metadata_name}"] = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        root = Path(str(distribution.locate_file("")))
+        candidates = _distribution_top_level_names(name, distribution)
+        for candidate in candidates:
+            package = root / candidate
+            if package.is_file():
+                entries[f"package/{candidate}"] = _realized_file_sha256(package)
+            elif package.is_dir():
+                for path in _runtime_source_files(package):
+                    relative = path.relative_to(package).as_posix()
+                    entries[f"package/{candidate}/{relative}"] = _realized_file_sha256(path)
+    direct_url = distribution.read_text("direct_url.json")
+    if direct_url is not None:
+        entries.update(_editable_distribution_entries(name, direct_url))
+    return sorted(entries.items())
+
+
+def _distribution_top_level_names(
+    name: str,
+    distribution: importlib_metadata.Distribution,
+) -> tuple[str, ...]:
+    declared = distribution.read_text("top_level.txt") or ""
+    names = {line.strip() for line in declared.splitlines() if line.strip()}
+    names.add(name.replace("-", "_"))
+    return tuple(sorted(names))
+
+
+def _editable_distribution_entries(name: str, direct_url: str) -> dict[str, str]:
+    try:
+        payload = json.loads(direct_url)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"runtime distribution direct_url.json is malformed: {name}") from exc
+    if not isinstance(payload, dict) or not bool(payload.get("dir_info", {}).get("editable")):
+        return {}
+    parsed = urlparse(str(payload.get("url") or ""))
+    if parsed.scheme != "file":
+        raise ValueError(f"editable runtime distribution has unsupported source URL: {name}")
+    source = Path(unquote(parsed.path)).resolve()
+    if not source.is_dir():
+        raise ValueError(f"editable runtime distribution source is unavailable: {name}")
+    return {
+        f"editable/{path.relative_to(source).as_posix()}": _realized_file_sha256(path)
+        for path in _runtime_source_files(source)
+    }
+
+
+def _runtime_source_files(root: Path) -> list[Path]:
+    excluded = {".git", ".mypy_cache", ".pytest_cache", ".ruff_cache", ".venv", "__pycache__", "build", "dist"}
+    return [
+        path
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+        and not any(part in excluded for part in path.relative_to(root).parts)
+        and path.suffix != ".pyc"
+    ]
+
+
+def _realized_file_sha256(path: Path) -> str:
+    stat = path.stat()
+    signature = (stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns, stat.st_ctime_ns)
+    cached = _REALIZED_FILE_DIGESTS.get(path)
+    if cached is not None and cached[0] == signature:
+        return cached[1]
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    _REALIZED_FILE_DIGESTS[path] = (signature, digest)
+    return digest
+
+
+def _update_inventory_digest(digest: Any, label: str, payload: bytes) -> None:
+    encoded_label = label.encode("utf-8")
+    digest.update(len(encoded_label).to_bytes(8, "big"))
+    digest.update(encoded_label)
+    digest.update(len(payload).to_bytes(8, "big"))
+    digest.update(payload)
+
+
+def repository_provenance(repository_dir: Path) -> dict[str, Any]:
+    source_root = _source_inventory_root(repository_dir)
+    source_package = _source_package_dir(source_root)
+    try:
+        root = _git(repository_dir, "rev-parse", "--show-toplevel").decode().strip()
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return _source_tree_provenance(source_root, source_package)
     root_path = Path(root)
+    if not _source_package_is_tracked(root_path, source_package):
+        return _source_tree_provenance(source_root, source_package)
     commit = _git(root_path, "rev-parse", "HEAD").decode().strip()
     status = _git(root_path, "status", "--porcelain=v1", "--untracked-files=all")
     diff = _git(root_path, "diff", "--binary", "HEAD")
@@ -277,7 +640,65 @@ def _repository_provenance(repository_dir: Path) -> dict[str, Any]:
         "commit": commit,
         "dirty": bool(status.strip()),
         "dirty_digest": digest.hexdigest(),
+        "source_inventory_sha256": _source_inventory_sha256(root_path, source_package),
+        "repository_kind": "git",
     }
+
+
+def _source_inventory_sha256(root: Path, source_package: Path | None = None) -> str:
+    selected = [root / "pyproject.toml", root / "uv.lock"]
+    source_root = source_package or _source_package_dir(root)
+    if source_root.is_dir():
+        selected.extend(
+            path
+            for path in source_root.rglob("*")
+            if path.is_file() and not path.is_symlink() and "__pycache__" not in path.parts and path.suffix != ".pyc"
+        )
+    for pattern in ("*.dist-info/METADATA", "*.dist-info/direct_url.json"):
+        selected.extend(path for path in root.glob(pattern) if path.is_file() and not path.is_symlink())
+    digest = hashlib.sha256()
+    for path in sorted(path for path in selected if path.is_file()):
+        relative = path.relative_to(root).as_posix().encode("utf-8")
+        digest.update(len(relative).to_bytes(8, "big"))
+        digest.update(relative)
+        digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def _source_tree_provenance(root: Path, source_package: Path) -> dict[str, Any]:
+    inventory = _source_inventory_sha256(root, source_package)
+    return {
+        "root": str(root),
+        "commit": f"source-sha256:{inventory}",
+        "dirty": False,
+        "dirty_digest": hashlib.sha256(b"").hexdigest(),
+        "source_inventory_sha256": inventory,
+        "repository_kind": "source_tree",
+    }
+
+
+def _source_package_dir(root: Path) -> Path:
+    source = root / "src" / "aec_bench"
+    return source if source.is_dir() else root / "aec_bench"
+
+
+def _source_package_is_tracked(repository_root: Path, package_dir: Path) -> bool:
+    try:
+        relative = (package_dir / "__init__.py").resolve().relative_to(repository_root.resolve())
+        _git(repository_root, "ls-files", "--error-unmatch", "--", relative.as_posix())
+    except (FileNotFoundError, subprocess.CalledProcessError, ValueError):
+        return False
+    return True
+
+
+def _source_inventory_root(repository_dir: Path) -> Path:
+    candidate = Path(repository_dir).resolve()
+    for parent in (candidate, *candidate.parents):
+        if (parent / "src" / "aec_bench").is_dir() or (parent / "aec_bench").is_dir():
+            return parent
+        if parent.name == "aec_bench" and parent.is_dir():
+            return parent.parent
+    raise ValueError(f"aec_bench source inventory is unavailable from {repository_dir}")
 
 
 def _callable_provenance(verifier: Any) -> dict[str, Any]:
@@ -304,9 +725,21 @@ def _package_variant(package_dir: Path) -> dict[str, Any] | None:
 
 def _run_artifact_hashes(run_dir: Path) -> dict[str, str]:
     selected: dict[str, str] = {}
-    names = {"submission.json", "trajectory.jsonl", "conversation.jsonl", "agent_result.json"}
+    names = {
+        "agent_result.json",
+        "agent_result.corrupt.json",
+        "conversation.jsonl",
+        "lifecycle_ledger.jsonl",
+        "metrics.json",
+        "raw_output.md",
+        "result.json",
+        "state.json",
+        "submission.json",
+        "trajectory.jsonl",
+        "verification.json",
+    }
     for path in sorted(run_dir.rglob("*")):
-        if path.is_file() and (path.name in names or path.name in {"verification.json", "metrics.json"}):
+        if path.is_file() and path.name in names and "experiments" not in path.relative_to(run_dir).parts:
             selected[str(path.relative_to(run_dir))] = _sha256(path)
     return selected
 
@@ -350,6 +783,16 @@ def _write_json(path: Path, payload: dict[str, Any]) -> None:
 
 
 def _append_jsonl(path: Path, payload: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(payload, sort_keys=True) + "\n")
+    mkdir_durable(path.parent)
+    lock_path = path.with_name(f".{path.name}.lock")
+    descriptor = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, sort_keys=True) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        _fsync_directory(path.parent)
+    finally:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)

--- a/src/aec_bench/meta_harness/evidence_lifecycle_local.py
+++ b/src/aec_bench/meta_harness/evidence_lifecycle_local.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import inspect
 import json
+import os
+import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
@@ -14,6 +16,8 @@ from typing import Any, cast
 from aec_bench.adapters.base import AdapterRequest
 from aec_bench.adapters.local_registry import LocalAdapterRegistry
 from aec_bench.contracts.task_definition import ToolSpec
+from aec_bench.contracts.trajectory import read_trajectory
+from aec_bench.ledger.durability import fsync_directory, mkdir_durable
 from aec_bench.meta_harness.evidence_lifecycle import (
     EvidenceLifecycleError,
     fail_checkpoint_attempt,
@@ -26,7 +30,10 @@ from aec_bench.meta_harness.evidence_lifecycle import (
     submit_evidence_checkpoint,
     validate_lifecycle_verification,
 )
-from aec_bench.meta_harness.evidence_lifecycle_experiment import record_lifecycle_experiment
+from aec_bench.meta_harness.evidence_lifecycle_experiment import (
+    LifecycleExperimentSweepContext,
+    record_lifecycle_experiment,
+)
 from aec_bench.trajectory.writer import TrajectoryWriter
 
 
@@ -208,6 +215,9 @@ def run_local_evidence_lifecycle_session(
     process_id: str = "process.lifecycle",
     registry: Any | None = None,
     visibility_policy: LifecycleVisibilityPolicy = LifecycleVisibilityPolicy.PERSISTENT_CONTEXT,
+    sweep_context: LifecycleExperimentSweepContext | None = None,
+    repository_dir: Path | None = None,
+    require_adapter_identity_match: bool = False,
 ) -> dict[str, Any]:
     """Run all checkpoints in one adapter execution and one model conversation."""
     if adapter_kind not in {"tool_loop", "pydantic_ai"}:
@@ -220,6 +230,15 @@ def run_local_evidence_lifecycle_session(
     initial = prepare_evidence_checkpoint(package, run)
     if initial["status"] == "complete":
         raise EvidenceLifecycleError("lifecycle run is already complete")
+    _seal_interrupted_sessions(
+        run=run,
+        lifecycle=initial,
+        model=model,
+        adapter_kind=adapter_kind,
+        max_turns=max_turns,
+        execution_mode="persistent_context",
+        memory_visibility_policy=visibility_policy.value,
+    )
 
     session_id = _next_session_id(run)
     session_dir = run / "sessions" / session_id
@@ -303,9 +322,11 @@ def run_local_evidence_lifecycle_session(
             max_turns=max_turns,
             session_id=session_id,
             provider_error=str(exc),
+            memory_visibility_policy=visibility_policy.value,
         )
-        _write_json(session_dir / "agent_result.json", failed_agent_result)
         lifecycle = read_evidence_lifecycle_state(package, run)
+        failed_agent_result["checkpoint_ids"] = _session_checkpoint_ids(lifecycle, session_id)
+        _write_json(session_dir / "agent_result.json", failed_agent_result)
         _build_local_task_run(
             package=package,
             run=run,
@@ -318,8 +339,10 @@ def run_local_evidence_lifecycle_session(
                 execution_mode="persistent_context",
                 memory_visibility_policy=visibility_policy.value,
                 max_turns=max_turns,
-                sessions=[failed_agent_result],
+                sessions=_persistent_context_sessions(run),
             ),
+            sweep_context=sweep_context,
+            repository_dir=repository_dir,
         )
         raise
     finally:
@@ -331,17 +354,37 @@ def run_local_evidence_lifecycle_session(
         adapter_kind=adapter_kind,
         max_turns=max_turns,
         session_id=session_id,
+        memory_visibility_policy=visibility_policy.value,
     )
-    returned_failure = _adapter_failure_kind(result)
+    returned_failure = (
+        "adapter_identity_mismatch"
+        if require_adapter_identity_match and agent_result["adapter_name"] != adapter_kind
+        else _adapter_failure_kind(result)
+    )
     if returned_failure is not None:
+        agent_result["status"] = "failed"
+        agent_result["failure_kind"] = returned_failure
+    lifecycle = read_evidence_lifecycle_state(package, run)
+    if returned_failure is not None and lifecycle["active_checkpoint_id"] is not None:
         fail_checkpoint_attempt(
             package,
             run,
             session_id=session_id,
             failure_kind=returned_failure,
         )
-    lifecycle = read_evidence_lifecycle_state(package, run)
-    agent_result["checkpoint_ids"] = [item["checkpoint_id"] for item in lifecycle["completed_checkpoints"]]
+        lifecycle = read_evidence_lifecycle_state(package, run)
+    if returned_failure is None and lifecycle["status"] != "complete":
+        returned_failure = "lifecycle_incomplete"
+        agent_result["status"] = "failed"
+        agent_result["failure_kind"] = returned_failure
+        fail_checkpoint_attempt(
+            package,
+            run,
+            session_id=session_id,
+            failure_kind=returned_failure,
+        )
+        lifecycle = read_evidence_lifecycle_state(package, run)
+    agent_result["checkpoint_ids"] = _session_checkpoint_ids(lifecycle, session_id)
     _write_json(session_dir / "agent_result.json", agent_result)
     _write_conversation(session_dir / "conversation.jsonl", result.transcript)
     if result.raw_output_text:
@@ -359,8 +402,85 @@ def run_local_evidence_lifecycle_session(
             execution_mode="persistent_context",
             memory_visibility_policy=visibility_policy.value,
             max_turns=max_turns,
-            sessions=[agent_result],
+            sessions=_persistent_context_sessions(run),
         ),
+        sweep_context=sweep_context,
+        repository_dir=repository_dir,
+    )
+
+
+def validate_completed_persistent_lifecycle_recovery(
+    package_dir: Path,
+    run_dir: Path,
+) -> dict[str, Any]:
+    """Validate durable evidence needed to seal a terminal persistent-session crash."""
+    lifecycle = read_evidence_lifecycle_state(Path(package_dir), Path(run_dir))
+    if lifecycle["status"] != "complete":
+        raise EvidenceLifecycleError("persistent terminal recovery requires complete lifecycle state")
+    session_ids = {
+        str(attempt["session_id"])
+        for checkpoint in lifecycle.get("checkpoint_runs", [])
+        for attempt in checkpoint.get("attempts", [])
+    }
+    if not session_ids:
+        raise EvidenceLifecycleError("complete lifecycle has no persistent session lineage")
+    for session_id in sorted(session_ids):
+        session_dir = Path(run_dir) / "sessions" / session_id
+        result_path = session_dir / "agent_result.json"
+        trajectory_path = session_dir / "trajectory.jsonl"
+        if not session_dir.is_dir() or not trajectory_path.is_file():
+            raise EvidenceLifecycleError(f"interrupted session lacks durable trajectory evidence: {session_id}")
+        _validate_session_trajectory(trajectory_path, session_id)
+        if result_path.is_file():
+            try:
+                _read_json(result_path)
+            except (OSError, ValueError):
+                pass
+    return lifecycle
+
+
+def recover_completed_persistent_lifecycle_session(
+    *,
+    package_dir: Path,
+    run_dir: Path,
+    model: str,
+    verifier: Any,
+    adapter_kind: str,
+    max_turns: int,
+    process_id: str,
+    visibility_policy: LifecycleVisibilityPolicy,
+    sweep_context: LifecycleExperimentSweepContext,
+    repository_dir: Path,
+) -> dict[str, Any]:
+    """Seal a complete persistent crash and publish an unscored canonical invocation."""
+    package = Path(package_dir)
+    run = Path(run_dir)
+    lifecycle = validate_completed_persistent_lifecycle_recovery(package, run)
+    _seal_interrupted_sessions(
+        run=run,
+        lifecycle=lifecycle,
+        model=model,
+        adapter_kind=adapter_kind,
+        max_turns=max_turns,
+        execution_mode="persistent_context",
+        memory_visibility_policy=visibility_policy.value,
+    )
+    return _build_local_task_run(
+        package=package,
+        run=run,
+        process_id=process_id,
+        lifecycle=lifecycle,
+        verifier=verifier,
+        agent=_normalized_agent_evidence(
+            model=model,
+            adapter_kind=adapter_kind,
+            execution_mode="persistent_context",
+            memory_visibility_policy=visibility_policy.value,
+            max_turns=max_turns,
+            sessions=_persistent_context_sessions(run),
+        ),
+        sweep_context=sweep_context,
+        repository_dir=repository_dir,
     )
 
 
@@ -375,6 +495,9 @@ def run_local_evidence_lifecycle_fresh_context(
     process_id: str = "process.lifecycle",
     registry: Any | None = None,
     visibility_policy: LifecycleVisibilityPolicy = LifecycleVisibilityPolicy.ARTIFACT_MEMORY,
+    sweep_context: LifecycleExperimentSweepContext | None = None,
+    repository_dir: Path | None = None,
+    require_adapter_identity_match: bool = False,
 ) -> dict[str, Any]:
     """Run every checkpoint in a fresh adapter and return the normalized local result."""
     package = Path(package_dir)
@@ -388,6 +511,7 @@ def run_local_evidence_lifecycle_fresh_context(
         max_turns=max_turns,
         registry=registry,
         visibility_policy=visibility_policy,
+        require_adapter_identity_match=require_adapter_identity_match,
     )
     try:
         lifecycle = run_evidence_lifecycle(package, run, episode_resolver=episode_resolver)
@@ -395,12 +519,7 @@ def run_local_evidence_lifecycle_fresh_context(
         lifecycle = read_evidence_lifecycle_state(package, run)
     except Exception:
         lifecycle = read_evidence_lifecycle_state(package, run)
-        spec = load_evidence_lifecycle_spec(package)
-        sessions = [
-            _read_json(run / "episodes" / checkpoint.checkpoint_id / "agent_result.json")
-            for checkpoint in spec.checkpoints
-            if (run / "episodes" / checkpoint.checkpoint_id / "agent_result.json").is_file()
-        ]
+        sessions = _fresh_context_sessions(run)
         _build_local_task_run(
             package=package,
             run=run,
@@ -415,14 +534,11 @@ def run_local_evidence_lifecycle_fresh_context(
                 max_turns=max_turns,
                 sessions=sessions,
             ),
+            sweep_context=sweep_context,
+            repository_dir=repository_dir,
         )
         raise
-    spec = load_evidence_lifecycle_spec(package)
-    sessions = [
-        _read_json(run / "episodes" / checkpoint.checkpoint_id / "agent_result.json")
-        for checkpoint in spec.checkpoints
-        if (run / "episodes" / checkpoint.checkpoint_id / "agent_result.json").is_file()
-    ]
+    sessions = _fresh_context_sessions(run)
     return _build_local_task_run(
         package=package,
         run=run,
@@ -437,6 +553,8 @@ def run_local_evidence_lifecycle_fresh_context(
             max_turns=max_turns,
             sessions=sessions,
         ),
+        sweep_context=sweep_context,
+        repository_dir=repository_dir,
     )
 
 
@@ -448,6 +566,7 @@ def build_local_evidence_lifecycle_episode_resolver(
     max_turns: int = 20,
     registry: Any | None = None,
     visibility_policy: LifecycleVisibilityPolicy = LifecycleVisibilityPolicy.ARTIFACT_MEMORY,
+    require_adapter_identity_match: bool = False,
 ) -> Any:
     """Build a resolver that creates a fresh adapter for every checkpoint."""
     if visibility_policy == LifecycleVisibilityPolicy.PERSISTENT_CONTEXT:
@@ -458,8 +577,17 @@ def build_local_evidence_lifecycle_episode_resolver(
         checkpoint_id = str(context["checkpoint_id"])
         workspace = str(context["workspace"])
         checkpoint_run = next(item for item in context["checkpoint_runs"] if item["checkpoint_id"] == checkpoint_id)
+        _seal_interrupted_sessions(
+            run=Path(context["run_dir"]),
+            lifecycle=context,
+            model=model,
+            adapter_kind=adapter_kind,
+            max_turns=max_turns,
+            execution_mode="fresh_context",
+            memory_visibility_policy=visibility_policy.value,
+        )
         session_id = f"{checkpoint_id}.session-{len(checkpoint_run['attempts']) + 1:03d}"
-        episode_dir = Path(context["run_dir"]) / "episodes" / checkpoint_id
+        episode_dir = Path(context["run_dir"]) / "episodes" / checkpoint_id / session_id
         episode_dir.mkdir(parents=True, exist_ok=True)
         trajectory_path = episode_dir / "trajectory.jsonl"
         trajectory_writer = TrajectoryWriter(path=str(trajectory_path))
@@ -526,6 +654,7 @@ def build_local_evidence_lifecycle_episode_resolver(
                     session_id=session_id,
                     provider_error=str(exc),
                     checkpoint_id=checkpoint_id,
+                    memory_visibility_policy=visibility_policy.value,
                 ),
             )
             raise
@@ -544,6 +673,7 @@ def build_local_evidence_lifecycle_episode_resolver(
             "resolved_model": getattr(result, "resolved_model", model),
             "configuration_record": getattr(result, "configuration_record", {"model": model}),
             "session_mode": "fresh",
+            "memory_visibility_policy": visibility_policy.value,
             "session_id": session_id,
             "max_turns": max_turns,
             "input_tokens": result.usage_input_tokens or 0,
@@ -553,10 +683,16 @@ def build_local_evidence_lifecycle_episode_resolver(
             "failure_kind": _enum_value(result.failure_kind),
             "provider_error": result.provider_error,
         }
-        _write_json(episode_dir / "agent_result.json", agent_result)
         _write_conversation(episode_dir / "conversation.jsonl", result.transcript)
-        returned_failure = _adapter_failure_kind(result)
+        returned_failure = (
+            "adapter_identity_mismatch"
+            if require_adapter_identity_match and agent_result["adapter_name"] != adapter_kind
+            else _adapter_failure_kind(result)
+        )
         if returned_failure is not None:
+            agent_result["status"] = "failed"
+            agent_result["failure_kind"] = returned_failure
+            _write_json(episode_dir / "agent_result.json", agent_result)
             fail_checkpoint_attempt(
                 Path(package_dir),
                 Path(context["run_dir"]),
@@ -564,6 +700,7 @@ def build_local_evidence_lifecycle_episode_resolver(
                 failure_kind=returned_failure,
             )
             raise _LocalAdapterExecutionFailure(f"adapter failed at checkpoint {checkpoint_id}: {returned_failure}")
+        _write_json(episode_dir / "agent_result.json", agent_result)
         return agent_result
 
     return resolve
@@ -655,6 +792,7 @@ def _agent_result(
     max_turns: int,
     session_id: str | None = None,
     checkpoint_ids: list[str] | None = None,
+    memory_visibility_policy: str,
 ) -> dict[str, Any]:
     return {
         "checkpoint_ids": checkpoint_ids or [],
@@ -665,6 +803,7 @@ def _agent_result(
         "resolved_model": getattr(result, "resolved_model", model),
         "configuration_record": getattr(result, "configuration_record", {"model": model}),
         "session_mode": "persistent",
+        "memory_visibility_policy": memory_visibility_policy,
         "session_id": session_id,
         "max_turns": max_turns,
         "input_tokens": result.usage_input_tokens or 0,
@@ -684,6 +823,8 @@ def _failed_agent_result(
     session_id: str,
     provider_error: str,
     checkpoint_id: str | None = None,
+    resolved_model: str = "unresolved",
+    memory_visibility_policy: str,
 ) -> dict[str, Any]:
     return {
         "checkpoint_id": checkpoint_id,
@@ -692,9 +833,10 @@ def _failed_agent_result(
         "model": model,
         "adapter": adapter_kind,
         "adapter_name": adapter_kind,
-        "resolved_model": model,
+        "resolved_model": resolved_model,
         "configuration_record": {"model": model, "max_turns": max_turns},
         "session_mode": "persistent" if checkpoint_id is None else "fresh",
+        "memory_visibility_policy": memory_visibility_policy,
         "session_id": session_id,
         "max_turns": max_turns,
         "input_tokens": 0,
@@ -722,11 +864,13 @@ def _normalized_agent_evidence(
         "cache_write_tokens",
     )
     totals = {field: sum(int(session.get(field, 0)) for session in sessions) for field in token_fields}
-    totals["failures"] = sum(session.get("status") == "failed" for session in sessions)
+    totals["failures"] = sum(session.get("status") not in {"completed", "ok"} for session in sessions)
+    resolved_adapters = sorted({str(session.get("adapter_name") or "unresolved") for session in sessions})
     return {
         "schema_version": "1",
         "model": model,
         "adapter": adapter_kind,
+        "resolved_adapters": resolved_adapters,
         "execution_mode": execution_mode,
         "memory_visibility_policy": memory_visibility_policy,
         "max_turns_per_session": max_turns,
@@ -752,10 +896,12 @@ def _build_local_task_run(
     lifecycle: dict[str, Any],
     verifier: Any,
     agent: dict[str, Any],
+    sweep_context: LifecycleExperimentSweepContext | None = None,
+    repository_dir: Path | None = None,
 ) -> dict[str, Any]:
     spec = load_evidence_lifecycle_spec(package)
     verifier_exception: Exception | None = None
-    if lifecycle["status"] == "complete":
+    if lifecycle["status"] == "complete" and agent["status"] == "completed":
         try:
             verification = validate_lifecycle_verification(verifier(package, run))
         except Exception as exc:
@@ -800,6 +946,8 @@ def _build_local_task_run(
         verifier=verifier,
         verification=verification,
         tool_schema=_lifecycle_tool_schema(agent["execution_mode"]),
+        sweep_context=sweep_context,
+        repository_dir=repository_dir,
     )
     if verifier_exception is not None:
         raise verifier_exception
@@ -832,6 +980,96 @@ def _build_local_task_run(
     }
 
 
+def _fresh_context_sessions(run_dir: Path) -> list[dict[str, Any]]:
+    return [_read_json(path) for path in sorted(Path(run_dir).glob("episodes/**/agent_result.json"))]
+
+
+def _persistent_context_sessions(run_dir: Path) -> list[dict[str, Any]]:
+    return [_read_json(path) for path in sorted(Path(run_dir).glob("sessions/*/agent_result.json"))]
+
+
+def _seal_interrupted_sessions(
+    *,
+    run: Path,
+    lifecycle: dict[str, Any],
+    model: str,
+    adapter_kind: str,
+    max_turns: int,
+    execution_mode: str,
+    memory_visibility_policy: str,
+) -> None:
+    checkpoint_runs = lifecycle.get("checkpoint_runs", [])
+    attempts_by_session: dict[str, list[tuple[str, dict[str, Any]]]] = {}
+    for checkpoint in checkpoint_runs:
+        checkpoint_id = str(checkpoint["checkpoint_id"])
+        for attempt in checkpoint.get("attempts", []):
+            session_id = str(attempt["session_id"])
+            attempts_by_session.setdefault(session_id, []).append((checkpoint_id, attempt))
+    for session_id, session_attempts in attempts_by_session.items():
+        first_checkpoint = session_attempts[0][0]
+        if execution_mode == "persistent_context":
+            session_dir = run / "sessions" / session_id
+            checkpoint_value = None
+        else:
+            session_dir = run / "episodes" / first_checkpoint / session_id
+            checkpoint_value = first_checkpoint
+        result_path = session_dir / "agent_result.json"
+        has_active_attempt = any(attempt.get("status") == "active" for _, attempt in session_attempts)
+        terminal_crash = lifecycle.get("status") == "complete" and all(
+            attempt.get("status") == "submitted" for _, attempt in session_attempts
+        )
+        if result_path.is_file() and not has_active_attempt:
+            try:
+                _read_json(result_path)
+            except (OSError, ValueError) as exc:
+                if not terminal_crash:
+                    raise EvidenceLifecycleError(f"interrupted session result is malformed: {session_id}") from exc
+                corrupt_path = session_dir / "agent_result.corrupt.json"
+                if corrupt_path.exists():
+                    raise EvidenceLifecycleError(
+                        f"terminal session already has quarantined result: {session_id}"
+                    ) from exc
+                result_path.replace(corrupt_path)
+                fsync_directory(session_dir)
+            else:
+                continue
+        trajectory_path = session_dir / "trajectory.jsonl"
+        if not session_dir.is_dir() or not trajectory_path.is_file():
+            raise EvidenceLifecycleError(f"interrupted session lacks durable trajectory evidence: {session_id}")
+        _validate_session_trajectory(trajectory_path, session_id)
+        if result_path.is_file():
+            payload = _read_json(result_path)
+        else:
+            payload = _failed_agent_result(
+                model=model,
+                adapter_kind=adapter_kind,
+                max_turns=max_turns,
+                session_id=session_id,
+                provider_error="session interrupted before a durable agent result was recorded",
+                checkpoint_id=checkpoint_value,
+                memory_visibility_policy=memory_visibility_policy,
+            )
+            payload["adapter_name"] = "unresolved"
+        payload["status"] = "failed"
+        payload["failure_kind"] = "interrupted_after_completion" if terminal_crash else "interrupted"
+        payload["checkpoint_ids"] = _session_checkpoint_ids(lifecycle, session_id)
+        if payload.get("provider_error") is None:
+            payload["provider_error"] = (
+                "session interrupted after lifecycle completion"
+                if terminal_crash
+                else "session interrupted before lifecycle completion"
+            )
+        _write_json(result_path, payload)
+
+
+def _session_checkpoint_ids(lifecycle: dict[str, Any], session_id: str) -> list[str]:
+    checkpoint_ids: list[str] = []
+    for checkpoint in lifecycle.get("checkpoint_runs", []):
+        if any(attempt.get("session_id") == session_id for attempt in checkpoint.get("attempts", [])):
+            checkpoint_ids.append(str(checkpoint["checkpoint_id"]))
+    return checkpoint_ids
+
+
 def _lifecycle_tool_schema(execution_mode: str) -> list[dict[str, str]]:
     functions: list[Callable[..., Any]] = [
         EvidenceLifecycleWorkspaceTool.list_workspace,
@@ -860,6 +1098,13 @@ def _read_json(path: Path) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise EvidenceLifecycleError(f"expected JSON object: {path}")
     return cast(dict[str, Any], payload)
+
+
+def _validate_session_trajectory(path: Path, session_id: str) -> None:
+    try:
+        read_trajectory(path)
+    except (OSError, ValueError) as exc:
+        raise EvidenceLifecycleError(f"session trajectory is malformed: {session_id}") from exc
 
 
 def _next_session_id(run_dir: Path) -> str:
@@ -898,5 +1143,15 @@ def _enum_value(value: Any) -> Any:
 
 
 def _write_json(path: Path, payload: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    mkdir_durable(path.parent)
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        temporary.replace(path)
+        fsync_directory(path.parent)
+    finally:
+        temporary.unlink(missing_ok=True)

--- a/src/aec_bench/meta_harness/evidence_lifecycle_trial_record.py
+++ b/src/aec_bench/meta_harness/evidence_lifecycle_trial_record.py
@@ -1,0 +1,1397 @@
+# ABOUTME: Imports one validated evidence-lifecycle run into the core TrialRecord ledger contract.
+# ABOUTME: Reconciles planned dimensions with package, run, verifier, metrics, and adaptation provenance.
+
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import os
+import shutil
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from threading import Lock
+from typing import Any, Literal, cast
+
+from aec_bench.contracts.agent_output import AgentOutput, AgentOutputStatus
+from aec_bench.contracts.evaluation_result import EvaluationResult, ValidityCheck
+from aec_bench.contracts.trajectory import read_trajectory
+from aec_bench.contracts.trial_record import (
+    AdaptationProvenance,
+    AgentReference,
+    ArtifactReference,
+    Completeness,
+    CostRecord,
+    EnvironmentSnapshot,
+    FileReference,
+    InputRecord,
+    LifecycleExecutionRecord,
+    LifecycleSessionRecord,
+    LifecycleTrialProvenance,
+    OutputRecord,
+    TaskReference,
+    TimingRecord,
+    TrialRecord,
+)
+from aec_bench.ledger.durability import (
+    fsync_directory as _fsync_directory,
+)
+from aec_bench.ledger.durability import (
+    fsync_tree as _fsync_tree,
+)
+from aec_bench.ledger.durability import (
+    mkdir_durable,
+)
+from aec_bench.ledger.writer import DuplicateTrialRecordError, write_trial_record
+from aec_bench.meta_harness.evidence_lifecycle import (
+    read_evidence_lifecycle_state,
+    validate_lifecycle_verification,
+)
+from aec_bench.meta_harness.evidence_lifecycle_ablation_plan import (
+    LifecycleAblationManifest,
+    LifecycleAblationPlan,
+    LifecycleAblationTrial,
+    build_lifecycle_ablation_plan,
+)
+from aec_bench.meta_harness.evidence_lifecycle_experiment import (
+    LifecycleExperimentManifest,
+    LifecycleExperimentMetrics,
+)
+from aec_bench.meta_harness.evidence_lifecycle_state import EvidenceLifecycleRunState
+from aec_bench.task_world_templates.lifecycles import lifecycle_package_variant
+
+
+@dataclass(frozen=True)
+class _CanonicalInvocation:
+    manifest_path: Path
+    manifest: dict[str, Any]
+    metrics_path: Path
+    verification_path: Path
+    index_entry: dict[str, Any]
+
+
+_INDEX_LOCKS_GUARD = Lock()
+_INDEX_LOCKS: dict[str, Lock] = {}
+
+
+def build_lifecycle_trial_record(
+    *,
+    manifest: LifecycleAblationManifest,
+    trial: LifecycleAblationTrial,
+    package_dir: Path,
+    run_dir: Path,
+    artifact_references: list[ArtifactReference] | None = None,
+) -> TrialRecord:
+    """Build one validated record from the planned working package and canonical invocation."""
+    return _build_lifecycle_trial_record(
+        manifest=manifest,
+        trial=trial,
+        package_dir=package_dir,
+        run_dir=run_dir,
+        artifact_references=artifact_references,
+        require_planned_paths=True,
+        plan=None,
+    )
+
+
+def _build_lifecycle_trial_record(
+    *,
+    manifest: LifecycleAblationManifest,
+    trial: LifecycleAblationTrial,
+    package_dir: Path,
+    run_dir: Path,
+    artifact_references: list[ArtifactReference] | None,
+    require_planned_paths: bool,
+    plan: LifecycleAblationPlan | None,
+) -> TrialRecord:
+    """Build a core record from a validated working tree or immutable snapshot."""
+    package = Path(package_dir)
+    run = Path(run_dir)
+    if require_planned_paths and package.resolve() != Path(trial.package_dir).resolve():
+        raise ValueError("supplied package directory does not match planned trial")
+    if require_planned_paths and run.resolve() != Path(trial.run_dir).resolve():
+        raise ValueError("supplied run directory does not match planned trial")
+
+    if require_planned_paths:
+        read_evidence_lifecycle_state(package, run)
+    else:
+        _validate_snapshotted_lifecycle_state(run)
+    state = _read_json(run / "state.json")
+    variant = lifecycle_package_variant(package)
+    if variant is None or variant.get("variant_id") != trial.variant_id:
+        raise ValueError("lifecycle package variant does not match planned trial")
+    if AdaptationProvenance.model_validate(variant.get("adaptation")) != trial.adaptation:
+        raise ValueError("lifecycle package adaptation does not match planned trial")
+
+    invocation = _canonical_invocation(run, manifest, trial)
+    experiment = invocation.manifest
+    verification = validate_lifecycle_verification(_read_json(invocation.verification_path))
+    metrics = LifecycleExperimentMetrics.model_validate(_read_json(invocation.metrics_path)).model_dump(mode="json")
+    _validate_artifact_hash(
+        invocation.verification_path,
+        experiment.get("outputs", {}).get("verification.json"),
+        "lifecycle verification",
+    )
+    _validate_artifact_hash(
+        invocation.metrics_path,
+        experiment.get("outputs", {}).get("metrics.json"),
+        "lifecycle metrics",
+    )
+    _validate_artifact_hash(
+        run / "verification.json",
+        experiment.get("outputs", {}).get("verification.json"),
+        "lifecycle verification",
+    )
+    _validate_artifact_hash(
+        run / "metrics.json",
+        experiment.get("outputs", {}).get("metrics.json"),
+        "lifecycle metrics",
+    )
+    _validate_declared_run_artifacts(run, experiment)
+    _validate_metrics_against_run(run, state, experiment, metrics, verification)
+    lifecycle = experiment.get("lifecycle", {})
+    if lifecycle.get("package_sha256") != state.get("package_sha256"):
+        raise ValueError("lifecycle experiment package hash does not match run state")
+    expected_lifecycle = {
+        "lifecycle_id": trial.lifecycle_id,
+        "world_id": trial.world_id,
+        "spec_sha256": trial.spec_sha256,
+        "package_sha256": trial.package_sha256,
+    }
+    if any(lifecycle.get(key) != value for key, value in expected_lifecycle.items()):
+        raise ValueError("lifecycle experiment identity does not match planned package revision")
+    expected_state = {
+        "lifecycle_id": trial.lifecycle_id,
+        "world_id": trial.world_id,
+        "lifecycle_spec_sha256": trial.spec_sha256,
+        "package_sha256": trial.package_sha256,
+    }
+    if any(state.get(key) != value for key, value in expected_state.items()):
+        raise ValueError("lifecycle run state does not match planned package revision")
+    if verification.get("lifecycle_id") != trial.lifecycle_id:
+        raise ValueError("lifecycle verification does not match planned lifecycle")
+    if lifecycle.get("variant") != variant:
+        raise ValueError("lifecycle experiment variant does not match package")
+
+    model = experiment.get("model", {})
+    execution = experiment.get("execution", {})
+    if model.get("requested_model") != trial.agent.model:
+        raise ValueError("lifecycle run model does not match planned trial")
+    if model.get("requested_adapter", model.get("adapter")) != trial.agent.adapter:
+        raise ValueError("lifecycle run adapter does not match planned trial")
+    if execution.get("mode") != trial.execution_mode.value:
+        raise ValueError("lifecycle run execution mode does not match planned trial")
+    if execution.get("memory_visibility_policy") != trial.memory_visibility_policy.value:
+        raise ValueError("lifecycle run visibility policy does not match planned trial")
+    if execution.get("max_turns_per_session") != trial.max_turns_per_session:
+        raise ValueError("lifecycle run turn limit does not match planned trial")
+
+    selected_plan = plan or build_lifecycle_ablation_plan(manifest)
+    planned = {item.trial_id: item for item in selected_plan.trials}.get(trial.trial_id)
+    if planned != trial:
+        raise ValueError("trial does not match the deterministic ablation plan")
+    expected_sweep = {
+        "schema_version": "1",
+        "sweep_experiment_id": manifest.experiment_id,
+        "planned_trial_id": trial.trial_id,
+        "plan_sha256": selected_plan.plan_sha256,
+        "condition_id": f"{trial.execution_mode.value}__{trial.memory_visibility_policy.value}",
+        "repetition": trial.repetition,
+    }
+    if experiment.get("sweep") != expected_sweep:
+        raise ValueError("lifecycle sweep context does not match planned trial")
+
+    repository = experiment.get("repository", {})
+    runtime_environment = experiment.get("environment", {})
+    python_version = runtime_environment.get("python_version")
+    if not isinstance(python_version, str) or not python_version:
+        raise ValueError("lifecycle invocation Python version is missing")
+    code_provenance = selected_plan.code_provenance
+    if (
+        repository.get("commit") != code_provenance.repository_commit
+        or repository.get("source_inventory_sha256") != code_provenance.source_inventory_sha256
+    ):
+        raise ValueError("lifecycle invocation repository does not match planned code provenance")
+    runtime_provenance = runtime_environment.get("runtime_provenance")
+    if runtime_provenance != trial.runtime_provenance.model_dump(mode="json"):
+        raise ValueError("lifecycle invocation runtime dependencies do not match planned trial")
+    planned_verifier = experiment.get("verifier", {})
+    verifier_entrypoint = planned_verifier.get("entrypoint") if isinstance(planned_verifier, dict) else None
+    if not isinstance(planned_verifier, dict) or (
+        planned_verifier.get("qualified_name") != code_provenance.verifier_qualified_name
+        or planned_verifier.get("source_sha256") != code_provenance.verifier_source_sha256
+    ):
+        raise ValueError("lifecycle invocation verifier does not match planned task verifier")
+    if not isinstance(verifier_entrypoint, dict) or (
+        verifier_entrypoint.get("qualified_name") != code_provenance.verifier_entrypoint_qualified_name
+        or verifier_entrypoint.get("source_sha256") != code_provenance.verifier_entrypoint_source_sha256
+    ):
+        raise ValueError("lifecycle invocation verifier entrypoint does not match planned provenance")
+    repository_commit = str(repository.get("commit") or "unknown")
+    package_files = lifecycle.get("package_files")
+    if not isinstance(package_files, dict) or not package_files:
+        raise ValueError("lifecycle experiment must contain package file hashes")
+    if package_files != _tree_hashes(package):
+        raise ValueError("lifecycle package files do not match canonical manifest")
+    input_files = [
+        FileReference(path=str(path), hash=str(digest), source="lifecycle_package")
+        for path, digest in sorted(package_files.items())
+    ]
+    instruction = _lifecycle_instruction(package)
+    execution_status = str(execution.get("status") or "failed")
+    agent_status = AgentOutputStatus.COMPLETED if execution_status == "completed" else AgentOutputStatus.FAILED
+    output_structurally_valid = state.get("status") == "complete"
+    verifier_completed = verification.get("overall") != "incomplete"
+    errors = _verification_failures(verification)
+    semantic_transition = metrics.get("semantic_transition")
+    operational_metrics = {key: value for key, value in metrics.items() if key != "semantic_transition"}
+    trajectories = sorted(str(path) for path in run.glob("**/trajectory.jsonl"))
+    conversations = sorted(str(path) for path in run.glob("**/conversation.jsonl"))
+    raw_outputs = sorted(str(path) for path in run.glob("**/raw_output.md"))
+    totals = {
+        "tokens_in": int(metrics.get("input_tokens", 0)),
+        "tokens_out": int(metrics.get("output_tokens", 0)),
+        "cache_read_tokens": int(metrics.get("cache_read_tokens", 0)),
+        "cache_write_tokens": int(metrics.get("cache_write_tokens", 0)),
+    }
+    total_seconds = float(metrics.get("whole_run_seconds") or 0.0)
+    created_at = str(experiment.get("created_at"))
+    artifacts = list(artifact_references or [])
+    if artifacts:
+        input_files = [
+            FileReference(
+                path=_snapshotted_package_path(artifacts, item.path),
+                hash=item.hash,
+                source=item.path,
+            )
+            for item in input_files
+        ]
+    invocation_manifest = next(
+        (artifact for artifact in artifacts if artifact.kind == "lifecycle_manifest"),
+        ArtifactReference(
+            kind="lifecycle_manifest",
+            path=str(invocation.manifest_path),
+            sha256=_sha256(invocation.manifest_path),
+            media_type="application/json",
+        ),
+    )
+    invocation_index = _artifact_by_kind(artifacts, "lifecycle_invocation_index")
+    ablation_manifest = _artifact_by_kind(artifacts, "lifecycle_ablation_manifest")
+    ablation_plan = _artifact_by_kind(artifacts, "lifecycle_ablation_plan")
+    sessions = _lifecycle_sessions(
+        run,
+        artifacts,
+        state=state,
+        experiment=experiment,
+        metrics=metrics,
+        verification=verification,
+    )
+    resolved_models = {session.resolved_model for session in sessions if session.resolved_model != "unresolved"}
+    resolved_model = next(iter(resolved_models)) if resolved_models else "unresolved"
+    resolved_adapters = {session.adapter for session in sessions if session.adapter != "unresolved"}
+    resolved_adapter = next(iter(resolved_adapters)) if resolved_adapters else "unresolved"
+    verifier = experiment.get("verifier", {})
+    verifier_source_sha256 = verifier.get("source_sha256")
+    if not isinstance(verifier_source_sha256, str):
+        raise ValueError("lifecycle verifier source hash is missing")
+    repository_kind = repository.get("repository_kind", "git")
+    if repository_kind not in {"git", "source_tree"}:
+        raise ValueError("lifecycle repository provenance kind is invalid")
+    execution_record = LifecycleExecutionRecord(
+        execution_mode=trial.execution_mode.value,
+        memory_visibility_policy=trial.memory_visibility_policy.value,
+        max_turns_per_session=int(execution.get("max_turns_per_session") or 1),
+        status=_execution_status(execution_status),
+        sessions=sessions,
+    )
+    lifecycle_provenance = LifecycleTrialProvenance(
+        lifecycle_id=str(lifecycle["lifecycle_id"]),
+        world_id=str(lifecycle["world_id"]),
+        spec_sha256=str(lifecycle["spec_sha256"]),
+        package_sha256=str(lifecycle["package_sha256"]),
+        repository_commit=repository_commit,
+        repository_kind=cast(Literal["git", "source_tree"], repository_kind),
+        repository_dirty=bool(repository.get("dirty")),
+        repository_dirty_digest=str(repository["dirty_digest"]),
+        runtime_provider=trial.runtime_provenance.provider,
+        runtime_distributions=trial.runtime_provenance.distributions,
+        runtime_dependency_sha256=trial.runtime_provenance.dependency_inventory_sha256,
+        verifier_qualified_name=str(verifier["qualified_name"]),
+        verifier_source_sha256=verifier_source_sha256,
+        invocation_manifest=invocation_manifest,
+        invocation_index=invocation_index,
+        ablation_manifest=ablation_manifest,
+        ablation_plan=ablation_plan,
+    )
+    raw_output_refs = [artifact.path for artifact in artifacts if artifact.kind == "raw_output"]
+    conversation_refs = [artifact.path for artifact in artifacts if artifact.kind == "conversation"]
+    trajectory_refs = [artifact.path for artifact in artifacts if artifact.kind == "trajectory"]
+    if artifacts:
+        trajectories = trajectory_refs
+        conversations = conversation_refs
+        raw_outputs = raw_output_refs
+    verification_reference = _artifact_by_kind(artifacts, "lifecycle_verification")
+    metrics_reference = _artifact_by_kind(artifacts, "lifecycle_metrics")
+    raw_output_path = _single_path(raw_output_refs, raw_outputs)
+    conversation_path = _single_path(conversation_refs, conversations)
+    trajectory_path = _single_path(trajectory_refs, trajectories)
+
+    return TrialRecord(
+        trial_id=trial.trial_id,
+        experiment_id=manifest.experiment_id,
+        timestamp=datetime.fromisoformat(created_at.replace("Z", "+00:00")),
+        task=TaskReference(
+            task_id=manifest.lifecycle_template_id,
+            task_revision=str(state["package_sha256"]),
+        ),
+        agent=AgentReference(
+            adapter=resolved_adapter,
+            model=resolved_model,
+            adapter_revision=repository_commit,
+            configuration={
+                "agent_name": trial.agent.name,
+                "requested_model": trial.agent.model,
+                "requested_adapter": trial.agent.adapter,
+                "parameters": trial.agent.parameters,
+                "variant_id": trial.variant_id,
+                "execution_mode": trial.execution_mode.value,
+                "memory_visibility_policy": trial.memory_visibility_policy.value,
+                "repetition": trial.repetition,
+                "manifest_sha256": selected_plan.manifest_sha256,
+                "plan_sha256": selected_plan.plan_sha256,
+                "resolved_models": model.get("resolved_models", []),
+                "session_configurations": model.get("session_configurations", []),
+                "lifecycle_experiment_id": experiment.get("experiment_id"),
+                "lifecycle_manifest_sha256": _sha256(invocation.manifest_path),
+                "package_sha256": state["package_sha256"],
+            },
+        ),
+        environment=EnvironmentSnapshot(
+            runtime_image=f"python:{python_version}",
+            compute_backend="local",
+            tool_versions={
+                "aec_bench_commit": repository_commit,
+                "python": python_version,
+            },
+        ),
+        inputs=InputRecord(
+            instruction=instruction,
+            input_files=input_files,
+        ),
+        outputs=OutputRecord(
+            agent_output=AgentOutput(
+                status=agent_status,
+                output_path=_artifact_output_root(trial, artifacts, run),
+                output_format="evidence_lifecycle",
+                error_message=None if agent_status is AgentOutputStatus.COMPLETED else "lifecycle execution failed",
+            ),
+            raw_output_path=raw_output_path,
+            conversation_path=conversation_path,
+            trajectory_path=trajectory_path,
+            agent_result={
+                "lifecycle_experiment_id": experiment.get("experiment_id"),
+                "execution_status": execution_status,
+                "verification_path": (
+                    verification_reference.path
+                    if verification_reference is not None
+                    else str(invocation.verification_path)
+                ),
+                "metrics_path": metrics_reference.path
+                if metrics_reference is not None
+                else str(invocation.metrics_path),
+                "manifest_path": invocation_manifest.path,
+                "trajectories": trajectories,
+                "conversations": conversations,
+                "raw_outputs": raw_outputs,
+            },
+            artifacts=artifacts or None,
+        ),
+        evaluation=EvaluationResult(
+            reward=float(verification["reward"]),
+            validity=ValidityCheck(
+                output_parseable=output_structurally_valid,
+                schema_valid=output_structurally_valid and verifier_completed,
+                verifier_completed=verifier_completed,
+                errors=errors,
+            ),
+            breakdown={
+                "lifecycle_gates": verification.get("gates", {}),
+                "semantic_transition": semantic_transition,
+                "operational_metrics": operational_metrics,
+            },
+        ),
+        timing=TimingRecord(
+            total_seconds=total_seconds,
+            agent_seconds=total_seconds,
+        ),
+        cost=CostRecord(
+            **totals,
+            estimated_cost_usd=metrics.get("estimated_cost_usd"),
+        ),
+        adaptation=trial.adaptation,
+        lifecycle_execution=execution_record,
+        lifecycle_provenance=lifecycle_provenance,
+        completeness=(
+            Completeness.COMPLETE
+            if (
+                artifacts
+                and sessions
+                and all(session.resolved_model != "unresolved" for session in sessions)
+                and all(session.adapter != "unresolved" for session in sessions)
+                and repository.get("repository_kind") == "git"
+                and not bool(repository.get("dirty"))
+            )
+            else Completeness.PARTIAL
+        ),
+    )
+
+
+def finalize_lifecycle_trial_record(
+    *,
+    manifest: LifecycleAblationManifest,
+    trial: LifecycleAblationTrial,
+    package_dir: Path,
+    run_dir: Path,
+) -> Path:
+    """Snapshot immutable lifecycle artifacts and append exactly one core record."""
+    record_path = Path(trial.ledger_path)
+    if record_path.exists():
+        raise DuplicateTrialRecordError(f"trial record already exists: {record_path}")
+    ledger_root = Path(manifest.ledger_root)
+    artifact_dir = ledger_root / manifest.experiment_id / "_artifacts" / trial.trial_id
+    if artifact_dir.exists():
+        record = _record_from_snapshot(
+            manifest=manifest,
+            trial=trial,
+            artifact_dir=artifact_dir,
+            ledger_root=ledger_root,
+            plan=None,
+        )
+        return write_trial_record(ledger_root=ledger_root, record=record)
+    _repair_shared_invocation_index(Path(run_dir), manifest, trial)
+    mkdir_durable(artifact_dir.parent)
+    staging = artifact_dir.with_name(f".{trial.trial_id}.staging-{uuid.uuid4().hex}")
+    try:
+        build_lifecycle_trial_record(
+            manifest=manifest,
+            trial=trial,
+            package_dir=Path(package_dir),
+            run_dir=Path(run_dir),
+        )
+        _stage_authoritative_snapshot(
+            manifest=manifest,
+            trial=trial,
+            package_dir=Path(package_dir),
+            run_dir=Path(run_dir),
+            staging=staging,
+        )
+        _validate_snapshot_layout(staging, manifest, trial, plan=None)
+        artifact_references = _snapshot_references(
+            staging=staging,
+            final=artifact_dir,
+            ledger_root=ledger_root,
+        )
+        record = _build_lifecycle_trial_record(
+            manifest=manifest,
+            trial=trial,
+            package_dir=staging / "package",
+            run_dir=staging / "run",
+            artifact_references=artifact_references,
+            require_planned_paths=False,
+            plan=None,
+        )
+        _fsync_tree(staging)
+        staging.replace(artifact_dir)
+        _fsync_directory(artifact_dir.parent)
+        return write_trial_record(ledger_root=ledger_root, record=record)
+    except Exception:
+        if staging.exists():
+            shutil.rmtree(staging)
+        raise
+
+
+def validate_lifecycle_ablation_record(
+    record: TrialRecord,
+    manifest: LifecycleAblationManifest,
+    trial: LifecycleAblationTrial,
+) -> None:
+    """Rebuild and compare one ledger record against its immutable planned snapshot."""
+    plan = build_lifecycle_ablation_plan(manifest)
+    planned = {item.trial_id: item for item in plan.trials}.get(trial.trial_id)
+    if planned != trial:
+        raise ValueError("existing TrialRecord does not match the deterministic ablation plan")
+    if record.experiment_id != manifest.experiment_id or record.trial_id != trial.trial_id:
+        raise ValueError("existing TrialRecord does not match the planned trial identity")
+    ledger_root = Path(manifest.ledger_root)
+    artifact_dir = ledger_root / manifest.experiment_id / "_artifacts" / trial.trial_id
+    if not artifact_dir.is_dir():
+        raise ValueError("existing TrialRecord does not have an immutable artifact snapshot")
+    expected = _record_from_snapshot(
+        manifest=manifest,
+        trial=trial,
+        artifact_dir=artifact_dir,
+        ledger_root=ledger_root,
+        plan=None,
+    )
+    if record != expected:
+        raise ValueError("existing TrialRecord does not match its immutable lifecycle ablation snapshot")
+
+
+def validate_lifecycle_ablation_snapshot(
+    manifest: LifecycleAblationManifest,
+    trial: LifecycleAblationTrial,
+) -> TrialRecord:
+    """Validate and reconstruct an unpublished immutable trial snapshot."""
+    plan = build_lifecycle_ablation_plan(manifest)
+    planned = {item.trial_id: item for item in plan.trials}.get(trial.trial_id)
+    if planned != trial:
+        raise ValueError("lifecycle snapshot does not match the deterministic ablation plan")
+    ledger_root = Path(manifest.ledger_root)
+    artifact_dir = ledger_root / manifest.experiment_id / "_artifacts" / trial.trial_id
+    if not artifact_dir.is_dir():
+        raise ValueError("lifecycle artifact snapshot does not exist")
+    return _record_from_snapshot(
+        manifest=manifest,
+        trial=trial,
+        artifact_dir=artifact_dir,
+        ledger_root=ledger_root,
+        plan=plan,
+    )
+
+
+def validate_historical_lifecycle_ablation_record(
+    record: TrialRecord,
+    manifest: LifecycleAblationManifest,
+    plan: LifecycleAblationPlan,
+    trial: LifecycleAblationTrial,
+) -> None:
+    """Validate one record against the plan captured at execution time."""
+    planned = {item.trial_id: item for item in plan.trials}.get(trial.trial_id)
+    if planned != trial:
+        raise ValueError("historical TrialRecord does not match its snapshotted ablation plan")
+    if record.experiment_id != manifest.experiment_id or record.trial_id != trial.trial_id:
+        raise ValueError("historical TrialRecord does not match its snapshotted trial identity")
+    ledger_root = Path(manifest.ledger_root)
+    artifact_dir = ledger_root / manifest.experiment_id / "_artifacts" / trial.trial_id
+    expected = _record_from_snapshot(
+        manifest=manifest,
+        trial=trial,
+        artifact_dir=artifact_dir,
+        ledger_root=ledger_root,
+        plan=plan,
+    )
+    if record != expected:
+        raise ValueError("historical TrialRecord does not match its immutable lifecycle ablation snapshot")
+
+
+def _record_from_snapshot(
+    *,
+    manifest: LifecycleAblationManifest,
+    trial: LifecycleAblationTrial,
+    artifact_dir: Path,
+    ledger_root: Path,
+    plan: LifecycleAblationPlan | None,
+) -> TrialRecord:
+    _validate_snapshot_layout(artifact_dir, manifest, trial, plan=plan)
+    artifacts = _snapshot_references(
+        staging=artifact_dir,
+        final=artifact_dir,
+        ledger_root=ledger_root,
+    )
+    return _build_lifecycle_trial_record(
+        manifest=manifest,
+        trial=trial,
+        package_dir=artifact_dir / "package",
+        run_dir=artifact_dir / "run",
+        artifact_references=artifacts,
+        require_planned_paths=False,
+        plan=plan,
+    )
+
+
+def _stage_authoritative_snapshot(
+    *,
+    manifest: LifecycleAblationManifest,
+    trial: LifecycleAblationTrial,
+    package_dir: Path,
+    run_dir: Path,
+    staging: Path,
+) -> None:
+    invocation = _canonical_invocation(run_dir, manifest, trial)
+    lifecycle = cast(dict[str, Any], invocation.manifest["lifecycle"])
+    package_files = cast(dict[str, str], lifecycle["package_files"])
+    outputs = cast(dict[str, Any], invocation.manifest["outputs"])
+    run_files = cast(dict[str, str], outputs["artifacts"])
+    for relative in sorted(package_files):
+        _copy_declared_file(package_dir, staging / "package", relative)
+    for relative in sorted(run_files):
+        _copy_declared_file(run_dir, staging / "run", relative)
+
+    experiment_id = str(invocation.manifest["experiment_id"])
+    canonical_dir = staging / "run" / "experiments" / experiment_id
+    canonical_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(invocation.manifest_path, canonical_dir / "experiment-manifest.json")
+    shutil.copy2(invocation.metrics_path, canonical_dir / "metrics.json")
+    shutil.copy2(invocation.verification_path, canonical_dir / "verification.json")
+
+    normalized_seal = dict(invocation.index_entry)
+    normalized_seal["manifest_path"] = "experiment-manifest.json"
+    _write_json(canonical_dir / "index-entry.json", normalized_seal)
+    normalized_index = dict(invocation.index_entry)
+    normalized_index["manifest_path"] = f"run/experiments/{experiment_id}/experiment-manifest.json"
+    _write_jsonl(staging / "experiment-index.jsonl", [normalized_index])
+
+    plan = build_lifecycle_ablation_plan(manifest)
+    persisted_manifest = Path(manifest.output_root) / "manifest.json"
+    if persisted_manifest.is_file() and _read_json(persisted_manifest) != manifest.model_dump(mode="json"):
+        raise ValueError("persisted ablation manifest does not match planned sweep")
+    persisted_plan = Path(manifest.output_root) / "plan.json"
+    if persisted_plan.is_file() and _read_json(persisted_plan) != plan.model_dump(mode="json"):
+        raise ValueError("persisted ablation plan does not match planned sweep")
+    _write_json(staging / "sweep" / "manifest.json", manifest.model_dump(mode="json"))
+    _write_json(staging / "sweep" / "plan.json", plan.model_dump(mode="json"))
+
+
+def _copy_declared_file(source_root: Path, destination_root: Path, raw_relative: str) -> None:
+    relative = Path(raw_relative)
+    if relative.is_absolute() or ".." in relative.parts:
+        raise ValueError(f"declared artifact path is unsafe: {raw_relative}")
+    source = source_root / relative
+    if source.is_symlink() or not source.is_file():
+        raise ValueError(f"declared artifact source is not a regular file: {source}")
+    destination = destination_root / relative
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, destination)
+
+
+def _validate_snapshot_layout(
+    artifact_dir: Path,
+    manifest: LifecycleAblationManifest,
+    trial: LifecycleAblationTrial,
+    *,
+    plan: LifecycleAblationPlan | None,
+) -> None:
+    snapshot_manifest = LifecycleAblationManifest.model_validate(_read_json(artifact_dir / "sweep" / "manifest.json"))
+    if snapshot_manifest != manifest:
+        raise ValueError("artifact snapshot ablation manifest does not match requested sweep")
+    expected_plan = plan or build_lifecycle_ablation_plan(manifest)
+    snapshot_plan = LifecycleAblationPlan.model_validate(_read_json(artifact_dir / "sweep" / "plan.json"))
+    if snapshot_plan != expected_plan:
+        raise ValueError("artifact snapshot ablation plan does not match requested sweep")
+    invocation = _canonical_invocation(artifact_dir / "run", manifest, trial)
+    lifecycle = cast(dict[str, Any], invocation.manifest["lifecycle"])
+    outputs = cast(dict[str, Any], invocation.manifest["outputs"])
+    expected = {
+        *(f"package/{relative}" for relative in cast(dict[str, str], lifecycle["package_files"])),
+        *(f"run/{relative}" for relative in cast(dict[str, str], outputs["artifacts"])),
+        f"run/experiments/{invocation.manifest['experiment_id']}/experiment-manifest.json",
+        f"run/experiments/{invocation.manifest['experiment_id']}/metrics.json",
+        f"run/experiments/{invocation.manifest['experiment_id']}/verification.json",
+        f"run/experiments/{invocation.manifest['experiment_id']}/index-entry.json",
+        "experiment-index.jsonl",
+        "sweep/manifest.json",
+        "sweep/plan.json",
+    }
+    actual = {path.relative_to(artifact_dir).as_posix() for path in artifact_dir.rglob("*") if path.is_file()}
+    if actual != expected:
+        missing = sorted(expected - actual)
+        unexpected = sorted(actual - expected)
+        raise ValueError(f"artifact snapshot file set mismatch; missing={missing}, unexpected={unexpected}")
+
+
+def _canonical_invocation(
+    run_dir: Path,
+    manifest: LifecycleAblationManifest,
+    trial: LifecycleAblationTrial,
+) -> _CanonicalInvocation:
+    candidates: list[tuple[Path, dict[str, Any]]] = []
+    for path in sorted((run_dir / "experiments").glob("*/experiment-manifest.json")):
+        if path.parent.name.startswith("."):
+            continue
+        payload = LifecycleExperimentManifest.model_validate(_read_json(path)).model_dump(mode="json")
+        sweep = payload.get("sweep")
+        if not isinstance(sweep, dict):
+            continue
+        if (
+            sweep.get("sweep_experiment_id") == manifest.experiment_id
+            and sweep.get("planned_trial_id") == trial.trial_id
+        ):
+            candidates.append((path, payload))
+    if len(candidates) != 1:
+        raise ValueError("expected exactly one canonical lifecycle invocation for planned trial")
+    manifest_path, payload = candidates[0]
+    experiment_id = str(payload["experiment_id"])
+    seal_path = manifest_path.parent / "index-entry.json"
+    index_path = run_dir.parent / "experiment-index.jsonl"
+    seal_entry = _read_json(seal_path) if seal_path.is_file() else None
+    if seal_entry is not None:
+        _validate_invocation_index_entry(
+            seal_entry,
+            entry_path=seal_path,
+            manifest_path=manifest_path,
+            manifest=payload,
+        )
+
+    shared_entries: list[dict[str, Any]] | None = None
+    if index_path.is_file():
+        try:
+            shared_entries = [entry for entry in _read_jsonl(index_path) if entry.get("experiment_id") == experiment_id]
+        except (json.JSONDecodeError, ValueError):
+            if seal_entry is None:
+                raise
+    if shared_entries is not None and len(shared_entries) > 1:
+        raise ValueError("canonical lifecycle invocation must have at most one shared index entry")
+    shared_entry = shared_entries[0] if shared_entries else None
+    if shared_entry is not None:
+        _validate_invocation_index_entry(
+            shared_entry,
+            entry_path=index_path,
+            manifest_path=manifest_path,
+            manifest=payload,
+        )
+    if (
+        seal_entry is not None
+        and shared_entry is not None
+        and not _equivalent_index_entries(
+            seal_entry,
+            shared_entry,
+        )
+    ):
+        raise ValueError("canonical lifecycle invocation seal conflicts with shared index entry")
+    index_entry = seal_entry or shared_entry
+    if index_entry is None:
+        raise ValueError("canonical lifecycle invocation has no sealed or shared index entry")
+    return _CanonicalInvocation(
+        manifest_path=manifest_path,
+        manifest=payload,
+        metrics_path=manifest_path.parent / "metrics.json",
+        verification_path=manifest_path.parent / "verification.json",
+        index_entry=index_entry,
+    )
+
+
+def _validate_invocation_index_entry(
+    entry: dict[str, Any],
+    *,
+    entry_path: Path,
+    manifest_path: Path,
+    manifest: dict[str, Any],
+) -> None:
+    if entry.get("experiment_id") != manifest.get("experiment_id"):
+        raise ValueError("canonical lifecycle invocation id does not match index entry")
+    indexed_path = Path(str(entry.get("manifest_path", "")))
+    if not indexed_path.is_absolute():
+        indexed_path = entry_path.parent / indexed_path
+    if indexed_path.resolve() != manifest_path.resolve():
+        raise ValueError("canonical lifecycle invocation path does not match index entry")
+    if entry.get("manifest_sha256") != _sha256(manifest_path):
+        raise ValueError("canonical lifecycle invocation hash does not match index entry")
+    if entry.get("sweep") != manifest.get("sweep"):
+        raise ValueError("canonical lifecycle invocation sweep does not match index entry")
+
+
+def _equivalent_index_entries(first: dict[str, Any], second: dict[str, Any]) -> bool:
+    return {key: value for key, value in first.items() if key != "manifest_path"} == {
+        key: value for key, value in second.items() if key != "manifest_path"
+    }
+
+
+def _repair_shared_invocation_index(
+    run_dir: Path,
+    manifest: LifecycleAblationManifest,
+    trial: LifecycleAblationTrial,
+) -> None:
+    invocation = _canonical_invocation(run_dir, manifest, trial)
+    index_path = run_dir.parent / "experiment-index.jsonl"
+    normalized = dict(invocation.index_entry)
+    normalized["manifest_path"] = str(invocation.manifest_path)
+    with _exclusive_index_lock(index_path):
+        needs_rewrite = not index_path.is_file()
+        try:
+            entries = (
+                _read_jsonl(index_path)
+                if index_path.is_file()
+                else _recover_index_entries_from_seals(index_path.parent)
+            )
+        except (json.JSONDecodeError, ValueError):
+            entries = _recover_index_entries_from_seals(index_path.parent)
+            needs_rewrite = True
+        matching = [entry for entry in entries if entry.get("experiment_id") == normalized["experiment_id"]]
+        if len(matching) > 1:
+            raise ValueError("canonical lifecycle invocation has duplicate shared index entries")
+        if matching:
+            if not _equivalent_index_entries(matching[0], normalized):
+                raise ValueError("canonical lifecycle invocation seal conflicts with shared index entry")
+            if needs_rewrite:
+                _write_jsonl_atomic(
+                    index_path,
+                    sorted(entries, key=lambda entry: str(entry.get("experiment_id", ""))),
+                )
+            return
+        entries.append(normalized)
+        _write_jsonl_atomic(index_path, sorted(entries, key=lambda entry: str(entry.get("experiment_id", ""))))
+
+
+@contextmanager
+def _exclusive_index_lock(index_path: Path) -> Iterator[None]:
+    mkdir_durable(index_path.parent)
+    lock_path = index_path.with_name(f".{index_path.name}.lock")
+    key = str(lock_path.resolve())
+    with _INDEX_LOCKS_GUARD:
+        thread_lock = _INDEX_LOCKS.setdefault(key, Lock())
+    with thread_lock:
+        descriptor = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX)
+            yield
+        finally:
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+            os.close(descriptor)
+
+
+def _recover_index_entries_from_seals(index_root: Path) -> list[dict[str, Any]]:
+    recovered: dict[str, dict[str, Any]] = {}
+    for seal_path in sorted(index_root.glob("*/experiments/*/index-entry.json")):
+        if seal_path.parent.name.startswith("."):
+            continue
+        entry = _read_json(seal_path)
+        manifest_path = seal_path.parent / "experiment-manifest.json"
+        manifest = LifecycleExperimentManifest.model_validate(_read_json(manifest_path)).model_dump(mode="json")
+        _validate_invocation_index_entry(
+            entry,
+            entry_path=seal_path,
+            manifest_path=manifest_path,
+            manifest=manifest,
+        )
+        normalized = dict(entry)
+        normalized["manifest_path"] = str(manifest_path)
+        experiment_id = str(normalized["experiment_id"])
+        if experiment_id in recovered and not _equivalent_index_entries(recovered[experiment_id], normalized):
+            raise ValueError(f"conflicting canonical invocation seals: {experiment_id}")
+        recovered[experiment_id] = normalized
+    return list(recovered.values())
+
+
+def _validate_declared_run_artifacts(run_dir: Path, experiment: dict[str, Any]) -> None:
+    outputs = experiment.get("outputs")
+    declared = outputs.get("artifacts") if isinstance(outputs, dict) else None
+    if not isinstance(declared, dict) or not declared:
+        raise ValueError("canonical lifecycle manifest must declare run artifact hashes")
+    required = {"lifecycle_ledger.jsonl", "metrics.json", "state.json", "verification.json"}
+    missing = sorted(required - set(declared))
+    if missing:
+        raise ValueError(f"canonical lifecycle manifest is missing required run artifacts: {', '.join(missing)}")
+    root = run_dir.resolve()
+    for raw_relative, expected in sorted(declared.items()):
+        relative = Path(str(raw_relative))
+        if relative.is_absolute() or ".." in relative.parts:
+            raise ValueError(f"canonical lifecycle manifest contains unsafe artifact path: {raw_relative}")
+        path = (run_dir / relative).resolve()
+        try:
+            path.relative_to(root)
+        except ValueError as exc:
+            raise ValueError(f"canonical lifecycle manifest artifact escapes run root: {raw_relative}") from exc
+        if not path.is_file() or not isinstance(expected, str) or _sha256(path) != expected:
+            raise ValueError(f"run artifact hash does not match canonical manifest: {raw_relative}")
+    interaction = experiment.get("interaction")
+    trajectories = interaction.get("trajectory_hashes") if isinstance(interaction, dict) else None
+    if not isinstance(trajectories, dict):
+        raise ValueError("canonical lifecycle manifest must declare trajectory hashes")
+    for relative, digest in trajectories.items():
+        if declared.get(relative) != digest:
+            raise ValueError(f"trajectory hash does not match declared run artifact: {relative}")
+
+
+def _validate_snapshotted_lifecycle_state(run_dir: Path) -> None:
+    state = EvidenceLifecycleRunState.model_validate(_read_json(run_dir / "state.json"))
+    if state.branch is not None:
+        raise ValueError("branched lifecycle snapshots are not supported by ablation finalization")
+    for checkpoint in state.checkpoint_runs:
+        if checkpoint.status.value != "submitted":
+            continue
+        if checkpoint.submission_sha256 is None:
+            raise ValueError(f"snapshotted checkpoint lacks submission hash: {checkpoint.checkpoint_id}")
+        path = run_dir / "episodes" / checkpoint.checkpoint_id / "submission.json"
+        if not path.is_file() or _sha256(path) != checkpoint.submission_sha256:
+            raise ValueError(f"snapshotted checkpoint submission hash mismatch: {checkpoint.checkpoint_id}")
+
+
+def _validate_metrics_against_run(
+    run_dir: Path,
+    state: dict[str, Any],
+    experiment: dict[str, Any],
+    metrics: dict[str, Any],
+    verification: dict[str, Any],
+) -> None:
+    checkpoint_runs = state.get("checkpoint_runs")
+    if not isinstance(checkpoint_runs, list):
+        raise ValueError("lifecycle state checkpoint_runs are malformed")
+    attempts = [
+        attempt
+        for checkpoint in checkpoint_runs
+        if isinstance(checkpoint, dict)
+        for attempt in checkpoint.get("attempts", [])
+        if isinstance(attempt, dict)
+    ]
+    expected = {
+        "checkpoint_count": sum(
+            isinstance(checkpoint, dict) and checkpoint.get("status") == "submitted" for checkpoint in checkpoint_runs
+        ),
+        "retries": sum(
+            max(0, len(checkpoint.get("attempts", [])) - 1)
+            for checkpoint in checkpoint_runs
+            if isinstance(checkpoint, dict)
+        ),
+        "failures": sum(attempt.get("status") == "failed" for attempt in attempts),
+    }
+    for field, value in expected.items():
+        if metrics.get(field) != value:
+            raise ValueError(f"lifecycle {field} does not match run state")
+
+    interaction = experiment.get("interaction")
+    trajectory_hashes = interaction.get("trajectory_hashes") if isinstance(interaction, dict) else None
+    if not isinstance(trajectory_hashes, dict):
+        raise ValueError("lifecycle invocation trajectory hashes are malformed")
+    entries_by_trajectory = [read_trajectory(run_dir / relative) for relative in sorted(trajectory_hashes)]
+    entries = [entry for trajectory in entries_by_trajectory for entry in trajectory]
+    tool_calls = [entry for entry in entries if entry.role == "tool_call"]
+    trajectory_metrics = {
+        "requests": sum(
+            len({entry.step for entry in trajectory if entry.step > 0}) for trajectory in entries_by_trajectory
+        ),
+        "tool_calls": len(tool_calls),
+        "reads": sum(entry.tool_name == "read_workspace_file" for entry in tool_calls),
+        "revisits": sum(entry.tool_name == "revisit_checkpoint" for entry in tool_calls),
+    }
+    for field, value in trajectory_metrics.items():
+        if metrics.get(field) != value:
+            raise ValueError(f"lifecycle {field} does not match trajectories")
+    if metrics.get("semantic_transition") != verification.get("semantic_metrics"):
+        raise ValueError("lifecycle semantic metrics do not match verification")
+    execution = experiment.get("execution")
+    if not isinstance(execution, dict) or (
+        execution.get("checkpoint_seconds") != metrics.get("checkpoint_seconds")
+        or execution.get("whole_run_seconds") != metrics.get("whole_run_seconds")
+    ):
+        raise ValueError("lifecycle execution timing does not match metrics")
+
+
+def _validate_artifact_hash(path: Path, expected: object, label: str) -> None:
+    if not isinstance(expected, str) or _sha256(path) != expected:
+        raise ValueError(f"{label} hash does not match manifest")
+
+
+def _copy_artifact_tree(
+    source: Path,
+    destination: Path,
+    *,
+    excluded_roots: set[str],
+    excluded_names: set[str] | None = None,
+) -> None:
+    excluded_names = excluded_names or set()
+    if not source.is_dir():
+        raise ValueError(f"artifact source directory does not exist: {source}")
+    for path in sorted(source.rglob("*")):
+        relative = path.relative_to(source)
+        if not relative.parts or relative.parts[0] in excluded_roots or path.name in excluded_names:
+            continue
+        if path.is_symlink():
+            raise ValueError(f"artifact snapshots do not accept symlinks: {path}")
+        if not path.is_file():
+            continue
+        target = destination / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(path, target)
+
+
+def _snapshot_references(
+    *,
+    staging: Path,
+    final: Path,
+    ledger_root: Path,
+) -> list[ArtifactReference]:
+    references: list[ArtifactReference] = []
+    for path in sorted(item for item in staging.rglob("*") if item.is_file()):
+        relative = path.relative_to(staging)
+        final_path = final / relative
+        references.append(
+            ArtifactReference(
+                kind=_artifact_kind(relative),
+                path=final_path.relative_to(ledger_root).as_posix(),
+                sha256=_sha256(path),
+                media_type=_media_type(path),
+            )
+        )
+    if not references:
+        raise ValueError("lifecycle artifact snapshot is empty")
+    return references
+
+
+def _artifact_kind(relative: Path) -> str:
+    path = relative.as_posix()
+    if path.startswith("run/experiments/") and path.endswith("/experiment-manifest.json"):
+        return "lifecycle_manifest"
+    if path.startswith("run/experiments/") and path.endswith("/index-entry.json"):
+        return "lifecycle_invocation_seal"
+    if path == "experiment-index.jsonl":
+        return "lifecycle_invocation_index"
+    if path == "sweep/manifest.json":
+        return "lifecycle_ablation_manifest"
+    if path == "sweep/plan.json":
+        return "lifecycle_ablation_plan"
+    if path == "run/verification.json":
+        return "lifecycle_verification"
+    if path == "run/metrics.json":
+        return "lifecycle_metrics"
+    if path.endswith("/trajectory.jsonl"):
+        return "trajectory"
+    if path.endswith("/conversation.jsonl"):
+        return "conversation"
+    if path.endswith("/raw_output.md"):
+        return "raw_output"
+    if path.endswith("/agent_result.json"):
+        return "agent_result"
+    if path.endswith("/agent_result.corrupt.json"):
+        return "corrupt_agent_result"
+    if path.endswith("/submission.json") or "/submissions/" in path:
+        return "checkpoint_submission"
+    if path == "run/state.json":
+        return "lifecycle_state"
+    if path == "run/lifecycle_ledger.jsonl":
+        return "lifecycle_ledger"
+    if path.startswith("package/"):
+        return "lifecycle_package"
+    return "lifecycle_run_artifact"
+
+
+def _media_type(path: Path) -> str:
+    return {
+        ".json": "application/json",
+        ".jsonl": "application/x-ndjson",
+        ".md": "text/markdown",
+        ".txt": "text/plain",
+    }.get(path.suffix.lower(), "application/octet-stream")
+
+
+def _lifecycle_sessions(
+    run_dir: Path,
+    artifacts: list[ArtifactReference],
+    *,
+    state: dict[str, Any],
+    experiment: dict[str, Any],
+    metrics: dict[str, Any],
+    verification: dict[str, Any],
+) -> list[LifecycleSessionRecord]:
+    outputs = cast(dict[str, Any], experiment["outputs"])
+    execution = cast(dict[str, Any], experiment["execution"])
+    model = cast(dict[str, Any], experiment["model"])
+    expected_execution_mode = str(execution.get("mode") or "")
+    expected_session_mode = "persistent" if expected_execution_mode == "persistent_context" else "fresh"
+    expected_visibility = str(execution.get("memory_visibility_policy") or "")
+    declared = cast(dict[str, str], outputs["artifacts"])
+    result_paths = sorted(Path(relative) for relative in declared if Path(relative).name == "agent_result.json")
+    payloads: dict[str, tuple[Path, dict[str, Any]]] = {}
+    configuration_records: list[dict[str, Any]] = []
+    for relative in result_paths:
+        payload = _read_json(run_dir / relative)
+        session_id = str(payload.get("session_id") or "")
+        if not session_id:
+            raise ValueError(f"lifecycle session is missing session_id: {relative}")
+        if session_id in payloads:
+            raise ValueError(f"lifecycle run contains duplicate session_id: {session_id}")
+        payloads[session_id] = (relative, payload)
+        configuration = payload.get("configuration_record")
+        if not isinstance(configuration, dict):
+            raise ValueError(f"lifecycle session configuration is malformed: {session_id}")
+        configuration_records.append(cast(dict[str, Any], configuration))
+
+    ordered_session_ids: list[str] = []
+    expected_checkpoints: dict[str, list[str]] = {}
+    expected_attempt_statuses: dict[str, list[str]] = {}
+    checkpoint_runs = state.get("checkpoint_runs")
+    if not isinstance(checkpoint_runs, list):
+        raise ValueError("lifecycle state checkpoint_runs are malformed")
+    for checkpoint in checkpoint_runs:
+        if not isinstance(checkpoint, dict):
+            raise ValueError("lifecycle state checkpoint record is malformed")
+        checkpoint_id = str(checkpoint.get("checkpoint_id") or "")
+        attempts = checkpoint.get("attempts")
+        if not isinstance(attempts, list):
+            raise ValueError(f"lifecycle checkpoint attempts are malformed: {checkpoint_id}")
+        if any(not isinstance(attempt, dict) for attempt in attempts):
+            raise ValueError(f"lifecycle checkpoint attempt is malformed: {checkpoint_id}")
+        checkpoint_status = str(checkpoint.get("status") or "")
+        if checkpoint_status == "submitted":
+            if not attempts:
+                raise ValueError(f"submitted checkpoint has no adapter attempt owner: {checkpoint_id}")
+            submitted_attempts = [attempt for attempt in attempts if attempt.get("status") == "submitted"]
+            if len(submitted_attempts) != 1 or attempts[-1] != submitted_attempts[0]:
+                raise ValueError(f"submitted checkpoint has ambiguous adapter attempt ownership: {checkpoint_id}")
+        elif any(attempt.get("status") == "submitted" for attempt in attempts):
+            raise ValueError(f"unsubmitted checkpoint contains submitted adapter attempt: {checkpoint_id}")
+        for attempt in attempts:
+            session_id = str(attempt.get("session_id") or "")
+            if not session_id:
+                raise ValueError(f"lifecycle checkpoint attempt has no session owner: {checkpoint_id}")
+            if attempt.get("execution_mode") != expected_execution_mode:
+                raise ValueError(f"lifecycle checkpoint attempt execution mode mismatch: {checkpoint_id}")
+            if session_id not in ordered_session_ids:
+                ordered_session_ids.append(session_id)
+            expected_checkpoints.setdefault(session_id, []).append(checkpoint_id)
+            expected_attempt_statuses.setdefault(session_id, []).append(str(attempt.get("status") or ""))
+    if set(payloads) != set(ordered_session_ids):
+        raise ValueError("lifecycle session artifacts do not match checkpoint attempt lineage")
+    if expected_execution_mode == "fresh_context" and any(
+        len(checkpoint_ids) != 1 for checkpoint_ids in expected_checkpoints.values()
+    ):
+        raise ValueError("fresh lifecycle session must own exactly one checkpoint attempt")
+
+    if execution.get("session_count") != len(payloads):
+        raise ValueError("lifecycle execution session_count does not match session artifacts")
+    if model.get("session_configurations") != configuration_records:
+        raise ValueError("lifecycle model session configurations do not match session artifacts")
+
+    sessions: list[LifecycleSessionRecord] = []
+    for session_id in ordered_session_ids:
+        relative, payload = payloads[session_id]
+        checkpoint_ids = payload.get("checkpoint_ids", [])
+        if not isinstance(checkpoint_ids, list):
+            raise ValueError(f"lifecycle session checkpoint_ids are malformed: {session_id}")
+        expected_ids = list(dict.fromkeys(expected_checkpoints[session_id]))
+        if checkpoint_ids != expected_ids:
+            raise ValueError(f"lifecycle session checkpoint coverage does not match state: {session_id}")
+        requested_adapter = str(payload.get("adapter") or "")
+        resolved_adapter = str(payload.get("adapter_name") or "")
+        if payload.get("session_mode") != expected_session_mode:
+            raise ValueError(f"lifecycle session execution mode does not match invocation: {session_id}")
+        if payload.get("memory_visibility_policy") != expected_visibility:
+            raise ValueError(f"lifecycle session visibility policy does not match invocation: {session_id}")
+        parts = relative.parts
+        if expected_session_mode == "persistent" and parts[:2] != ("sessions", session_id):
+            raise ValueError(f"persistent lifecycle session artifact path is invalid: {session_id}")
+        if expected_session_mode == "fresh" and (
+            len(parts) < 4 or parts[0] != "episodes" or parts[1] != expected_ids[0] or parts[2] != session_id
+        ):
+            raise ValueError(f"fresh lifecycle session artifact path is invalid: {session_id}")
+        if requested_adapter != model.get("requested_adapter", model.get("adapter")):
+            raise ValueError(f"lifecycle session requested adapter does not match invocation: {session_id}")
+        if not resolved_adapter:
+            raise ValueError(f"lifecycle session resolved adapter is missing: {session_id}")
+        if payload.get("max_turns") != execution.get("max_turns_per_session"):
+            raise ValueError(f"lifecycle session max_turns does not match invocation: {session_id}")
+        resolved_model = str(payload.get("resolved_model") or payload.get("model") or "")
+        if not resolved_model:
+            raise ValueError(f"lifecycle session resolved model is missing: {session_id}")
+        session_status = _session_status(str(payload.get("status") or "failed"))
+        attempts_submitted = all(status == "submitted" for status in expected_attempt_statuses[session_id])
+        identity_mismatch = (
+            resolved_adapter != requested_adapter
+            and session_status == "failed"
+            and payload.get("failure_kind") == "adapter_identity_mismatch"
+        )
+        unresolved_interruption = (
+            resolved_adapter == "unresolved"
+            and session_status == "failed"
+            and payload.get("failure_kind") in {"interrupted", "interrupted_after_completion"}
+        )
+        failure_kind = payload.get("failure_kind")
+        terminal_failure = (
+            attempts_submitted and session_status == "failed" and isinstance(failure_kind, str) and bool(failure_kind)
+        )
+        if resolved_adapter != requested_adapter and not (identity_mismatch or unresolved_interruption):
+            raise ValueError(f"lifecycle session resolved adapter does not match invocation: {session_id}")
+        if attempts_submitted != (session_status == "completed") and not (
+            attempts_submitted and (identity_mismatch or unresolved_interruption or terminal_failure)
+        ):
+            raise ValueError(f"lifecycle session status does not match checkpoint attempts: {session_id}")
+        session_artifacts = [
+            artifact for artifact in artifacts if f"/run/{relative.parent.as_posix()}/" in f"/{artifact.path}"
+        ]
+        sessions.append(
+            LifecycleSessionRecord(
+                session_id=session_id,
+                checkpoint_ids=expected_ids,
+                requested_adapter=requested_adapter,
+                adapter=resolved_adapter,
+                resolved_model=resolved_model,
+                execution_mode=cast(Literal["persistent_context", "fresh_context"], expected_execution_mode),
+                memory_visibility_policy=cast(
+                    Literal[
+                        "persistent_context",
+                        "artifact_memory",
+                        "raw_evidence_only",
+                        "current_release_only",
+                    ],
+                    expected_visibility,
+                ),
+                configuration=cast(dict[str, Any], payload.get("configuration_record") or {}),
+                status=session_status,
+                input_tokens=int(payload.get("input_tokens", 0)),
+                output_tokens=int(payload.get("output_tokens", 0)),
+                cache_read_tokens=int(payload.get("cache_read_tokens", 0)),
+                cache_write_tokens=int(payload.get("cache_write_tokens", 0)),
+                failure_kind=(str(payload["failure_kind"]) if payload.get("failure_kind") is not None else None),
+                provider_error=(str(payload["provider_error"]) if payload.get("provider_error") is not None else None),
+                artifacts=session_artifacts,
+            )
+        )
+    resolved_models = sorted({session.resolved_model for session in sessions})
+    if model.get("resolved_models") != resolved_models:
+        raise ValueError("lifecycle resolved models do not match session artifacts")
+    resolved_adapters = sorted({session.adapter for session in sessions})
+    if model.get("resolved_adapters") != resolved_adapters:
+        raise ValueError("lifecycle resolved adapters do not match session artifacts")
+    if any(session.status != "completed" for session in sessions) and (
+        execution.get("status") != "failed"
+        or verification.get("overall") != "incomplete"
+        or float(verification.get("reward", 0.0)) != 0.0
+    ):
+        raise ValueError("failed lifecycle sessions must remain an unscored failed execution")
+    token_fields = {
+        "input_tokens": "input_tokens",
+        "output_tokens": "output_tokens",
+        "cache_read_tokens": "cache_read_tokens",
+        "cache_write_tokens": "cache_write_tokens",
+    }
+    for metric_field, session_field in token_fields.items():
+        if metrics.get(metric_field) != sum(getattr(session, session_field) for session in sessions):
+            raise ValueError(f"lifecycle {metric_field} does not match session artifacts")
+    if execution.get("status") == "completed" and (
+        state.get("status") != "complete" or any(session.status != "completed" for session in sessions)
+    ):
+        raise ValueError("completed lifecycle execution contradicts state or session status")
+    return sessions
+
+
+def _session_status(status: str) -> Literal["completed", "failed", "partial"]:
+    if status in {"completed", "ok"}:
+        return "completed"
+    if status == "partial":
+        return "partial"
+    return "failed"
+
+
+def _execution_status(status: str) -> Literal["completed", "failed", "partial"]:
+    if status == "completed":
+        return "completed"
+    if status == "partial":
+        return "partial"
+    return "failed"
+
+
+def _artifact_output_root(
+    trial: LifecycleAblationTrial,
+    artifacts: list[ArtifactReference],
+    run_dir: Path,
+) -> str:
+    if not artifacts:
+        return str(run_dir)
+    experiment_id = Path(trial.ledger_path).parent.name
+    return (Path(experiment_id) / "_artifacts" / trial.trial_id / "run").as_posix()
+
+
+def _snapshotted_package_path(artifacts: list[ArtifactReference], package_path: str) -> str:
+    suffix = f"/package/{package_path}"
+    matches = [artifact.path for artifact in artifacts if artifact.path.endswith(suffix)]
+    if len(matches) != 1:
+        raise ValueError(f"snapshotted package artifact missing or ambiguous: {package_path}")
+    return matches[0]
+
+
+def _single_path(preferred: list[str], fallback: list[str]) -> str | None:
+    if len(preferred) == 1:
+        return preferred[0]
+    return fallback[0] if len(fallback) == 1 else None
+
+
+def _artifact_by_kind(artifacts: list[ArtifactReference], kind: str) -> ArtifactReference | None:
+    matches = [artifact for artifact in artifacts if artifact.kind == kind]
+    if len(matches) > 1:
+        raise ValueError(f"artifact snapshot contains duplicate {kind} records")
+    return matches[0] if matches else None
+
+
+def _lifecycle_instruction(package_dir: Path) -> str:
+    parts = [path.read_text(encoding="utf-8").strip() for path in sorted((package_dir / "instructions").glob("*.md"))]
+    instruction = "\n\n".join(part for part in parts if part)
+    if not instruction:
+        raise ValueError("lifecycle package instructions are empty")
+    return instruction
+
+
+def _verification_failures(verification: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    gates = verification.get("gates", {})
+    if not isinstance(gates, dict):
+        return ["verification gates are malformed"]
+    for gate_id, gate in gates.items():
+        if not isinstance(gate, dict):
+            failures.append(f"{gate_id}:malformed")
+            continue
+        for failure in gate.get("failures", []):
+            failures.append(f"{gate_id}:{failure}")
+    return failures
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return cast(dict[str, Any], payload)
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _write_jsonl(path: Path, payloads: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(payload, sort_keys=True) + "\n" for payload in payloads),
+        encoding="utf-8",
+    )
+
+
+def _write_jsonl_atomic(path: Path, payloads: list[dict[str, Any]]) -> None:
+    mkdir_durable(path.parent)
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        with temporary.open("x", encoding="utf-8") as handle:
+            handle.write("".join(json.dumps(payload, sort_keys=True) + "\n" for payload in payloads))
+            handle.flush()
+            os.fsync(handle.fileno())
+        temporary.replace(path)
+        _fsync_directory(path.parent)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.is_file():
+        raise ValueError(f"expected JSONL file: {path}")
+    records: list[dict[str, Any]] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not line.strip():
+            continue
+        payload = json.loads(line)
+        if not isinstance(payload, dict):
+            raise ValueError(f"expected JSON object at {path}:{line_number}")
+        records.append(cast(dict[str, Any], payload))
+    return records
+
+
+def _tree_hashes(root: Path) -> dict[str, str]:
+    return {
+        path.relative_to(root).as_posix(): _sha256(path)
+        for path in sorted(root.rglob("*"))
+        if path.is_file() and not path.is_symlink()
+    }
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()

--- a/src/aec_bench/task_world_templates/lifecycles/__init__.py
+++ b/src/aec_bench/task_world_templates/lifecycles/__init__.py
@@ -22,6 +22,7 @@ class LifecycleTemplateRegistration:
     verifier_name: str
     variant_module_name: str | None = None
     variant_ids_name: str | None = None
+    variant_get_name: str | None = None
     variant_metadata_name: str | None = None
 
 
@@ -35,6 +36,7 @@ _LIFECYCLES = {
             verifier_name="verify_ssc03_evidence_lifecycle",
             variant_module_name="aec_bench.task_world_templates.lifecycles.ssc03_drainage_variants",
             variant_ids_name="list_ssc03_lifecycle_variant_ids",
+            variant_get_name="get_ssc03_lifecycle_variant",
             variant_metadata_name="validated_ssc03_package_variant",
         )
     ]
@@ -53,6 +55,25 @@ def lifecycle_variant_ids(template_id: str) -> tuple[str, ...]:
         return ()
     module = import_module(registration.variant_module_name or registration.module_name)
     return tuple(getattr(module, registration.variant_ids_name)())
+
+
+def lifecycle_variant_metadata(template_id: str, variant_id: str) -> dict[str, Any]:
+    """Return validated host-side metadata for one registered public variant."""
+    registration = _entry(template_id)
+    if registration.variant_get_name is None:
+        raise KeyError(f"lifecycle template {template_id!r} does not declare variant metadata")
+    module = import_module(registration.variant_module_name or registration.module_name)
+    variant = getattr(module, registration.variant_get_name)(variant_id)
+    return cast(dict[str, Any], variant.model_dump(mode="json"))
+
+
+def registered_lifecycle_verifier(template_id: str) -> Callable[[Path, Path], dict[str, Any]]:
+    """Resolve the task-specific verifier that performs lifecycle scoring."""
+    registration = _entry(template_id)
+    return cast(
+        Callable[[Path, Path], dict[str, Any]],
+        getattr(import_module(registration.module_name), registration.verifier_name),
+    )
 
 
 def lifecycle_package_variant(package_dir: Path) -> dict[str, Any] | None:
@@ -102,8 +123,7 @@ def verify_lifecycle_template(package_dir: Path, run_dir: Path) -> dict[str, Any
     lifecycle = EvidenceLifecycleSpec.model_validate(_read_json(Path(package_dir) / "lifecycle.json"))
     if lifecycle != template.evidence_lifecycle:
         raise ValueError("materialized lifecycle contract does not match template.json")
-    registration = _entry(template.template_id)
-    verifier = getattr(import_module(registration.module_name), registration.verifier_name)
+    verifier = registered_lifecycle_verifier(template.template_id)
     return validate_lifecycle_verification(verifier(Path(package_dir), Path(run_dir)))
 
 

--- a/tests/cli/test_meta_harness.py
+++ b/tests/cli/test_meta_harness.py
@@ -7,6 +7,7 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import yaml
 from typer.testing import CliRunner
 
 from aec_bench.cli.main import app
@@ -16,6 +17,111 @@ from aec_bench.task_world_templates.lifecycles.ssc03_drainage_model import (
 
 runner = CliRunner()
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_meta_harness_lifecycle_ablation_dry_run_is_exact_and_write_free(tmp_path: Path) -> None:
+    config_path = tmp_path / "ablation.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "experiment_id": "cli-ablation",
+                "lifecycle_template_id": "drainage-model-evidence-lifecycle-review",
+                "variants": ["response_assertion_only"],
+                "agents": [
+                    {
+                        "name": "agent-a",
+                        "adapter": "tool_loop",
+                        "model": "model-a",
+                        "parameters": {"max_turns_per_session": 10},
+                    }
+                ],
+                "study_design": {
+                    "interpretation": "descriptive_calibration",
+                    "turn_budget_scope": "per_session",
+                    "execution_order": "deterministic_sequential_plan_order",
+                    "randomized": False,
+                    "counterbalanced": False,
+                    "causal_effects_supported": False,
+                },
+                "repetitions": 1,
+                "output_root": "output",
+                "ledger_root": "ledger",
+                "limits": {"max_trials": 4},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "--json",
+            "meta-harness",
+            "lifecycle-ablation",
+            "--config",
+            str(config_path),
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)["data"]
+    assert data["dry_run"] is True
+    assert data["plan"]["trial_count"] == 4
+    assert data["plan"]["study_design"]["causal_effects_supported"] is False
+    assert {item["status"] for item in data["trial_statuses"]} == {"pending"}
+    assert {item["memory_visibility_policy"] for item in data["trial_statuses"]} == {
+        "persistent_context",
+        "artifact_memory",
+        "raw_evidence_only",
+        "current_release_only",
+    }
+    assert all(Path(item["run_dir"]).is_absolute() for item in data["trial_statuses"])
+    assert not (tmp_path / "output").exists()
+    assert not (tmp_path / "ledger").exists()
+
+
+def test_meta_harness_lifecycle_ablation_rejects_ignored_agent_parameter(tmp_path: Path) -> None:
+    config_path = tmp_path / "invalid-ablation.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "experiment_id": "cli-ablation",
+                "lifecycle_template_id": "drainage-model-evidence-lifecycle-review",
+                "variants": ["response_assertion_only"],
+                "agents": [
+                    {
+                        "name": "agent-a",
+                        "adapter": "tool_loop",
+                        "model": "model-a",
+                        "parameters": {"seed": 42},
+                    }
+                ],
+                "output_root": "output",
+                "ledger_root": "ledger",
+                "limits": {"max_trials": 4},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "--json",
+            "meta-harness",
+            "lifecycle-ablation",
+            "--config",
+            str(config_path),
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 1
+    envelope = json.loads(result.output)
+    assert envelope["status"] == "error"
+    assert "unsupported lifecycle agent parameters: seed" in envelope["errors"][0]
 
 
 def test_meta_harness_lifecycle_commands_prepare_submit_and_report_state(tmp_path: Path) -> None:

--- a/tests/contracts/test_trial_record.py
+++ b/tests/contracts/test_trial_record.py
@@ -9,12 +9,16 @@ from aec_bench.contracts.evaluation_result import EvaluationResult, ValidityChec
 from aec_bench.contracts.trial_record import (
     AdaptationProvenance,
     AgentReference,
+    ArtifactReference,
     Completeness,
     CostRecord,
     DerivationStepRecord,
     EnvironmentSnapshot,
     FileReference,
     InputRecord,
+    LifecycleExecutionRecord,
+    LifecycleSessionRecord,
+    LifecycleTrialProvenance,
     OutputRecord,
     TaskReference,
     TimingRecord,
@@ -167,6 +171,163 @@ def test_trial_record_rejects_complete_missing_input_files() -> None:
     with pytest.raises(ValidationError, match="input_files"):
         build_trial_record(
             inputs=InputRecord(instruction="Review the task."),
+        )
+
+
+def test_trial_record_accepts_typed_lifecycle_execution_and_provenance() -> None:
+    invocation_manifest = ArtifactReference(
+        kind="lifecycle_manifest",
+        path="_artifacts/trial-001/experiment-manifest.json",
+        sha256="a" * 64,
+        media_type="application/json",
+    )
+    invocation_index = ArtifactReference(
+        kind="lifecycle_invocation_index",
+        path="_artifacts/trial-001/experiment-index.jsonl",
+        sha256="1" * 64,
+        media_type="application/x-ndjson",
+    )
+    ablation_manifest = ArtifactReference(
+        kind="lifecycle_ablation_manifest",
+        path="_artifacts/trial-001/sweep/manifest.json",
+        sha256="2" * 64,
+        media_type="application/json",
+    )
+    ablation_plan = ArtifactReference(
+        kind="lifecycle_ablation_plan",
+        path="_artifacts/trial-001/sweep/plan.json",
+        sha256="3" * 64,
+        media_type="application/json",
+    )
+    artifacts = [invocation_manifest, invocation_index, ablation_manifest, ablation_plan]
+    record = build_trial_record(
+        outputs=OutputRecord(
+            agent_output=AgentOutput(
+                status=AgentOutputStatus.COMPLETED,
+                output_path="_artifacts/trial-001",
+                output_format="evidence_lifecycle",
+            ),
+            artifacts=artifacts,
+        ),
+        lifecycle_execution=LifecycleExecutionRecord(
+            execution_mode="fresh_context",
+            memory_visibility_policy="artifact_memory",
+            max_turns_per_session=20,
+            status="completed",
+            sessions=[
+                LifecycleSessionRecord(
+                    session_id="initial_review.session-001",
+                    checkpoint_ids=["initial_review"],
+                    adapter="tool_loop",
+                    resolved_model="anthropic:claude-sonnet-4-20250514",
+                    status="completed",
+                    artifacts=[invocation_manifest],
+                )
+            ],
+        ),
+        lifecycle_provenance=LifecycleTrialProvenance(
+            lifecycle_id="ssc03.drainage-model-evidence-lifecycle",
+            world_id="aec.task_world.composite.drainage-model-evidence-lifecycle-review.v1",
+            spec_sha256="b" * 64,
+            package_sha256="c" * 64,
+            repository_commit="d" * 40,
+            repository_dirty=False,
+            repository_dirty_digest="e" * 64,
+            runtime_provider="anthropic",
+            runtime_distributions=("anthropic==1.0.0", "pydantic-ai-slim==1.0.0"),
+            runtime_dependency_sha256="1" * 64,
+            verifier_qualified_name="aec_bench.verify_ssc03",
+            verifier_source_sha256="f" * 64,
+            invocation_manifest=invocation_manifest,
+            invocation_index=invocation_index,
+            ablation_manifest=ablation_manifest,
+            ablation_plan=ablation_plan,
+        ),
+    )
+
+    assert record.lifecycle_execution is not None
+    assert record.lifecycle_execution.sessions[0].checkpoint_ids == ["initial_review"]
+    assert record.lifecycle_provenance is not None
+    assert record.lifecycle_provenance.package_sha256 == "c" * 64
+
+    dirty = record.model_dump(mode="json")
+    dirty["lifecycle_provenance"]["repository_dirty"] = True
+    with pytest.raises(ValidationError, match="clean_repository"):
+        TrialRecord.model_validate(dirty)
+
+
+def test_complete_lifecycle_record_requires_hashed_output_artifacts() -> None:
+    with pytest.raises(ValidationError, match="outputs.artifacts"):
+        build_trial_record(
+            lifecycle_execution={
+                "execution_mode": "persistent_context",
+                "memory_visibility_policy": "persistent_context",
+                "max_turns_per_session": 60,
+                "status": "completed",
+                "sessions": [
+                    {
+                        "session_id": "session-001",
+                        "checkpoint_ids": ["initial_review"],
+                        "adapter": "tool_loop",
+                        "resolved_model": "anthropic:claude-sonnet-4-20250514",
+                        "status": "completed",
+                        "artifacts": [
+                            {
+                                "kind": "lifecycle_manifest",
+                                "path": "manifest.json",
+                                "sha256": "f" * 64,
+                                "media_type": "application/json",
+                            }
+                        ],
+                    }
+                ],
+            },
+            lifecycle_provenance={
+                "lifecycle_id": "lifecycle.demo",
+                "world_id": "world.demo",
+                "spec_sha256": "a" * 64,
+                "package_sha256": "b" * 64,
+                "repository_commit": "c" * 40,
+                "repository_dirty": False,
+                "repository_dirty_digest": "d" * 64,
+                "runtime_provider": "anthropic",
+                "runtime_distributions": ["anthropic==1.0.0", "pydantic-ai-slim==1.0.0"],
+                "runtime_dependency_sha256": "1" * 64,
+                "verifier_qualified_name": "demo.verify",
+                "verifier_source_sha256": "e" * 64,
+                "invocation_manifest": {
+                    "kind": "lifecycle_manifest",
+                    "path": "manifest.json",
+                    "sha256": "f" * 64,
+                    "media_type": "application/json",
+                },
+            },
+        )
+
+
+def test_lifecycle_execution_rejects_resolved_model_drift() -> None:
+    with pytest.raises(ValidationError, match="resolved model must remain stable"):
+        LifecycleExecutionRecord(
+            execution_mode="fresh_context",
+            memory_visibility_policy="artifact_memory",
+            max_turns_per_session=20,
+            status="completed",
+            sessions=[
+                LifecycleSessionRecord(
+                    session_id="session-001",
+                    checkpoint_ids=["initial_review"],
+                    adapter="tool_loop",
+                    resolved_model="model-a",
+                    status="completed",
+                ),
+                LifecycleSessionRecord(
+                    session_id="session-002",
+                    checkpoint_ids=["response_review"],
+                    adapter="tool_loop",
+                    resolved_model="model-b",
+                    status="completed",
+                ),
+            ],
         )
 
 

--- a/tests/ledger/test_writer.py
+++ b/tests/ledger/test_writer.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 import pytest
 
+import aec_bench.ledger.durability as durability
+from aec_bench.ledger.durability import mkdir_durable
 from aec_bench.ledger.reader import _read_trial_record
 from aec_bench.ledger.writer import DuplicateTrialRecordError, write_trial_record
 from tests.support.trial_record_factories import make_trial_record
@@ -25,3 +27,17 @@ def test_write_trial_record_rejects_duplicate_trial_id(tmp_path: Path) -> None:
 
     with pytest.raises(DuplicateTrialRecordError, match="trial record already exists"):
         write_trial_record(ledger_root=tmp_path, record=record)
+
+
+def test_mkdir_durable_fsyncs_each_new_parent_entry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    flushed: list[Path] = []
+    monkeypatch.setattr(durability, "fsync_directory", flushed.append)
+    target = tmp_path / "ledger" / "experiment" / "_artifacts"
+
+    mkdir_durable(target)
+
+    assert target.is_dir()
+    assert flushed == [tmp_path, tmp_path / "ledger", tmp_path / "ledger" / "experiment"]

--- a/tests/meta_harness/test_evidence_lifecycle.py
+++ b/tests/meta_harness/test_evidence_lifecycle.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -852,9 +853,9 @@ def test_local_episode_resolver_builds_fresh_adapters_in_one_workspace(tmp_path:
     assert result["status"] == "complete"
     assert registry.build_count == 2
     assert len(set(registry.workspaces)) == 1
-    assert (run_dir / "episodes" / "initial_review" / "agent_result.json").exists()
-    assert (run_dir / "episodes" / "response_review" / "agent_result.json").exists()
-    assert (run_dir / "episodes" / "initial_review" / "conversation.jsonl").exists()
+    assert (run_dir / "episodes" / "initial_review" / "initial_review.session-001" / "agent_result.json").exists()
+    assert (run_dir / "episodes" / "response_review" / "response_review.session-001" / "agent_result.json").exists()
+    assert (run_dir / "episodes" / "initial_review" / "initial_review.session-001" / "conversation.jsonl").exists()
     state = _load_json(run_dir / "state.json")
     assert [[attempt["status"] for attempt in checkpoint["attempts"]] for checkpoint in state["checkpoint_runs"]] == [
         ["submitted"],
@@ -882,7 +883,34 @@ def test_local_episode_resolver_marks_provider_failure_immediately(tmp_path: Pat
     attempt = state["checkpoint_runs"][0]["attempts"][0]
     assert attempt["status"] == "failed"
     assert attempt["failure_kind"] == "adapter_exception"
-    assert (run_dir / "episodes" / "initial_review" / "agent_result.json").exists()
+    assert (run_dir / "episodes" / "initial_review" / "initial_review.session-001" / "agent_result.json").exists()
+
+
+def test_local_episode_resolver_preserves_failed_attempt_artifacts_on_retry(tmp_path: Path) -> None:
+    package = _write_package(tmp_path / "package")
+    run_dir = tmp_path / "run"
+    failed = build_local_evidence_lifecycle_episode_resolver(
+        package_dir=package,
+        model="test-model",
+        adapter_kind="tool_loop",
+        registry=_CrashingRegistry(),
+    )
+    with pytest.raises(RuntimeError, match="simulated crash"):
+        run_evidence_lifecycle(package, run_dir, episode_resolver=failed)
+    failed_result = run_dir / "episodes" / "initial_review" / "initial_review.session-001" / "agent_result.json"
+    failed_bytes = failed_result.read_bytes()
+
+    retry = build_local_evidence_lifecycle_episode_resolver(
+        package_dir=package,
+        model="test-model",
+        adapter_kind="tool_loop",
+        registry=_WritingRegistry(),
+    )
+    result = run_evidence_lifecycle(package, run_dir, episode_resolver=retry)
+
+    assert result["status"] == "complete"
+    assert failed_result.read_bytes() == failed_bytes
+    assert (run_dir / "episodes" / "initial_review" / "initial_review.session-002" / "agent_result.json").is_file()
 
 
 def test_local_runners_return_the_same_normalized_evidence_schema(tmp_path: Path) -> None:
@@ -927,6 +955,59 @@ def test_local_runners_return_the_same_normalized_evidence_schema(tmp_path: Path
         "cache_write_tokens": 0,
         "failures": 0,
     }
+
+
+def test_local_runner_records_aec_bench_source_provenance_not_caller_repository(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package = _write_package(tmp_path / "package")
+    caller_repository = tmp_path / "caller-repository"
+    caller_repository.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=caller_repository, check=True)
+    (caller_repository / "README.md").write_text("caller repository\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=caller_repository, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Lifecycle Test",
+            "-c",
+            "user.email=lifecycle@example.invalid",
+            "commit",
+            "-q",
+            "-m",
+            "initial",
+        ],
+        cwd=caller_repository,
+        check=True,
+    )
+    monkeypatch.chdir(caller_repository)
+    run_dir = tmp_path / "run"
+    verification = {
+        "lifecycle_id": "lifecycle.demo",
+        "reward": 1.0,
+        "overall": "pass",
+        "passed": True,
+        "gates": {"continuity": {"passed": True, "score": 1.0, "failures": []}},
+    }
+
+    run_local_evidence_lifecycle_fresh_context(
+        package_dir=package,
+        run_dir=run_dir,
+        model="test-model",
+        registry=_WritingRegistry(),
+        verifier=lambda _package, _run: verification,
+    )
+
+    invocation = _load_json(run_dir / "experiment-manifest.json")
+    expected_root = subprocess.check_output(
+        ["git", "rev-parse", "--show-toplevel"],
+        cwd=Path(lifecycle_local_runtime.__file__).resolve().parent,
+        text=True,
+    ).strip()
+    assert invocation["repository"]["root"] == expected_root
+    assert invocation["repository"]["root"] != str(caller_repository)
 
 
 @pytest.mark.parametrize("mode", ["persistent_context", "fresh_context"])

--- a/tests/meta_harness/test_evidence_lifecycle_ablation.py
+++ b/tests/meta_harness/test_evidence_lifecycle_ablation.py
@@ -1,0 +1,2112 @@
+# ABOUTME: Tests typed planning and execution for reproducible evidence-lifecycle ablations.
+# ABOUTME: Covers deterministic expansion, limits, resume, TrialRecord import, and ledger summaries.
+
+from __future__ import annotations
+
+import inspect
+import json
+import platform
+import shutil
+import subprocess
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+
+import aec_bench.ledger.writer as ledger_writer
+import aec_bench.meta_harness.evidence_lifecycle_ablation as ablation_runtime
+import aec_bench.meta_harness.evidence_lifecycle_ablation_plan as ablation_plan_runtime
+import aec_bench.meta_harness.evidence_lifecycle_experiment as experiment_runtime
+from aec_bench.contracts.experiment_manifest import AgentConfig
+from aec_bench.contracts.trial_record import Completeness, TrialRecord
+from aec_bench.ledger.writer import DuplicateTrialRecordError
+from aec_bench.meta_harness.evidence_lifecycle import (
+    open_checkpoint_attempt,
+    prepare_evidence_checkpoint,
+    read_evidence_lifecycle_state,
+    submit_evidence_checkpoint,
+)
+from aec_bench.meta_harness.evidence_lifecycle_ablation import (
+    LifecycleAblationCondition,
+    LifecycleAblationLimits,
+    LifecycleAblationManifest,
+    LifecycleAblationStudyDesign,
+    LifecycleAblationTrial,
+    LifecycleExecutionMode,
+    build_lifecycle_ablation_plan,
+    inspect_lifecycle_ablation_plan,
+    load_lifecycle_ablation_manifest,
+    run_lifecycle_ablation,
+)
+from aec_bench.meta_harness.evidence_lifecycle_evaluation import (
+    build_lifecycle_ablation_evaluation,
+    write_lifecycle_ablation_evaluation,
+)
+from aec_bench.meta_harness.evidence_lifecycle_experiment import LifecycleExperimentSweepContext, repository_provenance
+from aec_bench.meta_harness.evidence_lifecycle_local import (
+    LifecycleVisibilityPolicy,
+    run_local_evidence_lifecycle_fresh_context,
+)
+from aec_bench.meta_harness.evidence_lifecycle_trial_record import (
+    build_lifecycle_trial_record,
+    finalize_lifecycle_trial_record,
+)
+from aec_bench.task_world_templates.catalogue import get_template
+from aec_bench.task_world_templates.lifecycles import registered_lifecycle_verifier
+from aec_bench.task_world_templates.materializer import (
+    materialize_template_lifecycle,
+    verify_template_lifecycle,
+)
+
+TEMPLATE_ID = "drainage-model-evidence-lifecycle-review"
+VARIANTS = (
+    "staged_full_correction",
+    "semantic_no_op_release",
+    "response_assertion_only",
+    "memo_closeout_missing",
+)
+
+
+def test_lifecycle_ablation_condition_rejects_invalid_mode_policy_pairs() -> None:
+    with pytest.raises(ValidationError, match="persistent_context execution requires persistent_context visibility"):
+        LifecycleAblationCondition(
+            execution_mode=LifecycleExecutionMode.PERSISTENT_CONTEXT,
+            memory_visibility_policy=LifecycleVisibilityPolicy.ARTIFACT_MEMORY,
+        )
+    with pytest.raises(ValidationError, match="fresh_context execution cannot use persistent_context visibility"):
+        LifecycleAblationCondition(
+            execution_mode=LifecycleExecutionMode.FRESH_CONTEXT,
+            memory_visibility_policy=LifecycleVisibilityPolicy.PERSISTENT_CONTEXT,
+        )
+
+
+def test_lifecycle_ablation_manifest_rejects_duplicate_dimensions() -> None:
+    payload = _manifest(Path("outputs"), Path("ledger")).model_dump(mode="json")
+    payload["variants"] = [VARIANTS[0], VARIANTS[0]]
+    with pytest.raises(ValidationError, match="variant ids must be unique"):
+        LifecycleAblationManifest.model_validate(payload)
+
+
+def test_lifecycle_ablation_manifest_requires_descriptive_per_session_study_design() -> None:
+    payload = _manifest(Path("outputs"), Path("ledger")).model_dump(mode="json")
+    payload.pop("study_design")
+    with pytest.raises(ValidationError, match="study_design"):
+        LifecycleAblationManifest.model_validate(payload)
+
+    payload = _manifest(Path("outputs"), Path("ledger")).model_dump(mode="json")
+    payload["study_design"]["causal_effects_supported"] = True
+    with pytest.raises(ValidationError, match="causal_effects_supported"):
+        LifecycleAblationManifest.model_validate(payload)
+
+
+def test_lifecycle_ablation_manifest_requires_explicit_per_session_turn_limit() -> None:
+    payload = _manifest(Path("outputs"), Path("ledger")).model_dump(mode="json")
+    payload["agents"][0]["parameters"] = {"max_turns": 10}
+    with pytest.raises(ValidationError, match="max_turns_per_session"):
+        LifecycleAblationManifest.model_validate(payload)
+
+    payload = _manifest(Path("outputs"), Path("ledger")).model_dump(mode="json")
+    payload["agents"][0]["parameters"] = {}
+    with pytest.raises(ValidationError, match="max_turns_per_session"):
+        LifecycleAblationManifest.model_validate(payload)
+
+    payload = _manifest(Path("outputs"), Path("ledger")).model_dump(mode="json")
+    payload["agents"][0]["parameters"] = {"max_turns_per_session": 0}
+    with pytest.raises(ValidationError, match="positive integer"):
+        LifecycleAblationManifest.model_validate(payload)
+
+    payload = _manifest(Path("outputs"), Path("ledger")).model_dump(mode="json")
+    payload["agents"] = [payload["agents"][0], payload["agents"][0]]
+    with pytest.raises(ValidationError, match="agent names must be unique"):
+        LifecycleAblationManifest.model_validate(payload)
+
+    payload = _manifest(Path("outputs"), Path("ledger")).model_dump(mode="json")
+    payload["conditions"] = [payload["conditions"][0], payload["conditions"][0]]
+    with pytest.raises(ValidationError, match="ablation conditions must be unique"):
+        LifecycleAblationManifest.model_validate(payload)
+
+
+def test_lifecycle_ablation_plan_expands_deterministically_with_unique_ids(tmp_path: Path) -> None:
+    manifest = _manifest(tmp_path / "outputs", tmp_path / "ledger", repetitions=2)
+
+    first = build_lifecycle_ablation_plan(manifest)
+    second = build_lifecycle_ablation_plan(manifest)
+
+    assert first == second
+    assert first.trial_count == 64
+    assert len({trial.trial_id for trial in first.trials}) == first.trial_count
+    assert {trial.variant_id for trial in first.trials} == set(VARIANTS)
+    assert all(trial.adaptation.variation == {"change_topology": trial.variant_id} for trial in first.trials)
+    assert {trial.agent.name for trial in first.trials} == {"agent-a", "agent-b"}
+    assert {trial.memory_visibility_policy for trial in first.trials} == set(LifecycleVisibilityPolicy)
+    assert {trial.repetition for trial in first.trials} == {1, 2}
+    assert all(len(trial.trial_id) == len("trial-") + 64 for trial in first.trials)
+    assert all(Path(trial.run_dir).parent == tmp_path / "outputs" / "trials" for trial in first.trials)
+    assert all(Path(trial.ledger_path).parent == tmp_path / "ledger" / "ssc03-ablation" for trial in first.trials)
+    assert len(first.manifest_sha256) == 64
+    assert len(first.plan_sha256) == 64
+    assert first.plan_sha256 != first.manifest_sha256
+    assert all(len(trial.package_sha256) == 64 for trial in first.trials)
+    assert all(len(trial.spec_sha256) == 64 for trial in first.trials)
+    assert len(first.code_provenance.verifier_source_sha256) == 64
+    task_verifier = registered_lifecycle_verifier(TEMPLATE_ID)
+    verifier_path = Path(inspect.getsourcefile(task_verifier) or "")
+    assert first.code_provenance.verifier_qualified_name == f"{task_verifier.__module__}.{task_verifier.__qualname__}"
+    assert first.code_provenance.verifier_source_sha256 == _sha256(verifier_path)
+    assert len(first.code_provenance.source_inventory_sha256) == 64
+    assert first.study_design == manifest.study_design
+    assert first.study_design.interpretation == "descriptive_calibration"
+    assert first.study_design.turn_budget_scope == "per_session"
+    assert first.study_design.execution_order == "deterministic_sequential_plan_order"
+    assert first.study_design.randomized is False
+    assert first.study_design.counterbalanced is False
+    assert first.study_design.causal_effects_supported is False
+    assert {trial.max_turns_per_session for trial in first.trials} == {10}
+
+
+def test_lifecycle_ablation_plan_identity_binds_per_session_turn_limit(tmp_path: Path) -> None:
+    baseline_manifest = _single_manifest(tmp_path)
+    baseline = build_lifecycle_ablation_plan(baseline_manifest)
+    changed_agent = baseline_manifest.agents[0].model_copy(update={"parameters": {"max_turns_per_session": 11}})
+    changed_manifest = baseline_manifest.model_copy(update={"agents": (changed_agent,)})
+
+    changed = build_lifecycle_ablation_plan(changed_manifest)
+
+    assert changed.manifest_sha256 != baseline.manifest_sha256
+    assert changed.plan_sha256 != baseline.plan_sha256
+    assert changed.trials[0].trial_id != baseline.trials[0].trial_id
+
+
+def test_lifecycle_ablation_plan_and_trial_ids_bind_code_provenance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = _single_manifest(tmp_path)
+    baseline = build_lifecycle_ablation_plan(manifest)
+    drifted_provenance = baseline.code_provenance.model_copy(update={"trial_importer_source_sha256": "0" * 64})
+    monkeypatch.setattr(ablation_plan_runtime, "_ablation_code_provenance", lambda _template_id: drifted_provenance)
+
+    drifted = build_lifecycle_ablation_plan(manifest)
+
+    assert drifted.manifest_sha256 == baseline.manifest_sha256
+    assert drifted.plan_sha256 != baseline.plan_sha256
+    assert [trial.trial_id for trial in drifted.trials] != [trial.trial_id for trial in baseline.trials]
+
+
+def test_repository_provenance_uses_content_identity_outside_git(tmp_path: Path) -> None:
+    source = Path(inspect.getsourcefile(repository_provenance) or "").parents[2]
+    installed = tmp_path / "site-packages" / "aec_bench"
+    shutil.copytree(source / "aec_bench", installed)
+
+    first = repository_provenance(installed)
+    second = repository_provenance(installed)
+
+    assert first == second
+    assert first["repository_kind"] == "source_tree"
+    assert first["commit"] == f"source-sha256:{first['source_inventory_sha256']}"
+    assert first["dirty"] is False
+
+    importer = installed / "meta_harness" / "evidence_lifecycle_trial_record.py"
+    importer.write_text(importer.read_text(encoding="utf-8") + "\n# source drift\n", encoding="utf-8")
+    changed = repository_provenance(installed)
+    assert changed["source_inventory_sha256"] != first["source_inventory_sha256"]
+    assert changed["commit"] != first["commit"]
+
+
+def test_repository_provenance_does_not_attribute_ignored_install_to_caller_git(
+    tmp_path: Path,
+) -> None:
+    caller = tmp_path / "caller"
+    caller.mkdir()
+    (caller / ".gitignore").write_text(".venv/\n", encoding="utf-8")
+    (caller / "pyproject.toml").write_text("[project]\nname='caller'\nversion='1'\n", encoding="utf-8")
+    subprocess.run(["git", "init", "-q"], cwd=caller, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=caller, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=caller, check=True)
+    subprocess.run(["git", "add", ".gitignore", "pyproject.toml"], cwd=caller, check=True)
+    subprocess.run(["git", "commit", "-qm", "caller"], cwd=caller, check=True)
+    source = Path(inspect.getsourcefile(repository_provenance) or "").parents[2]
+    installed = caller / ".venv" / "lib" / "site-packages" / "aec_bench"
+    shutil.copytree(source / "aec_bench", installed)
+
+    provenance = repository_provenance(installed)
+
+    assert provenance["repository_kind"] == "source_tree"
+    assert Path(provenance["root"]) == installed.parent
+    assert provenance["commit"].startswith("source-sha256:")
+
+
+def test_repository_provenance_binds_installed_dependency_metadata(tmp_path: Path) -> None:
+    source = Path(inspect.getsourcefile(repository_provenance) or "").parents[2]
+    site_packages = tmp_path / "site-packages"
+    shutil.copytree(source / "aec_bench", site_packages / "aec_bench")
+    metadata_dir = site_packages / "pydantic_ai-1.0.0.dist-info"
+    metadata_dir.mkdir()
+    metadata_path = metadata_dir / "METADATA"
+    metadata_path.write_text("Name: pydantic-ai\nVersion: 1.0.0\n", encoding="utf-8")
+    first = repository_provenance(site_packages / "aec_bench")
+
+    metadata_path.write_text("Name: pydantic-ai\nVersion: 99.0.0\n", encoding="utf-8")
+    second = repository_provenance(site_packages / "aec_bench")
+
+    assert second["source_inventory_sha256"] != first["source_inventory_sha256"]
+    assert second["commit"] != first["commit"]
+
+
+def test_runtime_dependency_provenance_hashes_realized_bytes_not_stale_record(tmp_path: Path) -> None:
+    site_packages = tmp_path / "site-packages"
+    dependency = site_packages / "pydantic_ai" / "__init__.py"
+    dependency.parent.mkdir(parents=True)
+    dependency.write_text("BEHAVIOR = 'baseline'\n", encoding="utf-8")
+    metadata_dir = site_packages / "pydantic_ai-1.0.0.dist-info"
+    metadata_dir.mkdir()
+    (metadata_dir / "METADATA").write_text("Name: pydantic-ai\nVersion: 1.0.0\n", encoding="utf-8")
+    (metadata_dir / "RECORD").write_text(
+        "pydantic_ai/__init__.py,,\npydantic_ai-1.0.0.dist-info/METADATA,,\n",
+        encoding="utf-8",
+    )
+
+    before = experiment_runtime.runtime_dependency_provenance(
+        adapter_kind="tool_loop",
+        model_name="deterministic-replay",
+        search_paths=(site_packages,),
+    )
+    dependency.write_text("BEHAVIOR = 'changed-runtime'\n", encoding="utf-8")
+    after = experiment_runtime.runtime_dependency_provenance(
+        adapter_kind="tool_loop",
+        model_name="deterministic-replay",
+        search_paths=(site_packages,),
+    )
+
+    assert before["distributions"] == after["distributions"]
+    assert before["dependency_inventory_sha256"] != after["dependency_inventory_sha256"]
+
+
+def test_runtime_dependency_provenance_resolves_explicit_openai_provider(tmp_path: Path) -> None:
+    site_packages = tmp_path / "site-packages"
+    for distribution_name, package_name in (("pydantic-ai", "pydantic_ai"), ("openai", "openai")):
+        package = site_packages / package_name / "__init__.py"
+        package.parent.mkdir(parents=True)
+        package.write_text(f"BEHAVIOR = '{distribution_name}-baseline'\n", encoding="utf-8")
+        metadata_dir = site_packages / f"{package_name}-1.0.0.dist-info"
+        metadata_dir.mkdir()
+        (metadata_dir / "METADATA").write_text(
+            f"Name: {distribution_name}\nVersion: 1.0.0\n",
+            encoding="utf-8",
+        )
+        (metadata_dir / "RECORD").write_text(f"{package_name}/__init__.py,,\n", encoding="utf-8")
+
+    before = experiment_runtime.runtime_dependency_provenance(
+        adapter_kind="tool_loop",
+        model_name="openai:gpt-5.2",
+        search_paths=(site_packages,),
+    )
+    (site_packages / "openai" / "__init__.py").write_text(
+        "BEHAVIOR = 'openai-changed-runtime'\n",
+        encoding="utf-8",
+    )
+    after = experiment_runtime.runtime_dependency_provenance(
+        adapter_kind="tool_loop",
+        model_name="openai:gpt-5.2",
+        search_paths=(site_packages,),
+    )
+
+    assert before["provider"] == "openai"
+    assert "openai==1.0.0" in before["distributions"]
+    assert before["dependency_inventory_sha256"] != after["dependency_inventory_sha256"]
+
+
+def test_runtime_dependency_provenance_uses_first_distribution_search_path(tmp_path: Path) -> None:
+    roots = (tmp_path / "first", tmp_path / "second")
+    for root, version in zip(roots, ("1.0.0", "2.0.0"), strict=True):
+        package = root / "pydantic_ai" / "__init__.py"
+        package.parent.mkdir(parents=True)
+        package.write_text(f"BEHAVIOR = '{version}'\n", encoding="utf-8")
+        metadata_dir = root / f"pydantic_ai-{version}.dist-info"
+        metadata_dir.mkdir()
+        (metadata_dir / "METADATA").write_text(
+            f"Name: pydantic-ai\nVersion: {version}\n",
+            encoding="utf-8",
+        )
+        (metadata_dir / "RECORD").write_text("pydantic_ai/__init__.py,,\n", encoding="utf-8")
+
+    before = experiment_runtime.runtime_dependency_provenance(
+        adapter_kind="tool_loop",
+        model_name="deterministic-replay",
+        search_paths=roots,
+    )
+    (roots[0] / "pydantic_ai" / "__init__.py").write_text(
+        "BEHAVIOR = 'first-path-changed'\n",
+        encoding="utf-8",
+    )
+    after = experiment_runtime.runtime_dependency_provenance(
+        adapter_kind="tool_loop",
+        model_name="deterministic-replay",
+        search_paths=roots,
+    )
+
+    assert "pydantic-ai==1.0.0" in before["distributions"]
+    assert "pydantic-ai==2.0.0" not in before["distributions"]
+    assert before["dependency_inventory_sha256"] != after["dependency_inventory_sha256"]
+
+
+def test_lifecycle_ablation_plan_identity_binds_realized_dependency_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    site_packages = tmp_path / "site-packages"
+    dependency = site_packages / "pydantic_ai" / "__init__.py"
+    dependency.parent.mkdir(parents=True)
+    dependency.write_text("BEHAVIOR = 'baseline'\n", encoding="utf-8")
+    metadata_dir = site_packages / "pydantic_ai-1.0.0.dist-info"
+    metadata_dir.mkdir()
+    (metadata_dir / "METADATA").write_text("Name: pydantic-ai\nVersion: 1.0.0\n", encoding="utf-8")
+    (metadata_dir / "RECORD").write_text("pydantic_ai/__init__.py,,\n", encoding="utf-8")
+    monkeypatch.setattr(experiment_runtime, "_runtime_distribution_search_paths", lambda: (site_packages,))
+    manifest = _single_manifest(tmp_path)
+
+    baseline = build_lifecycle_ablation_plan(manifest)
+    dependency.write_text("BEHAVIOR = 'changed-runtime'\n", encoding="utf-8")
+    changed = build_lifecycle_ablation_plan(manifest)
+
+    assert baseline.trials[0].runtime_provenance != changed.trials[0].runtime_provenance
+    assert baseline.plan_sha256 != changed.plan_sha256
+    assert baseline.trials[0].trial_id != changed.trials[0].trial_id
+
+
+def test_repository_provenance_hashes_tracked_nonstandard_package_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "repo"
+    benchmark = root / "vendor" / "aec_bench"
+    benchmark.mkdir(parents=True)
+    (benchmark / "__init__.py").write_text('"""Tracked benchmark."""\n', encoding="utf-8")
+    adapter = benchmark / "adapters" / "tool_loop.py"
+    adapter.parent.mkdir()
+    adapter.write_text("BEHAVIOR = 'baseline'\n", encoding="utf-8")
+    (root / "pyproject.toml").write_text("[project]\nname='tracked-vendor'\nversion='1.0.0'\n", encoding="utf-8")
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=root, check=True)
+    subprocess.run(["git", "add", "."], cwd=root, check=True)
+    subprocess.run(["git", "commit", "-qm", "initial"], cwd=root, check=True)
+    monkeypatch.setattr(ablation_plan_runtime, "repository_provenance", lambda _path: repository_provenance(benchmark))
+    manifest = _single_manifest(tmp_path)
+
+    before_provenance = repository_provenance(benchmark)
+    before_plan = build_lifecycle_ablation_plan(manifest)
+    adapter.write_text("BEHAVIOR = 'changed-runtime'\n", encoding="utf-8")
+    after_provenance = repository_provenance(benchmark)
+    after_plan = build_lifecycle_ablation_plan(manifest)
+
+    assert before_provenance["repository_kind"] == "git"
+    assert before_provenance["source_inventory_sha256"] != after_provenance["source_inventory_sha256"]
+    assert before_plan.plan_sha256 != after_plan.plan_sha256
+    assert before_plan.trials[0].trial_id != after_plan.trials[0].trial_id
+
+
+def test_lifecycle_ablation_dry_run_applies_smoke_gate_without_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = _single_manifest(tmp_path)
+
+    def failing_verifier(_package: Path, _run: Path) -> dict[str, object]:
+        return {
+            "lifecycle_id": "drainage-model-evidence-lifecycle-review-v1",
+            "overall": "fail",
+            "passed": False,
+            "reward": 0.0,
+            "gates": {"probe": {"passed": False, "score": 0.0, "failures": ["forced"]}},
+        }
+
+    monkeypatch.setattr(ablation_runtime, "verify_template_lifecycle", failing_verifier)
+
+    inspection = inspect_lifecycle_ablation_plan(manifest)
+
+    assert inspection["trial_statuses"][0]["status"] == "conflict"
+    assert "failed deterministic smoke verification" in inspection["trial_statuses"][0]["reason"]
+    assert not Path(manifest.output_root).exists()
+    assert not Path(manifest.ledger_root).exists()
+
+
+def test_lifecycle_ablation_plan_rejects_unknown_public_variant(tmp_path: Path) -> None:
+    manifest = _manifest(tmp_path / "outputs", tmp_path / "ledger").model_copy(update={"variants": ("not_registered",)})
+
+    with pytest.raises(ValueError, match="unknown lifecycle variants.*not_registered"):
+        build_lifecycle_ablation_plan(manifest)
+
+
+def test_lifecycle_ablation_plan_enforces_trial_and_cost_limits(tmp_path: Path) -> None:
+    trial_limited = _manifest(tmp_path / "outputs", tmp_path / "ledger").model_copy(
+        update={"limits": LifecycleAblationLimits(max_trials=15)}
+    )
+    with pytest.raises(ValueError, match="planned trial count 32 exceeds max_trials 15"):
+        build_lifecycle_ablation_plan(trial_limited)
+
+    cost_limited = _manifest(tmp_path / "outputs", tmp_path / "ledger").model_copy(
+        update={
+            "estimated_cost_per_trial_usd": 0.25,
+            "limits": LifecycleAblationLimits(max_trials=100, max_estimated_cost_usd=7.5),
+        }
+    )
+    with pytest.raises(ValueError, match="planned estimated cost 8.0 exceeds limit 7.5"):
+        build_lifecycle_ablation_plan(cost_limited)
+
+
+def test_lifecycle_ablation_cost_limit_requires_per_trial_estimate(tmp_path: Path) -> None:
+    payload = _manifest(tmp_path / "outputs", tmp_path / "ledger").model_dump(mode="json")
+    payload["limits"]["max_estimated_cost_usd"] = 5.0
+
+    with pytest.raises(ValidationError, match="estimated_cost_per_trial_usd is required"):
+        LifecycleAblationManifest.model_validate(payload)
+
+
+def test_lifecycle_ablation_manifest_rejects_adapter_controls_runner_does_not_apply(
+    tmp_path: Path,
+) -> None:
+    payload = _manifest(tmp_path / "outputs", tmp_path / "ledger").model_dump(mode="json")
+    payload["agents"][0]["adapter"] = "direct"
+    with pytest.raises(ValidationError, match="require tool_loop or pydantic_ai"):
+        LifecycleAblationManifest.model_validate(payload)
+
+    payload = _manifest(tmp_path / "outputs", tmp_path / "ledger").model_dump(mode="json")
+    payload["agents"][0]["parameters"] = {"temperature": 0.0}
+    with pytest.raises(ValidationError, match="unsupported lifecycle agent parameters: temperature"):
+        LifecycleAblationManifest.model_validate(payload)
+
+
+def test_documented_lifecycle_ablation_example_is_a_valid_sixteen_trial_plan() -> None:
+    manifest = load_lifecycle_ablation_manifest(
+        Path(__file__).resolve().parents[2] / "docs" / "examples" / "meta-harness" / "lifecycle-ablation.example.yaml"
+    )
+
+    plan = build_lifecycle_ablation_plan(manifest)
+    assert plan.trial_count == 16
+    assert plan.study_design.causal_effects_supported is False
+    assert plan.trials[0].max_turns_per_session == 60
+
+
+def test_build_lifecycle_trial_record_maps_validated_working_provenance(tmp_path: Path) -> None:
+    manifest, trial, package, run_dir = _recorded_trial(tmp_path)
+
+    record = build_lifecycle_trial_record(
+        manifest=manifest,
+        trial=trial,
+        package_dir=package,
+        run_dir=run_dir,
+    )
+
+    assert record.trial_id == trial.trial_id
+    assert record.experiment_id == manifest.experiment_id
+    assert record.task.task_id == TEMPLATE_ID
+    assert record.task.task_revision == json.loads((run_dir / "state.json").read_text())["package_sha256"]
+    assert record.agent.adapter == trial.agent.adapter
+    assert record.agent.model == trial.agent.model
+    assert record.agent.adapter_revision
+    assert record.agent.configuration["variant_id"] == trial.variant_id
+    assert record.agent.configuration["execution_mode"] == trial.execution_mode.value
+    assert record.agent.configuration["memory_visibility_policy"] == trial.memory_visibility_policy.value
+    assert record.agent.configuration["plan_sha256"] == build_lifecycle_ablation_plan(manifest).plan_sha256
+    assert record.environment.tool_versions
+    assert record.inputs.input_files
+    assert {item.path for item in record.inputs.input_files} == set(
+        json.loads((run_dir / "experiment-manifest.json").read_text())["lifecycle"]["package_files"]
+    )
+    assert record.outputs.agent_output is not None
+    assert record.outputs.agent_result is not None
+    assert record.evaluation.reward == 1.0
+    assert record.evaluation.validity.verifier_completed is True
+    assert record.evaluation.breakdown is not None
+    assert record.evaluation.breakdown["semantic_transition"]["aggregate"]["retention"] == 1.0
+    assert record.adaptation is not None
+    assert record.adaptation.variation == {"change_topology": trial.variant_id}
+    assert record.lifecycle_execution is not None
+    assert record.lifecycle_provenance is not None
+    assert record.lifecycle_provenance.runtime_provider == trial.runtime_provenance.provider
+    assert record.lifecycle_provenance.runtime_distributions == trial.runtime_provenance.distributions
+    assert record.lifecycle_provenance.runtime_dependency_sha256 == trial.runtime_provenance.dependency_inventory_sha256
+    assert record.completeness is Completeness.PARTIAL
+    task_verifier = registered_lifecycle_verifier(TEMPLATE_ID)
+    assert record.lifecycle_provenance.verifier_qualified_name == (
+        f"{task_verifier.__module__}.{task_verifier.__qualname__}"
+    )
+    canonical = json.loads(next((run_dir / "experiments").glob("*/experiment-manifest.json")).read_text())
+    assert len(canonical["verifier"]["chain"]) == 2
+
+
+def test_finalize_lifecycle_trial_record_snapshots_artifacts_and_writes_once(tmp_path: Path) -> None:
+    manifest, trial, package, run_dir = _recorded_trial(tmp_path)
+
+    record_path = finalize_lifecycle_trial_record(
+        manifest=manifest,
+        trial=trial,
+        package_dir=package,
+        run_dir=run_dir,
+    )
+    original_record = record_path.read_bytes()
+    record = TrialRecord.model_validate_json(original_record)
+
+    assert record.lifecycle_provenance is not None
+    assert record.completeness is (
+        Completeness.PARTIAL if record.lifecycle_provenance.repository_dirty else Completeness.COMPLETE
+    )
+    assert record.outputs.artifacts
+    assert record.lifecycle_provenance.invocation_manifest in record.outputs.artifacts
+    for artifact in record.outputs.artifacts:
+        snapshotted = Path(manifest.ledger_root) / artifact.path
+        assert snapshotted.is_file()
+        assert _sha256(snapshotted) == artifact.sha256
+
+    shutil.rmtree(run_dir)
+    shutil.rmtree(package)
+    assert TrialRecord.model_validate_json(record_path.read_bytes()) == record
+    for artifact in record.outputs.artifacts:
+        assert (Path(manifest.ledger_root) / artifact.path).is_file()
+
+    with pytest.raises(DuplicateTrialRecordError):
+        finalize_lifecycle_trial_record(
+            manifest=manifest,
+            trial=trial,
+            package_dir=package,
+            run_dir=run_dir,
+        )
+    assert record_path.read_bytes() == original_record
+
+
+def test_finalize_lifecycle_trial_record_recovers_snapshot_left_before_record_write(tmp_path: Path) -> None:
+    manifest, trial, package, run_dir = _recorded_trial(tmp_path)
+    record_path = finalize_lifecycle_trial_record(
+        manifest=manifest,
+        trial=trial,
+        package_dir=package,
+        run_dir=run_dir,
+    )
+    original_record = record_path.read_bytes()
+    record = TrialRecord.model_validate_json(original_record)
+    assert record.outputs.artifacts
+    original_artifacts = {
+        artifact.path: (Path(manifest.ledger_root) / artifact.path).read_bytes()
+        for artifact in record.outputs.artifacts
+    }
+    record_path.unlink()
+
+    recovered = finalize_lifecycle_trial_record(
+        manifest=manifest,
+        trial=trial,
+        package_dir=package,
+        run_dir=run_dir,
+    )
+
+    assert recovered.read_bytes() == original_record
+    assert {
+        artifact.path: (Path(manifest.ledger_root) / artifact.path).read_bytes()
+        for artifact in record.outputs.artifacts
+    } == original_artifacts
+
+
+def test_run_lifecycle_ablation_snapshot_recovery_ignores_later_mutable_state_corruption(
+    tmp_path: Path,
+) -> None:
+    manifest, trial, package, run_dir = _recorded_trial(tmp_path)
+    record_path = finalize_lifecycle_trial_record(
+        manifest=manifest,
+        trial=trial,
+        package_dir=package,
+        run_dir=run_dir,
+    )
+    original = record_path.read_bytes()
+    record_path.unlink()
+    mutable_state_path = run_dir / "state.json"
+    mutable_state = json.loads(mutable_state_path.read_text(encoding="utf-8"))
+    mutable_state["checkpoint_runs"][0]["attempts"] = []
+    mutable_state_path.write_text(json.dumps(mutable_state), encoding="utf-8")
+
+    inspection = inspect_lifecycle_ablation_plan(manifest)
+    assert inspection["trial_statuses"][0]["status"] == "finalizable"
+    result = run_lifecycle_ablation(
+        manifest,
+        registry_factory=lambda *_args: (_ for _ in ()).throw(
+            AssertionError("immutable snapshot recovery must not inspect or execute the mutable run")
+        ),
+    )
+
+    assert result.imported_orphans == 1
+    assert Path(result.record_paths[0]).read_bytes() == original
+
+
+def test_lifecycle_ablation_inspection_ignores_malformed_mutable_contract_for_complete_record(
+    tmp_path: Path,
+) -> None:
+    manifest = _single_manifest(tmp_path).model_copy(update={"experiment_id": "ssc03-immutable-inspection"})
+    result = run_lifecycle_ablation(
+        manifest,
+        registry_factory=lambda _trial, package, _run: _GoldFreshRegistry(package),
+    )
+    (Path(manifest.output_root) / "manifest.json").write_text("{", encoding="utf-8")
+
+    inspection = inspect_lifecycle_ablation_plan(manifest)
+
+    assert inspection["trial_statuses"][0]["status"] == "complete"
+    assert Path(result.record_paths[0]).is_file()
+
+
+def test_finalize_lifecycle_trial_record_recovers_after_atomic_record_publish_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest, trial, package, run_dir = _recorded_trial(tmp_path)
+
+    def interrupted_temp_write(path: Path, _payload: str) -> None:
+        path.write_text("{", encoding="utf-8")
+        raise OSError("simulated power loss while writing record temp file")
+
+    with monkeypatch.context() as patch:
+        patch.setattr(ledger_writer, "_write_record_temp", interrupted_temp_write)
+        with pytest.raises(OSError, match="simulated power loss"):
+            finalize_lifecycle_trial_record(
+                manifest=manifest,
+                trial=trial,
+                package_dir=package,
+                run_dir=run_dir,
+            )
+
+    record_path = Path(trial.ledger_path)
+    artifact_dir = Path(manifest.ledger_root) / manifest.experiment_id / "_artifacts" / trial.trial_id
+    assert not record_path.exists()
+    assert artifact_dir.is_dir()
+    assert not list(record_path.parent.glob(f".{record_path.name}.*.tmp"))
+
+    recovered = finalize_lifecycle_trial_record(
+        manifest=manifest,
+        trial=trial,
+        package_dir=package,
+        run_dir=run_dir,
+    )
+
+    assert recovered == record_path
+    TrialRecord.model_validate_json(recovered.read_text(encoding="utf-8"))
+
+
+def test_finalize_lifecycle_trial_record_rejects_declared_session_artifact_tamper(tmp_path: Path) -> None:
+    manifest, trial, package, run_dir = _recorded_trial(tmp_path)
+    agent_result_path = next(run_dir.glob("**/agent_result.json"))
+    agent_result = json.loads(agent_result_path.read_text(encoding="utf-8"))
+    agent_result["resolved_model"] = "forged-model"
+    agent_result_path.write_text(json.dumps(agent_result), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="run artifact hash does not match canonical manifest"):
+        finalize_lifecycle_trial_record(
+            manifest=manifest,
+            trial=trial,
+            package_dir=package,
+            run_dir=run_dir,
+        )
+
+
+def test_finalize_lifecycle_trial_record_uses_canonical_manifest_not_mutable_alias(tmp_path: Path) -> None:
+    manifest, trial, package, run_dir = _recorded_trial(tmp_path)
+    mutable_path = run_dir / "experiment-manifest.json"
+    mutable = json.loads(mutable_path.read_text(encoding="utf-8"))
+    mutable["repository"]["commit"] = "f" * 40
+    mutable_path.write_text(json.dumps(mutable), encoding="utf-8")
+    canonical_path = next((run_dir / "experiments").glob("*/experiment-manifest.json"))
+    canonical = json.loads(canonical_path.read_text(encoding="utf-8"))
+
+    record_path = finalize_lifecycle_trial_record(
+        manifest=manifest,
+        trial=trial,
+        package_dir=package,
+        run_dir=run_dir,
+    )
+    record = TrialRecord.model_validate_json(record_path.read_text(encoding="utf-8"))
+
+    assert record.lifecycle_provenance is not None
+    assert record.lifecycle_provenance.repository_commit == canonical["repository"]["commit"]
+    assert record.lifecycle_provenance.repository_commit != mutable["repository"]["commit"]
+
+
+def test_finalized_trial_contains_no_mutable_working_run_references(tmp_path: Path) -> None:
+    manifest, trial, package, run_dir = _recorded_trial(tmp_path)
+    record_path = finalize_lifecycle_trial_record(
+        manifest=manifest,
+        trial=trial,
+        package_dir=package,
+        run_dir=run_dir,
+    )
+    record = TrialRecord.model_validate_json(record_path.read_text(encoding="utf-8"))
+    assert record.outputs.agent_result is not None
+
+    referenced_paths = [
+        record.outputs.agent_result["verification_path"],
+        record.outputs.agent_result["metrics_path"],
+        record.outputs.agent_result["manifest_path"],
+        *record.outputs.agent_result["trajectories"],
+        *record.outputs.agent_result["conversations"],
+        *record.outputs.agent_result["raw_outputs"],
+    ]
+    shutil.rmtree(run_dir)
+    shutil.rmtree(package)
+
+    assert referenced_paths
+    assert all(not Path(path).is_absolute() for path in referenced_paths)
+    assert all((Path(manifest.ledger_root) / path).is_file() for path in referenced_paths)
+
+
+def test_build_lifecycle_trial_record_rejects_tampered_metrics(tmp_path: Path) -> None:
+    manifest, trial, package, run_dir = _recorded_trial(tmp_path)
+    metrics_path = run_dir / "metrics.json"
+    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    metrics["reads"] = 999
+    metrics_path.write_text(json.dumps(metrics), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="lifecycle metrics hash does not match manifest"):
+        build_lifecycle_trial_record(
+            manifest=manifest,
+            trial=trial,
+            package_dir=package,
+            run_dir=run_dir,
+        )
+
+
+def test_build_lifecycle_trial_record_rejects_self_consistent_forged_token_totals(tmp_path: Path) -> None:
+    manifest, trial, package, run_dir = _recorded_trial(tmp_path)
+    canonical_manifest_path = next((run_dir / "experiments").glob("*/experiment-manifest.json"))
+    canonical_metrics_path = canonical_manifest_path.parent / "metrics.json"
+    metrics = json.loads(canonical_metrics_path.read_text(encoding="utf-8"))
+    metrics["input_tokens"] = 999
+    encoded_metrics = json.dumps(metrics, indent=2, sort_keys=True) + "\n"
+    canonical_metrics_path.write_text(encoded_metrics, encoding="utf-8")
+    (run_dir / "metrics.json").write_text(encoded_metrics, encoding="utf-8")
+    manifest_payload = json.loads(canonical_manifest_path.read_text(encoding="utf-8"))
+    metrics_sha256 = _sha256(canonical_metrics_path)
+    manifest_payload["outputs"]["metrics.json"] = metrics_sha256
+    manifest_payload["outputs"]["artifacts"]["metrics.json"] = metrics_sha256
+    canonical_manifest_path.write_text(json.dumps(manifest_payload), encoding="utf-8")
+    index_path = run_dir.parent / "experiment-index.jsonl"
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    index["manifest_sha256"] = _sha256(canonical_manifest_path)
+    index_path.write_text(json.dumps(index) + "\n", encoding="utf-8")
+    seal_path = canonical_manifest_path.parent / "index-entry.json"
+    seal = json.loads(seal_path.read_text(encoding="utf-8"))
+    seal["manifest_sha256"] = _sha256(canonical_manifest_path)
+    seal_path.write_text(json.dumps(seal), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="input_tokens does not match session artifacts"):
+        build_lifecycle_trial_record(
+            manifest=manifest,
+            trial=trial,
+            package_dir=package,
+            run_dir=run_dir,
+        )
+
+
+def test_build_lifecycle_trial_record_rejects_condition_mismatch(tmp_path: Path) -> None:
+    manifest, trial, package, run_dir = _recorded_trial(tmp_path)
+    mismatched_trial = trial.model_copy(
+        update={
+            "memory_visibility_policy": LifecycleVisibilityPolicy.RAW_EVIDENCE_ONLY,
+        }
+    )
+
+    with pytest.raises(ValueError, match="lifecycle run visibility policy does not match planned trial"):
+        build_lifecycle_trial_record(
+            manifest=manifest,
+            trial=mismatched_trial,
+            package_dir=package,
+            run_dir=run_dir,
+        )
+
+
+def test_build_lifecycle_trial_record_rejects_canonical_turn_limit_outside_plan(tmp_path: Path) -> None:
+    manifest, trial, package, run_dir = _recorded_trial(tmp_path)
+    experiment_path = next((run_dir / "experiments").glob("*/experiment-manifest.json"))
+    experiment = json.loads(experiment_path.read_text(encoding="utf-8"))
+    experiment["execution"]["max_turns_per_session"] = 999
+    experiment_path.write_text(json.dumps(experiment), encoding="utf-8")
+    manifest_hash = _sha256(experiment_path)
+    index_path = run_dir.parent / "experiment-index.jsonl"
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    index["manifest_sha256"] = manifest_hash
+    index_path.write_text(json.dumps(index) + "\n", encoding="utf-8")
+    seal_path = experiment_path.parent / "index-entry.json"
+    seal = json.loads(seal_path.read_text(encoding="utf-8"))
+    seal["manifest_sha256"] = manifest_hash
+    seal_path.write_text(json.dumps(seal), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="turn limit does not match planned trial"):
+        build_lifecycle_trial_record(
+            manifest=manifest,
+            trial=trial,
+            package_dir=package,
+            run_dir=run_dir,
+        )
+
+
+def test_build_lifecycle_trial_record_rejects_runtime_dependency_drift(tmp_path: Path) -> None:
+    manifest, trial, package, run_dir = _recorded_trial(tmp_path)
+    experiment_path = next((run_dir / "experiments").glob("*/experiment-manifest.json"))
+    experiment = json.loads(experiment_path.read_text(encoding="utf-8"))
+    experiment["environment"]["runtime_provenance"]["dependency_inventory_sha256"] = "0" * 64
+    experiment_path.write_text(json.dumps(experiment), encoding="utf-8")
+    manifest_hash = _sha256(experiment_path)
+    index_path = run_dir.parent / "experiment-index.jsonl"
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    index["manifest_sha256"] = manifest_hash
+    index_path.write_text(json.dumps(index) + "\n", encoding="utf-8")
+    seal_path = experiment_path.parent / "index-entry.json"
+    seal = json.loads(seal_path.read_text(encoding="utf-8"))
+    seal["manifest_sha256"] = manifest_hash
+    seal_path.write_text(json.dumps(seal), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="runtime dependencies do not match planned trial"):
+        build_lifecycle_trial_record(
+            manifest=manifest,
+            trial=trial,
+            package_dir=package,
+            run_dir=run_dir,
+        )
+
+
+def test_build_lifecycle_trial_record_rejects_sweep_context_mismatch(tmp_path: Path) -> None:
+    manifest, trial, package, run_dir = _recorded_trial(tmp_path)
+    experiment_path = next((run_dir / "experiments").glob("*/experiment-manifest.json"))
+    experiment = json.loads(experiment_path.read_text(encoding="utf-8"))
+    experiment["sweep"]["condition_id"] = "fresh_context__raw_evidence_only"
+    experiment_path.write_text(json.dumps(experiment), encoding="utf-8")
+    index_path = run_dir.parent / "experiment-index.jsonl"
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    index["sweep"] = experiment["sweep"]
+    index["manifest_sha256"] = _sha256(experiment_path)
+    index_path.write_text(json.dumps(index) + "\n", encoding="utf-8")
+    seal_path = experiment_path.parent / "index-entry.json"
+    seal = json.loads(seal_path.read_text(encoding="utf-8"))
+    seal["sweep"] = experiment["sweep"]
+    seal["manifest_sha256"] = _sha256(experiment_path)
+    seal_path.write_text(json.dumps(seal), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="lifecycle sweep context does not match planned trial"):
+        build_lifecycle_trial_record(
+            manifest=manifest,
+            trial=trial,
+            package_dir=package,
+            run_dir=run_dir,
+        )
+
+
+def test_run_lifecycle_ablation_executes_real_in_process_trial_and_skips_completed_resume(
+    tmp_path: Path,
+) -> None:
+    manifest = _single_manifest(tmp_path)
+    build_count = 0
+
+    def registry_factory(trial: LifecycleAblationTrial, package: Path, _run_dir: Path) -> object:
+        nonlocal build_count
+        build_count += 1
+        return _GoldFreshRegistry(package)
+
+    first = run_lifecycle_ablation(manifest, registry_factory=registry_factory)
+
+    assert first.planned_trials == 1
+    assert first.executed_trials == 1
+    assert first.imported_orphans == 0
+    assert first.skipped_trials == 0
+    assert first.failed_trials == 0
+    assert build_count == 1
+    assert Path(first.summary_path).is_file()
+    record_path = Path(first.record_paths[0])
+    record_bytes = record_path.read_bytes()
+    record = TrialRecord.model_validate_json(record_bytes)
+    assert record.lifecycle_provenance is not None
+    assert record.completeness is (
+        Completeness.PARTIAL if record.lifecycle_provenance.repository_dirty else Completeness.COMPLETE
+    )
+    assert record.lifecycle_execution is not None
+    assert len(record.lifecycle_execution.sessions) == 3
+    assert all(session.artifacts for session in record.lifecycle_execution.sessions)
+    invocation_path = Path(first.run_root) / "trials" / first.trial_ids[0] / "experiment-manifest.json"
+    invocation = json.loads(invocation_path.read_text())
+    assert invocation["sweep"]["planned_trial_id"] == first.trial_ids[0]
+
+    def forbidden_registry_factory(*_args: object) -> object:
+        raise AssertionError("completed trial must not invoke an adapter")
+
+    second = run_lifecycle_ablation(manifest, registry_factory=forbidden_registry_factory)
+
+    assert second.executed_trials == 0
+    assert second.skipped_trials == 1
+    assert second.record_paths == first.record_paths
+    assert second.summary_path == first.summary_path
+    assert record_path.read_bytes() == record_bytes
+
+
+def test_run_lifecycle_ablation_rejects_forged_existing_record_before_skip(tmp_path: Path) -> None:
+    manifest = _single_manifest(tmp_path)
+    first = run_lifecycle_ablation(
+        manifest,
+        registry_factory=lambda _trial, package, _run: _GoldFreshRegistry(package),
+    )
+    record_path = Path(first.record_paths[0])
+    forged = json.loads(record_path.read_text(encoding="utf-8"))
+    forged["agent"]["adapter"] = "pydantic_ai"
+    forged["agent"]["configuration"]["requested_model"] = "forged-model"
+    forged["agent"]["configuration"]["plan_sha256"] = "0" * 64
+    forged["lifecycle_execution"] = None
+    forged["lifecycle_provenance"] = None
+    forged["completeness"] = "partial"
+    TrialRecord.model_validate(forged)
+    record_path.write_text(json.dumps(forged), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="existing TrialRecord does not match"):
+        run_lifecycle_ablation(
+            manifest,
+            registry_factory=lambda *_args: (_ for _ in ()).throw(
+                AssertionError("forged record must fail before adapter execution")
+            ),
+        )
+
+
+def test_lifecycle_ablation_evaluation_rejects_forged_planned_record(tmp_path: Path) -> None:
+    manifest = _single_manifest(tmp_path)
+    result = run_lifecycle_ablation(
+        manifest,
+        registry_factory=lambda _trial, package, _run: _GoldFreshRegistry(package),
+    )
+    record_path = Path(result.record_paths[0])
+    forged = json.loads(record_path.read_text(encoding="utf-8"))
+    forged["experiment_id"] = manifest.experiment_id
+    forged["agent"]["configuration"]["requested_model"] = "forged-model"
+    record_path.write_text(json.dumps(forged), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="TrialRecord does not match"):
+        build_lifecycle_ablation_evaluation(manifest)
+
+
+def test_run_lifecycle_ablation_imports_completed_orphan_without_executor(tmp_path: Path) -> None:
+    manifest, trial, _package, _run_dir = _recorded_trial(tmp_path)
+    assert inspect_lifecycle_ablation_plan(manifest)["trial_statuses"][0]["status"] == "finalizable"
+
+    def forbidden_registry_factory(*_args: object) -> object:
+        raise AssertionError("completed orphan must be imported without an adapter")
+
+    result = run_lifecycle_ablation(manifest, registry_factory=forbidden_registry_factory)
+
+    assert result.executed_trials == 0
+    assert result.imported_orphans == 1
+    assert result.skipped_trials == 0
+    assert result.trial_ids == [trial.trial_id]
+    assert Path(result.record_paths[0]).is_file()
+
+
+def test_run_lifecycle_ablation_recovers_missing_shared_index_from_canonical_seal(
+    tmp_path: Path,
+) -> None:
+    manifest, trial, _package, run_dir = _recorded_trial(tmp_path)
+    index_path = run_dir.parent / "experiment-index.jsonl"
+    index_path.unlink()
+
+    inspection = inspect_lifecycle_ablation_plan(manifest)
+    assert inspection["trial_statuses"][0]["status"] == "finalizable"
+
+    def forbidden_registry_factory(*_args: object) -> object:
+        raise AssertionError("sealed orphan recovery must not invoke an adapter")
+
+    result = run_lifecycle_ablation(manifest, registry_factory=forbidden_registry_factory)
+
+    assert result.imported_orphans == 1
+    assert Path(trial.ledger_path).is_file()
+    repaired = [json.loads(line) for line in index_path.read_text(encoding="utf-8").splitlines()]
+    assert len(repaired) == 1
+    assert repaired[0]["sweep"]["planned_trial_id"] == trial.trial_id
+    record = TrialRecord.model_validate_json(Path(result.record_paths[0]).read_text(encoding="utf-8"))
+    assert record.outputs.artifacts is not None
+    assert any(artifact.kind == "lifecycle_invocation_seal" for artifact in record.outputs.artifacts)
+
+
+def test_run_lifecycle_ablation_rebuilds_truncated_shared_index_from_canonical_seal(
+    tmp_path: Path,
+) -> None:
+    manifest, trial, _package, run_dir = _recorded_trial(tmp_path)
+    index_path = run_dir.parent / "experiment-index.jsonl"
+    index_path.write_text('{"experiment_id":', encoding="utf-8")
+
+    inspection = inspect_lifecycle_ablation_plan(manifest)
+    assert inspection["trial_statuses"][0]["status"] == "finalizable"
+
+    result = run_lifecycle_ablation(
+        manifest,
+        registry_factory=lambda *_args: (_ for _ in ()).throw(
+            AssertionError("truncated index recovery must not invoke an adapter")
+        ),
+    )
+
+    assert result.imported_orphans == 1
+    repaired = [json.loads(line) for line in index_path.read_text(encoding="utf-8").splitlines()]
+    assert [entry["sweep"]["planned_trial_id"] for entry in repaired] == [trial.trial_id]
+
+
+def test_concurrent_finalization_repairs_shared_index_without_lost_entries(tmp_path: Path) -> None:
+    manifest = _single_manifest(tmp_path).model_copy(
+        update={
+            "experiment_id": "ssc03-concurrent-index-repair",
+            "variants": ("response_assertion_only", "memo_closeout_missing"),
+            "limits": LifecycleAblationLimits(max_trials=2),
+        }
+    )
+    plan = build_lifecycle_ablation_plan(manifest)
+    prepared: list[tuple[LifecycleAblationTrial, Path, Path]] = []
+    for trial in plan.trials:
+        package = materialize_template_lifecycle(
+            get_template(TEMPLATE_ID),
+            Path(trial.package_dir),
+            variant_id=trial.variant_id,
+        )
+        run_dir = Path(trial.run_dir)
+        run_local_evidence_lifecycle_fresh_context(
+            package_dir=package,
+            run_dir=run_dir,
+            model=trial.agent.model,
+            adapter_kind=trial.agent.adapter,
+            max_turns=trial.max_turns_per_session,
+            registry=_GoldFreshRegistry(package, resolved_model=trial.agent.model),
+            verifier=verify_template_lifecycle,
+            visibility_policy=trial.memory_visibility_policy,
+            sweep_context=LifecycleExperimentSweepContext(
+                sweep_experiment_id=manifest.experiment_id,
+                planned_trial_id=trial.trial_id,
+                plan_sha256=plan.plan_sha256,
+                condition_id=f"{trial.execution_mode.value}__{trial.memory_visibility_policy.value}",
+                repetition=trial.repetition,
+            ),
+        )
+        prepared.append((trial, package, run_dir))
+    index_path = Path(manifest.output_root) / "trials" / "experiment-index.jsonl"
+    index_path.unlink()
+
+    def finalize(item: tuple[LifecycleAblationTrial, Path, Path]) -> Path:
+        trial, package, run_dir = item
+        return finalize_lifecycle_trial_record(
+            manifest=manifest,
+            trial=trial,
+            package_dir=package,
+            run_dir=run_dir,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        records = list(executor.map(finalize, prepared))
+
+    assert all(path.is_file() for path in records)
+    entries = [json.loads(line) for line in index_path.read_text(encoding="utf-8").splitlines()]
+    assert {entry["sweep"]["planned_trial_id"] for entry in entries} == {trial.trial_id for trial in plan.trials}
+
+
+def test_run_lifecycle_ablation_rejects_submitted_checkpoint_without_attempt_owner(
+    tmp_path: Path,
+) -> None:
+    manifest = _single_manifest(tmp_path).model_copy(update={"experiment_id": "ssc03-unowned-checkpoint"})
+    trial = build_lifecycle_ablation_plan(manifest).trials[0]
+    package = materialize_template_lifecycle(
+        get_template(TEMPLATE_ID),
+        Path(trial.package_dir),
+        variant_id=trial.variant_id,
+    )
+    run_dir = Path(trial.run_dir)
+    prepared = prepare_evidence_checkpoint(package, run_dir)
+    gold = json.loads((package / "hidden" / "gold-submissions.json").read_text(encoding="utf-8"))
+    submission = Path(prepared["submission_path"])
+    submission.parent.mkdir(parents=True, exist_ok=True)
+    submission.write_text(json.dumps(gold["initial_review"]), encoding="utf-8")
+    submit_evidence_checkpoint(package, run_dir)
+
+    inspection = inspect_lifecycle_ablation_plan(manifest)
+    assert inspection["trial_statuses"][0]["status"] == "conflict"
+    assert "submitted checkpoint has no adapter attempt owner" in inspection["trial_statuses"][0]["reason"]
+
+    with pytest.raises(ValueError, match="submitted checkpoint has no adapter attempt owner"):
+        run_lifecycle_ablation(
+            manifest,
+            registry_factory=lambda *_args: (_ for _ in ()).throw(
+                AssertionError("unowned state must fail before adapter construction")
+            ),
+        )
+    assert not Path(trial.ledger_path).exists()
+
+
+def test_run_lifecycle_ablation_records_actual_adapter_mismatch_as_zero_reward_failure(
+    tmp_path: Path,
+) -> None:
+    manifest = _single_manifest(tmp_path).model_copy(update={"experiment_id": "ssc03-adapter-mismatch"})
+
+    result = run_lifecycle_ablation(
+        manifest,
+        registry_factory=lambda _trial, package, _run: _MismatchedAdapterRegistry(package),
+    )
+
+    assert result.failed_trials == 1
+    record = TrialRecord.model_validate_json(Path(result.record_paths[0]).read_text(encoding="utf-8"))
+    assert record.evaluation.reward == 0.0
+    assert record.agent.adapter == "pydantic_ai"
+    assert record.agent.configuration["requested_adapter"] == "tool_loop"
+    assert record.lifecycle_execution is not None
+    assert record.lifecycle_execution.status == "failed"
+    assert record.lifecycle_execution.sessions[0].requested_adapter == "tool_loop"
+    assert record.lifecycle_execution.sessions[0].adapter == "pydantic_ai"
+    assert record.lifecycle_execution.sessions[0].failure_kind == "adapter_identity_mismatch"
+
+
+def test_run_lifecycle_ablation_dispatches_persistent_condition_to_one_session(tmp_path: Path) -> None:
+    manifest = _single_manifest(tmp_path).model_copy(
+        update={
+            "experiment_id": "ssc03-persistent",
+            "conditions": (
+                LifecycleAblationCondition(
+                    execution_mode=LifecycleExecutionMode.PERSISTENT_CONTEXT,
+                    memory_visibility_policy=LifecycleVisibilityPolicy.PERSISTENT_CONTEXT,
+                ),
+            ),
+        }
+    )
+
+    result = run_lifecycle_ablation(
+        manifest,
+        registry_factory=lambda _trial, package, run: _GoldPersistentRegistry(package, run),
+    )
+
+    record = TrialRecord.model_validate_json(Path(result.record_paths[0]).read_text(encoding="utf-8"))
+    assert record.lifecycle_execution is not None
+    assert record.lifecycle_execution.execution_mode == "persistent_context"
+    assert record.lifecycle_execution.memory_visibility_policy == "persistent_context"
+    assert len(record.lifecycle_execution.sessions) == 1
+    assert record.lifecycle_execution.sessions[0].checkpoint_ids == [
+        "initial_review",
+        "response_review",
+        "closeout_review",
+    ]
+    group = build_lifecycle_ablation_evaluation(manifest).summary["groups"][0]
+    assert group["max_turns_per_session"] == 10
+    assert group["total_sessions"] == 1
+    assert group["total_configured_turn_capacity"] == 10
+
+
+def test_run_lifecycle_ablation_recovers_terminal_persistent_session_crash_without_adapter(
+    tmp_path: Path,
+) -> None:
+    manifest = _persistent_manifest(tmp_path, experiment_id="ssc03-terminal-persistent-crash")
+    _trial, _package, _run_dir, session_id = _terminal_persistent_state(manifest)
+
+    inspection = inspect_lifecycle_ablation_plan(manifest)
+    assert inspection["trial_statuses"][0]["status"] == "finalizable"
+    result = run_lifecycle_ablation(
+        manifest,
+        registry_factory=lambda *_args: (_ for _ in ()).throw(
+            AssertionError("terminal crash recovery must not rebuild or call an adapter")
+        ),
+    )
+
+    assert result.imported_orphans == 1
+    assert result.failed_trials == 1
+    record = TrialRecord.model_validate_json(Path(result.record_paths[0]).read_text(encoding="utf-8"))
+    assert record.evaluation.reward == 0.0
+    assert record.agent.model == "unresolved"
+    assert record.agent.adapter == "unresolved"
+    assert record.lifecycle_execution is not None
+    assert record.lifecycle_execution.status == "failed"
+    assert record.lifecycle_execution.sessions[0].session_id == session_id
+    assert record.lifecycle_execution.sessions[0].resolved_model == "unresolved"
+    assert record.lifecycle_execution.sessions[0].adapter == "unresolved"
+    assert record.lifecycle_execution.sessions[0].failure_kind == "interrupted_after_completion"
+
+
+def test_run_lifecycle_ablation_quarantines_torn_terminal_agent_result(
+    tmp_path: Path,
+) -> None:
+    manifest = _persistent_manifest(tmp_path, experiment_id="ssc03-torn-terminal-result")
+    _trial, _package, run_dir, session_id = _terminal_persistent_state(manifest)
+    result_path = run_dir / "sessions" / session_id / "agent_result.json"
+    result_path.write_text("{", encoding="utf-8")
+
+    inspection = inspect_lifecycle_ablation_plan(manifest)
+    assert inspection["trial_statuses"][0]["status"] == "finalizable"
+    result = run_lifecycle_ablation(
+        manifest,
+        registry_factory=lambda *_args: (_ for _ in ()).throw(
+            AssertionError("torn terminal result recovery must not call an adapter")
+        ),
+    )
+
+    record = TrialRecord.model_validate_json(Path(result.record_paths[0]).read_text(encoding="utf-8"))
+    assert record.evaluation.reward == 0.0
+    assert record.outputs.artifacts is not None
+    assert any(artifact.kind == "corrupt_agent_result" for artifact in record.outputs.artifacts)
+    assert record.lifecycle_execution is not None
+    assert record.lifecycle_execution.sessions[0].failure_kind == "interrupted_after_completion"
+
+
+def test_lifecycle_ablation_reports_torn_terminal_trajectory_as_conflict(tmp_path: Path) -> None:
+    manifest = _persistent_manifest(tmp_path, experiment_id="ssc03-torn-terminal-trajectory")
+    _trial, _package, run_dir, session_id = _terminal_persistent_state(manifest)
+    (run_dir / "sessions" / session_id / "trajectory.jsonl").write_text("{", encoding="utf-8")
+
+    inspection = inspect_lifecycle_ablation_plan(manifest)
+
+    assert inspection["trial_statuses"][0]["status"] == "conflict"
+    assert "trajectory is malformed" in inspection["trial_statuses"][0]["reason"]
+
+
+def test_run_lifecycle_ablation_records_provider_failure_after_terminal_submission(
+    tmp_path: Path,
+) -> None:
+    manifest = _persistent_manifest(tmp_path, experiment_id="ssc03-terminal-provider-failure")
+
+    result = run_lifecycle_ablation(
+        manifest,
+        registry_factory=lambda _trial, package, run: _TerminalProviderFailurePersistentRegistry(package, run),
+    )
+
+    assert result.failed_trials == 1
+    record = TrialRecord.model_validate_json(Path(result.record_paths[0]).read_text(encoding="utf-8"))
+    assert record.evaluation.reward == 0.0
+    assert record.evaluation.validity.verifier_completed is False
+    assert record.lifecycle_execution is not None
+    assert record.lifecycle_execution.status == "failed"
+    assert record.lifecycle_execution.sessions[0].status == "failed"
+    assert record.lifecycle_execution.sessions[0].failure_kind == "provider_error"
+    state = json.loads(
+        (Path(result.run_root) / "trials" / result.trial_ids[0] / "state.json").read_text(encoding="utf-8")
+    )
+    assert state["status"] == "complete"
+    assert all(
+        attempt["status"] == "submitted"
+        for checkpoint in state["checkpoint_runs"]
+        for attempt in checkpoint["attempts"]
+    )
+
+
+def test_run_lifecycle_ablation_rejects_attempt_mode_outside_planned_condition(
+    tmp_path: Path,
+) -> None:
+    manifest = _single_manifest(tmp_path).model_copy(update={"experiment_id": "ssc03-attempt-mode-conflict"})
+    trial = build_lifecycle_ablation_plan(manifest).trials[0]
+    package = materialize_template_lifecycle(
+        get_template(TEMPLATE_ID),
+        Path(trial.package_dir),
+        variant_id=trial.variant_id,
+    )
+    run_dir = Path(trial.run_dir)
+    context = prepare_evidence_checkpoint(package, run_dir)
+    open_checkpoint_attempt(
+        package,
+        run_dir,
+        session_id="initial_review.session-001",
+        execution_mode="persistent_context",
+    )
+    gold = json.loads((package / "hidden" / "gold-submissions.json").read_text(encoding="utf-8"))
+    submission = Path(context["submission_path"])
+    submission.parent.mkdir(parents=True, exist_ok=True)
+    submission.write_text(json.dumps(gold["initial_review"]), encoding="utf-8")
+    submit_evidence_checkpoint(package, run_dir)
+
+    inspection = inspect_lifecycle_ablation_plan(manifest)
+    assert inspection["trial_statuses"][0]["status"] == "conflict"
+    assert "attempt execution mode does not match planned trial" in inspection["trial_statuses"][0]["reason"]
+    with pytest.raises(ValueError, match="attempt execution mode does not match planned trial"):
+        run_lifecycle_ablation(
+            manifest,
+            registry_factory=lambda *_args: (_ for _ in ()).throw(
+                AssertionError("mode conflict must fail before adapter construction")
+            ),
+        )
+
+
+def test_run_lifecycle_ablation_rejects_fresh_session_shared_across_checkpoints(
+    tmp_path: Path,
+) -> None:
+    manifest = _single_manifest(tmp_path).model_copy(update={"experiment_id": "ssc03-shared-fresh-session"})
+    trial = build_lifecycle_ablation_plan(manifest).trials[0]
+    package = materialize_template_lifecycle(
+        get_template(TEMPLATE_ID),
+        Path(trial.package_dir),
+        variant_id=trial.variant_id,
+    )
+    run_dir = Path(trial.run_dir)
+    session_id = "shared.session-001"
+    gold = json.loads((package / "hidden" / "gold-submissions.json").read_text(encoding="utf-8"))
+    for expected_checkpoint in ("initial_review", "response_review"):
+        context = prepare_evidence_checkpoint(package, run_dir)
+        assert context["checkpoint_id"] == expected_checkpoint
+        open_checkpoint_attempt(
+            package,
+            run_dir,
+            session_id=session_id,
+            execution_mode="fresh_context",
+        )
+        submission = Path(context["submission_path"])
+        submission.parent.mkdir(parents=True, exist_ok=True)
+        submission.write_text(json.dumps(gold[expected_checkpoint]), encoding="utf-8")
+        submit_evidence_checkpoint(package, run_dir)
+
+    inspection = inspect_lifecycle_ablation_plan(manifest)
+    assert inspection["trial_statuses"][0]["status"] == "conflict"
+    assert "fresh session must own exactly one checkpoint" in inspection["trial_statuses"][0]["reason"]
+    with pytest.raises(ValueError, match="fresh session must own exactly one checkpoint"):
+        run_lifecycle_ablation(
+            manifest,
+            registry_factory=lambda *_args: (_ for _ in ()).throw(
+                AssertionError("shared fresh session must fail before adapter construction")
+            ),
+        )
+
+
+def test_run_lifecycle_ablation_ignores_incomplete_canonical_staging_directory(
+    tmp_path: Path,
+) -> None:
+    manifest, trial, package, run_dir = _recorded_trial(tmp_path)
+    canonical = next((run_dir / "experiments").glob("lifecycle-*"))
+    staging = canonical.with_name(f".{canonical.name}.staging-crash")
+    canonical.replace(staging)
+    (run_dir.parent / "experiment-index.jsonl").unlink()
+    registry = _GoldFreshRegistry(package)
+
+    inspection = inspect_lifecycle_ablation_plan(manifest)
+    assert inspection["trial_statuses"][0]["status"] == "resumable"
+    result = run_lifecycle_ablation(
+        manifest,
+        registry_factory=lambda _trial, _package, _run: registry,
+    )
+
+    assert result.executed_trials == 1
+    assert registry.build_count == 0
+    assert Path(trial.ledger_path).is_file()
+
+
+def test_run_lifecycle_ablation_resumes_matching_unfinalized_runtime_state(tmp_path: Path) -> None:
+    manifest = _single_manifest(tmp_path)
+    trial = build_lifecycle_ablation_plan(manifest).trials[0]
+    package = materialize_template_lifecycle(
+        get_template(TEMPLATE_ID),
+        Path(trial.package_dir),
+        variant_id=trial.variant_id,
+    )
+    prepared = prepare_evidence_checkpoint(package, Path(trial.run_dir))
+    assert prepared["checkpoint_id"] == "initial_review"
+    assert inspect_lifecycle_ablation_plan(manifest)["trial_statuses"][0]["status"] == "resumable"
+
+    result = run_lifecycle_ablation(
+        manifest,
+        registry_factory=lambda _trial, selected_package, _run: _GoldFreshRegistry(selected_package),
+    )
+
+    assert result.executed_trials == 1
+    assert result.imported_orphans == 0
+    assert inspect_lifecycle_ablation_plan(manifest)["trial_statuses"][0]["status"] == "complete"
+    state = read_evidence_lifecycle_state(package, Path(trial.run_dir))
+    assert state["status"] == "complete"
+
+
+def test_run_lifecycle_ablation_seals_interrupted_attempt_before_resume(tmp_path: Path) -> None:
+    manifest = _single_manifest(tmp_path).model_copy(update={"experiment_id": "ssc03-interrupted-resume"})
+    trial = build_lifecycle_ablation_plan(manifest).trials[0]
+    package = materialize_template_lifecycle(
+        get_template(TEMPLATE_ID),
+        Path(trial.package_dir),
+        variant_id=trial.variant_id,
+    )
+    run_dir = Path(trial.run_dir)
+    prepared = prepare_evidence_checkpoint(package, run_dir)
+    assert prepared["checkpoint_id"] == "initial_review"
+    interrupted_session = "initial_review.session-001"
+    open_checkpoint_attempt(
+        package,
+        run_dir,
+        session_id=interrupted_session,
+        execution_mode="fresh_context",
+    )
+    interrupted_dir = run_dir / "episodes" / "initial_review" / interrupted_session
+    interrupted_dir.mkdir(parents=True)
+    (interrupted_dir / "trajectory.jsonl").write_text("", encoding="utf-8")
+
+    result = run_lifecycle_ablation(
+        manifest,
+        registry_factory=lambda _trial, selected_package, _run: _GoldFreshRegistry(selected_package),
+    )
+
+    assert result.executed_trials == 1
+    assert result.failed_trials == 1
+    record = TrialRecord.model_validate_json(Path(result.record_paths[0]).read_text(encoding="utf-8"))
+    assert record.lifecycle_execution is not None
+    sessions = {session.session_id: session for session in record.lifecycle_execution.sessions}
+    assert sessions[interrupted_session].status == "failed"
+    assert sessions[interrupted_session].failure_kind == "interrupted"
+    assert sessions[interrupted_session].resolved_model == "unresolved"
+    assert sessions[interrupted_session].checkpoint_ids == ["initial_review"]
+    assert any(artifact.kind == "trajectory" for artifact in sessions[interrupted_session].artifacts)
+
+
+def test_run_lifecycle_ablation_seals_interrupted_persistent_session_before_resume(tmp_path: Path) -> None:
+    manifest = _single_manifest(tmp_path).model_copy(
+        update={
+            "experiment_id": "ssc03-interrupted-persistent-resume",
+            "conditions": (
+                LifecycleAblationCondition(
+                    execution_mode=LifecycleExecutionMode.PERSISTENT_CONTEXT,
+                    memory_visibility_policy=LifecycleVisibilityPolicy.PERSISTENT_CONTEXT,
+                ),
+            ),
+        }
+    )
+    trial = build_lifecycle_ablation_plan(manifest).trials[0]
+    package = materialize_template_lifecycle(
+        get_template(TEMPLATE_ID),
+        Path(trial.package_dir),
+        variant_id=trial.variant_id,
+    )
+    run_dir = Path(trial.run_dir)
+    prepare_evidence_checkpoint(package, run_dir)
+    open_checkpoint_attempt(
+        package,
+        run_dir,
+        session_id="session-001",
+        execution_mode="persistent_context",
+    )
+    interrupted_dir = run_dir / "sessions" / "session-001"
+    interrupted_dir.mkdir(parents=True)
+    (interrupted_dir / "trajectory.jsonl").write_text("", encoding="utf-8")
+
+    result = run_lifecycle_ablation(
+        manifest,
+        registry_factory=lambda _trial, selected_package, selected_run: _GoldPersistentRegistry(
+            selected_package, selected_run
+        ),
+    )
+
+    assert result.failed_trials == 1
+    record = TrialRecord.model_validate_json(Path(result.record_paths[0]).read_text(encoding="utf-8"))
+    assert record.lifecycle_execution is not None
+    sessions = {session.session_id: session for session in record.lifecycle_execution.sessions}
+    assert sessions["session-001"].failure_kind == "interrupted"
+    assert sessions["session-001"].resolved_model == "unresolved"
+    assert sessions["session-002"].status == "completed"
+
+
+def test_run_lifecycle_ablation_records_provider_failure_as_immutable_trial(tmp_path: Path) -> None:
+    manifest = _single_manifest(tmp_path).model_copy(update={"experiment_id": "ssc03-provider-failure"})
+
+    result = run_lifecycle_ablation(
+        manifest,
+        registry_factory=lambda _trial, _package, _run: _FailedRegistry(),
+    )
+
+    assert result.executed_trials == 1
+    assert result.failed_trials == 1
+    record = TrialRecord.model_validate_json(Path(result.record_paths[0]).read_text(encoding="utf-8"))
+    assert record.lifecycle_provenance is not None
+    assert record.completeness is (
+        Completeness.PARTIAL if record.lifecycle_provenance.repository_dirty else Completeness.COMPLETE
+    )
+    assert record.lifecycle_execution is not None
+    assert record.lifecycle_execution.status == "failed"
+    assert record.lifecycle_execution.sessions[0].failure_kind == "provider_error"
+    assert record.evaluation.reward == 0.0
+    assert record.evaluation.validity.verifier_completed is False
+    assert record.cost is not None
+    assert record.cost.tokens_in == 3
+
+    second = run_lifecycle_ablation(
+        manifest,
+        registry_factory=lambda *_args: (_ for _ in ()).throw(
+            AssertionError("finalized failure must not be retried under the same trial id")
+        ),
+    )
+    assert second.executed_trials == 0
+    assert second.skipped_trials == 1
+
+
+def test_run_lifecycle_ablation_normalizes_empty_agent_output_as_failed(tmp_path: Path) -> None:
+    manifest = _single_manifest(tmp_path).model_copy(update={"experiment_id": "ssc03-empty-output"})
+
+    result = run_lifecycle_ablation(
+        manifest,
+        registry_factory=lambda _trial, _package, _run: _EmptyRegistry(),
+    )
+
+    assert result.failed_trials == 1
+    record = TrialRecord.model_validate_json(Path(result.record_paths[0]).read_text(encoding="utf-8"))
+    assert record.outputs.agent_output is not None
+    assert record.outputs.agent_output.status.value == "failed"
+    assert record.lifecycle_execution is not None
+    assert record.lifecycle_execution.status == "failed"
+    assert record.lifecycle_execution.sessions[0].status == "failed"
+    assert record.lifecycle_execution.sessions[0].failure_kind == "agent_failed"
+    assert record.evaluation.validity.output_parseable is False
+    assert record.evaluation.validity.schema_valid is False
+
+
+def test_run_lifecycle_ablation_does_not_claim_schema_validity_after_verifier_exception(tmp_path: Path) -> None:
+    manifest = _single_manifest(tmp_path).model_copy(update={"experiment_id": "ssc03-invalid-schema"})
+
+    result = run_lifecycle_ablation(
+        manifest,
+        registry_factory=lambda _trial, package, _run: _InvalidSchemaRegistry(package),
+    )
+
+    assert result.failed_trials == 1
+    record = TrialRecord.model_validate_json(Path(result.record_paths[0]).read_text(encoding="utf-8"))
+    assert record.evaluation.validity.output_parseable is True
+    assert record.evaluation.validity.schema_valid is False
+    assert record.evaluation.validity.verifier_completed is False
+    assert record.evaluation.reward == 0.0
+
+
+@pytest.mark.parametrize("registry_name", ["provider_failure", "premature_completion"])
+def test_run_lifecycle_ablation_finalizes_persistent_execution_failures(
+    tmp_path: Path,
+    registry_name: str,
+) -> None:
+    registry = _FailedRegistry() if registry_name == "provider_failure" else _PrematurePersistentRegistry()
+    manifest = _single_manifest(tmp_path).model_copy(
+        update={
+            "experiment_id": f"ssc03-persistent-failure-{registry_name}",
+            "conditions": (
+                LifecycleAblationCondition(
+                    execution_mode=LifecycleExecutionMode.PERSISTENT_CONTEXT,
+                    memory_visibility_policy=LifecycleVisibilityPolicy.PERSISTENT_CONTEXT,
+                ),
+            ),
+        }
+    )
+
+    result = run_lifecycle_ablation(
+        manifest,
+        registry_factory=lambda _trial, _package, _run: registry,
+    )
+
+    assert result.failed_trials == 1
+    record = TrialRecord.model_validate_json(Path(result.record_paths[0]).read_text(encoding="utf-8"))
+    assert record.lifecycle_execution is not None
+    assert record.lifecycle_execution.status == "failed"
+    assert record.lifecycle_execution.sessions[0].status == "failed"
+    assert record.lifecycle_execution.sessions[0].checkpoint_ids == ["initial_review"]
+    assert record.evaluation.validity.verifier_completed is False
+
+
+def test_run_lifecycle_ablation_rejects_manifest_drift_before_adapter_call(tmp_path: Path) -> None:
+    manifest = _single_manifest(tmp_path)
+    first = run_lifecycle_ablation(
+        manifest,
+        registry_factory=lambda _trial, package, _run: _GoldFreshRegistry(package),
+    )
+    original_record = Path(first.record_paths[0]).read_bytes()
+    drifted = manifest.model_copy(
+        update={
+            "repetitions": 2,
+            "limits": LifecycleAblationLimits(max_trials=2),
+        }
+    )
+    inspection = inspect_lifecycle_ablation_plan(drifted)
+    assert {item["status"] for item in inspection["trial_statuses"]} == {"conflict"}
+    assert "artifact snapshot ablation manifest does not match requested sweep" in {
+        item["reason"] for item in inspection["trial_statuses"]
+    }
+
+    with pytest.raises(ValueError, match="does not match requested sweep"):
+        run_lifecycle_ablation(
+            drifted,
+            registry_factory=lambda *_args: (_ for _ in ()).throw(
+                AssertionError("manifest drift must fail before adapter execution")
+            ),
+        )
+
+    assert Path(first.record_paths[0]).read_bytes() == original_record
+
+
+def test_run_lifecycle_ablation_rejects_package_conflict_before_adapter_call(tmp_path: Path) -> None:
+    manifest = _single_manifest(tmp_path)
+    trial = build_lifecycle_ablation_plan(manifest).trials[0]
+    package = materialize_template_lifecycle(
+        get_template(TEMPLATE_ID),
+        Path(trial.package_dir),
+        variant_id=trial.variant_id,
+    )
+    gold_path = package / "hidden" / "gold-submissions.json"
+    gold = json.loads(gold_path.read_text(encoding="utf-8"))
+    gold["closeout_review"]["readiness_decision"] = "not_ready_to_issue"
+    gold_path.write_text(json.dumps(gold), encoding="utf-8")
+    inspection = inspect_lifecycle_ablation_plan(manifest)
+    assert inspection["trial_statuses"][0]["status"] == "conflict"
+    assert "variant identity does not match materialized package content" in inspection["trial_statuses"][0]["reason"]
+
+    with pytest.raises(ValueError, match="variant identity does not match materialized package content"):
+        run_lifecycle_ablation(
+            manifest,
+            registry_factory=lambda *_args: (_ for _ in ()).throw(
+                AssertionError("package conflict must fail before adapter execution")
+            ),
+        )
+
+    assert not Path(trial.ledger_path).exists()
+
+
+def test_lifecycle_ablation_evaluation_reads_only_core_trial_records(tmp_path: Path) -> None:
+    manifest = _single_manifest(tmp_path)
+    result = run_lifecycle_ablation(
+        manifest,
+        registry_factory=lambda _trial, package, _run: _GoldFreshRegistry(package),
+    )
+
+    first = build_lifecycle_ablation_evaluation(manifest)
+    summary = first.summary
+    assert summary["planned_trials"] == 1
+    assert summary["invocation_records"] == 1
+    assert summary["completed_trials"] == 1
+    assert summary["failed_trials"] == 0
+    assert summary["passed_trials"] == 1
+    assert summary["mean_reward"] == 1.0
+    assert summary["study_design"] == manifest.study_design.model_dump(mode="json")
+    assert summary["groups"] == [
+        {
+            "agent_name": "gold-replay",
+            "adapter": "tool_loop",
+            "requested_adapter": "tool_loop",
+            "resolved_adapters": ["tool_loop"],
+            "requested_model": "deterministic-replay",
+            "resolved_models": ["deterministic-replay"],
+            "variant_id": "response_assertion_only",
+            "execution_mode": "fresh_context",
+            "memory_visibility_policy": "artifact_memory",
+            "trials": 1,
+            "completed": 1,
+            "failed": 0,
+            "passed": 1,
+            "mean_reward": 1.0,
+            "mean_retention": 1.0,
+            "total_cost_usd": 0.0,
+            "turn_budget_scope": "per_session",
+            "max_turns_per_session": 10,
+            "total_sessions": 3,
+            "mean_sessions_per_trial": 3.0,
+            "total_configured_turn_capacity": 30,
+            "mean_configured_turn_capacity": 30.0,
+            "total_requests": 0,
+            "mean_requests": 0.0,
+            "total_tool_calls": 0,
+            "mean_tool_calls": 0.0,
+            "total_input_tokens": 30,
+            "mean_input_tokens": 30.0,
+            "total_output_tokens": 6,
+            "mean_output_tokens": 6.0,
+            "total_cache_read_tokens": 0,
+            "mean_cache_read_tokens": 0.0,
+            "total_cache_write_tokens": 0,
+            "mean_cache_write_tokens": 0.0,
+        }
+    ]
+
+    run_dir = Path(result.run_root) / "trials" / result.trial_ids[0]
+    verification = json.loads((run_dir / "verification.json").read_text(encoding="utf-8"))
+    verification["reward"] = 0.0
+    (run_dir / "verification.json").write_text(json.dumps(verification), encoding="utf-8")
+    second = build_lifecycle_ablation_evaluation(manifest)
+    assert second == first
+
+    path = write_lifecycle_ablation_evaluation(manifest)
+    assert path.is_file()
+    assert json.loads(path.read_text(encoding="utf-8"))["summary"] == summary
+
+
+def test_lifecycle_ablation_evaluation_uses_snapshotted_runtime_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = _single_manifest(tmp_path)
+    result = run_lifecycle_ablation(
+        manifest,
+        registry_factory=lambda _trial, package, _run: _GoldFreshRegistry(package),
+    )
+    record = TrialRecord.model_validate_json(Path(result.record_paths[0]).read_text(encoding="utf-8"))
+    original_environment = record.environment
+    monkeypatch.setattr(platform, "python_version", lambda: "99.99.99")
+
+    evaluation = build_lifecycle_ablation_evaluation(manifest)
+
+    assert evaluation.summary["invocation_records"] == 1
+    persisted = TrialRecord.model_validate_json(Path(result.record_paths[0]).read_text(encoding="utf-8"))
+    assert persisted.environment == original_environment
+
+
+def test_lifecycle_ablation_evaluation_uses_snapshotted_historical_plan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = _single_manifest(tmp_path)
+    result = run_lifecycle_ablation(
+        manifest,
+        registry_factory=lambda _trial, package, _run: _GoldFreshRegistry(package),
+    )
+    record = TrialRecord.model_validate_json(Path(result.record_paths[0]).read_text(encoding="utf-8"))
+    assert record.lifecycle_provenance is not None
+    assert record.lifecycle_provenance.ablation_plan is not None
+    baseline = build_lifecycle_ablation_plan(manifest)
+    drifted_provenance = baseline.code_provenance.model_copy(update={"trial_importer_source_sha256": "0" * 64})
+    monkeypatch.setattr(ablation_plan_runtime, "_ablation_code_provenance", lambda _template_id: drifted_provenance)
+
+    evaluation = build_lifecycle_ablation_evaluation(manifest)
+
+    assert evaluation.summary["planned_trials"] == 1
+    assert evaluation.summary["invocation_records"] == 1
+
+
+def _manifest(
+    output_root: Path,
+    ledger_root: Path,
+    *,
+    repetitions: int = 1,
+) -> LifecycleAblationManifest:
+    return LifecycleAblationManifest(
+        experiment_id="ssc03-ablation",
+        lifecycle_template_id=TEMPLATE_ID,
+        variants=VARIANTS,
+        agents=(
+            AgentConfig(
+                name="agent-b",
+                adapter="tool_loop",
+                model="model-b",
+                parameters={"max_turns_per_session": 10},
+            ),
+            AgentConfig(
+                name="agent-a",
+                adapter="tool_loop",
+                model="model-a",
+                parameters={"max_turns_per_session": 10},
+            ),
+        ),
+        study_design=_study_design(),
+        repetitions=repetitions,
+        output_root=str(output_root),
+        ledger_root=str(ledger_root),
+        limits=LifecycleAblationLimits(max_trials=100),
+    )
+
+
+def _single_manifest(tmp_path: Path) -> LifecycleAblationManifest:
+    return LifecycleAblationManifest(
+        experiment_id="ssc03-live",
+        lifecycle_template_id=TEMPLATE_ID,
+        variants=("response_assertion_only",),
+        agents=(
+            AgentConfig(
+                name="gold-replay",
+                adapter="tool_loop",
+                model="deterministic-replay",
+                parameters={"max_turns_per_session": 10},
+            ),
+        ),
+        study_design=_study_design(),
+        conditions=(
+            LifecycleAblationCondition(
+                execution_mode=LifecycleExecutionMode.FRESH_CONTEXT,
+                memory_visibility_policy=LifecycleVisibilityPolicy.ARTIFACT_MEMORY,
+            ),
+        ),
+        output_root=str(tmp_path / "live-output"),
+        ledger_root=str(tmp_path / "live-ledger"),
+        limits=LifecycleAblationLimits(max_trials=1),
+    )
+
+
+def _persistent_manifest(tmp_path: Path, *, experiment_id: str) -> LifecycleAblationManifest:
+    return _single_manifest(tmp_path).model_copy(
+        update={
+            "experiment_id": experiment_id,
+            "conditions": (
+                LifecycleAblationCondition(
+                    execution_mode=LifecycleExecutionMode.PERSISTENT_CONTEXT,
+                    memory_visibility_policy=LifecycleVisibilityPolicy.PERSISTENT_CONTEXT,
+                ),
+            ),
+        }
+    )
+
+
+def _recorded_trial(
+    tmp_path: Path,
+) -> tuple[LifecycleAblationManifest, LifecycleAblationTrial, Path, Path]:
+    manifest = LifecycleAblationManifest(
+        experiment_id="ssc03-import",
+        lifecycle_template_id=TEMPLATE_ID,
+        variants=("response_assertion_only",),
+        agents=(
+            AgentConfig(
+                name="agent-a",
+                adapter="tool_loop",
+                model="model-a",
+                parameters={"max_turns_per_session": 20},
+            ),
+        ),
+        study_design=_study_design(),
+        conditions=(
+            LifecycleAblationCondition(
+                execution_mode=LifecycleExecutionMode.FRESH_CONTEXT,
+                memory_visibility_policy=LifecycleVisibilityPolicy.ARTIFACT_MEMORY,
+            ),
+        ),
+        repetitions=1,
+        output_root=str(tmp_path / "outputs"),
+        ledger_root=str(tmp_path / "ledger"),
+        limits=LifecycleAblationLimits(max_trials=1),
+    )
+    trial = build_lifecycle_ablation_plan(manifest).trials[0]
+    package = materialize_template_lifecycle(
+        get_template(TEMPLATE_ID),
+        Path(trial.package_dir),
+        variant_id=trial.variant_id,
+    )
+    run_dir = Path(trial.run_dir)
+    run_local_evidence_lifecycle_fresh_context(
+        package_dir=package,
+        run_dir=run_dir,
+        model=trial.agent.model,
+        adapter_kind=trial.agent.adapter,
+        max_turns=20,
+        registry=_GoldFreshRegistry(package, resolved_model=trial.agent.model),
+        verifier=verify_template_lifecycle,
+        visibility_policy=trial.memory_visibility_policy,
+        sweep_context=LifecycleExperimentSweepContext(
+            sweep_experiment_id=manifest.experiment_id,
+            planned_trial_id=trial.trial_id,
+            plan_sha256=build_lifecycle_ablation_plan(manifest).plan_sha256,
+            condition_id=f"{trial.execution_mode.value}__{trial.memory_visibility_policy.value}",
+            repetition=trial.repetition,
+        ),
+    )
+    return manifest, trial, package, run_dir
+
+
+def _terminal_persistent_state(
+    manifest: LifecycleAblationManifest,
+) -> tuple[LifecycleAblationTrial, Path, Path, str]:
+    trial = build_lifecycle_ablation_plan(manifest).trials[0]
+    package = materialize_template_lifecycle(
+        get_template(TEMPLATE_ID),
+        Path(trial.package_dir),
+        variant_id=trial.variant_id,
+    )
+    run_dir = Path(trial.run_dir)
+    session_id = "session-001"
+    session_dir = run_dir / "sessions" / session_id
+    session_dir.mkdir(parents=True)
+    (session_dir / "trajectory.jsonl").write_text("", encoding="utf-8")
+    gold = json.loads((package / "hidden" / "gold-submissions.json").read_text(encoding="utf-8"))
+    while True:
+        context = prepare_evidence_checkpoint(package, run_dir)
+        if context["status"] == "complete":
+            break
+        checkpoint_id = context["checkpoint_id"]
+        open_checkpoint_attempt(
+            package,
+            run_dir,
+            session_id=session_id,
+            execution_mode="persistent_context",
+        )
+        submission = Path(context["submission_path"])
+        submission.parent.mkdir(parents=True, exist_ok=True)
+        submission.write_text(json.dumps(gold[checkpoint_id]), encoding="utf-8")
+        submit_evidence_checkpoint(package, run_dir)
+    return trial, package, run_dir, session_id
+
+
+def _study_design() -> LifecycleAblationStudyDesign:
+    return LifecycleAblationStudyDesign(
+        interpretation="descriptive_calibration",
+        turn_budget_scope="per_session",
+        execution_order="deterministic_sequential_plan_order",
+        randomized=False,
+        counterbalanced=False,
+        causal_effects_supported=False,
+    )
+
+
+def _sha256(path: Path) -> str:
+    import hashlib
+
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+class _GoldFreshRegistry:
+    def __init__(self, package: Path, *, resolved_model: str = "deterministic-replay") -> None:
+        self.gold = json.loads((package / "hidden" / "gold-submissions.json").read_text(encoding="utf-8"))
+        self.resolved_model = resolved_model
+        self.build_count = 0
+
+    def build(self, **_kwargs: object) -> object:
+        self.build_count += 1
+        gold = self.gold
+        resolved_model = self.resolved_model
+
+        class _GoldAdapter:
+            def execute(self, request: object) -> object:
+                output_path = Path(request.output_path)
+                checkpoint_id = output_path.stem
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                output_path.write_text(json.dumps(gold[checkpoint_id]), encoding="utf-8")
+                return SimpleNamespace(
+                    adapter_name="tool_loop",
+                    resolved_model=resolved_model,
+                    configuration_record={"model": resolved_model, "source": "in_process_replay"},
+                    agent_output=SimpleNamespace(status=SimpleNamespace(value="completed")),
+                    transcript=[],
+                    raw_output_text=None,
+                    provider_error=None,
+                    failure_kind=None,
+                    usage_input_tokens=10,
+                    usage_output_tokens=2,
+                    usage_cache_read_tokens=0,
+                    usage_cache_write_tokens=0,
+                )
+
+        return _GoldAdapter()
+
+
+class _InvalidSchemaRegistry(_GoldFreshRegistry):
+    def __init__(self, package: Path) -> None:
+        super().__init__(package)
+        self.gold["initial_review"]["review_matrix"] = []
+
+
+class _MismatchedAdapterRegistry(_GoldFreshRegistry):
+    def build(self, **kwargs: object) -> object:
+        adapter = super().build(**kwargs)
+        original_execute = adapter.execute
+
+        def execute(request: object) -> object:
+            result = original_execute(request)
+            result.adapter_name = "pydantic_ai"
+            return result
+
+        adapter.execute = execute
+        return adapter
+
+
+class _FailedRegistry:
+    def build(self, **_kwargs: object) -> object:
+        class _FailedAdapter:
+            def execute(self, _request: object) -> object:
+                return SimpleNamespace(
+                    adapter_name="tool_loop",
+                    resolved_model="deterministic-replay",
+                    configuration_record={"model": "deterministic-replay", "source": "in_process_replay"},
+                    agent_output=SimpleNamespace(status=SimpleNamespace(value="failed")),
+                    transcript=[],
+                    raw_output_text=None,
+                    provider_error="provider unavailable",
+                    failure_kind=SimpleNamespace(value="provider_error"),
+                    usage_input_tokens=3,
+                    usage_output_tokens=0,
+                    usage_cache_read_tokens=0,
+                    usage_cache_write_tokens=0,
+                )
+
+        return _FailedAdapter()
+
+
+class _EmptyRegistry:
+    def build(self, **_kwargs: object) -> object:
+        class _EmptyAdapter:
+            def execute(self, _request: object) -> object:
+                return SimpleNamespace(
+                    adapter_name="tool_loop",
+                    resolved_model="deterministic-replay",
+                    configuration_record={"model": "deterministic-replay", "source": "in_process_replay"},
+                    agent_output=SimpleNamespace(status=SimpleNamespace(value="empty")),
+                    transcript=[],
+                    raw_output_text=None,
+                    provider_error=None,
+                    failure_kind=None,
+                    usage_input_tokens=0,
+                    usage_output_tokens=0,
+                    usage_cache_read_tokens=0,
+                    usage_cache_write_tokens=0,
+                )
+
+        return _EmptyAdapter()
+
+
+class _PrematurePersistentRegistry:
+    def build(self, **_kwargs: object) -> object:
+        class _PrematureAdapter:
+            def execute(self, _request: object) -> object:
+                return SimpleNamespace(
+                    adapter_name="tool_loop",
+                    resolved_model="deterministic-replay",
+                    configuration_record={"model": "deterministic-replay", "source": "in_process_replay"},
+                    agent_output=SimpleNamespace(status=SimpleNamespace(value="completed")),
+                    transcript=[],
+                    raw_output_text="Stopped before submitting the active checkpoint.",
+                    provider_error=None,
+                    failure_kind=None,
+                    usage_input_tokens=1,
+                    usage_output_tokens=1,
+                    usage_cache_read_tokens=0,
+                    usage_cache_write_tokens=0,
+                )
+
+        return _PrematureAdapter()
+
+
+class _GoldPersistentRegistry:
+    def __init__(self, package: Path, run_dir: Path) -> None:
+        self.package = package
+        self.run_dir = run_dir
+        self.gold = json.loads((package / "hidden" / "gold-submissions.json").read_text(encoding="utf-8"))
+
+    def build(self, *, native_tools: list[object], **_kwargs: object) -> object:
+        submit_checkpoint = next(tool for tool in native_tools if tool.__name__ == "submit_checkpoint")
+        registry = self
+
+        class _GoldPersistentAdapter:
+            def execute(self, _request: object) -> object:
+                while True:
+                    state = read_evidence_lifecycle_state(registry.package, registry.run_dir)
+                    checkpoint_id = state["active_checkpoint_id"]
+                    if checkpoint_id is None:
+                        break
+                    submission = registry.run_dir / "workspace" / "submissions" / f"{checkpoint_id}.json"
+                    submission.parent.mkdir(parents=True, exist_ok=True)
+                    submission.write_text(json.dumps(registry.gold[checkpoint_id]), encoding="utf-8")
+                    response = json.loads(submit_checkpoint(checkpoint_id))
+                    if response["status"] == "complete":
+                        break
+                return SimpleNamespace(
+                    adapter_name="tool_loop",
+                    resolved_model="deterministic-replay",
+                    configuration_record={"model": "deterministic-replay", "source": "in_process_replay"},
+                    agent_output=SimpleNamespace(status=SimpleNamespace(value="completed")),
+                    transcript=[],
+                    raw_output_text="Lifecycle complete.",
+                    provider_error=None,
+                    failure_kind=None,
+                    usage_input_tokens=30,
+                    usage_output_tokens=6,
+                    usage_cache_read_tokens=0,
+                    usage_cache_write_tokens=0,
+                )
+
+        return _GoldPersistentAdapter()
+
+
+class _TerminalProviderFailurePersistentRegistry(_GoldPersistentRegistry):
+    def build(self, **kwargs: object) -> object:
+        adapter = super().build(**kwargs)
+        original_execute = adapter.execute
+
+        def execute(request: object) -> object:
+            result = original_execute(request)
+            result.agent_output = SimpleNamespace(status=SimpleNamespace(value="failed"))
+            result.failure_kind = SimpleNamespace(value="provider_error")
+            result.provider_error = "provider stream failed after terminal submission"
+            return result
+
+        adapter.execute = execute
+        return adapter


### PR DESCRIPTION
## Summary

Adds the executable SSC-03 lifecycle calibration substrate on top of the controlled semantic variants from #12.

- defines a strict, content-bound manifest and expanded plan for model × variant × context-policy × repetition trials
- supports persistent-context and fresh-context execution, deterministic dry-run inspection, resume, orphan import, and immutable finalization
- records typed lifecycle sessions, actual adapter/model identity, provider failures, usage, costs, checkpoint ownership, and runtime-dependency provenance in core `TrialRecord` entries
- derives evaluation summaries only from ledger records and their snapshotted historical plan
- hardens canonical invocation publication, shared-index recovery, snapshot/record durability, and interrupted-session recovery
- documents and ships a 16-trial public SSC-03 calibration example

## Study-design boundary

This is a **descriptive calibration sweep**, not a randomized causal ablation.

The persisted study design fixes:

- turn budget scope: per session
- execution order: deterministic sequential plan order
- randomization: false
- counterbalancing: false
- causal effects supported: false

Persistent and fresh-context conditions do not have equal total turn capacity. The evaluator reports resource envelopes and group means, but emits no winner, pairwise effect, or causal estimate.

## Integrity and recovery guarantees

- every submitted checkpoint has exactly one final submitted attempt owner
- every fresh session owns exactly one checkpoint; retries receive distinct attempt-specific sessions
- requested and actual adapter identity must reconcile before reward attribution
- terminal persistent crashes are finalized as unresolved, zero-reward failures without rebuilding an adapter
- torn terminal `agent_result.json` files are quarantined and preserved; malformed trajectories fail closed
- per-invocation seals are authoritative and the shared index is lock-repaired from valid seals
- session results, snapshots, records, and new ancestor entries are atomically published and fsync-durable
- a valid immutable snapshot has authority over later mutable package/run corruption

## Provenance boundary

Plan and trial identity bind:

- materialized task package/spec and controlled variant adaptation
- registered verifier/dispatcher source
- the actual tracked `aec_bench` package path, including nonstandard repository layouts
- the selected runtime provider and realized bytes of the active dependency closure
- model, adapter, context policy, repetition, and per-session turn limit

Runtime dependency files are reread rather than trusting stale `RECORD` hashes. Editable installs resolve `direct_url.json`, first import-path precedence is preserved, unknown explicit provider prefixes fail closed, and invocation finalization requires the recaptured runtime fingerprint to equal the planned trial.

## Suggested review order

1. `evidence_lifecycle_ablation_plan.py` — manifest, study design, identities, resource limits
2. `evidence_lifecycle_ablation.py` — inspect/run/resume orchestration
3. `evidence_lifecycle_local.py` — persistent/fresh execution and interrupted-session sealing
4. `evidence_lifecycle_experiment.py` — canonical invocation and source/runtime provenance
5. `evidence_lifecycle_trial_record.py` — immutable snapshot import and reconciliation
6. `evidence_lifecycle_evaluation.py` — ledger-only descriptive summaries
7. contracts, durability helpers, CLI/docs, then tests

## Verification

- Ruff format: 1,560 files clean
- Ruff check: all checks passed
- strict mypy: 12 touched source files clean
- documented contracts mypy scope: 33 source files clean
- focused lifecycle/ledger/CLI suite: 210 passed
- full suite: 5,250 passed, 20 skipped, 5 unchanged warnings
- independent consistency review: no reproducible P0/P1 across recovery, immutable finalization, ownership, source identity, dependency bytes, provider inference, or import-path precedence

## Stack

- Base: #12
- Merge after #12
