### PR TITLE
Add evidence-only lifecycle transfer evaluation

### DIFF
--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -152,6 +152,8 @@ Fresh-context requests own exactly one checkpoint. Persistent execution remains 
 
 Immutable, append-only record of one trial.
 
+`task.visibility` carries the task's explicit `public | holdout` classification when known. The field is optional so historical records still parse, but evaluation code must treat a missing value as unknown rather than inferring visibility from task names, paths, experiment IDs, or variant IDs.
+
 Required fields:
 
 - `trial_id`
@@ -191,6 +193,22 @@ Key rule:
 - ledger publication is exclusive, fsync-durable through newly created ancestors, and atomic; an artifact snapshot left before record publication is recoverable without another model call.
 - session-result publication is atomic and fsync-durable; a torn result from a terminal persistent session is quarantined and replaced by an unresolved zero-reward failure only when its submitted ownership and complete trajectory validate.
 - malformed trajectory history is a conflict and is never truncated or inferred during recovery.
+
+### LifecycleTransferEvaluationSpec / LifecycleTransferSummary
+
+**Boundary:** Immutable lifecycle ledger evidence -> Descriptive holdout evaluation
+
+`LifecycleTransferEvaluationSpec` freezes one selected execution condition and two disjoint sets of content-addressed record references: public calibration support and holdout targets. Each reference binds the experiment ID, trial ID, canonical ledger path, and TrialRecord SHA-256. The selected condition binds model, adapter, runtime-dependency fingerprint, execution mode, model-visible memory policy, and per-session turn limit.
+
+The build-only evaluator validates record bytes and every referenced immutable snapshot artifact before considering eligibility. It reconciles task visibility and package identity with snapshotted variant metadata, condition and runtime provenance with the invocation manifest, and canonical reward and validity with the verification artifact. Public calibration records and holdout targets must carry explicit task visibility, `completeness=complete`, and completed verifier evidence. Targets must match the selected condition exactly and use a package hash distinct from every integrity-valid calibration input.
+
+`LifecycleTransferSummary` reports support counts, per-target eligibility and reasons, canonical verifier reward and validity, optional semantic diagnostics, and mean eligible target reward. Its study design is fixed to `descriptive_holdout_generalization`, selected from `public_calibration`, with causal effects and cross-run learning unsupported. Zero eligible targets produce `mean_target_reward=null`.
+
+Key rule:
+
+- this contract describes holdout generalization under a frozen condition; it does not estimate a transfer effect, select a winner, or demonstrate learner transfer.
+- the evaluator never changes the verifier-owned `TrialRecord.evaluation`.
+- the first contract is intentionally build-only: generic evaluation persistence and CLI publication remain deferred until holdout/internal visibility is enforced there.
 
 ### EvaluationResult
 

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -76,6 +76,8 @@ Public and holdout tasks must remain structurally separate. Holdout-derived feed
 
 Python enforcement direction:
 - visibility fields in task metadata,
+- preserve explicit task visibility in new TrialRecords while accepting missing visibility only for historical parsing;
+- treat missing visibility as ineligible for public-calibration or holdout evaluation rather than inferring it from names or storage paths;
 - filtering built into query/report surfaces,
 - reviewer and export paths respect holdout policy.
 
@@ -152,6 +154,8 @@ Python enforcement direction:
 - publish session results, snapshots, and records atomically and fsync-durably through every new ancestor, and recover terminal-session crashes, artifact-only finalization, or a locked shared invocation index from durable evidence without rerunning the agent;
 - quarantine a torn terminal session result before publishing a conservative unresolved failure, but reject malformed trajectory history rather than silently truncating or reconstructing it;
 - persist the study design with each lifecycle calibration and never make causal claims beyond its budget and ordering controls;
+- evaluate holdout generalization only from hash-pinned complete records and immutable snapshot artifacts under an exactly matched selected condition;
+- keep holdout-derived transfer summaries build-only until their persistence and publication surfaces enforce internal visibility;
 - keep true holdout evidence outside public variant registries and committed packages.
 
 ---

--- a/docs/evaluation-guide.md
+++ b/docs/evaluation-guide.md
@@ -75,6 +75,12 @@ The LLM reviewer follows the same boundary. It can flag verifier
 miscalibration, missing evidence, or event candidates, but it never edits
 `reward.json` or `details.json`.
 
+### Descriptive holdout generalization
+
+Lifecycle transfer evaluation is a post-verifier evidence contract, not another execution stage. It reads hash-pinned immutable `TrialRecord` and snapshot artifacts, requires explicit public-calibration and holdout visibility, and checks an exact selected execution condition before reporting target reward. Partial records, incomplete verification, shared source/target package identity, condition drift, or artifact tampering produce `not_evaluable` with explicit reasons.
+
+The result describes holdout generalization under a condition selected on public calibration evidence. It does not report a causal effect, winner, or cross-run learner transfer, and semantic-transition metrics remain optional diagnostics rather than a replacement score. The current API is build-only because generic evaluation persistence does not yet enforce a holdout/internal publication boundary.
+
 ---
 
 ## Trace Analysis Rules

--- a/docs/meta-harness-guide.md
+++ b/docs/meta-harness-guide.md
@@ -138,6 +138,16 @@ The manifest accepts only lifecycle controls that the current runner applies: `t
 
 The ledger-derived `EvaluationArtifact` repeats the hash-bound study design and reports each group's session count, configured turn capacity, requests, tool calls, tokens, reward, retention, and cost. It deliberately emits no pairwise effect, winner, or causal estimate. A future causal phase must define retry-aware total-trial budget allocation and randomized or counterbalanced execution before such comparisons are valid.
 
+### Evidence-only holdout evaluation
+
+The transfer-evaluation contract is a pure post-verifier read over content-addressed `TrialRecord` references and their immutable snapshot artifacts. It performs no model, adapter, provider, or verifier execution. Record visibility is reconciled with the snapshotted task-owned variant metadata; package and runtime provenance, execution condition, verifier reward, and verifier validity are reconciled with the immutable invocation and verification artifacts. A selected condition is frozen across model, adapter, runtime dependency fingerprint, execution mode, memory visibility policy, and per-session turn limit.
+
+Calibration support must be explicitly `public`; targets must be explicitly `holdout`. Missing visibility is not inferred. Both sides must be complete and verifier-finished, every referenced artifact must still match its recorded hash, and a target package must differ from every integrity-valid calibration input regardless of visibility or condition. Calibration failures remain typed `not_supporting` results, while target failures remain typed `not_evaluable` results, each with explicit reasons. If no target is eligible, mean target reward is `null`, not zero or perfect performance.
+
+The fixed study design calls this `descriptive_holdout_generalization` selected from `public_calibration`. It reports canonical holdout verifier reward and validity plus optional semantic diagnostics without computing an effect, uplift, winner, or learner-transfer claim. It does not mutate the underlying verifier result.
+
+This first surface is deliberately a library build function only. There is no CLI, campaign runner, private target materializer, or generic `EvaluationArtifact` write path. The generic `_evaluations/` directory does not yet enforce an internal/holdout publication boundary, so persisting holdout-derived summaries there would create an avoidable leakage surface.
+
 ```bash
 aec-bench meta-harness lifecycle-run-local \
   --package lifecycle-package \

--- a/src/aec_bench/contracts/trial_record.py
+++ b/src/aec_bench/contracts/trial_record.py
@@ -16,6 +16,7 @@ from pydantic import (
 
 from aec_bench.contracts.agent_output import AgentOutput
 from aec_bench.contracts.evaluation_result import EvaluationResult
+from aec_bench.contracts.task_definition import Visibility
 from aec_bench.contracts.validators import NonEmptyStr, StrictModel, ensure_non_empty_string
 
 
@@ -27,6 +28,7 @@ class Completeness(StrEnum):
 class TaskReference(StrictModel):
     task_id: NonEmptyStr
     task_revision: NonEmptyStr
+    visibility: Visibility | None = None
 
 
 class AgentReference(StrictModel):
@@ -188,6 +190,13 @@ class LifecycleExecutionRecord(StrictModel):
     max_turns_per_session: PositiveInt
     status: Literal["completed", "failed", "partial"]
     sessions: list[LifecycleSessionRecord] = Field(default_factory=list)
+
+    @field_validator("max_turns_per_session", mode="before")
+    @classmethod
+    def validate_strict_turn_limit(cls, value: object) -> object:
+        if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+            raise ValueError("max_turns_per_session must be a positive integer")
+        return value
 
     @model_validator(mode="after")
     def validate_session_consistency(self) -> "LifecycleExecutionRecord":

--- a/src/aec_bench/harness/harbor_import.py
+++ b/src/aec_bench/harness/harbor_import.py
@@ -147,6 +147,7 @@ def import_harbor_trial(
         task=TaskReference(
             task_id=task.task_id,
             task_revision=harbor_result.task_checksum,
+            visibility=task.visibility,
         ),
         agent=AgentReference(
             adapter=harbor_result.agent_info.name,

--- a/src/aec_bench/harness/local_import.py
+++ b/src/aec_bench/harness/local_import.py
@@ -269,6 +269,7 @@ def build_trial_record(
         task=TaskReference(
             task_id=task.task_id,
             task_revision="local",
+            visibility=task.visibility,
         ),
         agent=AgentReference(
             adapter=adapter_kind,

--- a/src/aec_bench/harness/trial_record_builder.py
+++ b/src/aec_bench/harness/trial_record_builder.py
@@ -46,7 +46,11 @@ def build_trial_record(
         trial_id=trial_id,
         experiment_id=experiment_id,
         timestamp=timestamp or datetime.now(UTC),
-        task=TaskReference(task_id=task.task_id, task_revision=task_revision),
+        task=TaskReference(
+            task_id=task.task_id,
+            task_revision=task_revision,
+            visibility=task.visibility,
+        ),
         agent=AgentReference(
             adapter=result.adapter_name,
             model=result.resolved_model,

--- a/src/aec_bench/meta_harness/evidence_lifecycle_transfer.py
+++ b/src/aec_bench/meta_harness/evidence_lifecycle_transfer.py
@@ -1,0 +1,624 @@
+# ABOUTME: Builds descriptive holdout-generalization summaries from immutable lifecycle records.
+# ABOUTME: Enforces visibility, provenance integrity, and exact selected-condition identity without execution.
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from pydantic import NonNegativeInt, PositiveInt, ValidationError, field_validator, model_validator
+
+from aec_bench.contracts.evaluation_result import ValidityCheck
+from aec_bench.contracts.task_definition import Visibility
+from aec_bench.contracts.trial_record import ArtifactReference, Completeness, TrialRecord
+from aec_bench.contracts.validators import NonEmptyStr, StrictModel
+from aec_bench.meta_harness.evidence_lifecycle_episode import (
+    LifecycleExecutionMode,
+    LifecycleVisibilityPolicy,
+)
+from aec_bench.meta_harness.evidence_lifecycle_experiment import LifecycleExperimentManifest
+from aec_bench.meta_harness.evidence_lifecycle_metrics import LifecycleSemanticMetrics
+from aec_bench.meta_harness.evidence_lifecycle_state import (
+    EvidenceLifecycleRunState,
+    LifecycleVerificationResult,
+)
+
+
+class LifecycleTransferRecordReference(StrictModel):
+    experiment_id: NonEmptyStr
+    trial_id: NonEmptyStr
+    ledger_path: NonEmptyStr
+    sha256: NonEmptyStr
+
+    @field_validator("sha256")
+    @classmethod
+    def validate_sha256(cls, value: str) -> str:
+        return ArtifactReference.validate_sha256(value)
+
+    @field_validator("ledger_path")
+    @classmethod
+    def validate_canonical_ledger_path(cls, value: str) -> str:
+        if not _is_canonical_absolute_path(value):
+            raise ValueError("lifecycle transfer ledger_path must be an absolute canonical path")
+        return value
+
+
+class LifecycleTransferCondition(StrictModel):
+    model: NonEmptyStr
+    adapter: NonEmptyStr
+    runtime_dependency_sha256: NonEmptyStr
+    execution_mode: LifecycleExecutionMode
+    memory_visibility_policy: LifecycleVisibilityPolicy
+    max_turns_per_session: PositiveInt
+
+    @field_validator("runtime_dependency_sha256")
+    @classmethod
+    def validate_runtime_hash(cls, value: str) -> str:
+        return ArtifactReference.validate_sha256(value)
+
+    @field_validator("max_turns_per_session", mode="before")
+    @classmethod
+    def validate_strict_turn_limit(cls, value: object) -> object:
+        if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+            raise ValueError("max_turns_per_session must be a positive integer")
+        return value
+
+    @model_validator(mode="after")
+    def validate_mode_policy_pair(self) -> LifecycleTransferCondition:
+        if (
+            self.execution_mode is LifecycleExecutionMode.PERSISTENT_CONTEXT
+            and self.memory_visibility_policy is not LifecycleVisibilityPolicy.PERSISTENT_CONTEXT
+        ):
+            raise ValueError("persistent_context execution requires persistent_context visibility")
+        if (
+            self.execution_mode is LifecycleExecutionMode.FRESH_CONTEXT
+            and self.memory_visibility_policy is LifecycleVisibilityPolicy.PERSISTENT_CONTEXT
+        ):
+            raise ValueError("fresh_context execution cannot use persistent_context visibility")
+        return self
+
+
+class LifecycleTransferStudyDesign(StrictModel):
+    interpretation: Literal["descriptive_holdout_generalization"]
+    selection_basis: Literal["public_calibration"]
+    causal_effects_supported: Literal[False]
+    cross_run_learning_supported: Literal[False]
+
+
+class LifecycleTransferEvaluationSpec(StrictModel):
+    schema_version: Literal["1"] = "1"
+    study_design: LifecycleTransferStudyDesign
+    selected_condition: LifecycleTransferCondition
+    public_calibration_records: tuple[LifecycleTransferRecordReference, ...]
+    holdout_target_records: tuple[LifecycleTransferRecordReference, ...]
+
+    @field_validator("public_calibration_records", "holdout_target_records")
+    @classmethod
+    def validate_record_references(
+        cls,
+        value: tuple[LifecycleTransferRecordReference, ...],
+    ) -> tuple[LifecycleTransferRecordReference, ...]:
+        if not value:
+            raise ValueError("lifecycle transfer record references must not be empty")
+        if any(not _is_canonical_absolute_path(item.ledger_path) for item in value):
+            raise ValueError("lifecycle transfer ledger_path must be an absolute canonical path")
+        logical_identities = [_reference_logical_identity(item) for item in value]
+        physical_identities = [_reference_physical_identity(item) for item in value]
+        if len(logical_identities) != len(set(logical_identities)) or len(physical_identities) != len(
+            set(physical_identities)
+        ):
+            raise ValueError("duplicate lifecycle transfer record reference")
+        return tuple(sorted(value, key=_reference_sort_key))
+
+    @model_validator(mode="after")
+    def validate_disjoint_record_sets(self) -> LifecycleTransferEvaluationSpec:
+        calibration_logical = {_reference_logical_identity(item) for item in self.public_calibration_records}
+        target_logical = {_reference_logical_identity(item) for item in self.holdout_target_records}
+        calibration_physical = {_reference_physical_identity(item) for item in self.public_calibration_records}
+        target_physical = {_reference_physical_identity(item) for item in self.holdout_target_records}
+        if calibration_logical & target_logical or calibration_physical & target_physical:
+            raise ValueError("duplicate lifecycle transfer record reference across evidence sets")
+        return self
+
+
+class LifecycleTransferCalibrationResult(StrictModel):
+    record: LifecycleTransferRecordReference
+    status: Literal["supports_selected_condition", "not_supporting"]
+    reasons: tuple[NonEmptyStr, ...] = ()
+
+
+class LifecycleTransferTargetResult(StrictModel):
+    record: LifecycleTransferRecordReference
+    status: Literal["eligible", "not_evaluable"]
+    reasons: tuple[NonEmptyStr, ...] = ()
+    verifier_reward: float | None = None
+    verifier_validity: ValidityCheck | None = None
+    semantic_diagnostics: LifecycleSemanticMetrics | None = None
+    diagnostic_reasons: tuple[NonEmptyStr, ...] = ()
+
+
+class LifecycleTransferSummary(StrictModel):
+    schema_version: Literal["1"] = "1"
+    evaluation_id: NonEmptyStr
+    status: Literal["evaluated", "not_evaluable"]
+    study_design: LifecycleTransferStudyDesign
+    selected_condition: LifecycleTransferCondition
+    calibration_record_count: NonNegativeInt
+    calibration_support_count: NonNegativeInt
+    target_record_count: NonNegativeInt
+    eligible_target_count: NonNegativeInt
+    mean_target_reward: float | None
+    calibration_results: tuple[LifecycleTransferCalibrationResult, ...]
+    target_results: tuple[LifecycleTransferTargetResult, ...]
+
+
+@dataclass(frozen=True)
+class _LoadedRecord:
+    record: TrialRecord | None
+    reasons: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _LoadedArtifacts:
+    content_by_path: dict[str, bytes]
+    reasons: tuple[str, ...]
+
+
+def build_lifecycle_transfer_evaluation(
+    spec: LifecycleTransferEvaluationSpec,
+) -> LifecycleTransferSummary:
+    """Describe holdout performance under one condition supported by public calibration evidence."""
+    spec = LifecycleTransferEvaluationSpec.model_validate(spec.model_dump(mode="json"))
+    calibration_loaded = [(_reference, _load_record(_reference)) for _reference in spec.public_calibration_records]
+    calibration_results: list[LifecycleTransferCalibrationResult] = []
+    supporting_records: list[TrialRecord] = []
+    calibration_packages: set[str] = set()
+    for reference, loaded in calibration_loaded:
+        reasons = list(loaded.reasons)
+        if loaded.record is not None:
+            provenance = loaded.record.lifecycle_provenance
+            if not loaded.reasons and provenance is not None:
+                calibration_packages.add(provenance.package_sha256)
+            reasons.extend(_record_eligibility_reasons(loaded.record, expected_visibility=Visibility.PUBLIC))
+            reasons.extend(_condition_mismatch_reasons(loaded.record, spec.selected_condition))
+        normalized_reasons = _unique_reasons(reasons)
+        if not normalized_reasons and loaded.record is not None:
+            supporting_records.append(loaded.record)
+        calibration_results.append(
+            LifecycleTransferCalibrationResult(
+                record=reference,
+                status="supports_selected_condition" if not normalized_reasons else "not_supporting",
+                reasons=normalized_reasons,
+            )
+        )
+
+    target_results: list[LifecycleTransferTargetResult] = []
+    eligible_rewards: list[float] = []
+    for reference in spec.holdout_target_records:
+        loaded = _load_record(reference)
+        reasons = list(loaded.reasons)
+        semantic_diagnostics: LifecycleSemanticMetrics | None = None
+        diagnostic_reasons: tuple[str, ...] = ()
+        if loaded.record is not None:
+            reasons.extend(_record_eligibility_reasons(loaded.record, expected_visibility=Visibility.HOLDOUT))
+            reasons.extend(_condition_mismatch_reasons(loaded.record, spec.selected_condition))
+            if not supporting_records:
+                reasons.append("no_public_calibration_support")
+            provenance = loaded.record.lifecycle_provenance
+            if provenance is not None and provenance.package_sha256 in calibration_packages:
+                reasons.append("target_package_matches_calibration")
+            semantic_diagnostics, diagnostic_reasons = _semantic_diagnostics(loaded.record)
+        elif not supporting_records:
+            reasons.append("no_public_calibration_support")
+        normalized_reasons = _unique_reasons(reasons)
+        eligible = not normalized_reasons and loaded.record is not None
+        reward = loaded.record.evaluation.reward if eligible and loaded.record is not None else None
+        if reward is not None:
+            eligible_rewards.append(reward)
+        target_results.append(
+            LifecycleTransferTargetResult(
+                record=reference,
+                status="eligible" if eligible else "not_evaluable",
+                reasons=normalized_reasons,
+                verifier_reward=reward,
+                verifier_validity=(
+                    loaded.record.evaluation.validity if eligible and loaded.record is not None else None
+                ),
+                semantic_diagnostics=semantic_diagnostics if eligible else None,
+                diagnostic_reasons=diagnostic_reasons,
+            )
+        )
+
+    return LifecycleTransferSummary(
+        evaluation_id=f"lifecycle-transfer-{_canonical_sha256(spec.model_dump(mode='json'))}",
+        status="evaluated" if eligible_rewards else "not_evaluable",
+        study_design=spec.study_design,
+        selected_condition=spec.selected_condition,
+        calibration_record_count=len(calibration_results),
+        calibration_support_count=len(supporting_records),
+        target_record_count=len(target_results),
+        eligible_target_count=len(eligible_rewards),
+        mean_target_reward=(sum(eligible_rewards) / len(eligible_rewards) if eligible_rewards else None),
+        calibration_results=tuple(calibration_results),
+        target_results=tuple(target_results),
+    )
+
+
+def _load_record(reference: LifecycleTransferRecordReference) -> _LoadedRecord:
+    path = Path(reference.ledger_path)
+    reasons: list[str] = []
+    try:
+        path = path.resolve()
+    except OSError:
+        return _LoadedRecord(record=None, reasons=("record_path_unresolvable",))
+    if path.parent.name != reference.experiment_id or path.name != f"{reference.trial_id}.json":
+        reasons.append("record_path_not_canonical")
+    try:
+        record_bytes = path.read_bytes()
+    except FileNotFoundError:
+        reasons.append("record_missing")
+        return _LoadedRecord(record=None, reasons=_unique_reasons(reasons))
+    except OSError:
+        reasons.append("record_unreadable")
+        return _LoadedRecord(record=None, reasons=_unique_reasons(reasons))
+    if hashlib.sha256(record_bytes).hexdigest() != reference.sha256:
+        reasons.append("record_sha256_mismatch")
+        return _LoadedRecord(record=None, reasons=_unique_reasons(reasons))
+    try:
+        record = TrialRecord.model_validate_json(record_bytes)
+    except (ValidationError, ValueError):
+        reasons.append("record_invalid")
+        return _LoadedRecord(record=None, reasons=_unique_reasons(reasons))
+    if record.experiment_id != reference.experiment_id or record.trial_id != reference.trial_id:
+        reasons.append("record_identity_mismatch")
+    ledger_root = path.parent.parent
+    loaded_artifacts = _load_artifacts(record, ledger_root=ledger_root)
+    reasons.extend(loaded_artifacts.reasons)
+    if not loaded_artifacts.reasons:
+        reasons.extend(_snapshot_record_reasons(record, artifacts=loaded_artifacts.content_by_path))
+    return _LoadedRecord(record=record, reasons=_unique_reasons(reasons))
+
+
+def _load_artifacts(record: TrialRecord, *, ledger_root: Path) -> _LoadedArtifacts:
+    artifacts = record.outputs.artifacts
+    if not artifacts:
+        return _LoadedArtifacts(content_by_path={}, reasons=("immutable_snapshot_missing",))
+    reasons: list[str] = []
+    content_by_path: dict[str, bytes] = {}
+    seen: set[str] = set()
+    root = ledger_root.resolve()
+    for artifact in artifacts:
+        if artifact.path in seen:
+            reasons.append("duplicate_artifact_reference")
+            continue
+        seen.add(artifact.path)
+        relative = Path(artifact.path)
+        if relative.is_absolute() or ".." in relative.parts:
+            reasons.append("artifact_path_escapes_ledger")
+            continue
+        try:
+            path = (root / relative).resolve()
+        except OSError:
+            reasons.append("artifact_unresolvable")
+            continue
+        try:
+            path.relative_to(root)
+        except ValueError:
+            reasons.append("artifact_path_escapes_ledger")
+            continue
+        try:
+            content = path.read_bytes()
+        except FileNotFoundError:
+            reasons.append("artifact_missing")
+            continue
+        except OSError:
+            reasons.append("artifact_unreadable")
+            continue
+        if hashlib.sha256(content).hexdigest() != artifact.sha256:
+            reasons.append("artifact_sha256_mismatch")
+            continue
+        content_by_path[artifact.path] = content
+    return _LoadedArtifacts(content_by_path=content_by_path, reasons=_unique_reasons(reasons))
+
+
+def _snapshot_record_reasons(
+    record: TrialRecord,
+    *,
+    artifacts: dict[str, bytes],
+) -> tuple[str, ...]:
+    provenance = record.lifecycle_provenance
+    execution = record.lifecycle_execution
+    if provenance is None or execution is None:
+        return ()
+    verification_reference = _artifact_by_kind(record, "lifecycle_verification")
+    state_reference = _artifact_by_kind(record, "lifecycle_state")
+    if verification_reference is None or state_reference is None or provenance.invocation_index is None:
+        return ("snapshot_contract_missing",)
+    try:
+        manifest = _read_artifact_object(artifacts, provenance.invocation_manifest)
+        invocation_index = _read_artifact_object(artifacts, provenance.invocation_index)
+        verification = _read_artifact_object(artifacts, verification_reference)
+        state = _read_artifact_object(artifacts, state_reference)
+        manifest = LifecycleExperimentManifest.model_validate(manifest).model_dump(mode="json")
+        verification_result = LifecycleVerificationResult.model_validate(verification)
+        state_result = EvidenceLifecycleRunState.model_validate(state)
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
+        return ("snapshot_contract_invalid",)
+
+    lifecycle = manifest.get("lifecycle")
+    repository = manifest.get("repository")
+    environment = manifest.get("environment")
+    verifier = manifest.get("verifier")
+    model = manifest.get("model")
+    execution_snapshot = manifest.get("execution")
+    outputs = manifest.get("outputs")
+    snapshot_sections = (lifecycle, repository, environment, verifier, model, execution_snapshot, outputs)
+    if not all(isinstance(item, dict) for item in snapshot_sections):
+        return ("snapshot_contract_invalid",)
+    assert isinstance(lifecycle, dict)
+    assert isinstance(repository, dict)
+    assert isinstance(environment, dict)
+    assert isinstance(verifier, dict)
+    assert isinstance(model, dict)
+    assert isinstance(execution_snapshot, dict)
+    assert isinstance(outputs, dict)
+    runtime = environment.get("runtime_provenance")
+    variant = lifecycle.get("variant")
+    declared_artifacts = outputs.get("artifacts")
+    if not isinstance(runtime, dict) or not isinstance(variant, dict) or not isinstance(declared_artifacts, dict):
+        return ("snapshot_contract_invalid",)
+    manifest_sweep = manifest.get("sweep")
+    index_sweep = invocation_index.get("sweep")
+    if not isinstance(manifest_sweep, dict) or not isinstance(index_sweep, dict):
+        return ("snapshot_contract_invalid",)
+    if (
+        invocation_index.get("manifest_sha256") != provenance.invocation_manifest.sha256
+        or outputs.get("verification.json") != verification_reference.sha256
+        or declared_artifacts.get("verification.json") != verification_reference.sha256
+        or declared_artifacts.get("state.json") != state_reference.sha256
+        or manifest_sweep != index_sweep
+        or manifest_sweep.get("sweep_experiment_id") != record.experiment_id
+        or manifest_sweep.get("planned_trial_id") != record.trial_id
+    ):
+        return ("snapshot_record_mismatch",)
+    try:
+        runtime_distributions = _string_tuple(runtime.get("distributions"))
+        resolved_models = tuple(sorted(_string_tuple(model.get("resolved_models"))))
+        resolved_adapters = tuple(sorted(_string_tuple(model.get("resolved_adapters"))))
+    except ValueError:
+        return ("snapshot_contract_invalid",)
+    snapshot_turn_limit = execution_snapshot.get("max_turns_per_session")
+    snapshot_session_count = execution_snapshot.get("session_count")
+    if not _is_strict_positive_int(snapshot_turn_limit) or not _is_non_negative_int(snapshot_session_count):
+        return ("snapshot_contract_invalid",)
+    if snapshot_session_count != len(execution.sessions):
+        return ("snapshot_record_mismatch",)
+
+    state_checkpoint_ids = {checkpoint.checkpoint_id for checkpoint in state_result.checkpoint_runs}
+    session_checkpoint_ids = {
+        checkpoint_id for session in execution.sessions for checkpoint_id in session.checkpoint_ids
+    }
+    if (
+        verification_result.lifecycle_id != provenance.lifecycle_id
+        or (verification_result.template_id is not None and verification_result.template_id != record.task.task_id)
+        or state_result.lifecycle_id != provenance.lifecycle_id
+        or state_result.world_id != provenance.world_id
+        or state_result.lifecycle_spec_sha256 != provenance.spec_sha256
+        or state_result.package_sha256 != provenance.package_sha256
+        or state_checkpoint_ids != session_checkpoint_ids
+    ):
+        return ("snapshot_record_mismatch",)
+
+    output_structurally_valid = state_result.status.value == "complete"
+    verifier_completed = verification_result.overall != "incomplete"
+    expected_validity = ValidityCheck(
+        output_parseable=output_structurally_valid,
+        schema_valid=output_structurally_valid and verifier_completed,
+        verifier_completed=verifier_completed,
+        errors=_verification_failures(verification_result),
+    )
+    expected_completeness = (
+        Completeness.COMPLETE
+        if (
+            record.outputs.artifacts
+            and execution.sessions
+            and all(session.resolved_model != "unresolved" for session in execution.sessions)
+            and all(session.adapter != "unresolved" for session in execution.sessions)
+            and repository.get("repository_kind", "git") == "git"
+            and not bool(repository.get("dirty"))
+        )
+        else Completeness.PARTIAL
+    )
+
+    record_visibility = record.task.visibility.value if record.task.visibility is not None else None
+    snapshot_visibility = variant.get("visibility")
+    if record.task.visibility is None and "visibility" not in record.task.model_fields_set:
+        snapshot_visibility = None
+    expected_values = {
+        "task_revision": lifecycle.get("package_sha256"),
+        "visibility": snapshot_visibility,
+        "lifecycle_id": lifecycle.get("lifecycle_id"),
+        "world_id": lifecycle.get("world_id"),
+        "spec_sha256": lifecycle.get("spec_sha256"),
+        "package_sha256": lifecycle.get("package_sha256"),
+        "repository_commit": repository.get("commit"),
+        "repository_kind": repository.get("repository_kind", "git"),
+        "repository_dirty": bool(repository.get("dirty")),
+        "repository_dirty_digest": repository.get("dirty_digest"),
+        "runtime_provider": runtime.get("provider"),
+        "runtime_distributions": runtime_distributions,
+        "runtime_dependency_sha256": runtime.get("dependency_inventory_sha256"),
+        "verifier_qualified_name": verifier.get("qualified_name"),
+        "verifier_source_sha256": verifier.get("source_sha256"),
+        "resolved_models": resolved_models,
+        "resolved_adapters": resolved_adapters,
+        "execution_mode": execution_snapshot.get("mode"),
+        "memory_visibility_policy": execution_snapshot.get("memory_visibility_policy"),
+        "max_turns_per_session": snapshot_turn_limit,
+        "execution_status": execution_snapshot.get("status"),
+        "reward": verification_result.reward,
+        "validity": expected_validity.model_dump(mode="json"),
+        "completeness": expected_completeness.value,
+    }
+    actual_values = {
+        "task_revision": record.task.task_revision,
+        "visibility": record_visibility,
+        "lifecycle_id": provenance.lifecycle_id,
+        "world_id": provenance.world_id,
+        "spec_sha256": provenance.spec_sha256,
+        "package_sha256": provenance.package_sha256,
+        "repository_commit": provenance.repository_commit,
+        "repository_kind": provenance.repository_kind,
+        "repository_dirty": provenance.repository_dirty,
+        "repository_dirty_digest": provenance.repository_dirty_digest,
+        "runtime_provider": provenance.runtime_provider,
+        "runtime_distributions": provenance.runtime_distributions,
+        "runtime_dependency_sha256": provenance.runtime_dependency_sha256,
+        "verifier_qualified_name": provenance.verifier_qualified_name,
+        "verifier_source_sha256": provenance.verifier_source_sha256,
+        "resolved_models": (record.agent.model,),
+        "resolved_adapters": (record.agent.adapter,),
+        "execution_mode": execution.execution_mode,
+        "memory_visibility_policy": execution.memory_visibility_policy,
+        "max_turns_per_session": execution.max_turns_per_session,
+        "execution_status": execution.status,
+        "reward": record.evaluation.reward,
+        "validity": record.evaluation.validity.model_dump(mode="json"),
+        "completeness": record.completeness.value,
+    }
+    if expected_values != actual_values:
+        return ("snapshot_record_mismatch",)
+    breakdown = record.evaluation.breakdown if isinstance(record.evaluation.breakdown, dict) else {}
+    verification_gates = {gate_id: gate.model_dump(mode="json") for gate_id, gate in verification_result.gates.items()}
+    if breakdown.get("lifecycle_gates") != verification_gates:
+        return ("snapshot_record_mismatch",)
+    semantic_metrics = (
+        verification_result.semantic_metrics.model_dump(mode="json")
+        if verification_result.semantic_metrics is not None
+        else None
+    )
+    if breakdown.get("semantic_transition") != semantic_metrics:
+        return ("snapshot_record_mismatch",)
+    return ()
+
+
+def _artifact_by_kind(record: TrialRecord, kind: str) -> ArtifactReference | None:
+    matches = [artifact for artifact in record.outputs.artifacts or () if artifact.kind == kind]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _read_artifact_object(artifacts: dict[str, bytes], artifact: ArtifactReference) -> dict[str, object]:
+    content = artifacts.get(artifact.path)
+    if content is None:
+        raise ValueError("snapshot artifact bytes are unavailable")
+    payload = json.loads(content)
+    if not isinstance(payload, dict):
+        raise ValueError("snapshot artifact must contain a JSON object")
+    return payload
+
+
+def _record_eligibility_reasons(record: TrialRecord, *, expected_visibility: Visibility) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if record.task.visibility is None:
+        reasons.append("missing_task_visibility")
+    elif record.task.visibility is not expected_visibility:
+        reasons.append("calibration_not_public" if expected_visibility is Visibility.PUBLIC else "target_not_holdout")
+    if record.completeness is not Completeness.COMPLETE:
+        reasons.append("record_incomplete")
+    if not record.evaluation.validity.verifier_completed:
+        reasons.append("verifier_incomplete")
+    if record.lifecycle_execution is None:
+        reasons.append("missing_lifecycle_execution")
+    if record.lifecycle_provenance is None:
+        reasons.append("missing_lifecycle_provenance")
+    return _unique_reasons(reasons)
+
+
+def _condition_mismatch_reasons(
+    record: TrialRecord,
+    expected: LifecycleTransferCondition,
+) -> tuple[str, ...]:
+    execution = record.lifecycle_execution
+    provenance = record.lifecycle_provenance
+    if execution is None or provenance is None:
+        return ()
+    actual = {
+        "model": record.agent.model,
+        "adapter": record.agent.adapter,
+        "runtime_dependency_sha256": provenance.runtime_dependency_sha256,
+        "execution_mode": execution.execution_mode,
+        "memory_visibility_policy": execution.memory_visibility_policy,
+        "max_turns_per_session": execution.max_turns_per_session,
+    }
+    expected_values = expected.model_dump(mode="json")
+    reason_by_field = {
+        "model": "model_mismatch",
+        "adapter": "adapter_mismatch",
+        "runtime_dependency_sha256": "runtime_dependency_mismatch",
+        "execution_mode": "execution_mode_mismatch",
+        "memory_visibility_policy": "memory_visibility_policy_mismatch",
+        "max_turns_per_session": "max_turns_per_session_mismatch",
+    }
+    reasons = [reason_by_field[field] for field, value in actual.items() if value != expected_values[field]]
+    return _unique_reasons(reasons)
+
+
+def _semantic_diagnostics(record: TrialRecord) -> tuple[LifecycleSemanticMetrics | None, tuple[str, ...]]:
+    breakdown = record.evaluation.breakdown
+    semantic = breakdown.get("semantic_transition") if isinstance(breakdown, dict) else None
+    if semantic is None:
+        return None, ()
+    try:
+        return LifecycleSemanticMetrics.model_validate(semantic), ()
+    except ValidationError:
+        return None, ("invalid_semantic_transition_metrics",)
+
+
+def _reference_logical_identity(reference: LifecycleTransferRecordReference) -> tuple[str, str]:
+    return reference.experiment_id, reference.trial_id
+
+
+def _reference_physical_identity(reference: LifecycleTransferRecordReference) -> str:
+    return str(Path(reference.ledger_path).resolve())
+
+
+def _reference_sort_key(reference: LifecycleTransferRecordReference) -> tuple[str, str, str, str]:
+    return reference.experiment_id, reference.trial_id, reference.ledger_path, reference.sha256
+
+
+def _unique_reasons(reasons: list[str] | tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(sorted(set(reasons)))
+
+
+def _is_canonical_absolute_path(value: str) -> bool:
+    path = Path(value)
+    try:
+        return path.is_absolute() and path == path.resolve()
+    except OSError:
+        return False
+
+
+def _is_strict_positive_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+
+def _is_non_negative_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+def _verification_failures(verification: LifecycleVerificationResult) -> list[str]:
+    return [f"{gate_id}:{failure}" for gate_id, gate in verification.gates.items() for failure in gate.failures]
+
+
+def _string_tuple(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list | tuple) or any(not isinstance(item, str) for item in value):
+        raise ValueError("snapshot field must be a string sequence")
+    return tuple(value)
+
+
+def _canonical_sha256(payload: object) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()

--- a/src/aec_bench/meta_harness/evidence_lifecycle_trial_record.py
+++ b/src/aec_bench/meta_harness/evidence_lifecycle_trial_record.py
@@ -19,6 +19,7 @@ from typing import Any, Literal, cast
 
 from aec_bench.contracts.agent_output import AgentOutput, AgentOutputStatus
 from aec_bench.contracts.evaluation_result import EvaluationResult, ValidityCheck
+from aec_bench.contracts.task_definition import Visibility
 from aec_bench.contracts.trajectory import read_trajectory
 from aec_bench.contracts.trial_record import (
     AdaptationProvenance,
@@ -177,6 +178,12 @@ def _build_lifecycle_trial_record(
         raise ValueError("lifecycle verification does not match planned lifecycle")
     if lifecycle.get("variant") != variant:
         raise ValueError("lifecycle experiment variant does not match package")
+    if not isinstance(variant, dict) or not isinstance(variant.get("visibility"), str):
+        raise ValueError("lifecycle package variant visibility is missing")
+    try:
+        task_visibility = Visibility(variant["visibility"])
+    except ValueError as exc:
+        raise ValueError("lifecycle package variant visibility is invalid") from exc
 
     model = experiment.get("model", {})
     execution = experiment.get("execution", {})
@@ -348,6 +355,7 @@ def _build_lifecycle_trial_record(
         task=TaskReference(
             task_id=manifest.lifecycle_template_id,
             task_revision=str(state["package_sha256"]),
+            visibility=task_visibility,
         ),
         agent=AgentReference(
             adapter=resolved_adapter,
@@ -538,7 +546,7 @@ def validate_lifecycle_ablation_record(
         ledger_root=ledger_root,
         plan=None,
     )
-    if record != expected:
+    if not _matches_historical_record(record, expected):
         raise ValueError("existing TrialRecord does not match its immutable lifecycle ablation snapshot")
 
 
@@ -585,8 +593,22 @@ def validate_historical_lifecycle_ablation_record(
         ledger_root=ledger_root,
         plan=plan,
     )
-    if record != expected:
+    if not _matches_historical_record(record, expected):
         raise ValueError("historical TrialRecord does not match its immutable lifecycle ablation snapshot")
+
+
+def _matches_historical_record(record: TrialRecord, expected: TrialRecord) -> bool:
+    """Allow only the omitted visibility field used by records written before that field existed."""
+    if record == expected:
+        return True
+    if record.task.visibility is not None or "visibility" in record.task.model_fields_set:
+        return False
+    legacy_expected = expected.model_copy(
+        update={
+            "task": expected.task.model_copy(update={"visibility": None}),
+        }
+    )
+    return record == legacy_expected
 
 
 def _record_from_snapshot(

--- a/tests/harness/test_harbor_import.py
+++ b/tests/harness/test_harbor_import.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from aec_bench.contracts.agent_output import AgentOutputStatus
+from aec_bench.contracts.task_definition import Visibility
 from aec_bench.contracts.trial_record import Completeness
 from aec_bench.harness.harbor_import import (
     HarborImportError,
@@ -33,6 +34,7 @@ def test_import_harbor_trial_maps_real_successful_trial() -> None:
     assert record.experiment_id == "6834bc30-3801-4a45-a114-afb2d3764b7d"
     assert record.task.task_id == "mechanical/heat-load/audit-office-building/brisbane-8rm"
     assert record.task.task_revision == "b3b51915e026ccfe5393293338afb9360eefdd1d4d17c55760494334241403c5"
+    assert record.task.visibility is Visibility.PUBLIC
     assert record.agent.adapter == "tool-loop-anthropic"
     assert record.agent.adapter_revision == "1.0.0"
     assert record.agent.model == "claude-sonnet-4-6"

--- a/tests/harness/test_local_import.py
+++ b/tests/harness/test_local_import.py
@@ -7,6 +7,7 @@ import json
 from pathlib import Path
 
 from aec_bench.contracts.agent_output import AgentOutputStatus
+from aec_bench.contracts.task_definition import Visibility
 from aec_bench.contracts.trial_record import Completeness, TimingRecord, TrialRecord
 from aec_bench.harness.local_import import (
     ARTIFACT_FILENAMES,
@@ -132,6 +133,7 @@ def test_build_trial_record_constructs_valid_record(tmp_path: Path) -> None:
     assert isinstance(record, TrialRecord)
     assert record.trial_id == "trial-001"
     assert record.experiment_id == "exp-001"
+    assert record.task.visibility is Visibility.PUBLIC
     assert record.agent.model == "test-model"
     assert record.outputs.agent_output.status == AgentOutputStatus.COMPLETED
     assert record.cost is not None

--- a/tests/harness/test_trial_record_builder.py
+++ b/tests/harness/test_trial_record_builder.py
@@ -62,6 +62,7 @@ def test_build_trial_record_uses_adapter_configuration_record() -> None:
     )
 
     assert record.agent.configuration == {"model": "gpt-5.4-mini", "max_turns": 4}
+    assert record.task.visibility == task.visibility
     assert record.outputs.agent_result == {
         "failure_kind": None,
         "provider_error": None,

--- a/tests/meta_harness/test_evidence_lifecycle_ablation.py
+++ b/tests/meta_harness/test_evidence_lifecycle_ablation.py
@@ -21,6 +21,7 @@ import aec_bench.meta_harness.evidence_lifecycle_ablation_plan as ablation_plan_
 import aec_bench.meta_harness.evidence_lifecycle_experiment as experiment_runtime
 import aec_bench.meta_harness.evidence_lifecycle_trial_record as trial_record_runtime
 from aec_bench.contracts.experiment_manifest import AgentConfig
+from aec_bench.contracts.task_definition import Visibility
 from aec_bench.contracts.trial_record import Completeness, TrialRecord
 from aec_bench.ledger.writer import DuplicateTrialRecordError
 from aec_bench.meta_harness.evidence_lifecycle import (
@@ -50,9 +51,17 @@ from aec_bench.meta_harness.evidence_lifecycle_local import (
     LifecycleVisibilityPolicy,
     run_local_evidence_lifecycle_fresh_context,
 )
+from aec_bench.meta_harness.evidence_lifecycle_transfer import (
+    LifecycleTransferCondition,
+    LifecycleTransferEvaluationSpec,
+    LifecycleTransferRecordReference,
+    LifecycleTransferStudyDesign,
+    build_lifecycle_transfer_evaluation,
+)
 from aec_bench.meta_harness.evidence_lifecycle_trial_record import (
     build_lifecycle_trial_record,
     finalize_lifecycle_trial_record,
+    validate_historical_lifecycle_ablation_record,
 )
 from aec_bench.task_world_templates.catalogue import get_template
 from aec_bench.task_world_templates.lifecycles import registered_lifecycle_verifier
@@ -513,6 +522,7 @@ def test_build_lifecycle_trial_record_maps_validated_working_provenance(tmp_path
     assert record.experiment_id == manifest.experiment_id
     assert record.task.task_id == TEMPLATE_ID
     assert record.task.task_revision == json.loads((run_dir / "state.json").read_text())["package_sha256"]
+    assert record.task.visibility is Visibility.PUBLIC
     assert record.agent.adapter == trial.agent.adapter
     assert record.agent.model == trial.agent.model
     assert record.agent.adapter_revision
@@ -584,6 +594,67 @@ def test_finalize_lifecycle_trial_record_snapshots_artifacts_and_writes_once(tmp
             run_dir=run_dir,
         )
     assert record_path.read_bytes() == original_record
+
+
+def test_historical_lifecycle_record_without_visibility_still_validates_but_is_not_backfilled(
+    tmp_path: Path,
+) -> None:
+    manifest, trial, package, run_dir = _recorded_trial(tmp_path)
+    record_path = finalize_lifecycle_trial_record(
+        manifest=manifest,
+        trial=trial,
+        package_dir=package,
+        run_dir=run_dir,
+    )
+    payload = json.loads(record_path.read_text(encoding="utf-8"))
+    payload["task"].pop("visibility")
+    record_path.write_text(json.dumps(payload), encoding="utf-8")
+    historical = TrialRecord.model_validate_json(record_path.read_text(encoding="utf-8"))
+    plan = build_lifecycle_ablation_plan(manifest)
+
+    validate_historical_lifecycle_ablation_record(historical, manifest, plan, trial)
+
+    assert historical.task.visibility is None
+    assert "visibility" not in historical.task.model_fields_set
+    target_path = Path(manifest.ledger_root) / "holdout" / "target-001.json"
+    target_reference = LifecycleTransferRecordReference(
+        experiment_id="holdout",
+        trial_id="target-001",
+        ledger_path=str(target_path),
+        sha256="0" * 64,
+    )
+    assert historical.lifecycle_execution is not None
+    assert historical.lifecycle_provenance is not None
+    summary = build_lifecycle_transfer_evaluation(
+        LifecycleTransferEvaluationSpec(
+            study_design=LifecycleTransferStudyDesign(
+                interpretation="descriptive_holdout_generalization",
+                selection_basis="public_calibration",
+                causal_effects_supported=False,
+                cross_run_learning_supported=False,
+            ),
+            selected_condition=LifecycleTransferCondition(
+                model=historical.agent.model,
+                adapter=historical.agent.adapter,
+                runtime_dependency_sha256=historical.lifecycle_provenance.runtime_dependency_sha256,
+                execution_mode=historical.lifecycle_execution.execution_mode,
+                memory_visibility_policy=historical.lifecycle_execution.memory_visibility_policy,
+                max_turns_per_session=historical.lifecycle_execution.max_turns_per_session,
+            ),
+            public_calibration_records=(
+                LifecycleTransferRecordReference(
+                    experiment_id=historical.experiment_id,
+                    trial_id=historical.trial_id,
+                    ledger_path=str(record_path),
+                    sha256=_sha256(record_path),
+                ),
+            ),
+            holdout_target_records=(target_reference,),
+        )
+    )
+
+    assert "missing_task_visibility" in summary.calibration_results[0].reasons
+    assert "snapshot_record_mismatch" not in summary.calibration_results[0].reasons
 
 
 def test_finalize_lifecycle_trial_record_recovers_snapshot_left_before_record_write(tmp_path: Path) -> None:

--- a/tests/meta_harness/test_evidence_lifecycle_transfer.py
+++ b/tests/meta_harness/test_evidence_lifecycle_transfer.py
@@ -1,0 +1,1169 @@
+# ABOUTME: Tests descriptive holdout generalization over immutable lifecycle TrialRecords.
+# ABOUTME: Enforces visibility, condition identity, provenance integrity, and non-causal summaries.
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from aec_bench.contracts.evaluation_result import EvaluationResult, ValidityCheck
+from aec_bench.contracts.task_definition import Visibility
+from aec_bench.contracts.trial_record import (
+    AgentReference,
+    ArtifactReference,
+    Completeness,
+    EnvironmentSnapshot,
+    FileReference,
+    InputRecord,
+    LifecycleExecutionRecord,
+    LifecycleSessionRecord,
+    LifecycleTrialProvenance,
+    OutputRecord,
+    TaskReference,
+    TimingRecord,
+    TrialRecord,
+)
+from aec_bench.meta_harness.evidence_lifecycle_metrics import score_semantic_transitions
+from aec_bench.meta_harness.evidence_lifecycle_transfer import (
+    LifecycleTransferCondition,
+    LifecycleTransferEvaluationSpec,
+    LifecycleTransferRecordReference,
+    LifecycleTransferStudyDesign,
+    build_lifecycle_transfer_evaluation,
+)
+
+_RUNTIME_SHA256 = "1" * 64
+
+
+def test_distinct_complete_holdout_under_public_selected_condition_is_evaluated(
+    tmp_path: Path,
+) -> None:
+    condition = _condition()
+    calibration = _write_record(
+        tmp_path,
+        experiment_id="public-calibration",
+        trial_id="calibration-001",
+        visibility=Visibility.PUBLIC,
+        package_sha256="a" * 64,
+        reward=1.0,
+        condition=condition,
+    )
+    semantic = score_semantic_transitions(
+        checkpoint_ids=("initial", "corrected"),
+        expected={"initial": {"decision": "hold"}, "corrected": {"decision": "release"}},
+        actual={"initial": {"decision": "hold"}, "corrected": {"decision": "release"}},
+    )
+    target = _write_record(
+        tmp_path,
+        experiment_id="private-holdout",
+        trial_id="target-001",
+        visibility=Visibility.HOLDOUT,
+        package_sha256="b" * 64,
+        reward=0.75,
+        condition=condition,
+        semantic_transition=semantic.model_dump(mode="json"),
+    )
+    target_bytes = target.record_path.read_bytes()
+
+    result = build_lifecycle_transfer_evaluation(
+        _spec(condition=condition, calibration=(calibration.reference,), targets=(target.reference,))
+    )
+
+    assert result.status == "evaluated"
+    assert result.study_design.interpretation == "descriptive_holdout_generalization"
+    assert result.study_design.selection_basis == "public_calibration"
+    assert result.study_design.causal_effects_supported is False
+    assert result.study_design.cross_run_learning_supported is False
+    assert result.calibration_support_count == 1
+    assert result.eligible_target_count == 1
+    assert result.mean_target_reward == 0.75
+    assert result.target_results[0].verifier_reward == 0.75
+    assert result.target_results[0].verifier_validity is not None
+    assert result.target_results[0].verifier_validity.verifier_completed is True
+    assert result.target_results[0].semantic_diagnostics == semantic
+    assert target.record_path.read_bytes() == target_bytes
+    assert TrialRecord.model_validate_json(target_bytes).evaluation.reward == 0.75
+    serialized = result.model_dump(mode="json")
+    assert "transfer_effect" not in serialized
+    assert "winner" not in serialized
+
+
+@pytest.mark.parametrize(
+    ("calibration_visibility", "expected_reason"),
+    [
+        (None, "missing_task_visibility"),
+        (Visibility.HOLDOUT, "calibration_not_public"),
+    ],
+)
+def test_calibration_requires_explicit_public_visibility(
+    tmp_path: Path,
+    calibration_visibility: Visibility | None,
+    expected_reason: str,
+) -> None:
+    condition = _condition()
+    calibration = _write_record(
+        tmp_path,
+        experiment_id="calibration",
+        trial_id="calibration-001",
+        visibility=calibration_visibility,
+        package_sha256="a" * 64,
+        reward=1.0,
+        condition=condition,
+    )
+    target = _write_record(
+        tmp_path,
+        experiment_id="holdout",
+        trial_id="target-001",
+        visibility=Visibility.HOLDOUT,
+        package_sha256="b" * 64,
+        reward=1.0,
+        condition=condition,
+    )
+
+    result = build_lifecycle_transfer_evaluation(
+        _spec(condition=condition, calibration=(calibration.reference,), targets=(target.reference,))
+    )
+
+    assert result.status == "not_evaluable"
+    assert result.calibration_support_count == 0
+    assert expected_reason in result.calibration_results[0].reasons
+    assert "no_public_calibration_support" in result.target_results[0].reasons
+    assert result.mean_target_reward is None
+
+
+@pytest.mark.parametrize(
+    ("target_visibility", "expected_reason"),
+    [
+        (None, "missing_task_visibility"),
+        (Visibility.PUBLIC, "target_not_holdout"),
+    ],
+)
+def test_target_requires_explicit_holdout_visibility(
+    tmp_path: Path,
+    target_visibility: Visibility | None,
+    expected_reason: str,
+) -> None:
+    condition = _condition()
+    calibration = _write_record(
+        tmp_path,
+        experiment_id="calibration",
+        trial_id="calibration-001",
+        visibility=Visibility.PUBLIC,
+        package_sha256="a" * 64,
+        reward=1.0,
+        condition=condition,
+    )
+    target = _write_record(
+        tmp_path,
+        experiment_id="target",
+        trial_id="target-001",
+        visibility=target_visibility,
+        package_sha256="b" * 64,
+        reward=1.0,
+        condition=condition,
+    )
+
+    result = build_lifecycle_transfer_evaluation(
+        _spec(condition=condition, calibration=(calibration.reference,), targets=(target.reference,))
+    )
+
+    assert result.status == "not_evaluable"
+    assert expected_reason in result.target_results[0].reasons
+    assert result.mean_target_reward is None
+
+
+def test_target_package_must_be_distinct_from_every_supporting_calibration_package(
+    tmp_path: Path,
+) -> None:
+    condition = _condition()
+    calibration = _write_record(
+        tmp_path,
+        experiment_id="calibration",
+        trial_id="calibration-001",
+        visibility=Visibility.PUBLIC,
+        package_sha256="a" * 64,
+        reward=1.0,
+        condition=condition,
+    )
+    target = _write_record(
+        tmp_path,
+        experiment_id="target",
+        trial_id="target-001",
+        visibility=Visibility.HOLDOUT,
+        package_sha256="a" * 64,
+        reward=1.0,
+        condition=condition,
+    )
+
+    result = build_lifecycle_transfer_evaluation(
+        _spec(condition=condition, calibration=(calibration.reference,), targets=(target.reference,))
+    )
+
+    assert result.status == "not_evaluable"
+    assert result.target_results[0].reasons == ("target_package_matches_calibration",)
+    assert result.mean_target_reward is None
+
+
+def test_target_package_must_be_distinct_from_any_integrity_valid_calibration_input(
+    tmp_path: Path,
+) -> None:
+    selected = _condition()
+    supporting = _write_record(
+        tmp_path,
+        experiment_id="calibration",
+        trial_id="calibration-supporting",
+        visibility=Visibility.PUBLIC,
+        package_sha256="a" * 64,
+        reward=1.0,
+        condition=selected,
+    )
+    other_condition = _write_record(
+        tmp_path,
+        experiment_id="calibration",
+        trial_id="calibration-other-model",
+        visibility=None,
+        package_sha256="b" * 64,
+        reward=1.0,
+        condition=selected.model_copy(update={"model": "other-model"}),
+    )
+    target = _write_record(
+        tmp_path,
+        experiment_id="target",
+        trial_id="target-001",
+        visibility=Visibility.HOLDOUT,
+        package_sha256="b" * 64,
+        reward=1.0,
+        condition=selected,
+    )
+
+    result = build_lifecycle_transfer_evaluation(
+        _spec(
+            condition=selected,
+            calibration=(supporting.reference, other_condition.reference),
+            targets=(target.reference,),
+        )
+    )
+
+    assert result.calibration_support_count == 1
+    assert "missing_task_visibility" in result.calibration_results[0].reasons
+    assert result.status == "not_evaluable"
+    assert result.target_results[0].reasons == ("target_package_matches_calibration",)
+
+
+@pytest.mark.parametrize(
+    ("completeness", "verifier_completed", "expected_reason"),
+    [
+        (Completeness.PARTIAL, True, "record_incomplete"),
+        (Completeness.COMPLETE, False, "verifier_incomplete"),
+    ],
+)
+def test_partial_or_unverified_target_is_not_evaluable(
+    tmp_path: Path,
+    completeness: Completeness,
+    verifier_completed: bool,
+    expected_reason: str,
+) -> None:
+    condition = _condition()
+    calibration = _write_record(
+        tmp_path,
+        experiment_id="calibration",
+        trial_id="calibration-001",
+        visibility=Visibility.PUBLIC,
+        package_sha256="a" * 64,
+        reward=1.0,
+        condition=condition,
+    )
+    target = _write_record(
+        tmp_path,
+        experiment_id="target",
+        trial_id="target-001",
+        visibility=Visibility.HOLDOUT,
+        package_sha256="b" * 64,
+        reward=0.0,
+        condition=condition,
+        completeness=completeness,
+        verifier_completed=verifier_completed,
+    )
+
+    result = build_lifecycle_transfer_evaluation(
+        _spec(condition=condition, calibration=(calibration.reference,), targets=(target.reference,))
+    )
+
+    assert result.status == "not_evaluable"
+    assert expected_reason in result.target_results[0].reasons
+    assert result.mean_target_reward is None
+
+
+def test_partial_calibration_record_cannot_support_the_selected_condition(tmp_path: Path) -> None:
+    condition = _condition()
+    calibration = _write_record(
+        tmp_path,
+        experiment_id="calibration",
+        trial_id="calibration-001",
+        visibility=Visibility.PUBLIC,
+        package_sha256="a" * 64,
+        reward=1.0,
+        condition=condition,
+        completeness=Completeness.PARTIAL,
+    )
+    target = _write_record(
+        tmp_path,
+        experiment_id="target",
+        trial_id="target-001",
+        visibility=Visibility.HOLDOUT,
+        package_sha256="b" * 64,
+        reward=1.0,
+        condition=condition,
+    )
+
+    result = build_lifecycle_transfer_evaluation(
+        _spec(condition=condition, calibration=(calibration.reference,), targets=(target.reference,))
+    )
+
+    assert result.calibration_support_count == 0
+    assert "record_incomplete" in result.calibration_results[0].reasons
+    assert "no_public_calibration_support" in result.target_results[0].reasons
+
+
+@pytest.mark.parametrize(
+    ("updates", "expected_reason"),
+    [
+        ({"model": "other-model"}, "model_mismatch"),
+        ({"adapter": "other-adapter"}, "adapter_mismatch"),
+        ({"runtime_dependency_sha256": "2" * 64}, "runtime_dependency_mismatch"),
+        (
+            {
+                "execution_mode": "persistent_context",
+                "memory_visibility_policy": "persistent_context",
+            },
+            "execution_mode_mismatch",
+        ),
+        ({"memory_visibility_policy": "raw_evidence_only"}, "memory_visibility_policy_mismatch"),
+        ({"max_turns_per_session": 21}, "max_turns_per_session_mismatch"),
+    ],
+)
+def test_target_must_match_every_selected_condition_dimension(
+    tmp_path: Path,
+    updates: dict[str, object],
+    expected_reason: str,
+) -> None:
+    selected = _condition()
+    calibration = _write_record(
+        tmp_path,
+        experiment_id="calibration",
+        trial_id="calibration-001",
+        visibility=Visibility.PUBLIC,
+        package_sha256="a" * 64,
+        reward=1.0,
+        condition=selected,
+    )
+    target = _write_record(
+        tmp_path,
+        experiment_id="target",
+        trial_id="target-001",
+        visibility=Visibility.HOLDOUT,
+        package_sha256="b" * 64,
+        reward=1.0,
+        condition=selected.model_copy(update=updates),
+    )
+
+    result = build_lifecycle_transfer_evaluation(
+        _spec(condition=selected, calibration=(calibration.reference,), targets=(target.reference,))
+    )
+
+    assert result.status == "not_evaluable"
+    assert expected_reason in result.target_results[0].reasons
+    assert result.mean_target_reward is None
+
+
+@pytest.mark.parametrize("tamper", ["record", "artifact"])
+def test_tampered_record_or_snapshot_artifact_is_not_evaluable(tmp_path: Path, tamper: str) -> None:
+    condition = _condition()
+    calibration = _write_record(
+        tmp_path,
+        experiment_id="calibration",
+        trial_id="calibration-001",
+        visibility=Visibility.PUBLIC,
+        package_sha256="a" * 64,
+        reward=1.0,
+        condition=condition,
+    )
+    target = _write_record(
+        tmp_path,
+        experiment_id="target",
+        trial_id="target-001",
+        visibility=Visibility.HOLDOUT,
+        package_sha256="b" * 64,
+        reward=1.0,
+        condition=condition,
+    )
+    if tamper == "record":
+        target.record_path.write_bytes(target.record_path.read_bytes() + b"\n")
+        expected_reason = "record_sha256_mismatch"
+    else:
+        target.snapshot_path.write_text("tampered", encoding="utf-8")
+        expected_reason = "artifact_sha256_mismatch"
+
+    result = build_lifecycle_transfer_evaluation(
+        _spec(condition=condition, calibration=(calibration.reference,), targets=(target.reference,))
+    )
+
+    assert result.status == "not_evaluable"
+    assert expected_reason in result.target_results[0].reasons
+    assert result.mean_target_reward is None
+
+
+@pytest.mark.parametrize(
+    "tampered_field",
+    ["reward", "validity_errors", "completeness", "visibility", "package_sha256"],
+)
+def test_rehashed_record_fields_must_still_match_the_immutable_snapshot(
+    tmp_path: Path,
+    tampered_field: str,
+) -> None:
+    condition = _condition()
+    calibration = _write_record(
+        tmp_path,
+        experiment_id="calibration",
+        trial_id="calibration-001",
+        visibility=Visibility.PUBLIC,
+        package_sha256="a" * 64,
+        reward=1.0,
+        condition=condition,
+    )
+    target_visibility = Visibility.PUBLIC if tampered_field == "visibility" else Visibility.HOLDOUT
+    target_package = "a" * 64 if tampered_field == "package_sha256" else "b" * 64
+    target = _write_record(
+        tmp_path,
+        experiment_id="target",
+        trial_id="target-001",
+        visibility=target_visibility,
+        package_sha256=target_package,
+        reward=1.0,
+        condition=condition,
+        completeness=(Completeness.PARTIAL if tampered_field == "completeness" else Completeness.COMPLETE),
+        repository_kind=("source_tree" if tampered_field == "completeness" else "git"),
+    )
+    payload = json.loads(target.record_path.read_text(encoding="utf-8"))
+    if tampered_field == "reward":
+        payload["evaluation"]["reward"] = 0.25
+    elif tampered_field == "validity_errors":
+        payload["evaluation"]["validity"]["errors"] = ["forged"]
+    elif tampered_field == "completeness":
+        payload["completeness"] = "complete"
+    elif tampered_field == "visibility":
+        payload["task"]["visibility"] = "holdout"
+    else:
+        payload["task"]["task_revision"] = "b" * 64
+        payload["lifecycle_provenance"]["package_sha256"] = "b" * 64
+    target.record_path.write_text(json.dumps(payload), encoding="utf-8")
+    reference = target.reference.model_copy(update={"sha256": _sha256(target.record_path)})
+
+    result = build_lifecycle_transfer_evaluation(
+        _spec(condition=condition, calibration=(calibration.reference,), targets=(reference,))
+    )
+
+    assert result.status == "not_evaluable"
+    assert "snapshot_record_mismatch" in result.target_results[0].reasons
+    assert result.mean_target_reward is None
+
+
+def test_repointed_verification_artifact_must_match_the_invocation_manifest(tmp_path: Path) -> None:
+    condition = _condition()
+    calibration = _write_record(
+        tmp_path,
+        experiment_id="calibration",
+        trial_id="calibration-001",
+        visibility=Visibility.PUBLIC,
+        package_sha256="a" * 64,
+        reward=1.0,
+        condition=condition,
+    )
+    target = _write_record(
+        tmp_path,
+        experiment_id="target",
+        trial_id="target-001",
+        visibility=Visibility.HOLDOUT,
+        package_sha256="b" * 64,
+        reward=1.0,
+        condition=condition,
+    )
+    forged_verification = target.snapshot_path.with_name("forged-verification.json")
+    forged_payload = json.loads(target.snapshot_path.read_text(encoding="utf-8"))
+    forged_payload["reward"] = 0.25
+    forged_verification.write_text(json.dumps(forged_payload), encoding="utf-8")
+    payload = json.loads(target.record_path.read_text(encoding="utf-8"))
+    payload["evaluation"]["reward"] = 0.25
+    payload["outputs"]["artifacts"][0] = {
+        "kind": "lifecycle_verification",
+        "path": forged_verification.relative_to(target.record_path.parents[1]).as_posix(),
+        "sha256": _sha256(forged_verification),
+        "media_type": "application/json",
+    }
+    target.record_path.write_text(json.dumps(payload), encoding="utf-8")
+    reference = target.reference.model_copy(update={"sha256": _sha256(target.record_path)})
+
+    result = build_lifecycle_transfer_evaluation(
+        _spec(condition=condition, calibration=(calibration.reference,), targets=(reference,))
+    )
+
+    assert result.status == "not_evaluable"
+    assert "snapshot_record_mismatch" in result.target_results[0].reasons
+
+
+@pytest.mark.parametrize("integrity_failure", ["missing", "path_escape"])
+def test_missing_or_escaping_snapshot_artifact_is_not_evaluable(
+    tmp_path: Path,
+    integrity_failure: str,
+) -> None:
+    condition = _condition()
+    calibration = _write_record(
+        tmp_path,
+        experiment_id="calibration",
+        trial_id="calibration-001",
+        visibility=Visibility.PUBLIC,
+        package_sha256="a" * 64,
+        reward=1.0,
+        condition=condition,
+    )
+    target = _write_record(
+        tmp_path,
+        experiment_id="target",
+        trial_id="target-001",
+        visibility=Visibility.HOLDOUT,
+        package_sha256="b" * 64,
+        reward=1.0,
+        condition=condition,
+    )
+    reference = target.reference
+    if integrity_failure == "missing":
+        target.snapshot_path.unlink()
+        expected_reason = "artifact_missing"
+    else:
+        payload = json.loads(target.record_path.read_text(encoding="utf-8"))
+        payload["outputs"]["artifacts"][0]["path"] = "../outside.json"
+        target.record_path.write_text(json.dumps(payload), encoding="utf-8")
+        reference = reference.model_copy(update={"sha256": _sha256(target.record_path)})
+        expected_reason = "artifact_path_escapes_ledger"
+
+    result = build_lifecycle_transfer_evaluation(
+        _spec(condition=condition, calibration=(calibration.reference,), targets=(reference,))
+    )
+
+    assert result.status == "not_evaluable"
+    assert expected_reason in result.target_results[0].reasons
+
+
+def test_eligible_zero_reward_is_evaluated_as_zero_not_missing_evidence(tmp_path: Path) -> None:
+    condition = _condition()
+    calibration = _write_record(
+        tmp_path,
+        experiment_id="calibration",
+        trial_id="calibration-001",
+        visibility=Visibility.PUBLIC,
+        package_sha256="a" * 64,
+        reward=1.0,
+        condition=condition,
+    )
+    target = _write_record(
+        tmp_path,
+        experiment_id="target",
+        trial_id="target-001",
+        visibility=Visibility.HOLDOUT,
+        package_sha256="b" * 64,
+        reward=0.0,
+        condition=condition,
+    )
+
+    result = build_lifecycle_transfer_evaluation(
+        _spec(condition=condition, calibration=(calibration.reference,), targets=(target.reference,))
+    )
+
+    assert result.status == "evaluated"
+    assert result.eligible_target_count == 1
+    assert result.mean_target_reward == 0.0
+    assert result.target_results[0].verifier_validity is not None
+
+
+def test_input_order_does_not_change_evaluation_identity_or_summary(tmp_path: Path) -> None:
+    condition = _condition()
+    calibrations = tuple(
+        _write_record(
+            tmp_path,
+            experiment_id="calibration",
+            trial_id=f"calibration-{index}",
+            visibility=Visibility.PUBLIC,
+            package_sha256=character * 64,
+            reward=1.0,
+            condition=condition,
+        )
+        for index, character in enumerate(("a", "b"), start=1)
+    )
+    targets = tuple(
+        _write_record(
+            tmp_path,
+            experiment_id="target",
+            trial_id=f"target-{index}",
+            visibility=Visibility.HOLDOUT,
+            package_sha256=character * 64,
+            reward=reward,
+            condition=condition,
+        )
+        for index, (character, reward) in enumerate((("c", 0.25), ("d", 0.75)), start=1)
+    )
+
+    forward = build_lifecycle_transfer_evaluation(
+        _spec(
+            condition=condition,
+            calibration=tuple(item.reference for item in calibrations),
+            targets=tuple(item.reference for item in targets),
+        )
+    )
+    reverse = build_lifecycle_transfer_evaluation(
+        _spec(
+            condition=condition,
+            calibration=tuple(item.reference for item in reversed(calibrations)),
+            targets=tuple(item.reference for item in reversed(targets)),
+        )
+    )
+
+    assert forward == reverse
+    assert forward.mean_target_reward == 0.5
+
+
+def test_cloned_record_identity_cannot_reuse_one_immutable_invocation(tmp_path: Path) -> None:
+    condition = _condition()
+    calibration = _write_record(
+        tmp_path,
+        experiment_id="calibration",
+        trial_id="calibration-001",
+        visibility=Visibility.PUBLIC,
+        package_sha256="a" * 64,
+        reward=1.0,
+        condition=condition,
+    )
+    target = _write_record(
+        tmp_path,
+        experiment_id="target",
+        trial_id="target-001",
+        visibility=Visibility.HOLDOUT,
+        package_sha256="b" * 64,
+        reward=1.0,
+        condition=condition,
+    )
+    clone_path = target.record_path.with_name("target-002.json")
+    clone_payload = json.loads(target.record_path.read_text(encoding="utf-8"))
+    clone_payload["trial_id"] = "target-002"
+    clone_path.write_text(json.dumps(clone_payload), encoding="utf-8")
+    clone_reference = LifecycleTransferRecordReference(
+        experiment_id="target",
+        trial_id="target-002",
+        ledger_path=str(clone_path),
+        sha256=_sha256(clone_path),
+    )
+
+    result = build_lifecycle_transfer_evaluation(
+        _spec(
+            condition=condition,
+            calibration=(calibration.reference,),
+            targets=(target.reference, clone_reference),
+        )
+    )
+
+    assert result.eligible_target_count == 1
+    assert result.target_results[1].status == "not_evaluable"
+    assert "snapshot_record_mismatch" in result.target_results[1].reasons
+
+
+def test_malformed_verifier_result_cannot_support_evaluation(tmp_path: Path) -> None:
+    condition = _condition()
+    calibration = _write_record(
+        tmp_path,
+        experiment_id="calibration",
+        trial_id="calibration-001",
+        visibility=Visibility.PUBLIC,
+        package_sha256="a" * 64,
+        reward=1.0,
+        condition=condition,
+        verification_overall="nonsense",
+    )
+    target = _write_record(
+        tmp_path,
+        experiment_id="target",
+        trial_id="target-001",
+        visibility=Visibility.HOLDOUT,
+        package_sha256="b" * 64,
+        reward=1.0,
+        condition=condition,
+    )
+
+    result = build_lifecycle_transfer_evaluation(
+        _spec(condition=condition, calibration=(calibration.reference,), targets=(target.reference,))
+    )
+
+    assert result.calibration_support_count == 0
+    assert "snapshot_contract_invalid" in result.calibration_results[0].reasons
+
+
+@pytest.mark.parametrize(
+    ("verification_lifecycle_id", "verification_template_id"),
+    [
+        ("wrong-lifecycle", "drainage-model-evidence-lifecycle-review"),
+        ("lifecycle-calibration-001", "wrong-template"),
+    ],
+)
+def test_verifier_identity_must_match_the_lifecycle_record(
+    tmp_path: Path,
+    verification_lifecycle_id: str,
+    verification_template_id: str,
+) -> None:
+    condition = _condition()
+    calibration = _write_record(
+        tmp_path,
+        experiment_id="calibration",
+        trial_id="calibration-001",
+        visibility=Visibility.PUBLIC,
+        package_sha256="a" * 64,
+        reward=1.0,
+        condition=condition,
+        verification_lifecycle_id=verification_lifecycle_id,
+        verification_template_id=verification_template_id,
+    )
+    target = _write_record(
+        tmp_path,
+        experiment_id="target",
+        trial_id="target-001",
+        visibility=Visibility.HOLDOUT,
+        package_sha256="b" * 64,
+        reward=1.0,
+        condition=condition,
+    )
+
+    result = build_lifecycle_transfer_evaluation(
+        _spec(condition=condition, calibration=(calibration.reference,), targets=(target.reference,))
+    )
+
+    assert result.calibration_support_count == 0
+    assert "snapshot_record_mismatch" in result.calibration_results[0].reasons
+
+
+@pytest.mark.parametrize("value", [True, 20.0, "20"])
+def test_recorded_condition_turn_limit_is_a_strict_integer(value: object) -> None:
+    payload = LifecycleExecutionRecord(
+        execution_mode="fresh_context",
+        memory_visibility_policy="artifact_memory",
+        max_turns_per_session=20,
+        status="completed",
+        sessions=[
+            LifecycleSessionRecord(
+                session_id="session-001",
+                adapter="tool_loop",
+                resolved_model="model-a",
+                status="completed",
+            )
+        ],
+    ).model_dump(mode="json")
+    payload["max_turns_per_session"] = value
+
+    with pytest.raises(ValidationError, match="positive integer"):
+        LifecycleExecutionRecord.model_validate(payload)
+
+
+def test_duplicate_record_references_are_rejected(tmp_path: Path) -> None:
+    condition = _condition()
+    calibration = _write_record(
+        tmp_path,
+        experiment_id="calibration",
+        trial_id="calibration-001",
+        visibility=Visibility.PUBLIC,
+        package_sha256="a" * 64,
+        reward=1.0,
+        condition=condition,
+    )
+    target = _write_record(
+        tmp_path,
+        experiment_id="target",
+        trial_id="target-001",
+        visibility=Visibility.HOLDOUT,
+        package_sha256="b" * 64,
+        reward=1.0,
+        condition=condition,
+    )
+
+    with pytest.raises(ValidationError, match="duplicate lifecycle transfer record reference"):
+        _spec(
+            condition=condition,
+            calibration=(calibration.reference, calibration.reference),
+            targets=(target.reference,),
+        )
+
+
+def test_path_aliases_cannot_duplicate_one_physical_record(tmp_path: Path) -> None:
+    condition = _condition()
+    calibration = _write_record(
+        tmp_path,
+        experiment_id="calibration",
+        trial_id="calibration-001",
+        visibility=Visibility.PUBLIC,
+        package_sha256="a" * 64,
+        reward=1.0,
+        condition=condition,
+    )
+    target = _write_record(
+        tmp_path,
+        experiment_id="target",
+        trial_id="target-001",
+        visibility=Visibility.HOLDOUT,
+        package_sha256="b" * 64,
+        reward=1.0,
+        condition=condition,
+    )
+    alias_path = target.record_path.parent / ".." / target.record_path.parent.name / target.record_path.name
+    alias = target.reference.model_copy(update={"ledger_path": str(alias_path)})
+
+    with pytest.raises(ValidationError, match="canonical"):
+        _spec(
+            condition=condition,
+            calibration=(calibration.reference,),
+            targets=(target.reference, alias),
+        )
+
+
+@pytest.mark.parametrize("value", [True, 1.0, "1"])
+def test_selected_condition_turn_limit_is_a_strict_integer(value: object) -> None:
+    payload = _condition().model_dump(mode="json")
+    payload["max_turns_per_session"] = value
+
+    with pytest.raises(ValidationError, match="positive integer"):
+        LifecycleTransferCondition.model_validate(payload)
+
+
+def _spec(
+    *,
+    condition: LifecycleTransferCondition,
+    calibration: tuple[LifecycleTransferRecordReference, ...],
+    targets: tuple[LifecycleTransferRecordReference, ...],
+) -> LifecycleTransferEvaluationSpec:
+    return LifecycleTransferEvaluationSpec(
+        study_design=LifecycleTransferStudyDesign(
+            interpretation="descriptive_holdout_generalization",
+            selection_basis="public_calibration",
+            causal_effects_supported=False,
+            cross_run_learning_supported=False,
+        ),
+        selected_condition=condition,
+        public_calibration_records=calibration,
+        holdout_target_records=targets,
+    )
+
+
+def _condition() -> LifecycleTransferCondition:
+    return LifecycleTransferCondition(
+        model="model-a",
+        adapter="tool_loop",
+        runtime_dependency_sha256=_RUNTIME_SHA256,
+        execution_mode="fresh_context",
+        memory_visibility_policy="artifact_memory",
+        max_turns_per_session=20,
+    )
+
+
+class _WrittenRecord:
+    def __init__(
+        self,
+        *,
+        reference: LifecycleTransferRecordReference,
+        record_path: Path,
+        snapshot_path: Path,
+    ) -> None:
+        self.reference = reference
+        self.record_path = record_path
+        self.snapshot_path = snapshot_path
+
+
+def _write_record(
+    tmp_path: Path,
+    *,
+    experiment_id: str,
+    trial_id: str,
+    visibility: Visibility | None,
+    package_sha256: str,
+    reward: float,
+    condition: LifecycleTransferCondition,
+    completeness: Completeness = Completeness.COMPLETE,
+    verifier_completed: bool = True,
+    semantic_transition: dict[str, object] | None = None,
+    repository_kind: str = "git",
+    verification_overall: str | None = None,
+    verification_lifecycle_id: str | None = None,
+    verification_template_id: str = "drainage-model-evidence-lifecycle-review",
+) -> _WrittenRecord:
+    ledger_root = tmp_path / "ledger"
+    artifact_root = ledger_root / experiment_id / "_artifacts" / trial_id
+    artifact_root.mkdir(parents=True, exist_ok=True)
+    snapshot_path = artifact_root / "verification.json"
+    verification_payload: dict[str, object] = {
+        "reward": reward,
+        "overall": verification_overall or ("pass" if verifier_completed else "incomplete"),
+        "lifecycle_id": verification_lifecycle_id or f"lifecycle-{trial_id}",
+        "template_id": verification_template_id,
+        "passed": verifier_completed,
+        "gates": {
+            "terminal": {
+                "passed": verifier_completed,
+                "score": reward,
+                "failures": [] if verifier_completed else ["incomplete"],
+            }
+        },
+    }
+    if semantic_transition is not None:
+        verification_payload["semantic_metrics"] = semantic_transition
+    snapshot_path.write_text(json.dumps(verification_payload, sort_keys=True), encoding="utf-8")
+    snapshot = ArtifactReference(
+        kind="lifecycle_verification",
+        path=snapshot_path.relative_to(ledger_root).as_posix(),
+        sha256=_sha256(snapshot_path),
+        media_type="application/json",
+    )
+    state_path = artifact_root / "state.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "3",
+                "lifecycle_id": f"lifecycle-{trial_id}",
+                "world_id": f"world-{trial_id}",
+                "lifecycle_spec_sha256": "3" * 64,
+                "package_sha256": package_sha256,
+                "status": "complete",
+                "active_checkpoint_id": None,
+                "checkpoint_runs": [
+                    {
+                        "checkpoint_id": checkpoint_id,
+                        "status": "submitted",
+                        "submission_path": f"episodes/{checkpoint_id}/submission.json",
+                        "submission_sha256": "7" * 64,
+                    }
+                    for checkpoint_id in ("initial", "corrected")
+                ],
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    state_reference = ArtifactReference(
+        kind="lifecycle_state",
+        path=state_path.relative_to(ledger_root).as_posix(),
+        sha256=_sha256(state_path),
+        media_type="application/json",
+    )
+    invocation_path = artifact_root / "experiment-manifest.json"
+    visibility_value = visibility.value if visibility is not None else None
+    invocation_payload = {
+        "schema_version": "1",
+        "experiment_id": f"invocation-{trial_id}",
+        "created_at": "2026-07-12T00:00:00+00:00",
+        "repository": {
+            "commit": "commit-abc",
+            "repository_kind": repository_kind,
+            "dirty": False,
+            "dirty_digest": "4" * 64,
+        },
+        "environment": {
+            "runtime_provenance": {
+                "provider": "local",
+                "distributions": ["aec-bench==0.1.0"],
+                "dependency_inventory_sha256": condition.runtime_dependency_sha256,
+            }
+        },
+        "lifecycle": {
+            "lifecycle_id": f"lifecycle-{trial_id}",
+            "world_id": f"world-{trial_id}",
+            "spec_sha256": "3" * 64,
+            "package_sha256": package_sha256,
+            "variant": {"visibility": visibility_value},
+        },
+        "verifier": {
+            "qualified_name": "tests.verify",
+            "source_sha256": "5" * 64,
+        },
+        "model": {
+            "resolved_models": [condition.model],
+            "resolved_adapters": [condition.adapter],
+        },
+        "execution": {
+            "mode": condition.execution_mode,
+            "memory_visibility_policy": condition.memory_visibility_policy,
+            "max_turns_per_session": condition.max_turns_per_session,
+            "status": "completed",
+            "session_count": 1,
+        },
+        "interaction": {},
+        "sweep": {
+            "schema_version": "1",
+            "sweep_experiment_id": experiment_id,
+            "planned_trial_id": trial_id,
+            "plan_sha256": "6" * 64,
+            "condition_id": f"{condition.execution_mode}__{condition.memory_visibility_policy}",
+            "repetition": 1,
+        },
+        "outputs": {
+            "verification.json": snapshot.sha256,
+            "artifacts": {
+                "verification.json": snapshot.sha256,
+                "state.json": state_reference.sha256,
+            },
+        },
+    }
+    invocation_path.write_text(json.dumps(invocation_payload, sort_keys=True), encoding="utf-8")
+    invocation = ArtifactReference(
+        kind="lifecycle_manifest",
+        path=invocation_path.relative_to(ledger_root).as_posix(),
+        sha256=_sha256(invocation_path),
+        media_type="application/json",
+    )
+    index_path = artifact_root / "index-entry.json"
+    index_path.write_text(
+        json.dumps(
+            {
+                "experiment_id": invocation_payload["experiment_id"],
+                "manifest_sha256": _sha256(invocation_path),
+                "sweep": invocation_payload["sweep"],
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    invocation_index = ArtifactReference(
+        kind="lifecycle_invocation_index",
+        path=index_path.relative_to(ledger_root).as_posix(),
+        sha256=_sha256(index_path),
+        media_type="application/json",
+    )
+    ablation_manifest_path = artifact_root / "ablation-manifest.json"
+    ablation_manifest_path.write_text(json.dumps({"schema_version": "1"}, sort_keys=True), encoding="utf-8")
+    ablation_manifest = ArtifactReference(
+        kind="lifecycle_ablation_manifest",
+        path=ablation_manifest_path.relative_to(ledger_root).as_posix(),
+        sha256=_sha256(ablation_manifest_path),
+        media_type="application/json",
+    )
+    ablation_plan_path = artifact_root / "ablation-plan.json"
+    ablation_plan_path.write_text(json.dumps({"schema_version": "1"}, sort_keys=True), encoding="utf-8")
+    ablation_plan = ArtifactReference(
+        kind="lifecycle_ablation_plan",
+        path=ablation_plan_path.relative_to(ledger_root).as_posix(),
+        sha256=_sha256(ablation_plan_path),
+        media_type="application/json",
+    )
+    breakdown = {
+        "lifecycle_gates": verification_payload["gates"],
+        "semantic_transition": semantic_transition,
+        "operational_metrics": {},
+    }
+    record = TrialRecord(
+        trial_id=trial_id,
+        experiment_id=experiment_id,
+        timestamp=datetime(2026, 7, 12, tzinfo=UTC),
+        task=TaskReference(
+            task_id="drainage-model-evidence-lifecycle-review",
+            task_revision=package_sha256,
+            visibility=visibility,
+        ),
+        agent=AgentReference(
+            adapter=condition.adapter,
+            model=condition.model,
+            adapter_revision="commit-abc",
+            configuration={},
+        ),
+        environment=EnvironmentSnapshot(
+            runtime_image="python:3.13",
+            compute_backend="local",
+            tool_versions={"aec_bench": "commit-abc"},
+        ),
+        inputs=InputRecord(
+            instruction="Review the evolving evidence.",
+            input_files=[FileReference(path="input.json", hash="input-sha")],
+        ),
+        outputs=OutputRecord(
+            artifacts=[
+                snapshot,
+                state_reference,
+                invocation,
+                invocation_index,
+                ablation_manifest,
+                ablation_plan,
+            ]
+        ),
+        evaluation=EvaluationResult(
+            reward=reward,
+            validity=ValidityCheck(
+                output_parseable=True,
+                schema_valid=verifier_completed,
+                verifier_completed=verifier_completed,
+                errors=[] if verifier_completed else ["terminal:incomplete"],
+            ),
+            breakdown=breakdown,
+        ),
+        timing=TimingRecord(total_seconds=1.0),
+        lifecycle_execution=LifecycleExecutionRecord(
+            execution_mode=condition.execution_mode,
+            memory_visibility_policy=condition.memory_visibility_policy,
+            max_turns_per_session=condition.max_turns_per_session,
+            status="completed",
+            sessions=[
+                LifecycleSessionRecord(
+                    session_id=f"{trial_id}-session",
+                    checkpoint_ids=["initial", "corrected"],
+                    requested_adapter=condition.adapter,
+                    adapter=condition.adapter,
+                    resolved_model=condition.model,
+                    execution_mode=condition.execution_mode,
+                    memory_visibility_policy=condition.memory_visibility_policy,
+                    status="completed",
+                    artifacts=[snapshot],
+                )
+            ],
+        ),
+        lifecycle_provenance=LifecycleTrialProvenance(
+            lifecycle_id=f"lifecycle-{trial_id}",
+            world_id=f"world-{trial_id}",
+            spec_sha256="3" * 64,
+            package_sha256=package_sha256,
+            repository_commit="commit-abc",
+            repository_kind=repository_kind,
+            repository_dirty=False,
+            repository_dirty_digest="4" * 64,
+            runtime_provider="local",
+            runtime_distributions=("aec-bench==0.1.0",),
+            runtime_dependency_sha256=condition.runtime_dependency_sha256,
+            verifier_qualified_name="tests.verify",
+            verifier_source_sha256="5" * 64,
+            invocation_manifest=invocation,
+            invocation_index=invocation_index,
+            ablation_manifest=ablation_manifest,
+            ablation_plan=ablation_plan,
+        ),
+        completeness=completeness,
+    )
+    record_path = ledger_root / experiment_id / f"{trial_id}.json"
+    record_path.parent.mkdir(parents=True, exist_ok=True)
+    record_path.write_text(record.model_dump_json(indent=2), encoding="utf-8")
+    return _WrittenRecord(
+        reference=LifecycleTransferRecordReference(
+            experiment_id=experiment_id,
+            trial_id=trial_id,
+            ledger_path=str(record_path),
+            sha256=_sha256(record_path),
+        ),
+        record_path=record_path,
+        snapshot_path=snapshot_path,
+    )
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()


### PR DESCRIPTION
## Summary

- Preserve explicit task visibility in newly written TrialRecords while allowing historical records that omitted the field to keep validating without backfilling it.
- Add a build-only, ledger-derived lifecycle transfer evaluator with typed study design, selected condition, record references, calibration support, target eligibility, and summary contracts.
- Require explicit public calibration and holdout target visibility, exact selected-condition identity, complete verifier-finished records, distinct target packages, and immutable record/snapshot integrity.
- Reconcile TrialRecord claims against typed invocation, state, verification, and sweep artifacts before reporting canonical target reward, validity, or optional semantic diagnostics.
- Document the holdout boundary and deliberately defer CLI publication, generic evaluation persistence, target materialization, and model execution.

## Interpretation boundary

This PR reports **descriptive holdout generalization** under a condition selected from public calibration evidence. It does not estimate causal effects, select a winner, demonstrate learner transfer, or claim continual learning.

The evaluator performs no model, adapter, provider, verifier, or campaign execution and requires no provider credentials.

## Stack

This draft is stacked on [PR #15](https://github.com/TheodoreGalanos/aec-bench/pull/15) and targets its head branch, `feat/ssc03-prime-lifecycle-export`.

## Validation

- Full suite: 5,320 passed, 20 skipped, 5 known warnings.
- Affected tests: 123 passed, 4 skipped.
- Transfer evaluator: 40 passed.
- Repository-wide Ruff lint and format checks: clean.
- Declared contracts mypy gate plus strict checks for all changed source modules: clean.
- Staged diff check: clean.
- Independent final correctness review: no P0-P2 findings.
