### PR TITLE
Add action-conditioned lifecycle evidence

### DIFF
--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -140,11 +140,23 @@ Key rule:
 
 **Boundary:** Evidence-lifecycle host -> Episode environment -> Evidence-lifecycle host
 
-`LifecycleEpisodeRequest` is content-bound to the lifecycle and package hashes and carries host-allocated episode, attempt, and session identity; ordered checkpoint ownership; execution mode; visibility policy; requested adapter/model identity; the per-session turn limit; model-visible instruction; confined workspace and submission paths; and completed-checkpoint lineage. The host asks the environment to durably prepare its empty attempt artifacts, publishes the request, records its SHA-256 in the active attempt, then executes. Recovery and TrialRecord finalization reject request bytes or stable identity that disagree with attempt state, package state, or the declared execution condition.
+`LifecycleEpisodeRequest` is content-bound to the lifecycle and package hashes and carries host-allocated episode, attempt, and session identity; ordered checkpoint ownership; execution mode; visibility policy; requested adapter/model identity; the per-session turn limit; model-visible instruction; confined workspace and submission paths; completed-checkpoint lineage; the public conditional-evidence catalogue; and hashes of conditional evidence acquired by prior attempts. The host asks the environment to durably prepare its empty attempt artifacts, publishes the request, records its SHA-256 in the active attempt, then executes. Recovery and TrialRecord finalization reject request bytes or stable identity that disagree with attempt state, package state, or the declared execution condition.
 
 `LifecycleEpisodeResult` returns only execution-owned state: exact request identity, checkpoint ownership, requested and resolved adapter/model identity, per-session turn limit, configuration, status, failures, and token usage. Strict validation rejects undeclared fields, including verifier gates, pass/fail, expected answers, and reward. The host publishes a validated per-attempt result, preserves failed candidate submissions under their owning sessions, and alone validates and archives successful checkpoint submissions, releases later evidence, and invokes the task-owned verifier after lifecycle execution.
 
 Fresh-context requests own exactly one checkpoint. Persistent execution remains a separate one-session orchestration and must not be represented as repeated fresh episode calls.
+
+### ConditionalEvidenceSpec / EvidenceRequestActionRecord
+
+**Boundary:** Public lifecycle package -> Evidence-lifecycle host -> Model-visible workspace
+
+`ConditionalEvidenceSpec` is an optional checkpoint contract containing a positive request budget and one or more public `EvidenceRequestSpec` records. Each request carries a safe ID, title, description, and same-checkpoint prerequisite IDs. IDs are unique, prerequisites must exist, the graph is acyclic, and every request's transitive prerequisite closure plus the request itself must fit within the checkpoint budget. Public request records cannot contain source paths.
+
+The task-owned hidden resolution manifest has exact `(checkpoint_id, request_id)` correspondence with the public catalogue and confines every source to `hidden/evidence_requests/<checkpoint-id>/<request-id>/`. The model-visible projection is fixed at `workspace/inbox/<checkpoint-id>/requests/<request-id>/`; ordinary checkpoint releases cannot occupy the reserved `requests/` namespace.
+
+`EvidenceRequestActionRecord` binds globally contiguous action identity, owning and requested checkpoint identity, request ID and reason, host-bound session/attempt ownership, typed outcome/rejection, pre/post observable-state hashes, canonical and workspace artifact paths and SHA-256 values, budget arithmetic, and branch inheritance. Successful first releases consume one unit; repeated successful requests and typed rejections consume zero. Malformed or blank model-facing arguments are bounded host-call validation failures and do not create lifecycle request actions. Package corruption and session-boundary mismatches are also host failures, not scored model rejections.
+
+Canonical action transactions are published under `run/evidence_requests/<action-id>/` before workspace projection and state commit. Recovery must adopt matching bytes exactly once, reject conflicts, repair missing transition/action ledger entries, and never restore consumed budget on retry or branch.
 
 ### TrialRecord
 
@@ -184,6 +196,7 @@ Key rule:
 - a `complete` record must contain enough provenance to support reproducibility claims.
 - a complete lifecycle record must reference hashed immutable output artifacts; paths back into a mutable working run are not sufficient.
 - lifecycle finalization must reconcile every session, token total, task revision, verification result, and artifact hash against the canonical invocation and its immutable snapshot before publication.
+- action-capable lifecycle snapshots must contain every canonical evidence-request action, commit marker, released artifact, public catalogue, and model-visible projection; state, metrics, protocol hash, and tool-schema hash must reconcile without using model prose.
 - the planned runtime provider, sorted dependency distributions, and realized dependency-byte fingerprint must exactly match the canonical invocation before publication.
 - every submitted lifecycle checkpoint must resolve to exactly one final submitted attempt and a durable session owner.
 - every fresh-context session must own exactly one checkpoint; retries use distinct attempt-specific sessions.

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -133,6 +133,9 @@ For evidence-lifecycle tasks, the host owns file disclosure and checkpoint trans
 
 Python enforcement direction:
 - release only the active checkpoint's declared evidence;
+- expose conditional evidence only through public request IDs and a finite host-owned budget sufficient to reach every declared request; never expose hidden resolution paths or expected outcomes;
+- bind every boundary-valid evidence request to the active host-owned session and attempt, publish a canonical sequence-addressed and hash-bound transaction before model visibility, and record typed zero-cost rejections without leaking valid alternatives;
+- retain acquired conditional evidence and consumed budget across retry and branch inheritance; a derived run cannot unsee evidence visible at its branch point;
 - archive and hash submissions before advancing;
 - represent revision of an earlier submission as a derived branch;
 - persist attempts, interruptions, failures, resumes, revisits, and visibility policy;
@@ -142,6 +145,7 @@ Python enforcement direction:
 - refuse non-empty lifecycle materialization targets and validate variant identity against package content before verification or indexing;
 - finalize lifecycle sweeps through one append-only core `TrialRecord` per planned invocation;
 - snapshot and hash lifecycle inputs and outputs under the ledger before claiming a complete record;
+- snapshot and reconcile conditional action records, commit markers, released bytes, public catalogues, workspace projections, action metrics, and interaction-protocol/tool-schema fingerprints;
 - bind plan and trial identity to materialized package/spec hashes, the actual registered scorer, and the declared aec-bench source inventory;
 - bind each trial to the selected runtime provider and the realized bytes of its active dependency closure, then recapture and reconcile that fingerprint at invocation finalization;
 - retain each fresh or persistent attempt in its own session directory, including interrupted attempts with unresolved provider identity;

--- a/docs/evaluation-guide.md
+++ b/docs/evaluation-guide.md
@@ -75,9 +75,15 @@ The LLM reviewer follows the same boundary. It can flag verifier
 miscalibration, missing evidence, or event candidates, but it never edits
 `reward.json` or `details.json`.
 
+### Conditional-evidence diagnostics
+
+Evidence-request actions are not directly scored and the request protocol does not own reward. They can change later observations and thereby influence a submission that the task verifier scores. Lifecycle operational metrics derive boundary-valid request actions, first successful releases, repeated releases, typed rejections, consumed budget, and released artifact count from durable host action records rather than model prose. Malformed tool calls remain trajectory evidence but are not lifecycle request actions. The invocation manifest separately binds the versioned request protocol and exact model-visible tool schema.
+
+These values diagnose information-gathering behavior and action efficiency. A successful request is not automatically a useful request, and fewer actions are not automatically better. Reward remains task-owned until a task verifier defines what evidence and engineering consequences were sufficient.
+
 ### Descriptive holdout generalization
 
-Lifecycle transfer evaluation is a post-verifier evidence contract, not another execution stage. It reads hash-pinned immutable `TrialRecord` and snapshot artifacts, requires explicit public-calibration and holdout visibility, and checks an exact selected execution condition before reporting target reward. Partial records, incomplete verification, shared source/target package identity, condition drift, or artifact tampering produce `not_evaluable` with explicit reasons.
+Lifecycle transfer evaluation is a post-verifier evidence contract, not another execution stage. It reads hash-pinned immutable `TrialRecord` and snapshot artifacts, requires explicit public-calibration and holdout visibility, and checks an exact selected execution condition before reporting target reward. Version-4 action snapshots additionally reconcile the public request catalogue, action history, canonical transaction bytes, workspace projections, action metrics, and interaction-protocol/tool-schema fingerprints. Partial records, incomplete verification, shared source/target package identity, condition drift, missing action evidence, or artifact tampering produce `not_evaluable` with explicit reasons.
 
 The result describes holdout generalization under a condition selected on public calibration evidence. It does not report a causal effect, winner, or cross-run learner transfer, and semantic-transition metrics remain optional diagnostics rather than a replacement score. The current API is build-only because generic evaluation persistence does not yet enforce a holdout/internal publication boundary.
 

--- a/docs/meta-harness-guide.md
+++ b/docs/meta-harness-guide.md
@@ -49,9 +49,25 @@ Two additional fresh-context policies define later ablations without deleting au
 
 The host workspace tool enforces visibility. All released evidence, archived submissions, trajectories, and conversations remain on disk for audit regardless of the model-visible policy.
 
+### Action-conditioned evidence
+
+A checkpoint may optionally declare a public conditional-evidence catalogue: bounded request IDs, descriptions, prerequisites, and a finite budget. Every declared request must remain reachable: its transitive prerequisites plus the request itself must fit within that budget. The public contract contains no release path or expected outcome. A task-owned `hidden/evidence-request-resolutions.json` manifest maps those IDs to confined package directories, and the host exposes the catalogue at `workspace/checkpoints/<checkpoint-id>/evidence-requests.json`.
+
+Action-capable packages add one model-visible tool:
+
+```text
+request_evidence(checkpoint_id, request_id, reason)
+```
+
+The host supplies session and attempt identity. A first valid unique request consumes one budget unit and publishes only its selected packet under `workspace/inbox/<checkpoint-id>/requests/<request-id>/`. A repeated successful request returns `already_released` without another charge. Typed rejections for inactive checkpoints, unknown IDs, unmet prerequisites, exhausted budgets, or unsupported checkpoints release nothing and consume zero; responses do not enumerate valid alternatives or hidden mappings.
+
+Each boundary-valid request becomes a lock-serialized canonical transaction under `run/evidence_requests/<action-id>/` before its model-visible projection and state commit. The record binds outcome, reason, session/attempt ownership, pre/post observable-state hashes, budget arithmetic, and artifact hashes. Malformed or blank tool arguments return a bounded error without creating a lifecycle action; they remain visible in the ordinary tool trajectory. Recovery adopts an identically published transaction exactly once, repairs missing ledger entries, and fails closed on conflicting bytes. Acquired evidence and consumed budget survive retry and are inherited by a branch through its branch point.
+
+Fresh episode requests bind the current public catalogue and hashes of previously acquired conditional evidence. Persistent local, fresh-context, and local Prime execution expose the same three public arguments. Packages without a conditional catalogue retain their previous tool set. Invocation manifests bind the versioned action protocol and exact tool schema; immutable snapshots include canonical transactions, catalogues, and workspace projections. See the [SSC-03 richer interaction roadmap](ssc03-richer-interaction-roadmap.md) for the hydraulic and holdout progression.
+
 ### Typed episode boundary
 
-Fresh-context execution crosses a strict `LifecycleEpisodeEnvironment` boundary. Before execution, the host validates the released checkpoint, gives the environment a chance to seal interrupted artifacts, allocates the session and attempt IDs, and constructs a content-bound `LifecycleEpisodeRequest`. The environment durably prepares its empty attempt artifacts; the host then publishes `episode_request.json`, records its SHA-256 in the active attempt, and only then calls `execute`. This ordering leaves recoverable identity even if the process stops in the narrow publication-to-execution window. The request carries lifecycle/package hashes, checkpoint ownership, the exact workspace and submission paths, execution mode, visibility policy, requested adapter/model identity, per-session turn limit, and completed-checkpoint lineage. Recovery reconstructs the expected request from current state and declared environment configuration; finalization reconciles the request hash and stable identity against the immutable snapshot.
+Fresh-context execution crosses a strict `LifecycleEpisodeEnvironment` boundary. Before execution, the host validates the released checkpoint, gives the environment a chance to seal interrupted artifacts, allocates the session and attempt IDs, and constructs a content-bound `LifecycleEpisodeRequest`. The environment durably prepares its empty attempt artifacts; the host then publishes `episode_request.json`, records its SHA-256 in the active attempt, and only then calls `execute`. This ordering leaves recoverable identity even if the process stops in the narrow publication-to-execution window. The request carries lifecycle/package hashes, checkpoint ownership, the exact workspace and submission paths, execution mode, visibility policy, requested adapter/model identity, per-session turn limit, completed-checkpoint lineage, the public conditional-evidence catalogue when present, and hashes of conditional evidence acquired by earlier attempts. Recovery reconstructs the expected request from current state and declared environment configuration; finalization reconciles the request hash and stable identity against the immutable snapshot.
 
 The environment returns a `LifecycleEpisodeResult` containing only execution identity, requested and resolved adapter/model identity, configuration, status, failure details, and token usage. Extra fields are rejected, so an adapter cannot return task-owned gates, pass/fail, or reward through the episode seam. The host requires request/result identity to match exactly and publishes a host-validated `episode_result.json` for every returned result or synthesized execution failure. Exceptions, returned failures, identity drift, and missing or invalid submissions close the active attempt as failed and cannot advance the lifecycle. A candidate submission left by a failed attempt is moved under that attempt's session directory and hash-bound as audit evidence; a retry must create its own candidate.
 
@@ -59,7 +75,7 @@ The environment returns a `LifecycleEpisodeResult` containing only execution ide
 
 ### Local Prime lifecycle boundary
 
-The local Prime lifecycle export exposes the persistent condition through a Verifiers `StatefulToolEnv`. One rollout owns the complete lifecycle and one model conversation. The adapter references existing materialized public packages by absolute path, binds their lifecycle-spec and package hashes, binds the exact local AEC-Bench source provenance, and reuses the host lifecycle workspace and control tools. It does not copy the packages or move checkpoint, visibility, submission, or revisit authority into Prime.
+The local Prime lifecycle export exposes the persistent condition through a Verifiers `StatefulToolEnv`. One rollout owns the complete lifecycle and one model conversation. The adapter references existing materialized public packages by absolute path, binds their lifecycle-spec and package hashes, binds the exact local AEC-Bench source provenance, and reuses the host lifecycle workspace and control tools. Conditional packages also receive the same session-bound `request_evidence` tool; mixed action-capable and legacy selections are rejected so the environment has one honest tool schema. The adapter does not copy the packages or move checkpoint, visibility, evidence-request, submission, or revisit authority into Prime.
 
 The task-owned lifecycle verifier remains the only reward authority and runs only after terminal completion. Incomplete rollouts close their active attempt and receive zero reward. This export is a local execution boundary, not evidence of hosted publication or training, a fresh-context comparison, transfer, or continual learning. See the [Prime Lab integration guide](prime-lab-guide.md) for the export and loading commands.
 
@@ -165,7 +181,7 @@ Every local invocation writes root-level latest views plus an immutable experime
 - `experiments/<experiment-id>/` preserves the canonical record and its `index-entry.json` seal for each failed, interrupted, resumed, or completed invocation;
 - `experiment-index.jsonl` is the shared discovery view, points to each canonical manifest by hash, and is rebuilt under a file lock from valid per-invocation seals after an interrupted append so concurrent repairs cannot lose entries.
 
-This apparatus is an adaptation microscope for fixed-model behavior under staged evidence. Checkpoint progression is ordered and submission-gated; semantic verification occurs over the accumulated lifecycle. It does **not** yet provide action-conditioned evidence transitions, cross-run learner updates, demonstrated transfer, or continual learning.
+This apparatus is an adaptation microscope for fixed-model behavior under staged evidence. Checkpoint progression is ordered and submission-gated; semantic verification occurs over the accumulated lifecycle. It now provides bounded actions that condition subsequent evidence visibility. It does **not** yet provide executable hydraulic state transitions, cross-run learner updates, demonstrated transfer, or continual learning.
 
 ### Semantic transition diagnostics
 

--- a/docs/prime-lab-guide.md
+++ b/docs/prime-lab-guide.md
@@ -85,8 +85,12 @@ One Verifiers rollout spans the whole lifecycle in one persistent conversation.
 The model receives later evidence only after it submits the active checkpoint.
 The environment reuses the host-owned `list_workspace`, `read_workspace_file`,
 `write_checkpoint_submission`, `submit_checkpoint`, and `revisit_checkpoint`
-tools, so the same visibility, path-confinement, immutable-submission, and
-checkpoint-order rules apply inside and outside Prime.
+tools. A package with a conditional-evidence catalogue also receives the
+session-bound `request_evidence(checkpoint_id, request_id, reason)` tool. Legacy
+packages retain the original tool set, and a selected export cannot mix the two
+capabilities. The same visibility, path-confinement, finite-budget,
+immutable-submission, and checkpoint-order rules therefore apply inside and
+outside Prime.
 
 Export one or more materialized public variants with absolute paths:
 
@@ -112,6 +116,14 @@ Reward remains task-owned. `submit_checkpoint` ends the rollout only after the
 final checkpoint is accepted; the registered lifecycle verifier then scores the
 complete run. An incomplete rollout is closed as failed and receives zero
 reward instead of being scored from partial state.
+
+Conditional evidence does not give Prime release authority. Public request IDs,
+descriptions, prerequisites, statuses, and remaining budget are visible in the
+checkpoint catalogue. Hidden package paths stay task-owned. Every boundary-valid
+request is recorded in the same canonical, sequence-addressed and hash-bound host transaction
+used by local persistent and fresh-context execution; malformed arguments return
+a bounded error without becoming lifecycle actions. Session and attempt identity
+are injected by the environment and are not model arguments.
 
 Load the generated package from outside the AEC-Bench repository root. The
 repository has a top-level `agents/` directory that can otherwise shadow the

--- a/docs/ssc03-long-horizon-pr10-pr17.learning.md
+++ b/docs/ssc03-long-horizon-pr10-pr17.learning.md
@@ -1,0 +1,580 @@
+---
+title: From Long Prompts to Rich Engineering Interactions
+date: 2026-07-12
+topic: AEC-Bench long-horizon work from PR10 through PR17
+tags: [aec-bench, long-horizon, ssc-03, provenance, evaluation]
+status: captured
+---
+
+# Learning Capsule: From Long Prompts to Rich Engineering Interactions
+
+## One-Line Takeaway
+
+PR10–PR17 turned one static AI task into a staged review where evidence arrives over time and progress is recorded; a configured task can now offer limited evidence requests, but hydraulic calculations and durable learning remain future work.
+
+**First reading:** Read [the three-checkpoint story](#the-concrete-three-checkpoint-story), [the stack at a glance](#the-whole-stack-at-a-glance), each PR's “Why it mattered” sentence, [where we stand](#where-we-stand-before-pr18), and [the records-room analogy](#best-analogy). Use the detailed PR sections as a reference when PR18 depends on them.
+
+**Scope:** This guide freezes the story at the end of PR17, before PR18. Here, “added” means implemented and tested on the named branch; it does not necessarily mean merged into `main`.
+
+## Starting Intuition
+
+The tempting first idea was that a **long-horizon task** should be a longer task: more pages, more calculations, more steps, and a larger final answer.
+
+That idea is understandable, but it misses the difficult part of real engineering work. An AI can receive a 200-page report in one prompt and still complete a one-shot task. The input is large, but nothing changes while the AI is working. It does not have to wait for a revised drawing, preserve an earlier decision, notice that a new report contradicts an old memo, or refuse to close a finding—a logged review issue—when evidence is missing.
+
+Our course correction was:
+
+> A task becomes meaningfully long-horizon when the situation changes over time and later work depends on preserving the right meaning from earlier work.
+
+That led us away from a “formula marathon” and toward an engineering review loop:
+
+```text
+inspect the current files
+  -> record what passes, fails, or is missing
+  -> receive revised evidence
+  -> update only what the revision justifies
+  -> preserve everything that should stay stable
+  -> close findings only when the required evidence exists
+  -> decide honestly whether the package is ready for use
+```
+
+We chose **SSC-03**, the project label for a stormwater and drainage task family, as the working example. This guide uses **AI model** for the reviewer and **hydraulic model** for the drainage calculation program. The first lifecycle does not ask the AI model to design the whole drainage system. It asks the AI model to check whether a hydraulic-model run, its report, and the later design memo that relies on that report share a trustworthy chain of evidence.
+
+The harness does not update the AI model's learned **weights**, the numerical settings created during training, during these runs. The AI may remember earlier messages or reread saved files, but no durable learner state changes across separate runs. We are building a foundation that may later support **post-training**—training performed after a base model has been created. We are not yet demonstrating **continual learning**, where a system keeps durable learning from a stream of encounters over time.
+
+## Refined Understanding
+
+The work from PR10 to PR17 is best understood as building a trusted structure around the AI model one layer at a time.
+
+The smallest useful mental model is:
+
+```text
+task files
+   ↓
+AEC-Bench reveals the files allowed at this stage
+   ↓
+the AI reviews them and writes a submission
+   ↓
+if the submission has the required structure,
+AEC-Bench archives it and advances the task
+   ↓
+the task's checker, which is separate from the model-running environment,
+scores the completed work
+   ↓
+for campaign runs, a frozen copy protected by a digital fingerprint
+preserves the declared evidence supporting the recorded result
+```
+
+The AI model is the participant. AEC-Bench is the trusted supervisor and records clerk. The model-running environment is the room where the participant works. The task's checker—not the AI or the room operator—decides whether the work is correct.
+
+### Three different meanings of “memory” or “state”
+
+These are easy to mix up:
+
+1. **Conversation memory:** The model can still see earlier messages in the same conversation.
+2. **Saved task state:** AEC-Bench has stored earlier files, submissions, attempts, and decisions on disk.
+3. **Durable learner change:** Training or another learning process changes what the system carries into later, separate runs—for example, updated model weights.
+
+PR10–PR17 build mechanisms for exposing and measuring the first two. They do not yet provide comparative model results or establish the third.
+
+### Why the work came as a stack of pull requests
+
+A **pull request**, or **PR**, is a reviewable bundle of code and documentation changes. Each PR below establishes one rule about who may control what before the next layer depends on it:
+
+```text
+stage the task
+  -> measure changes
+  -> create controlled cases
+  -> run reproducible campaigns
+  -> separate host and environment authority
+  -> test one continuing lifecycle in a local external environment
+  -> define honest reporting for separate test cases
+  -> let AI requests reveal limited extra evidence
+```
+
+“Stacked” means that each later draft branch starts from and depends on the earlier branch. Review the layers from PR10 upward. At this guide's capture date, PR10 is merged and PR11–PR17 are open draft PRs.
+
+Trying to jump straight to a rich hydraulic environment would have left basic questions unanswered. Who controls evidence and reward? What survives a crash, and how do we know which model and files produced a result? Can a retry silently inherit an old answer, or can a secret test-case result leak into public summaries? The stack answers those questions before the physical world becomes more complicated.
+
+## Core Concepts
+
+- **Long-horizon means change over time:** A large prompt is not enough; later work must depend on earlier evidence and decisions.
+- **The host remains trusted:** AEC-Bench controls evidence, checkpoint progression, verification, and reward.
+- **Memory is controlled, not assumed:** Conversation history and saved task files are separate from learning in model parameters.
+- **Every result needs receipts:** Files, code, settings, attempts, and scores must remain traceable to their exact sources, and later alterations must be detectable.
+- **The progression is deliberate:** First build trustworthy interaction and records, then add executable engineering consequences.
+
+### Meet the main pieces
+
+| Term | Simple meaning |
+|---|---|
+| **AEC-Bench** | Software for building and testing AI tasks in architecture, engineering, and construction. |
+| **Task world** | The engineering situation: its files, rules, events, tools, and expected state. |
+| **SSC-03** | The project label for this stormwater and drainage task family. Treat it as a name; do not invent an expansion for “SSC.” |
+| **Host** | The trusted AEC-Bench controller. It decides what is visible, which stage is active, and when checking occurs. |
+| **Environment** | The runtime that presents prompts and tools to the model and returns execution details. It does not decide correctness or reward. |
+| **Model or agent** | The AI participant doing the engineering review. |
+| **Verifier** | Task-owned checking code that decides whether the submitted work meets the task rules. |
+| **Reward** | The score produced from verifier-owned evidence. |
+| **Harness** | The software that runs one task and records what happened. |
+| **Meta-harness** | The experiment manager around the harness. It plans and compares many task runs. |
+
+### The concrete three-checkpoint story
+
+The original SSC-03 lifecycle has three checkpoints.
+
+- A **checkpoint** is a formal stopping point where the AI records its decisions before more evidence appears.
+- **Governing** means accepted as a source that design decisions may rely on.
+- A **finding** is a logged review issue.
+- **Ready to issue** means this synthetic package meets the task's internal closeout rules.
+
+“Ready to issue” does not mean the evidence is approved or safe for use on a real project.
+
+1. **Initial provenance review**
+   - The list of files used for the drainage calculation, called an input manifest, points to an older catchment file and area even though the project's accepted basis contains newer values.
+   - The model should identify that the current run cannot yet govern the design.
+   - One finding remains open and the package is not ready to issue.
+
+2. **Response and rerun review**
+   - A corrected input manifest, a replacement run, and a reissued hydraulic report arrive.
+   - The run and report may now be accepted.
+   - The design memo still refers to the old run, so the final design claim remains unsupported.
+   - A fluent but unsafe reviewer may be tempted to declare victory too early. The task should reject that.
+
+3. **Final closeout review**
+   - A corrected memo arrives and properly cites the governing run and report.
+   - The remaining finding can now close.
+   - Only at this point should the package become ready to issue.
+
+This is intentionally a provenance review. **Provenance** means the receipt trail showing where a conclusion came from: which source revision, which model run, which report, which memo, and which decision.
+
+### The whole stack at a glance
+
+| Step | Pull request | Question answered in plain language |
+|---|---|---|
+| 1 | [PR #10](https://github.com/TheodoreGalanos/aec-bench/pull/10) | Can one task unfold safely through several evidence deliveries? |
+| 2 | [PR #11](https://github.com/TheodoreGalanos/aec-bench/pull/11) | Can we tell whether the model updated correctly rather than merely ending correctly? |
+| 3 | [PR #12](https://github.com/TheodoreGalanos/aec-bench/pull/12) | Can we expose several controlled kinds of change and non-change? |
+| 4 | [PR #13](https://github.com/TheodoreGalanos/aec-bench/pull/13) | Can we plan, run, recover, and preserve a whole calibration campaign? |
+| 5 | [PR #14](https://github.com/TheodoreGalanos/aec-bench/pull/14) | Can another model-running environment execute a checkpoint without taking control of correctness or reward? |
+| 6 | [PR #15](https://github.com/TheodoreGalanos/aec-bench/pull/15) | Can a local external model-running environment carry one continuing review through every checkpoint without taking over checking? |
+| 7 | [PR #16](https://github.com/TheodoreGalanos/aec-bench/pull/16) | Can we report results on separate test cases without pretending they prove learning or cause and effect? |
+| 8 | [PR #17](https://github.com/TheodoreGalanos/aec-bench/pull/17) | Can a limited AI request change which evidence becomes visible next? |
+
+### Step 1 — PR10: Turn one review into an evidence lifecycle
+
+Before PR10, a large task could still reveal everything at once. PR10 created the three-checkpoint story above and made AEC-Bench control the order of evidence release.
+
+An **evidence lifecycle** is one evolving review in which information arrives in stages and later work depends on earlier work.
+
+PR10 added several important rules:
+
+- Future evidence stays hidden until the submission is readable JSON with the correct checkpoint ID and required top-level fields. This checks only that an answer was submitted in the expected shape; the verifier judges engineering correctness later.
+- A submitted checkpoint is archived and cannot be silently rewritten.
+- A **revisit** can read an earlier submission without changing it.
+- A **branch** creates a new derived run from an earlier checkpoint instead of editing the parent history.
+- A crash can be resumed from durable state instead of pretending the run never happened.
+- The run records identifying receipts for the repository and checker code, hashes every task-package file, and records the model setup, prompts, tool calls, timing, token use, estimated cost, and result files.
+
+PR10 also created four execution-and-visibility conditions controlling which earlier information remains available to the model:
+
+| Condition | What the model receives |
+|---|---|
+| **Persistent context** | The same conversation continues across all checkpoints. |
+| **Fresh context with artifact memory** | A new conversation starts with accumulated released evidence and earlier submitted review files visible. |
+| **Fresh context with raw evidence only** | A new conversation sees accumulated source evidence but not earlier submissions. |
+| **Fresh context with current release only** | A new conversation sees only the current checkpoint's instruction and evidence. |
+
+A **visibility policy** is simply the rule deciding which saved materials the model may see. It does not delete the audit copy.
+
+Why PR10 mattered: we could now ask whether a model preserved findings and decisions across revisions instead of asking only whether its final review looked plausible.
+
+Boundary: PR10 kept the evidence schedule fixed. It added neither AI-chosen evidence, hydraulic execution, nor a model-performance campaign.
+
+Why the next step was needed: PR10's final score and runtime logs could not show whether the model changed its engineering conclusions for the right reason.
+
+### Step 2 — PR11: Measure acquisition, retention, and interference
+
+Suppose two models give the same final answer. Their journeys may still be very different:
+
+- one began correctly and updated when new evidence arrived;
+- one guessed the future answer before the evidence existed;
+- one fixed the changed fact but damaged several facts that should have stayed stable;
+- one reached the right final answer only by correcting its own earlier error.
+
+PR11 extracts a few named fields from each checkpoint submission and stores each as one small fact that can be compared over time. The code calls these facts **semantic atoms**. Examples include “the run is non-governing,” “finding F-PRV03-001 is open,” and “the package is not ready.”
+
+It then added diagnostics that do not change reward:
+
+| Diagnostic | Simple question |
+|---|---|
+| **Initial accuracy** | Was the first review correct? |
+| **Acquisition** | When new evidence justified a change, did the model move from the correct old state to the correct new state? |
+| **Update precision** | Of everything the model changed, how much changed to a correct value? |
+| **Update recall** | Of everything that needed to change, how much ended correctly? |
+| **Update F1** | What single score balances update precision and update recall? |
+| **Retention** | Did correct facts that should remain stable stay correct? |
+| **Interference** | After new evidence arrived, did a correct fact that should have stayed stable become wrong? |
+
+A model that predicts a future answer before supporting evidence arrives does not receive acquisition credit later. It may be correct later, but the metric does not count that as evidence-driven acquisition because its earlier state did not match the correct earlier state.
+
+If a metric had no opportunity to occur—for example, no facts were supposed to change—AEC-Bench leaves that rate blank (`null`) rather than calling it either a failure or a perfect score.
+
+Why PR11 mattered: “eventually correct” and “updated correctly” became different measurable behaviours.
+
+Boundary: these diagnostics describe behaviour within one lifecycle run. They do not change reward or show that the learner itself changed.
+
+Why the next step was needed: measurements need controlled situations that exercise different kinds of update and non-update.
+
+### Step 3 — PR12: Create four controlled public variants
+
+A **variant** is a deliberately changed version of the same basic task. A **public calibration variant** is a publicly defined diagnostic case used to understand behaviour and choose a setup before a separate evaluation. A **holdout** is meant to be a different test case kept out of that calibration work—the secret final exam, in the analogy. PR12 added four public variants:
+
+1. **Full correction** (`staged_full_correction`)
+   - A corrected input manifest, a replacement run, and a reissued hydraulic report arrive.
+   - A corrected memo arrives later.
+   - The model should update and eventually close the package.
+
+2. **Irrelevant note** (`semantic_no_op_release`)
+   - A new administrative note arrives but changes no engineering fact.
+   - The model should preserve its current conclusions instead of inventing progress.
+   - At closeout, the corrected run, report, and memo arrive together. Only then should the model update and close the package.
+
+3. **Claim without evidence** (`response_assertion_only`)
+   - At the response checkpoint, a note says the model was corrected but supplies no corrected technical files.
+   - The complete corrected chain arrives only at closeout.
+   - The model should not treat an assertion as proof.
+
+4. **Missing closeout memo** (`memo_closeout_missing`)
+   - The rerun is valid, but the required corrected memo is not supplied.
+   - The package should remain not ready.
+
+These are public calibration cases whose definitions live in the repository, but the AI is not shown which variant label is active. AEC-Bench records that label outside visible evidence and ties it to the exact package bytes using a **hash**—a digital fingerprint.
+
+Why PR12 mattered: we could test useful non-change, unsupported claims, delayed closure, and full correction using one controlled family.
+
+Boundary: these were public cases with a host-fixed schedule. PR12 added no model campaign, holdout run, or learner update.
+
+Why the next step was needed: we had good cases and records for individual runs, but no runner for a planned batch and no standard TrialRecord stored in a permanent register.
+
+### Step 4 — PR13: Build the calibration campaign runner and frozen-record pipeline
+
+PR13 turned the variants and memory conditions into an exact plan. The example committed in PR13 expands to:
+
+```text
+4 public variants
+× 4 conversation and visibility conditions
+× 1 model setup
+× 1 repetition
+= 16 planned trials
+```
+
+A **manifest** is the configuration file stating what should run. A **dry run** expands and checks that plan without calling a model provider or writing campaign ledger records.
+
+Every trial identity is built from the exact variant, task files, checker and AEC-Bench source, requested model and adapter, runtime files actually used by the adapter, provider, and checker, memory condition, repetition, and turn limit. Changing any of these changes the trial identity. An **adapter** is the bridge between AEC-Bench and the model-running system. A **turn limit** is the maximum number of model exchanges allowed in one session. A **repetition** means running the same planned setup again.
+
+PR13 added the standardized campaign-level record-keeping machinery:
+
+- A **TrialRecord** is the structured cover sheet for one trial.
+- A **snapshot** is the frozen copy of the exact files supporting that cover sheet.
+- A **ledger** is the append-only archive of finalized TrialRecords.
+- **Append-only** means new history may be added, but old history is not silently replaced.
+- An **atomic write** makes each published file appear complete rather than half-written. If a valid snapshot lands before its TrialRecord, recovery can finish publication without rerunning the model.
+- **Recovery** finishes publication from already saved evidence without unnecessarily rerunning the model.
+- **Fail closed** means stop on conflicting evidence instead of guessing.
+
+“Finalized” means sealed against silent replacement, not successful. A finalized record may describe a passing run, a zero-reward failure, or a run marked partial because some provenance was unavailable.
+
+The word `ablation` appears in some code and filenames. It usually means changing one factor at a time to test cause and effect. Our campaign does less: it runs a fixed grid of public cases and context settings to describe what happens.
+
+The turn limit applies per session. A persistent trial normally has one session, while a fresh-context trial opens one session per checkpoint and another session for each retry. The conditions therefore do not have equal total turn capacity. The run order is fixed too. The averages can help us spot questions, but they cannot prove that one memory condition caused better results.
+
+Why PR13 mattered: once a result was final, its supporting files and software identity were frozen. Later code edits, changed working files, or a different model connector could not silently redefine that historical record. If a completed run had already saved valid evidence, publication could resume without rerunning the model.
+
+Boundary: PR13 made campaign records trustworthy. It did not establish a causal effect or add the richer engineering world.
+
+Why the next step was needed: the handover between trusted AEC-Bench logic and a model-running environment still needed an exact, enforceable boundary.
+
+### Step 5 — PR14: Separate host authority from environment execution
+
+PR14 introduced two strict forms:
+
+1. The host sends an **episode request**.
+2. The environment returns an **episode result**.
+
+An **episode** is one work session with a fixed identity and limits across this boundary. In fresh-context mode, one episode handles one checkpoint.
+
+“Typed” means the forms allow an exact set of named fields. Extra fields are rejected.
+
+A **session** is one continuous AI conversation. An **attempt** is one try at completing a checkpoint; a retry opens another attempt.
+
+The request tells the environment:
+
+> Work on this checkpoint, in this workspace, under this host-created session and attempt identity, using this AI setup, visibility policy, and turn limit—the maximum number of conversation turns.
+
+The environment may report:
+
+> This exact session completed or failed. The environment used this connector and model and counted this many tokens—small pieces of text used for usage accounting.
+
+It may not report:
+
+> The engineering answer is correct, the task passed, or the reward is 1.
+
+Those decisions remain with AEC-Bench and the task-owned verifier. The environment cannot grade itself.
+
+The episode request receives a hash, so recovery and finalization can prove which exact request the environment received. A failed attempt's candidate answer is preserved under that failed attempt and cannot silently become the retry's answer.
+
+Why PR14 mattered: a compatible fresh-context environment could execute one checkpoint without gaining control over advancement, correctness, or reward.
+
+Boundary: PR14 defined the handover for fresh-context episodes; it did not demonstrate hosted execution or training.
+
+Why the next step was needed: PR14 covered one fresh conversation working on one checkpoint. PR15 needed to show that an external framework could carry one continuing conversation across the whole lifecycle while AEC-Bench kept the same control.
+
+### Step 6 — PR15: Export and test one persistent lifecycle in a local Prime/Verifiers-compatible environment
+
+**Prime** is a platform for evaluating and training AI models. **Verifiers** is the Python framework used to define environments that Prime can run. PR15 used Verifiers locally only; it did not use Prime's hosted service. A **rollout** is one AI journey through a task.
+
+PR15 added and tested a local Verifiers environment capable of letting one rollout cover one complete persistent lifecycle:
+
+```text
+one model
++ one continuing conversation
++ all three checkpoints
+= one rollout
+```
+
+The connection to Prime/Verifiers is intentionally small. It reuses the existing task package and current AEC-Bench source code instead of copying them, and checks their digital fingerprints before setup and reward.
+
+Inside the rollout, the AI can list and read visible files, write the current submission, submit a checkpoint, and revisit an earlier accepted checkpoint. AEC-Bench still controls evidence release. Only the final task verifier can award reward; an incomplete rollout receives zero.
+
+Why PR15 mattered: a locally generated Verifiers environment could carry scripted actions through all three checkpoints while AEC-Bench retained control of evidence, progression, checking, and reward.
+
+Boundary: PR15 established a tested local execution capability using scripted tool actions. It did not call a model provider or demonstrate hosted training, model performance, or a fresh-versus-persistent comparison.
+
+Why the next step was needed: before running separate test cases, we needed a conservative rule for what a holdout result is allowed to mean.
+
+### Step 7 — PR16: Define honest holdout reporting
+
+The word **transfer** is easy to misuse. Good performance on a different case does not automatically show that the model learned from an earlier case or that the earlier interaction caused the improvement.
+
+PR16 added an evidence-only evaluator. Although its code name includes `transfer`, its allowed claim is narrower: **descriptive holdout generalisation**, meaning a report of how one selected setup performed on separate records without claiming that earlier cases caused any improvement.
+
+The evaluator does not call a model, rerun a task, or rerun a verifier. It reads TrialRecords and frozen snapshots; incomplete or unverifiable records are marked ineligible.
+
+It receives:
+
+- **public calibration records:** records declared as public calibration support for the chosen setup;
+- **holdout target records:** records explicitly labelled as targets outside public calibration; and
+- a **selected condition**, meaning the exact AI setup: model, connector, software fingerprint, context mode, visibility policy, and turn limit that every eligible record must match.
+
+The evaluator rejects incomplete records, records not labelled as public calibration or holdout, runs made with a different setup, and records whose saved fingerprints no longer match. It also requires every holdout package to differ from every valid calibration package. Only then does it report the existing verifier scores.
+
+PR16 cannot prove that the setup was chosen before anyone saw the holdout. Different file contents also do not prove that the holdout is a genuinely different engineering problem. Later work must create the private boundary and freeze the condition before any holdout is used.
+
+PR16 is **build-only**. That means the checking function exists for other code to call, but there is no public command, private-target campaign runner, or standard place to publish its summaries yet. This avoids creating a path through which secret holdout information could accidentally be written into public results.
+
+Why PR16 mattered: it established the wording and evidence contract before we spent money on model runs or exposed a private target.
+
+Boundary: PR16 defines eligibility rules and permitted wording only. It creates neither the holdout cases nor a transfer result.
+
+Why the next step was needed: the interaction still followed a mostly fixed evidence schedule. The model could react to new information but could not choose what information to seek.
+
+### Step 8 — PR17: Let an AI request more evidence and change what it sees next
+
+In real engineering work, reviewers ask for information:
+
+- “Show me the governing source revision.”
+- “Give me the outlet inspection record.”
+- “I need the updated calculation note before I can close this finding.”
+
+PR17 added generic support for that behaviour. A checkpoint may now declare a public **request catalogue** containing:
+
+- safe request names;
+- a plain description of each request;
+- any prerequisite request that must come first; and
+- a finite request budget.
+
+The public catalogue's fixed schema has no hidden source-path or expected-answer field. Its titles and descriptions are free text, so task authors must still avoid leaking hints through that prose. A task-owned hidden map connects each public request name to its real evidence folder.
+
+The model calls:
+
+```text
+request_evidence(checkpoint_id, request_id, reason)
+```
+
+The host supplies the real session and attempt identity. The first valid request for an item reveals only the selected packet and consumes one request ticket. Repeating the same successful request is safe and costs nothing extra. A well-formed but disallowed request—wrong checkpoint, unknown name, missing prerequisite, or no tickets left—reveals nothing and consumes no ticket.
+
+AEC-Bench records every nonblank request made from the active session after checking that the task package is intact. This includes requests that release evidence, repeat an earlier request, or are rejected by the request rules. Each permanent receipt shows the attempt, reason, budget change, outcome, and file fingerprints. Blank calls, wrong-session calls, and damaged packages do not become request actions; they return a system error and may fail the attempt. Only one process can update the run at a time, and an interrupted save can be recovered from the saved record.
+
+Requested evidence and spent budget survive a retry. A branch inherits the request history, released evidence, and spent budget accumulated through its branch point. Its visibility policy may still hide some inherited evidence from the model, while the audit copy remains.
+
+The request tool works in all three local execution modes: one continuing conversation, fresh conversations, and the Prime/Verifiers environment. Tasks with no request choices keep their existing tools, and each run uses one consistent tool set. AEC-Bench includes the request history in its saved experiment records so later checks can see exactly what the model asked for.
+
+PR17 tested this general mechanism with generated local task packages and scripted request calls. It proves the capability and audit contract, not that a model will choose useful evidence. It did **not** add request choices to SSC-03's four public calibration variants; the richer hydraulic task still needs to define useful engineering requests.
+
+Why PR17 mattered: this is the first layer where the model can choose which one of several declared evidence packets becomes visible within a checkpoint. Earlier submission actions could trigger the next fixed release, but could not choose its contents.
+
+```text
+model chooses a permitted request
+  -> host checks the menu, prerequisites, and budget
+  -> one selected evidence packet becomes visible
+  -> the model's next decision can use that evidence
+```
+
+Boundary: PR17 changed which evidence a task with request choices could make visible. It did not change hydraulic physics, measure model performance, or update the learner.
+
+Why PR18 is needed: we now need an executable engineering world whose outputs follow deterministically from its inputs.
+
+### Optional reference: the full run sequence after PR17
+
+For a package configured with request choices, the complete flow is now:
+
+1. AEC-Bench validates the task package and creates the run state.
+2. It reveals the active checkpoint's ordinary evidence and, if that checkpoint declares requestable extra evidence, its public request catalogue. Future checkpoint catalogues remain hidden.
+3. It opens an attempt owned by one model session.
+4. The model reads visible files.
+5. The model may spend its finite request budget on declared evidence packets.
+6. Every recorded request action and every released file is durably preserved.
+7. The model writes its checkpoint submission.
+8. AEC-Bench archives a submission that has the expected shape and only then reveals the next checkpoint.
+9. The lifecycle repeats until closeout or failure.
+10. The task verifier checks the accumulated engineering state.
+11. The experiment manager records metrics and exact provenance.
+12. AEC-Bench freezes a TrialRecord and snapshot.
+13. A later evaluator may read those frozen records without rerunning the model.
+
+Steps 1–10 describe lifecycle execution itself. Steps 11–13 occur when that run is wrapped in the campaign and finalization machinery; a bare local or Prime rollout does not automatically publish a TrialRecord.
+
+### Where we stand before PR18
+
+We now have:
+
+- controlled evidence release;
+- explicit memory and visibility conditions;
+- checks for correct changes and correct non-changes;
+- four public, controlled test cases;
+- reproducible planning for batches of runs and frozen records protected by digital fingerprints;
+- a strict host/environment boundary;
+- a tested local external model-running environment capable of carrying one continuing review through all checkpoints;
+- rules for honestly reporting results on separate test cases; and
+- limited request actions that can reveal declared evidence.
+
+We still do not have:
+
+- an executable drainage-calculation world containing temporary stormwater storage, flow-control outlets, pipes, pits, and a checked water-level profile;
+- model actions that change physical engineering state;
+- a protected source of private test cases;
+- a completed public model campaign;
+- evidence that a model improved across runs; or
+- continual learning.
+
+PR18 will add a deterministic hydraulic world: the same inputs must always produce the same checked outputs, and every run must remain tied to the exact set and revisions of its input files. PR18 will not yet give the AI hydraulic control. The planned PR19 layer will connect limited AI actions to those computations.
+
+For the planned steps beyond PR17, read the [SSC-03 richer interaction roadmap](ssc03-richer-interaction-roadmap.md).
+
+### Glossary for the terms most likely to appear during PR18
+
+The implementation terms below are safe to skip on a first reading.
+
+| Term | Plain-language translation |
+|---|---|
+| **Adapter** | The connector between AEC-Bench and a model-running system. |
+| **Provider** | The service or local runtime that supplies model responses. |
+| **Package** | The generated task folder containing public instructions, evidence, hidden host data, and lifecycle rules. |
+| **Materialize** | Generate that concrete package folder from a reusable task definition. |
+| **Artifact** | Any saved file used or produced by a run. |
+| **Content-bound** | Tied to exact file contents, so changing the bytes changes the identity. |
+| **Immutable** | Treated as unchangeable after publication; later edits are detected and rejected. |
+| **Canonical** | The authoritative copy used for checking and recovery. |
+| **Projection** | A controlled model-visible copy or view of authoritative information. |
+| **Transaction** | The complete durable record of one request and its result. |
+| **Atomic** | A save becomes visible as a complete unit or not at all. |
+| **`fsync`-durable** | The program asks the operating system to push saved data to durable storage before declaring success. |
+| **Lock-serialized** | Only one writer may change the relevant run state at a time. |
+| **Idempotent** | Repeating the same successful action has no extra effect or cost. |
+| **Hydraulic engine or solver** | The calculation program that turns drainage inputs into flows, levels, velocities, and storage results. |
+| **Detention basin** | Temporary stormwater storage that slows the release of water. |
+| **Outlet** | The structure through which stored water leaves the basin. |
+| **Orifice** | A restricted opening used to control flow. |
+| **Emergency weir** | A higher overflow path used when normal storage or outlet capacity is exceeded. |
+| **Tailwater** | The downstream water level pushing back against an outlet or pipe. |
+| **HGL** | Hydraulic grade line: a way of showing water pressure and level along the network. |
+| **Freeboard** | The safety height between the expected water level and the top of a basin or structure. |
+| **Deterministic** | The same declared inputs always produce the same checked outputs. |
+
+## Best Analogy
+
+Use this as an analogy, not as a literal description: imagine a drainage engineer reviewing a project inside a controlled records room run by a strict clerk.
+
+| In our system | In the records room |
+|---|---|
+| Model | The reviewing engineer |
+| Host | The clerk controlling the room |
+| Lifecycle | The review from initial issue through response and closeout |
+| Checkpoint | One formal review meeting |
+| Evidence release | The folder issued for that meeting |
+| Submission | The engineer's signed review sheet |
+| Persistent context | The same engineer attends every meeting and remembers the discussion |
+| Fresh context | A new engineer starts each meeting |
+| Visibility policy | Which old folders and review sheets the new engineer receives |
+| Verifier | The checker separate from the room operator who decides whether the review is correct |
+| Ledger | The permanent project register |
+| TrialRecord and snapshot | The register entry plus a sealed evidence box |
+| PR17 request catalogue | A menu of extra folders the engineer may request |
+| PR17 request budget | A limited number of request tickets |
+| Holdout | A different sealed project used as the later test |
+
+PR10–PR16 built the staged room, memory experiments, authority rules, and records vault around the existing checker. PR17 made it possible for a task with request choices to let the engineer choose from a limited menu of extra folders. PR18 begins constructing the working hydraulic model. PR19 will connect the engineer's choices to hydraulic calculations.
+
+The analogy's limit is important: a human engineer may learn permanently from the project. Our current runs do not update the AI model. It receives context and files during a run; no durable model learning has been shown.
+
+## Boundary Examples
+
+| Case | Fit | Why |
+|---|---|---|
+| Give an AI one 200-page report in one prompt | Not a lifecycle | This is a large-input task, but evidence does not arrive over time. |
+| Release evidence A, require a submission, then release B | Good for PR10 | This is a staged evidence lifecycle, but the schedule is still fixed by the host. |
+| Keep one conversation across all three checkpoints | Good for persistent context | The model has conversation memory, but this is not continual learning. |
+| Start a fresh conversation and provide earlier submissions | Good for artifact memory | The conversation is new, but saved task memory is deliberately visible. |
+| Release an administrative note that changes no engineering fact | Good for PR12 | The correct behaviour is retention, not unnecessary editing. |
+| Let a task offer the AI one declared source packet to request | Good for PR17 | A limited action changes what the AI sees next. It does not change the hydraulic world. |
+| Let an AI change a flow-control opening, called an orifice, and recompute water levels | Future fit | This is a physically consequential interaction planned after the executable world exists. |
+| Read frozen public and holdout TrialRecords | Partial | This supports descriptive holdout reporting, not a causal transfer claim. |
+| Update model weights later from a collected batch of runs | Outside PR10–PR17 | This is post-training. |
+| Repeatedly update durable learner state as new encounters arrive | Outside PR10–PR17 | This is continual learning. |
+
+## Flashcards
+
+| Front | Back |
+|---|---|
+| What makes a task long-horizon rather than merely long? | Information and decisions unfold over time, and later work depends on preserving the right earlier state. |
+| Why does AEC-Bench control evidence release and reward? | So the model or execution environment cannot reveal future evidence, advance itself, or grade its own work. |
+| What is the difference between persistent context and continual learning? | Persistent context remembers one conversation. Continual learning creates durable learning across encounters or runs. |
+| What did PR11 add beyond the final reward? | Diagnostics for initial accuracy, acquisition, update quality, retention, and interference. |
+| Why are PR12's four variants called calibration variants? | They are public, controlled cases used to understand behaviour and choose a future setup, not secret holdouts. |
+| Why is PR13's campaign descriptive rather than causal? | Runs stay in one fixed order, and some conditions receive more total model turns than others, so differences cannot confidently be attributed to the memory condition alone. |
+| What authority does the PR14 environment not have? | It cannot decide checkpoint acceptance, correctness, pass/fail, or reward. |
+| What exactly did PR17 allow a model action to change? | Which declared evidence packet becomes visible, within prerequisites and a finite request budget. It did not change hydraulic physics. |
+
+## Recall Prompts
+
+- Reconstruct the three-checkpoint SSC-03 story without looking back. Why is the package not ready after the response review?
+- Explain the difference between conversation memory, saved task state, and learning in model weights.
+- Describe a case where the final answer is correct but PR11 acquisition should still be poor.
+- Explain why an irrelevant new document is useful for testing retention.
+- Describe the difference between the host and the environment using your own analogy.
+- Explain why a matching hash establishes identity but not engineering truth.
+- State the strongest honest claim supported by PR16.
+- State exactly what PR17 proves and the first thing it still cannot do.
+
+## Open Questions
+
+- Which hydraulic engine can run reliably and reproducibly in the supported PR18 environment?
+- What is the smallest detention, outlet, pipe, tailwater, and HGL world that is still recognisably an engineering system?
+- Which input changes should force recomputation, and which outputs should remain unchanged?
+- How will we prove that the executable world's reports and checker calculations use the same set and revisions of input files?
+- Which public evidence requests are genuinely equivalent in information value, and how should request budgets be set?
+- At what point should a model action change physical state rather than only reveal evidence?
+- What private target is structurally different enough to test generalisation without leaking its rules?
+- Which AI setup will be chosen and locked before any holdout is used?
+- What additional evidence would be required before we could say “post-training helped,” “the model transferred,” or “continual learning occurred”?

--- a/docs/ssc03-richer-interaction-roadmap.md
+++ b/docs/ssc03-richer-interaction-roadmap.md
@@ -1,0 +1,99 @@
+# ABOUTME: Defines the staged path from SSC-03 evidence review to action-conditioned hydraulic interactions.
+# ABOUTME: Separates implemented substrate claims from future environment, holdout, and model-evidence work.
+
+# SSC-03 Richer Interaction Roadmap
+
+## Direction
+
+The objective is not to make a static task longer. It is to approach a richer interaction in controlled steps: evidence arrives over time, the model can choose bounded information-gathering actions, those actions change what it can observe, later actions can produce engineering consequences, and every observation remains attributable to a host-owned state transition.
+
+This is a substrate for ordinary post-training and evaluation first. It is not yet continual learning. A persistent conversation, durable state, or behavior that improves later in one rollout does not establish learning across runs or parameter updates.
+
+## Established stack
+
+| Layer | Established capability |
+| --- | --- |
+| PR10 | Host-controlled staged evidence and memory-visibility conditions |
+| PR11 | Reward-independent acquisition, retention, update, and interference metrics |
+| PR12 | Controlled public SSC-03 calibration variants |
+| PR13 | Reproducible campaigns, immutable TrialRecords, recovery, and ledger summaries |
+| PR14 | Typed host/environment episode ownership without verifier or reward delegation |
+| PR15 | Local Prime rollout spanning one complete persistent lifecycle |
+| PR16 | Build-only descriptive holdout evaluation from immutable evidence |
+| PR17 | Bounded actions that condition model-visible evidence |
+
+## PR17: action-conditioned evidence protocol
+
+PR17 introduces one generic host operation:
+
+```text
+request_evidence(checkpoint_id, request_id, reason)
+```
+
+The public checkpoint contract declares request IDs, descriptions, prerequisites, and a finite budget. It contains no source paths or expected outcomes. A task-owned hidden manifest resolves each declared ID to a confined package directory.
+
+The host binds the active session and attempt; the model cannot provide either. The first valid request publishes only the selected packet and consumes one budget unit. A repeated successful request is idempotent and consumes zero. Unknown, inactive, unsupported, prerequisite-blocked, and budget-exhausted requests produce typed, non-leaking rejections and consume zero.
+
+Every boundary-valid request receives a globally ordered action record with pre/post observable-state hashes, budget arithmetic, outcome, session/attempt ownership, and released artifact hashes. Malformed or blank tool arguments return a bounded error without creating a lifecycle action. Canonical transactions live under `run/evidence_requests/<action-id>/`; model-visible projections live under `workspace/inbox/<checkpoint>/requests/<request-id>/`. Publication is lock-serialized, staged, fsync-durable, crash-recoverable, and reconciled to the append-only lifecycle ledger.
+
+Requested evidence survives a failed attempt, remains consumed on retry, and is inherited by a branch through its branch point. Visibility remains policy-controlled: cumulative evidence policies retain it, while `current_release_only` hides it after checkpoint advancement without deleting audit files.
+
+Conditional packages expose the same three-argument tool through persistent local, fresh-context, and local Prime execution. Packages with no request catalogue keep their prior tool set. Invocation manifests hash the protocol and exact tool schema; reward-independent metrics count released, repeated, rejected, and budget-consuming actions. Immutable snapshots contain the canonical transactions, workspace projections, and public catalogues.
+
+What PR17 proves:
+
+- a model-visible action can condition subsequent model-visible evidence;
+- the resulting observation is bounded, hash-bound, and attributable;
+- retry, branch, local adapter, Prime, ledger, and snapshot boundaries preserve the same action history.
+
+What PR17 does not prove:
+
+- that an action changes a hydraulic system;
+- that a model selects useful evidence;
+- transfer to a distinct target;
+- learning across runs or continual learning.
+
+## PR18: executable hydraulic world
+
+Build a small deterministic public detention/outlet/network world around the SSC-03-LH-01 direction. Use two upstream catchments, a detention basin, an orifice and emergency weir, a short pipe/pit network, tailwater, and explicit discharge, velocity, HGL, storage, and freeboard criteria.
+
+The first gate is engine compatibility, not environment authoring. Prior local probes found that `swmm-toolkit==0.17.0` imports its namespace but its native solver/output modules exit unsuccessfully under the tested Python 3.12 and 3.13 runtimes, with no local `swmm5` executable available. PR18 must therefore run a controlled compatibility matrix before selecting an engine. A benchmark-owned deterministic hydraulic kernel remains the fallback and must be described honestly rather than presented as SWMM-equivalent fidelity.
+
+An existing EPA SWMM Example 3 detention source-pack commit must be reconciled into the PR18 stack. It already carries official source URLs and hashes, a model summary, manual targets, mismatch notes, verification cases, and an implementation brief. Reuse that packet; do not create a duplicate source pack to avoid branch integration.
+
+PR18 finishes only when source state, run identity, report outputs, tolerances, and verifier calculations are deterministic and content-bound. It still need not expose model-controlled hydraulic actions.
+
+## PR19: interactive hydraulic lifecycle
+
+Connect the PR17 operation protocol to PR18's executable world. Initial actions should remain bounded and typed, for example:
+
+- request a declared source revision;
+- run hydrology for one declared scenario;
+- run detention/outlet analysis for one option;
+- run network HGL for one declared downstream boundary.
+
+Each operation must bind its arguments to the visible source-state hash and produce an immutable request/result/artifact chain. Public calibration revisions should exercise distinct dependency topologies: IDF/climate input, tailwater, outlet geometry, and an administrative no-op. The verifier checks selective recomputation, unaffected-decision retention, run/report/memo propagation, and readiness; action efficiency remains diagnostic until sufficiency is established.
+
+## PR20: sealed holdout boundary
+
+Introduce an external provider seam for private materializers, operation resolvers, and verifiers. The public repository contains only generic fake-provider fixtures. Real target IDs, prompts, source packets, action mappings, gold outputs, verifier rules, and per-trial annotations remain outside public registries and exports.
+
+The first private synthetic target should be a pump-station duty lifecycle. It shares the abstract interaction contract but changes the physical and documentary graph: wet-well levels, rising main and pump curve, system curve, duty point, power/NPSH, and selection note. This is a stronger structural holdout than a renamed stormwater network.
+
+## PR21: preregistered campaign and condition selection
+
+Run the public calibration campaign, select one execution condition using only public evidence, and freeze model, adapter, realized runtime dependency hash, execution mode, visibility policy, turn limit, action-protocol hash, and tool-schema hash before mounting any holdout target.
+
+This is the first phase that needs provider credentials and a spend/repetition budget. It also needs approval that private synthetic target content may be sent to the selected provider.
+
+## PR22: redacted one-shot audit
+
+Run the frozen condition against the sealed target once under the preregistered repetition policy. Publish only aggregate descriptive results and generic behavioral categories. Keep exact target content, traces, verifier details, and action mappings internal. Use PR16's evaluator to report holdout generalization, not causal transfer or continual learning.
+
+## Inputs still needed
+
+No provider credentials are needed through PR20.
+
+Engineering review is needed for plausible parameter ranges, coupled scenarios, tolerances, dependency invalidation, equivalent information requests, closure policy, pump curves, NPSH, wet-well behavior, and operating rules. Infrastructure work is needed for the controlled solver matrix, private package storage, access-controlled ledgers, and redacted reporting.
+
+The progression is deliberate: first make actions observable and auditable, then make them physically consequential, then hide a structurally distinct target, and only then spend model budget.

--- a/src/aec_bench/meta_harness/evidence_lifecycle.py
+++ b/src/aec_bench/meta_harness/evidence_lifecycle.py
@@ -4,12 +4,14 @@
 from __future__ import annotations
 
 import copy
+import fcntl
 import hashlib
 import json
 import os
 import shutil
 import tempfile
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -33,20 +35,61 @@ from aec_bench.meta_harness.evidence_lifecycle_state import (
     CheckpointRunRecord,
     CheckpointRunStatus,
     EvidenceLifecycleRunState,
+    EvidenceRequestOutcome,
+    EvidenceRequestRejection,
     LifecycleBranchRecord,
     LifecycleRunStatus,
     LifecycleTransitionKind,
-    LifecycleTransitionRecord,
     LifecycleVerificationResult,
 )
-from aec_bench.meta_harness.ledger import append_ledger_entry, read_ledger
+from aec_bench.meta_harness.evidence_request_protocol import (
+    EvidenceLifecycleError as EvidenceLifecycleError,
+)
+from aec_bench.meta_harness.evidence_request_protocol import (
+    EvidenceRequestResolution as EvidenceRequestResolution,
+)
+from aec_bench.meta_harness.evidence_request_protocol import (
+    EvidenceRequestResolutionManifest as EvidenceRequestResolutionManifest,
+)
+from aec_bench.meta_harness.evidence_request_protocol import (
+    _append_transition,
+    _branch_action_state_sha256,
+    _checkpoint,
+    _evidence_request_catalog,
+    _validate_evidence_request_state_contract,
+)
+from aec_bench.meta_harness.evidence_request_protocol import (
+    evidence_request_catalog_payload as evidence_request_catalog_payload,
+)
+from aec_bench.meta_harness.evidence_request_protocol import (
+    evidence_request_protocol_identity as evidence_request_protocol_identity,
+)
+from aec_bench.meta_harness.evidence_request_protocol import (
+    validate_evidence_request_run_state as validate_evidence_request_run_state,
+)
+from aec_bench.meta_harness.evidence_request_store import (
+    _assert_evidence_request_artifacts_unchanged,
+    _copy_file_atomic,
+    _copy_release,
+    _inherit_evidence_request_transactions,
+    _ledger_path,
+    _load_evidence_request_resolutions,
+    _read_json,
+    _record_evidence_request_action,
+    _recover_evidence_request_transactions,
+    _sha256,
+    _state_path,
+    _sync_evidence_request_ledger,
+    _sync_transition_ledger,
+    _workspace,
+    _write_evidence_request_catalog,
+    _write_json,
+    _write_state,
+)
+from aec_bench.meta_harness.ledger import append_ledger_entry
 from aec_bench.task_world_templates.contracts import EvidenceCheckpointSpec, EvidenceLifecycleSpec
 
 LifecycleVerifier = Callable[[Path, Path], dict[str, Any] | LifecycleVerificationResult]
-
-
-class EvidenceLifecycleError(RuntimeError):
-    """Raised when a lifecycle package or checkpoint transition is invalid."""
 
 
 class LifecycleEpisodeExecutionError(EvidenceLifecycleError):
@@ -78,9 +121,17 @@ def prepare_evidence_checkpoint(package_dir: Path, run_dir: Path) -> dict[str, A
     """Release exactly the next checkpoint into the persistent agent workspace."""
     package = Path(package_dir)
     run = Path(run_dir)
+    with _lifecycle_state_lock(run):
+        return _prepare_evidence_checkpoint_locked(package, run)
+
+
+def _prepare_evidence_checkpoint_locked(package: Path, run: Path) -> dict[str, Any]:
+    """Release the next checkpoint while holding the per-run mutation lock."""
     spec = load_evidence_lifecycle_spec(package)
+    if any(checkpoint.conditional_evidence is not None for checkpoint in spec.checkpoints):
+        _load_evidence_request_resolutions(package, spec)
     if _state_path(run).exists():
-        state = _load_state(package, run, spec)
+        state = _load_state(package, run, spec, lock_held=True)
     else:
         _preflight_checkpoint(package, spec.checkpoints[0])
         state = _initialize_state(package, run, spec)
@@ -123,6 +174,7 @@ def prepare_evidence_checkpoint(package_dir: Path, run_dir: Path) -> dict[str, A
     )
     state.status = LifecycleRunStatus.AWAITING_CHECKPOINT_SUBMISSION
     state.active_checkpoint_id = checkpoint.checkpoint_id
+    _write_evidence_request_catalog(run, checkpoint, checkpoint_run)
     _write_state(run, state)
     _sync_transition_ledger(run, state)
     append_ledger_entry(
@@ -136,6 +188,164 @@ def prepare_evidence_checkpoint(package_dir: Path, run_dir: Path) -> dict[str, A
     return _checkpoint_context(run, checkpoint, state)
 
 
+def request_evidence_checkpoint(
+    package_dir: Path,
+    run_dir: Path,
+    *,
+    checkpoint_id: str,
+    request_id: str,
+    reason: str,
+    session_id: str,
+) -> dict[str, Any]:
+    """Release one declared conditional evidence packet for the active attempt."""
+    if not checkpoint_id.strip() or not request_id.strip() or not reason.strip():
+        raise EvidenceLifecycleError("evidence request checkpoint, request, and reason must not be blank")
+    package = Path(package_dir)
+    run = Path(run_dir)
+    with _lifecycle_state_lock(run):
+        return _request_evidence_checkpoint_locked(
+            package,
+            run,
+            checkpoint_id=checkpoint_id,
+            request_id=request_id,
+            reason=reason,
+            session_id=session_id,
+        )
+
+
+def _request_evidence_checkpoint_locked(
+    package: Path,
+    run: Path,
+    *,
+    checkpoint_id: str,
+    request_id: str,
+    reason: str,
+    session_id: str,
+) -> dict[str, Any]:
+    spec = load_evidence_lifecycle_spec(package)
+    resolutions = _load_evidence_request_resolutions(package, spec)
+    state = _load_state(package, run, spec, lock_held=True)
+    active_checkpoint_id = state.active_checkpoint_id
+    if active_checkpoint_id is None:
+        raise EvidenceLifecycleError("no checkpoint is active")
+    checkpoint = _checkpoint(spec, active_checkpoint_id)
+    checkpoint_run = state.checkpoint(active_checkpoint_id)
+    attempt = checkpoint_run.active_attempt
+    if attempt is None:
+        raise EvidenceLifecycleError("no checkpoint attempt is active")
+    if attempt.session_id != session_id:
+        raise EvidenceLifecycleError(
+            f"active attempt belongs to {attempt.session_id}; cannot request evidence from {session_id}"
+        )
+
+    if checkpoint_id != active_checkpoint_id:
+        return _record_evidence_request_action(
+            run,
+            spec,
+            state,
+            requested_checkpoint_id=checkpoint_id,
+            request_id=request_id,
+            reason=reason,
+            session_id=session_id,
+            outcome=EvidenceRequestOutcome.REJECTED,
+            rejection=EvidenceRequestRejection.INACTIVE_CHECKPOINT,
+        )
+
+    conditional = checkpoint.conditional_evidence
+    if conditional is None:
+        return _record_evidence_request_action(
+            run,
+            spec,
+            state,
+            requested_checkpoint_id=checkpoint_id,
+            request_id=request_id,
+            reason=reason,
+            session_id=session_id,
+            outcome=EvidenceRequestOutcome.REJECTED,
+            rejection=EvidenceRequestRejection.NOT_SUPPORTED,
+        )
+
+    request = next((item for item in conditional.requests if item.request_id == request_id), None)
+    if request is None:
+        return _record_evidence_request_action(
+            run,
+            spec,
+            state,
+            requested_checkpoint_id=checkpoint_id,
+            request_id=request_id,
+            reason=reason,
+            session_id=session_id,
+            outcome=EvidenceRequestOutcome.REJECTED,
+            rejection=EvidenceRequestRejection.UNKNOWN_REQUEST,
+        )
+
+    prior_release = next(
+        (
+            action
+            for action in checkpoint_run.evidence_request_actions
+            if action.request_id == request_id and action.outcome == EvidenceRequestOutcome.RELEASED
+        ),
+        None,
+    )
+    if prior_release is not None:
+        _assert_evidence_request_artifacts_unchanged(run, prior_release)
+        return _record_evidence_request_action(
+            run,
+            spec,
+            state,
+            requested_checkpoint_id=checkpoint_id,
+            request_id=request_id,
+            reason=reason,
+            session_id=session_id,
+            outcome=EvidenceRequestOutcome.ALREADY_RELEASED,
+            released_artifacts=prior_release.released_artifacts,
+        )
+
+    released_ids = {
+        action.request_id
+        for action in checkpoint_run.evidence_request_actions
+        if action.outcome == EvidenceRequestOutcome.RELEASED
+    }
+    if not set(request.prerequisite_request_ids).issubset(released_ids):
+        return _record_evidence_request_action(
+            run,
+            spec,
+            state,
+            requested_checkpoint_id=checkpoint_id,
+            request_id=request_id,
+            reason=reason,
+            session_id=session_id,
+            outcome=EvidenceRequestOutcome.REJECTED,
+            rejection=EvidenceRequestRejection.PREREQUISITES_INCOMPLETE,
+        )
+    if checkpoint_run.evidence_request_budget_remaining < 1:
+        return _record_evidence_request_action(
+            run,
+            spec,
+            state,
+            requested_checkpoint_id=checkpoint_id,
+            request_id=request_id,
+            reason=reason,
+            session_id=session_id,
+            outcome=EvidenceRequestOutcome.REJECTED,
+            rejection=EvidenceRequestRejection.BUDGET_EXHAUSTED,
+        )
+
+    resolution = resolutions[(checkpoint_id, request_id)]
+    source = package / resolution.source_path
+    return _record_evidence_request_action(
+        run,
+        spec,
+        state,
+        requested_checkpoint_id=checkpoint_id,
+        request_id=request_id,
+        reason=reason,
+        session_id=session_id,
+        outcome=EvidenceRequestOutcome.RELEASED,
+        release_source=source,
+    )
+
+
 def submit_evidence_checkpoint(
     package_dir: Path,
     run_dir: Path,
@@ -145,8 +355,19 @@ def submit_evidence_checkpoint(
     """Accept one structurally valid submission and preserve it outside the workspace."""
     package = Path(package_dir)
     run = Path(run_dir)
+    with _lifecycle_state_lock(run):
+        return _submit_evidence_checkpoint_locked(package, run, episode_result=episode_result)
+
+
+def _submit_evidence_checkpoint_locked(
+    package: Path,
+    run: Path,
+    *,
+    episode_result: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Submit the active checkpoint while holding the per-run mutation lock."""
     spec = load_evidence_lifecycle_spec(package)
-    state = _load_state(package, run, spec)
+    state = _load_state(package, run, spec, lock_held=True)
     checkpoint_id = state.active_checkpoint_id
     if not checkpoint_id:
         raise EvidenceLifecycleError("no checkpoint is awaiting submission")
@@ -222,8 +443,29 @@ def branch_evidence_lifecycle(
     package = Path(package_dir)
     parent_run = Path(parent_run_dir)
     branch_run = Path(branch_run_dir)
+    with _lifecycle_state_lock(parent_run):
+        return _branch_evidence_lifecycle_locked(
+            package,
+            parent_run,
+            branch_run,
+            checkpoint_id=checkpoint_id,
+            branch_id=branch_id,
+            reason=reason,
+        )
+
+
+def _branch_evidence_lifecycle_locked(
+    package: Path,
+    parent_run: Path,
+    branch_run: Path,
+    *,
+    checkpoint_id: str,
+    branch_id: str,
+    reason: str,
+) -> dict[str, Any]:
+    """Create a branch from a stable parent state held under its mutation lock."""
     spec = load_evidence_lifecycle_spec(package)
-    parent_state = _load_state(package, parent_run, spec)
+    parent_state = _load_state(package, parent_run, spec, lock_held=True)
     _assert_prior_submissions_unchanged(parent_run, parent_state)
     try:
         branch_index = next(
@@ -252,6 +494,16 @@ def branch_evidence_lifecycle(
                     released_files=list(inherited.released_files),
                     submission_path=inherited.submission_path,
                     submission_sha256=inherited.submission_sha256,
+                    attempts=[
+                        attempt.model_copy(deep=True, update={"inherited_from_parent": True})
+                        for attempt in inherited.attempts
+                    ],
+                    evidence_request_budget=inherited.evidence_request_budget,
+                    evidence_request_budget_remaining=inherited.evidence_request_budget_remaining,
+                    evidence_request_actions=[
+                        action.model_copy(deep=True, update={"inherited_from_parent": True})
+                        for action in inherited.evidence_request_actions
+                    ],
                     inherited_from_parent=True,
                 )
             )
@@ -261,10 +513,29 @@ def branch_evidence_lifecycle(
                     checkpoint_id=checkpoint.checkpoint_id,
                     status=CheckpointRunStatus.ACTIVE,
                     released_files=list(parent_checkpoint.released_files),
+                    attempts=[
+                        attempt.model_copy(deep=True, update={"inherited_from_parent": True})
+                        for attempt in parent_checkpoint.attempts
+                    ],
+                    evidence_request_budget=parent_checkpoint.evidence_request_budget,
+                    evidence_request_budget_remaining=parent_checkpoint.evidence_request_budget_remaining,
+                    evidence_request_actions=[
+                        action.model_copy(deep=True, update={"inherited_from_parent": True})
+                        for action in parent_checkpoint.evidence_request_actions
+                    ],
                 )
             )
         else:
-            checkpoint_runs.append(CheckpointRunRecord(checkpoint_id=checkpoint.checkpoint_id))
+            request_budget = (
+                checkpoint.conditional_evidence.request_budget if checkpoint.conditional_evidence is not None else 0
+            )
+            checkpoint_runs.append(
+                CheckpointRunRecord(
+                    checkpoint_id=checkpoint.checkpoint_id,
+                    evidence_request_budget=request_budget,
+                    evidence_request_budget_remaining=request_budget,
+                )
+            )
 
     state = EvidenceLifecycleRunState(
         lifecycle_id=spec.lifecycle_id,
@@ -279,6 +550,11 @@ def branch_evidence_lifecycle(
             parent_run_dir=str(parent_run),
             branched_from_checkpoint_id=checkpoint_id,
             parent_submission_sha256=parent_checkpoint.submission_sha256,
+            parent_action_state_sha256=_branch_action_state_sha256(
+                parent_state,
+                branch_index=branch_index,
+                inherited_only=False,
+            ),
             reason=reason,
         ),
     )
@@ -307,6 +583,14 @@ def branch_evidence_lifecycle(
             if index < branch_index:
                 _inherit_submission(parent_run, staging_run, checkpoint)
 
+        _inherit_evidence_request_transactions(parent_run, staging_run, state)
+        for checkpoint in spec.checkpoints[: branch_index + 1]:
+            _write_evidence_request_catalog(
+                staging_run,
+                checkpoint,
+                state.checkpoint(checkpoint.checkpoint_id),
+            )
+
         parent_archive = parent_run / "episodes" / checkpoint_id / "submission.json"
         staged_origin = workspace / "branch_origin" / f"{checkpoint_id}.json"
         staged_submission = workspace / _checkpoint(spec, checkpoint_id).submission_path
@@ -318,6 +602,7 @@ def branch_evidence_lifecycle(
         )
         _write_state(staging_run, state)
         _sync_transition_ledger(staging_run, state)
+        _sync_evidence_request_ledger(staging_run, state)
         final_origin = _workspace(branch_run) / "branch_origin" / f"{checkpoint_id}.json"
         final_submission = _workspace(branch_run) / _checkpoint(spec, checkpoint_id).submission_path
         append_ledger_entry(
@@ -346,8 +631,27 @@ def open_checkpoint_attempt(
     """Open a checkpoint attempt, interrupting an abandoned active attempt."""
     package = Path(package_dir)
     run = Path(run_dir)
+    with _lifecycle_state_lock(run):
+        return _open_checkpoint_attempt_locked(
+            package,
+            run,
+            session_id=session_id,
+            execution_mode=execution_mode,
+            episode_request_sha256=episode_request_sha256,
+        )
+
+
+def _open_checkpoint_attempt_locked(
+    package: Path,
+    run: Path,
+    *,
+    session_id: str,
+    execution_mode: str,
+    episode_request_sha256: str | None,
+) -> dict[str, Any]:
+    """Open an attempt while holding the per-run mutation lock."""
     spec = load_evidence_lifecycle_spec(package)
-    state = _load_state(package, run, spec)
+    state = _load_state(package, run, spec, lock_held=True)
     checkpoint_id = state.active_checkpoint_id
     if checkpoint_id is None:
         raise EvidenceLifecycleError("no checkpoint is active")
@@ -400,8 +704,25 @@ def fail_checkpoint_attempt(
     """Close the active checkpoint attempt after an execution failure."""
     package = Path(package_dir)
     run = Path(run_dir)
+    with _lifecycle_state_lock(run):
+        return _fail_checkpoint_attempt_locked(
+            package,
+            run,
+            session_id=session_id,
+            failure_kind=failure_kind,
+        )
+
+
+def _fail_checkpoint_attempt_locked(
+    package: Path,
+    run: Path,
+    *,
+    session_id: str,
+    failure_kind: str,
+) -> dict[str, Any]:
+    """Fail an attempt while holding the per-run mutation lock."""
     spec = load_evidence_lifecycle_spec(package)
-    state = _load_state(package, run, spec)
+    state = _load_state(package, run, spec, lock_held=True)
     checkpoint_id = state.active_checkpoint_id
     if checkpoint_id is None:
         raise EvidenceLifecycleError("no checkpoint is active")
@@ -443,8 +764,25 @@ def revisit_evidence_checkpoint(
     """Return and log an immutable prior checkpoint without rewinding the run."""
     package = Path(package_dir)
     run = Path(run_dir)
+    with _lifecycle_state_lock(run):
+        return _revisit_evidence_checkpoint_locked(
+            package,
+            run,
+            checkpoint_id=checkpoint_id,
+            reason=reason,
+        )
+
+
+def _revisit_evidence_checkpoint_locked(
+    package: Path,
+    run: Path,
+    *,
+    checkpoint_id: str,
+    reason: str,
+) -> dict[str, Any]:
+    """Record a revisit while holding the per-run mutation lock."""
     spec = load_evidence_lifecycle_spec(package)
-    state = _load_state(package, run, spec)
+    state = _load_state(package, run, spec, lock_held=True)
     _assert_prior_submissions_unchanged(run, state)
     try:
         checkpoint_run = state.checkpoint(checkpoint_id)
@@ -501,10 +839,16 @@ def run_evidence_lifecycle(
         raw_context = prepare_evidence_checkpoint(package_dir, run_dir)
         if raw_context["status"] == "complete":
             return raw_context
-        context = LifecycleEpisodeContext.from_runtime_context(raw_context)
+        context = LifecycleEpisodeContext.from_runtime_context(
+            raw_context,
+            visibility_policy=episode_environment.memory_visibility_policy,
+        )
         _recover_host_episode_attempt(context, episode_environment)
         episode_environment.recover(context)
-        context = LifecycleEpisodeContext.from_runtime_context(prepare_evidence_checkpoint(package_dir, run_dir))
+        context = LifecycleEpisodeContext.from_runtime_context(
+            prepare_evidence_checkpoint(package_dir, run_dir),
+            visibility_policy=episode_environment.memory_visibility_policy,
+        )
         _preserve_prior_attempt_submission(context)
         checkpoint_run = next(item for item in context.checkpoint_runs if item.checkpoint_id == context.checkpoint_id)
         attempt_sequence = len(checkpoint_run.attempts) + 1
@@ -516,6 +860,7 @@ def run_evidence_lifecycle(
             attempt_id=attempt_id,
             session_id=session_id,
         )
+        request = _adopt_compatible_durable_episode_request(request)
         try:
             episode_environment.prepare(request)
         except Exception as exc:
@@ -780,6 +1125,8 @@ def _build_episode_request(
         instruction_path=context.instruction_path,
         submission_path=context.submission_path,
         released_files=context.released_files,
+        evidence_request_catalog=context.evidence_request_catalog,
+        released_evidence_artifacts=context.released_evidence_artifacts,
         completed_checkpoint_ids=context.completed_checkpoint_ids,
     )
 
@@ -813,7 +1160,7 @@ def _persist_episode_request(request: LifecycleEpisodeRequest) -> Path:
     """Publish the host-authored request before making its attempt active."""
     request_dir = Path(request.run_dir) / "episodes" / request.checkpoint_id / request.session_id
     request_path = request_dir / "episode_request.json"
-    payload = json.dumps(request.model_dump(mode="json"), indent=2, sort_keys=True) + "\n"
+    payload = _episode_request_json(request)
     return _persist_host_json(
         request_path,
         payload,
@@ -845,7 +1192,7 @@ def _recover_host_episode_attempt(
         attempt_id=attempt.attempt_id,
         session_id=attempt.session_id,
     )
-    if request != expected_request:
+    if request != expected_request and not _matches_legacy_v1_episode_request(request, expected_request):
         raise EvidenceLifecycleError(f"interrupted episode request identity mismatch: {attempt.attempt_id}")
     result_path = result_dir / "episode_result.json"
     if result_path.is_file():
@@ -948,7 +1295,7 @@ def _quarantine_prepared_host_artifacts(request: LifecycleEpisodeRequest) -> tup
         if not source.is_file():
             raise EvidenceLifecycleError(f"reserved episode result path is not a file: {source}")
         if filename == "episode_request.json":
-            expected = json.dumps(request.model_dump(mode="json"), indent=2, sort_keys=True) + "\n"
+            expected = _episode_request_json(request)
             if source.read_text(encoding="utf-8") == expected:
                 continue
         destination = result_dir / f"environment_prepared_{filename}"
@@ -958,6 +1305,49 @@ def _quarantine_prepared_host_artifacts(request: LifecycleEpisodeRequest) -> tup
         fsync_directory(result_dir)
         quarantined.append(filename)
     return tuple(quarantined)
+
+
+def _adopt_compatible_durable_episode_request(
+    request: LifecycleEpisodeRequest,
+) -> LifecycleEpisodeRequest:
+    """Reuse an exact durable request, including the pre-v2 shape, before environment preparation."""
+    request_path = (
+        Path(request.run_dir) / "episodes" / request.checkpoint_id / request.session_id / "episode_request.json"
+    )
+    if not request_path.is_file():
+        return request
+    try:
+        durable = LifecycleEpisodeRequest.model_validate(_read_json(request_path))
+    except (EvidenceLifecycleError, ValidationError):
+        return request
+    if durable == request or _matches_legacy_v1_episode_request(durable, request):
+        return durable
+    return request
+
+
+def _matches_legacy_v1_episode_request(
+    durable: LifecycleEpisodeRequest,
+    expected: LifecycleEpisodeRequest,
+) -> bool:
+    """Accept only the exact field projection emitted by the v1 episode contract."""
+    v2_fields = {"evidence_request_catalog", "released_evidence_artifacts"}
+    if (
+        durable.schema_version != "1"
+        or expected.schema_version != "2"
+        or not v2_fields.isdisjoint(durable.model_fields_set)
+        or durable.evidence_request_catalog is not None
+        or durable.released_evidence_artifacts
+        or expected.evidence_request_catalog is not None
+        or expected.released_evidence_artifacts
+    ):
+        return False
+    return durable == expected.model_copy(update={"schema_version": "1"})
+
+
+def _episode_request_json(request: LifecycleEpisodeRequest) -> str:
+    excluded = {"evidence_request_catalog", "released_evidence_artifacts"} if request.schema_version == "1" else set()
+    payload = request.model_dump(mode="json", exclude=excluded)
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
 
 
 def _close_episode_failure(
@@ -1177,7 +1567,18 @@ def _initialize_state(
         world_id=spec.world_id,
         lifecycle_spec_sha256=_spec_sha256(spec),
         package_sha256=_package_sha256(package_dir),
-        checkpoint_runs=[CheckpointRunRecord(checkpoint_id=item.checkpoint_id) for item in spec.checkpoints],
+        checkpoint_runs=[
+            CheckpointRunRecord(
+                checkpoint_id=item.checkpoint_id,
+                evidence_request_budget=(
+                    item.conditional_evidence.request_budget if item.conditional_evidence is not None else 0
+                ),
+                evidence_request_budget_remaining=(
+                    item.conditional_evidence.request_budget if item.conditional_evidence is not None else 0
+                ),
+            )
+            for item in spec.checkpoints
+        ],
     )
     _write_state(run_dir, state)
     return state
@@ -1187,16 +1588,26 @@ def _load_state(
     package_dir: Path,
     run_dir: Path,
     spec: EvidenceLifecycleSpec,
+    *,
+    lock_held: bool = False,
 ) -> EvidenceLifecycleRunState:
+    if not _state_path(run_dir).is_file():
+        raise EvidenceLifecycleError(f"lifecycle state not found: {_state_path(run_dir)}")
+    if not lock_held:
+        with _lifecycle_state_lock(run_dir):
+            return _load_state(package_dir, run_dir, spec, lock_held=True)
     path = _state_path(run_dir)
     if not path.is_file():
         raise EvidenceLifecycleError(f"lifecycle state not found: {path}")
     payload = _read_json(path)
     version = payload.get("schema_version")
     try:
-        if version == "3":
+        if version == "4":
             state = EvidenceLifecycleRunState.model_validate(payload)
             migrated = False
+        elif version == "3":
+            state = _migrate_v3_state(payload, spec)
+            migrated = True
         elif version == "2":
             state = _migrate_v2_state(payload, package_dir, spec)
             migrated = True
@@ -1216,9 +1627,12 @@ def _load_state(
         raise EvidenceLifecycleError("lifecycle contract does not match lifecycle run")
     if state.package_sha256 != _package_sha256(package_dir):
         raise EvidenceLifecycleError("package does not match lifecycle run")
+    _validate_evidence_request_state_contract(state, spec)
     if migrated:
         _write_state(run_dir, state)
+    _recover_evidence_request_transactions(run_dir, spec, state)
     _sync_transition_ledger(run_dir, state)
+    _sync_evidence_request_ledger(run_dir, state)
     return state
 
 
@@ -1228,6 +1642,16 @@ def _assert_prior_submissions_unchanged(run_dir: Path, state: EvidenceLifecycleR
         branch_origin = _workspace(run_dir) / "branch_origin" / f"{checkpoint_id}.json"
         if not branch_origin.is_file() or _sha256(branch_origin) != state.branch.parent_submission_sha256:
             raise EvidenceLifecycleError(f"branch origin submission changed: {checkpoint_id}")
+        branch_index = next(
+            index for index, checkpoint in enumerate(state.checkpoint_runs) if checkpoint.checkpoint_id == checkpoint_id
+        )
+        action_state_sha256 = _branch_action_state_sha256(
+            state,
+            branch_index=branch_index,
+            inherited_only=True,
+        )
+        if action_state_sha256 != state.branch.parent_action_state_sha256:
+            raise EvidenceLifecycleError(f"branch origin evidence request state changed: {checkpoint_id}")
     for completed in state.checkpoint_runs:
         if completed.status != CheckpointRunStatus.SUBMITTED:
             continue
@@ -1252,6 +1676,8 @@ def _preflight_checkpoint(package_dir: Path, checkpoint: EvidenceCheckpointSpec)
         raise EvidenceLifecycleError(f"checkpoint release not found: {release_source}")
     if not instruction_source.is_file() or instruction_source.is_symlink():
         raise EvidenceLifecycleError(f"checkpoint instruction not found: {instruction_source}")
+    if checkpoint.conditional_evidence is not None and (release_source / "requests").exists():
+        raise EvidenceLifecycleError("checkpoint release uses the reserved requests namespace")
     return instruction_source.read_text(encoding="utf-8")
 
 
@@ -1283,25 +1709,6 @@ def _materialize_checkpoint_release(
         shutil.rmtree(staging_root, ignore_errors=True)
 
 
-def _copy_release(source: Path, destination: Path) -> list[str]:
-    if not source.is_dir() or source.is_symlink():
-        raise EvidenceLifecycleError(f"checkpoint release not found: {source}")
-    destination.mkdir(parents=True, exist_ok=False)
-    released: list[str] = []
-    for source_path in sorted(source.rglob("*")):
-        if source_path.is_symlink():
-            raise EvidenceLifecycleError(f"checkpoint releases may not contain symlinks: {source_path}")
-        relative = source_path.relative_to(source)
-        destination_path = destination / relative
-        if source_path.is_dir():
-            destination_path.mkdir(parents=True, exist_ok=True)
-            continue
-        destination_path.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(source_path, destination_path)
-        released.append(relative.as_posix())
-    return released
-
-
 def _copy_checkpoint_instruction(
     package_dir: Path,
     workspace: Path,
@@ -1329,27 +1736,11 @@ def _inherit_submission(
     )
 
 
-def _copy_file_atomic(source: Path, destination: Path) -> None:
-    if not source.is_file():
-        raise EvidenceLifecycleError(f"branch source artifact not found: {source}")
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    temporary = destination.with_suffix(destination.suffix + ".tmp")
-    shutil.copy2(source, temporary)
-    temporary.replace(destination)
-
-
 def _write_text_atomic(destination: Path, content: str) -> None:
     destination.parent.mkdir(parents=True, exist_ok=True)
     temporary = destination.with_suffix(destination.suffix + ".tmp")
     temporary.write_text(content, encoding="utf-8")
     temporary.replace(destination)
-
-
-def _checkpoint(spec: EvidenceLifecycleSpec, checkpoint_id: str) -> EvidenceCheckpointSpec:
-    for checkpoint in spec.checkpoints:
-        if checkpoint.checkpoint_id == checkpoint_id:
-            return checkpoint
-    raise EvidenceLifecycleError(f"unknown checkpoint in lifecycle state: {checkpoint_id}")
 
 
 def _checkpoint_context(
@@ -1359,7 +1750,7 @@ def _checkpoint_context(
 ) -> dict[str, Any]:
     workspace = _workspace(run_dir)
     checkpoint_run = state.checkpoint(checkpoint.checkpoint_id)
-    return {
+    context = {
         "lifecycle_id": state.lifecycle_id,
         "world_id": state.world_id,
         "lifecycle_spec_sha256": state.lifecycle_spec_sha256,
@@ -1380,6 +1771,10 @@ def _checkpoint_context(
         "transitions": [item.model_dump(mode="json") for item in state.transitions],
         "branch": state.branch.model_dump(mode="json") if state.branch is not None else None,
     }
+    catalog = _evidence_request_catalog(checkpoint, checkpoint_run)
+    if catalog is not None:
+        context["evidence_request_catalog"] = catalog
+    return context
 
 
 def _result_context(run_dir: Path, state: EvidenceLifecycleRunState) -> dict[str, Any]:
@@ -1417,43 +1812,47 @@ def _attempt_context(attempt: CheckpointAttemptRecord) -> dict[str, Any]:
     return attempt.model_dump(mode="json")
 
 
-def _append_transition(
-    state: EvidenceLifecycleRunState,
-    *,
-    kind: LifecycleTransitionKind,
-    from_checkpoint_id: str | None,
-    to_checkpoint_id: str | None,
-    reason: str,
-) -> None:
-    state.transitions.append(
-        LifecycleTransitionRecord(
-            transition_id=f"transition-{len(state.transitions) + 1:03d}",
-            kind=kind,
-            from_checkpoint_id=from_checkpoint_id,
-            to_checkpoint_id=to_checkpoint_id,
-            reason=reason,
+def _migrate_v3_state(
+    payload: dict[str, Any],
+    spec: EvidenceLifecycleSpec,
+) -> EvidenceLifecycleRunState:
+    if any(checkpoint.conditional_evidence is not None for checkpoint in spec.checkpoints):
+        raise EvidenceLifecycleError("v3 lifecycle state cannot be paired with conditional evidence")
+    for checkpoint in payload.get("checkpoint_runs", []):
+        if not isinstance(checkpoint, dict):
+            raise EvidenceLifecycleError("invalid v3 lifecycle checkpoint state")
+        if checkpoint.get("inherited_from_parent") and checkpoint.get("attempts"):
+            raise EvidenceLifecycleError("v3 inherited checkpoint cannot contain attempts")
+        forbidden = {
+            "evidence_request_budget",
+            "evidence_request_budget_remaining",
+            "evidence_request_actions",
+        }
+        if forbidden.intersection(checkpoint):
+            raise EvidenceLifecycleError("v3 lifecycle state cannot contain evidence request fields")
+    migrated = copy.deepcopy(payload)
+    for checkpoint in migrated.get("checkpoint_runs", []):
+        checkpoint["evidence_request_budget"] = 0
+        checkpoint["evidence_request_budget_remaining"] = 0
+        checkpoint["evidence_request_actions"] = []
+    migrated["schema_version"] = "3"
+    branch = migrated.get("branch")
+    if isinstance(branch, dict):
+        branch.pop("parent_action_state_sha256", None)
+        provisional = EvidenceLifecycleRunState.model_validate(migrated)
+        branch_checkpoint_id = str(branch["branched_from_checkpoint_id"])
+        branch_index = next(
+            index
+            for index, checkpoint in enumerate(provisional.checkpoint_runs)
+            if checkpoint.checkpoint_id == branch_checkpoint_id
         )
-    )
-
-
-def _sync_transition_ledger(run_dir: Path, state: EvidenceLifecycleRunState) -> None:
-    ledger_path = _ledger_path(run_dir)
-    recorded = {
-        str(entry.get("summary", {}).get("transition_id"))
-        for entry in read_ledger(ledger_path)
-        if entry.get("stage") == "lifecycle_transition"
-    }
-    for transition in state.transitions:
-        if transition.transition_id in recorded:
-            continue
-        append_ledger_entry(
-            ledger_path,
-            process_id=state.lifecycle_id,
-            stage="lifecycle_transition",
-            status=transition.kind.value,
-            summary=transition.model_dump(mode="json"),
-            artifact_refs=[],
+        branch["parent_action_state_sha256"] = _branch_action_state_sha256(
+            provisional,
+            branch_index=branch_index,
+            inherited_only=False,
         )
+    migrated["schema_version"] = "4"
+    return EvidenceLifecycleRunState.model_validate(migrated)
 
 
 def _migrate_v2_state(
@@ -1461,10 +1860,28 @@ def _migrate_v2_state(
     package_dir: Path,
     spec: EvidenceLifecycleSpec,
 ) -> EvidenceLifecycleRunState:
+    if any(checkpoint.conditional_evidence is not None for checkpoint in spec.checkpoints):
+        raise EvidenceLifecycleError("v2 lifecycle state cannot be paired with conditional evidence")
     migrated = copy.deepcopy(payload)
-    migrated["schema_version"] = "3"
     migrated["lifecycle_spec_sha256"] = _spec_sha256(spec)
     migrated["package_sha256"] = _package_sha256(package_dir)
+    migrated["schema_version"] = "3"
+    branch = migrated.get("branch")
+    if isinstance(branch, dict):
+        branch.pop("parent_action_state_sha256", None)
+        provisional = EvidenceLifecycleRunState.model_validate(migrated)
+        branch_checkpoint_id = str(branch["branched_from_checkpoint_id"])
+        branch_index = next(
+            index
+            for index, checkpoint in enumerate(provisional.checkpoint_runs)
+            if checkpoint.checkpoint_id == branch_checkpoint_id
+        )
+        branch["parent_action_state_sha256"] = _branch_action_state_sha256(
+            provisional,
+            branch_index=branch_index,
+            inherited_only=False,
+        )
+    migrated["schema_version"] = "4"
     return EvidenceLifecycleRunState.model_validate(migrated)
 
 
@@ -1473,6 +1890,8 @@ def _migrate_legacy_state(
     package_dir: Path,
     spec: EvidenceLifecycleSpec,
 ) -> EvidenceLifecycleRunState:
+    if any(checkpoint.conditional_evidence is not None for checkpoint in spec.checkpoints):
+        raise EvidenceLifecycleError("legacy lifecycle state cannot be paired with conditional evidence")
     completed = {item["checkpoint_id"]: item for item in payload.get("completed_checkpoints", [])}
     active_checkpoint_id = payload.get("active_checkpoint_id")
     checkpoint_runs = []
@@ -1509,51 +1928,23 @@ def _migrate_legacy_state(
     )
 
 
-def _workspace(run_dir: Path) -> Path:
-    return run_dir / "workspace"
-
-
-def _state_path(run_dir: Path) -> Path:
-    return run_dir / "state.json"
-
-
-def _ledger_path(run_dir: Path) -> Path:
-    return run_dir / "lifecycle_ledger.jsonl"
-
-
-def _write_state(run_dir: Path, state: EvidenceLifecycleRunState) -> None:
-    path = _state_path(run_dir)
-    temporary = path.with_suffix(".json.tmp")
-    _write_json(temporary, state.model_dump(mode="json"))
-    temporary.replace(path)
-
-
-def _read_json(path: Path) -> dict[str, Any]:
+@contextmanager
+def _lifecycle_state_lock(run_dir: Path) -> Iterator[None]:
+    lock_dir = run_dir / ".locks"
+    mkdir_durable(lock_dir)
+    lock_path = lock_dir / "lifecycle-state.lock"
+    descriptor = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
     try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise EvidenceLifecycleError(f"invalid JSON artifact: {path}") from exc
-    if not isinstance(payload, dict):
-        raise EvidenceLifecycleError(f"JSON artifact must contain an object: {path}")
-    return payload
-
-
-def _write_json(path: Path, payload: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
-
-
-def _sha256(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(64 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
 
 
 def _spec_sha256(spec: EvidenceLifecycleSpec) -> str:
     payload = json.dumps(
-        spec.model_dump(mode="json"),
+        spec.model_dump(mode="json", exclude_none=True),
         sort_keys=True,
         separators=(",", ":"),
     ).encode("utf-8")

--- a/src/aec_bench/meta_harness/evidence_lifecycle_episode.py
+++ b/src/aec_bench/meta_harness/evidence_lifecycle_episode.py
@@ -15,6 +15,7 @@ from aec_bench.contracts.validators import NonEmptyStr, StrictModel
 from aec_bench.meta_harness.evidence_lifecycle_state import (
     CheckpointRunRecord,
     LifecycleRunStatus,
+    ReleasedEvidenceArtifact,
 )
 
 
@@ -54,6 +55,36 @@ class LifecycleCompletedCheckpoint(StrictModel):
         return ArtifactReference.validate_sha256(value)
 
 
+class LifecycleEvidenceRequestOption(StrictModel):
+    request_id: NonEmptyStr
+    title: NonEmptyStr
+    description: NonEmptyStr
+    prerequisite_request_ids: tuple[NonEmptyStr, ...] = ()
+    status: Literal[
+        "available",
+        "released",
+        "budget_exhausted",
+        "prerequisites_incomplete",
+    ]
+
+
+class LifecycleEvidenceRequestCatalog(StrictModel):
+    schema_version: Literal["1"] = "1"
+    checkpoint_id: NonEmptyStr
+    request_budget: NonNegativeInt
+    remaining_budget: NonNegativeInt
+    requests: tuple[LifecycleEvidenceRequestOption, ...] = ()
+
+    @model_validator(mode="after")
+    def validate_budget_and_ids(self) -> LifecycleEvidenceRequestCatalog:
+        if self.remaining_budget > self.request_budget:
+            raise ValueError("remaining evidence request budget cannot exceed its initial budget")
+        request_ids = [request.request_id for request in self.requests]
+        if len(request_ids) != len(set(request_ids)):
+            raise ValueError("episode evidence request ids must be unique")
+        return self
+
+
 class LifecycleEpisodeContext(StrictModel):
     """Validated host state available before an episode attempt is opened."""
 
@@ -71,6 +102,8 @@ class LifecycleEpisodeContext(StrictModel):
     instruction_path: NonEmptyStr
     submission_path: NonEmptyStr
     released_files: tuple[NonEmptyStr, ...] = ()
+    evidence_request_catalog: LifecycleEvidenceRequestCatalog | None = None
+    released_evidence_artifacts: tuple[ReleasedEvidenceArtifact, ...] = ()
     completed_checkpoints: tuple[LifecycleCompletedCheckpoint, ...] = ()
     checkpoint_runs: tuple[CheckpointRunRecord, ...]
 
@@ -90,8 +123,26 @@ class LifecycleEpisodeContext(StrictModel):
         return self
 
     @classmethod
-    def from_runtime_context(cls, payload: dict[str, Any]) -> LifecycleEpisodeContext:
-        """Select and validate the stable episode fields from lifecycle runtime state."""
+    def from_runtime_context(
+        cls,
+        payload: dict[str, Any],
+        *,
+        visibility_policy: LifecycleVisibilityPolicy | str,
+    ) -> LifecycleEpisodeContext:
+        """Select the stable episode fields and hash-bind every visible requested artifact."""
+        policy = LifecycleVisibilityPolicy(visibility_policy)
+        checkpoint_runs = tuple(payload["checkpoint_runs"])
+        active_checkpoint = next(item for item in checkpoint_runs if item["checkpoint_id"] == payload["checkpoint_id"])
+        visible_checkpoint_runs = (
+            (active_checkpoint,) if policy is LifecycleVisibilityPolicy.CURRENT_RELEASE_ONLY else checkpoint_runs
+        )
+        released_evidence_artifacts = tuple(
+            artifact
+            for checkpoint in visible_checkpoint_runs
+            for action in checkpoint.get("evidence_request_actions", ())
+            if action.get("outcome") == "released"
+            for artifact in action.get("released_artifacts", ())
+        )
         return cls(
             lifecycle_id=payload["lifecycle_id"],
             world_id=payload["world_id"],
@@ -107,8 +158,10 @@ class LifecycleEpisodeContext(StrictModel):
             instruction_path=payload["instruction_path"],
             submission_path=payload["submission_path"],
             released_files=tuple(payload.get("released_files", ())),
+            evidence_request_catalog=payload.get("evidence_request_catalog"),
+            released_evidence_artifacts=released_evidence_artifacts,
             completed_checkpoints=tuple(payload.get("completed_checkpoints", ())),
-            checkpoint_runs=tuple(payload["checkpoint_runs"]),
+            checkpoint_runs=checkpoint_runs,
         )
 
     @property
@@ -119,7 +172,7 @@ class LifecycleEpisodeContext(StrictModel):
 class LifecycleEpisodeRequest(StrictModel):
     """Host-authored execution request for one lifecycle environment call."""
 
-    schema_version: Literal["1"] = "1"
+    schema_version: Literal["1", "2"] = "2"
     episode_id: NonEmptyStr
     lifecycle_id: NonEmptyStr
     world_id: NonEmptyStr
@@ -141,6 +194,8 @@ class LifecycleEpisodeRequest(StrictModel):
     instruction_path: NonEmptyStr
     submission_path: NonEmptyStr
     released_files: tuple[NonEmptyStr, ...] = ()
+    evidence_request_catalog: LifecycleEvidenceRequestCatalog | None = None
+    released_evidence_artifacts: tuple[ReleasedEvidenceArtifact, ...] = ()
     completed_checkpoint_ids: tuple[NonEmptyStr, ...] = ()
 
     @field_validator("lifecycle_spec_sha256", "package_sha256")
@@ -163,6 +218,12 @@ class LifecycleEpisodeRequest(StrictModel):
             raise ValueError("completed checkpoint ids must be unique")
         if len(set(self.released_files)) != len(self.released_files):
             raise ValueError("released files must be unique")
+        if self.evidence_request_catalog is not None:
+            if self.evidence_request_catalog.checkpoint_id != self.checkpoint_id:
+                raise ValueError("evidence request catalogue must match the active checkpoint")
+        artifact_paths = [artifact.path for artifact in self.released_evidence_artifacts]
+        if len(artifact_paths) != len(set(artifact_paths)):
+            raise ValueError("released evidence artifact paths must be unique")
         return self
 
 

--- a/src/aec_bench/meta_harness/evidence_lifecycle_experiment.py
+++ b/src/aec_bench/meta_harness/evidence_lifecycle_experiment.py
@@ -35,7 +35,10 @@ from aec_bench.ledger.durability import (
 from aec_bench.ledger.durability import (
     mkdir_durable,
 )
-from aec_bench.meta_harness.evidence_lifecycle import read_evidence_lifecycle_state
+from aec_bench.meta_harness.evidence_lifecycle import (
+    evidence_request_protocol_identity,
+    read_evidence_lifecycle_state,
+)
 from aec_bench.meta_harness.evidence_lifecycle_metrics import LifecycleSemanticMetrics
 from aec_bench.meta_harness.ledger import read_ledger
 from aec_bench.task_world_templates.lifecycles import (
@@ -45,12 +48,18 @@ from aec_bench.task_world_templates.lifecycles import (
 
 
 class LifecycleExperimentMetrics(StrictModel):
-    schema_version: NonEmptyStr = "1"
+    schema_version: Literal["1", "2"] = "2"
     checkpoint_count: NonNegativeInt
     requests: NonNegativeInt
     tool_calls: NonNegativeInt
     reads: NonNegativeInt
     revisits: NonNegativeInt
+    evidence_request_calls: NonNegativeInt = 0
+    accepted_evidence_requests: NonNegativeInt = 0
+    already_released_evidence_requests: NonNegativeInt = 0
+    rejected_evidence_requests: NonNegativeInt = 0
+    evidence_request_budget_consumed: NonNegativeInt = 0
+    evidence_request_artifacts_released: NonNegativeInt = 0
     retries: NonNegativeInt
     failures: NonNegativeInt
     input_tokens: NonNegativeInt
@@ -173,6 +182,21 @@ def record_lifecycle_experiment(
     verifier_chain = [verifier_entrypoint]
     if registered_verifier != verifier_entrypoint:
         verifier_chain.append(registered_verifier)
+    interaction = {
+        **prompts,
+        "tool_schema": tool_schema,
+        "trajectory_hashes": {str(path.relative_to(run)): _sha256(path) for path in trajectories},
+    }
+    if any(tool.get("name") == "request_evidence" for tool in tool_schema):
+        tool_schema_payload = json.dumps(
+            tool_schema,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        interaction["evidence_request_protocol"] = {
+            **evidence_request_protocol_identity(),
+            "tool_schema_sha256": hashlib.sha256(tool_schema_payload).hexdigest(),
+        }
     manifest = LifecycleExperimentManifest(
         experiment_id=experiment_id,
         created_at=datetime.now(UTC).isoformat(),
@@ -210,11 +234,7 @@ def record_lifecycle_experiment(
             "checkpoint_seconds": metrics.checkpoint_seconds,
             "whole_run_seconds": metrics.whole_run_seconds,
         },
-        interaction={
-            **prompts,
-            "tool_schema": tool_schema,
-            "trajectory_hashes": {str(path.relative_to(run)): _sha256(path) for path in trajectories},
-        },
+        interaction=interaction,
         outputs={
             "verification.json": _sha256(verification_path),
             "metrics.json": _sha256(metrics_path),
@@ -284,6 +304,9 @@ def _build_metrics(
     tool_calls = [entry for entry in entries if entry.role == "tool_call"]
     state = _read_json(run_dir / "state.json")
     attempts = [attempt for checkpoint in state["checkpoint_runs"] for attempt in checkpoint.get("attempts", [])]
+    evidence_request_actions = [
+        action for checkpoint in state["checkpoint_runs"] for action in checkpoint.get("evidence_request_actions", [])
+    ]
     timing = _lifecycle_timing(run_dir)
     totals = agent["totals"]
     resolved_model = next(
@@ -305,6 +328,20 @@ def _build_metrics(
         tool_calls=len(tool_calls),
         reads=sum(entry.tool_name == "read_workspace_file" for entry in tool_calls),
         revisits=sum(entry.tool_name == "revisit_checkpoint" for entry in tool_calls),
+        evidence_request_calls=len(evidence_request_actions),
+        accepted_evidence_requests=sum(action.get("outcome") == "released" for action in evidence_request_actions),
+        already_released_evidence_requests=sum(
+            action.get("outcome") == "already_released" for action in evidence_request_actions
+        ),
+        rejected_evidence_requests=sum(action.get("outcome") == "rejected" for action in evidence_request_actions),
+        evidence_request_budget_consumed=sum(
+            int(action.get("budget_consumed", 0)) for action in evidence_request_actions
+        ),
+        evidence_request_artifacts_released=sum(
+            len(action.get("released_artifacts", []))
+            for action in evidence_request_actions
+            if action.get("outcome") == "released"
+        ),
         retries=sum(max(0, len(checkpoint.get("attempts", [])) - 1) for checkpoint in state["checkpoint_runs"]),
         failures=sum(attempt["status"] == "failed" for attempt in attempts),
         input_tokens=int(totals["input_tokens"]),
@@ -745,8 +782,14 @@ def _run_artifact_hashes(run_dir: Path) -> dict[str, str]:
         "verification.json",
     }
     for path in sorted(run_dir.rglob("*")):
-        if path.is_file() and path.name in names and "experiments" not in path.relative_to(run_dir).parts:
-            selected[str(path.relative_to(run_dir))] = _sha256(path)
+        relative = path.relative_to(run_dir)
+        requested_evidence = (
+            relative.parts[:1] == ("evidence_requests",)
+            or (relative.parts[:2] == ("workspace", "inbox") and "requests" in relative.parts[2:])
+            or (relative.parts[:2] == ("workspace", "checkpoints") and path.name == "evidence-requests.json")
+        )
+        if path.is_file() and (path.name in names or requested_evidence) and "experiments" not in relative.parts:
+            selected[str(relative)] = _sha256(path)
     return selected
 
 

--- a/src/aec_bench/meta_harness/evidence_lifecycle_local.py
+++ b/src/aec_bench/meta_harness/evidence_lifecycle_local.py
@@ -25,6 +25,7 @@ from aec_bench.meta_harness.evidence_lifecycle import (
     open_checkpoint_attempt,
     prepare_evidence_checkpoint,
     read_evidence_lifecycle_state,
+    request_evidence_checkpoint,
     revisit_evidence_checkpoint,
     run_evidence_lifecycle,
     submit_evidence_checkpoint,
@@ -58,6 +59,35 @@ class EvidenceLifecycleControlTool:
     package_dir: Path
     run_dir: Path
     session_id: str = "manual"
+
+    def request_evidence(self, checkpoint_id: str, request_id: str, reason: str) -> str:
+        """Request one declared evidence packet using the active checkpoint budget."""
+        if not checkpoint_id.strip() or not request_id.strip() or not reason.strip():
+            return json.dumps(
+                {
+                    "status": "rejected",
+                    "error": "evidence request arguments must not be blank",
+                }
+            )
+        result = request_evidence_checkpoint(
+            self.package_dir,
+            self.run_dir,
+            checkpoint_id=checkpoint_id,
+            request_id=request_id,
+            reason=reason,
+            session_id=self.session_id,
+        )
+        payload: dict[str, Any] = {
+            "status": result["outcome"],
+            "checkpoint_id": result["requested_checkpoint_id"],
+            "request_id": result["request_id"],
+            "remaining_budget": result["budget_after"],
+        }
+        if result["outcome"] in {"released", "already_released"}:
+            payload["released_files"] = [artifact["workspace_path"] for artifact in result["released_artifacts"]]
+        if result["rejection"] is not None:
+            payload["rejection"] = result["rejection"]
+        return json.dumps(payload)
 
     def submit_checkpoint(self, checkpoint_id: str) -> str:
         """Submit the named checkpoint and release the next evidence packet.
@@ -258,6 +288,49 @@ def run_local_evidence_lifecycle_session(
         run_dir=run,
         visibility_policy=visibility_policy,
     )
+    supports_evidence_requests = _supports_evidence_requests(package)
+    native_tools = [
+        workspace_tool.list_workspace,
+        workspace_tool.read_workspace_file,
+        workspace_tool.write_checkpoint_submission,
+    ]
+    tool_specs = [
+        ToolSpec(name="list_workspace", source="builtin", description="List visible lifecycle files."),
+        ToolSpec(
+            name="read_workspace_file",
+            source="builtin",
+            description="Read one visible lifecycle file.",
+        ),
+        ToolSpec(
+            name="write_checkpoint_submission",
+            source="builtin",
+            description="Write the active checkpoint JSON submission.",
+        ),
+    ]
+    if supports_evidence_requests:
+        native_tools.append(control.request_evidence)
+        tool_specs.append(
+            ToolSpec(
+                name="request_evidence",
+                source="builtin",
+                description="Request one declared evidence packet within the active checkpoint budget.",
+            )
+        )
+    native_tools.extend([control.submit_checkpoint, control.revisit_checkpoint])
+    tool_specs.extend(
+        [
+            ToolSpec(
+                name="submit_checkpoint",
+                source="builtin",
+                description="Archive the active checkpoint and release the next evidence packet.",
+            ),
+            ToolSpec(
+                name="revisit_checkpoint",
+                source="builtin",
+                description="Inspect and log an immutable prior checkpoint without rewinding the run.",
+            ),
+        ]
+    )
     resolved_registry = registry or LocalAdapterRegistry()
     try:
         adapter = resolved_registry.build(
@@ -265,46 +338,22 @@ def run_local_evidence_lifecycle_session(
             model_name=model,
             workspace=initial["workspace"],
             trajectory_writer=trajectory_writer,
-            native_tools=[
-                workspace_tool.list_workspace,
-                workspace_tool.read_workspace_file,
-                workspace_tool.write_checkpoint_submission,
-                control.submit_checkpoint,
-                control.revisit_checkpoint,
-            ],
+            native_tools=native_tools,
             enable_bash=False,
         )
         result = adapter.execute(
             AdapterRequest(
-                instruction=_persistent_session_instruction(initial),
+                instruction=_persistent_session_instruction(
+                    initial,
+                    supports_evidence_requests=supports_evidence_requests,
+                ),
                 system_prompt=_workspace_policy(
                     initial,
                     persistent=True,
                     visibility_policy=visibility_policy,
+                    supports_evidence_requests=supports_evidence_requests,
                 ),
-                tools=[
-                    ToolSpec(name="list_workspace", source="builtin", description="List visible lifecycle files."),
-                    ToolSpec(
-                        name="read_workspace_file",
-                        source="builtin",
-                        description="Read one visible lifecycle file.",
-                    ),
-                    ToolSpec(
-                        name="write_checkpoint_submission",
-                        source="builtin",
-                        description="Write the active checkpoint JSON submission.",
-                    ),
-                    ToolSpec(
-                        name="submit_checkpoint",
-                        source="builtin",
-                        description="Archive the active checkpoint and release the next evidence packet.",
-                    ),
-                    ToolSpec(
-                        name="revisit_checkpoint",
-                        source="builtin",
-                        description="Inspect and log an immutable prior checkpoint without rewinding the run.",
-                    ),
-                ],
+                tools=tool_specs,
                 configuration={"max_turns": max_turns},
                 output_path=str(Path(initial["workspace"]) / "output.md"),
                 output_format="markdown",
@@ -657,6 +706,12 @@ class LocalEvidenceLifecycleEpisodeEnvironment:
             run_dir=run_dir,
             visibility_policy=self.memory_visibility_policy,
         )
+        control = EvidenceLifecycleControlTool(
+            package_dir=Path(self.package_dir),
+            run_dir=run_dir,
+            session_id=request.session_id,
+        )
+        supports_evidence_requests = _supports_evidence_requests(self.package_dir)
         tools = [
             ToolSpec(name="list_workspace", source="builtin", description="List visible lifecycle files."),
             ToolSpec(name="read_workspace_file", source="builtin", description="Read one visible lifecycle file."),
@@ -666,6 +721,20 @@ class LocalEvidenceLifecycleEpisodeEnvironment:
                 description="Write the active checkpoint JSON submission.",
             ),
         ]
+        native_tools = [
+            workspace_tool.list_workspace,
+            workspace_tool.read_workspace_file,
+            workspace_tool.write_checkpoint_submission,
+        ]
+        if supports_evidence_requests:
+            native_tools.append(control.request_evidence)
+            tools.append(
+                ToolSpec(
+                    name="request_evidence",
+                    source="builtin",
+                    description="Request one declared evidence packet within the active checkpoint budget.",
+                )
+            )
         resolved_registry = self.registry or LocalAdapterRegistry()
         try:
             adapter = resolved_registry.build(
@@ -673,11 +742,7 @@ class LocalEvidenceLifecycleEpisodeEnvironment:
                 model_name=self.model,
                 workspace=request.workspace,
                 trajectory_writer=trajectory_writer,
-                native_tools=[
-                    workspace_tool.list_workspace,
-                    workspace_tool.read_workspace_file,
-                    workspace_tool.write_checkpoint_submission,
-                ],
+                native_tools=native_tools,
                 enable_bash=False,
             )
             adapter_result = adapter.execute(
@@ -687,6 +752,7 @@ class LocalEvidenceLifecycleEpisodeEnvironment:
                         request.model_dump(mode="json"),
                         persistent=False,
                         visibility_policy=self.memory_visibility_policy,
+                        supports_evidence_requests=supports_evidence_requests,
                     ),
                     tools=tools,
                     configuration={"max_turns": self.max_turns},
@@ -779,11 +845,23 @@ def build_local_evidence_lifecycle_episode_environment(
     )
 
 
-def _persistent_session_instruction(initial: dict[str, Any]) -> str:
+def _persistent_session_instruction(
+    initial: dict[str, Any],
+    *,
+    supports_evidence_requests: bool,
+) -> str:
+    conditional_guidance = ""
+    if supports_evidence_requests:
+        conditional_guidance = (
+            "Before submitting, inspect checkpoints/<checkpoint_id>/evidence-requests.json. You may call "
+            "request_evidence when that active checkpoint declares a request catalogue; the remaining budget "
+            "is finite.\n"
+        )
     return (
         "This is one staged evidence lifecycle. Complete every checkpoint in this same session.\n\n"
         "For each checkpoint:\n"
         "1. Use list_workspace and read_workspace_file to inspect the active instruction and released evidence.\n"
+        f"{conditional_guidance}"
         "2. Call write_checkpoint_submission with the active checkpoint_id and required JSON content.\n"
         "3. Call submit_checkpoint with the active checkpoint_id.\n"
         "4. If the tool releases another checkpoint, read its returned instruction and continue.\n"
@@ -804,6 +882,7 @@ def _workspace_policy(
     *,
     persistent: bool,
     visibility_policy: LifecycleVisibilityPolicy,
+    supports_evidence_requests: bool,
 ) -> str:
     if visibility_policy in {
         LifecycleVisibilityPolicy.PERSISTENT_CONTEXT,
@@ -830,12 +909,14 @@ def _workspace_policy(
             "contains the immutable parent snapshot used for comparison."
         )
     policy += f" Host visibility policy: {visibility_policy.value}."
+    if supports_evidence_requests:
+        policy += " Declared within-checkpoint evidence is released only by request_evidence."
     if persistent:
-        return (
-            policy
-            + " Future evidence is released only by the submit_checkpoint tool. Preserve review continuity across "
+        policy += (
+            " Next-checkpoint evidence is released only by submit_checkpoint. Preserve review continuity across "
             "the full session."
         )
+        return policy
     return policy + " This is a fresh checkpoint context; reconstruct continuity from the persisted review artifacts."
 
 
@@ -854,6 +935,8 @@ def _tool_response(result: dict[str, Any]) -> dict[str, Any]:
                 "released_files": result["released_files"],
             }
         )
+        if result.get("evidence_request_catalog") is not None:
+            payload["evidence_request_catalog"] = result["evidence_request_catalog"]
     return payload
 
 
@@ -1072,7 +1155,10 @@ def _build_local_task_run(
         agent=agent,
         verifier=verifier,
         verification=verification,
-        tool_schema=_lifecycle_tool_schema(agent["execution_mode"]),
+        tool_schema=_lifecycle_tool_schema(
+            agent["execution_mode"],
+            supports_evidence_requests=_supports_evidence_requests(package),
+        ),
         sweep_context=sweep_context,
         repository_dir=repository_dir,
     )
@@ -1130,6 +1216,8 @@ def _seal_interrupted_sessions(
     for checkpoint in checkpoint_runs:
         checkpoint_id = str(checkpoint["checkpoint_id"])
         for attempt in checkpoint.get("attempts", []):
+            if attempt.get("inherited_from_parent"):
+                continue
             session_id = str(attempt["session_id"])
             attempts_by_session.setdefault(session_id, []).append((checkpoint_id, attempt))
     for session_id, session_attempts in attempts_by_session.items():
@@ -1197,12 +1285,23 @@ def _session_checkpoint_ids(lifecycle: dict[str, Any], session_id: str) -> list[
     return checkpoint_ids
 
 
-def _lifecycle_tool_schema(execution_mode: str) -> list[dict[str, str]]:
+def _supports_evidence_requests(package_dir: Path) -> bool:
+    spec = load_evidence_lifecycle_spec(Path(package_dir))
+    return any(checkpoint.conditional_evidence is not None for checkpoint in spec.checkpoints)
+
+
+def _lifecycle_tool_schema(
+    execution_mode: str,
+    *,
+    supports_evidence_requests: bool,
+) -> list[dict[str, str]]:
     functions: list[Callable[..., Any]] = [
         EvidenceLifecycleWorkspaceTool.list_workspace,
         EvidenceLifecycleWorkspaceTool.read_workspace_file,
         EvidenceLifecycleWorkspaceTool.write_checkpoint_submission,
     ]
+    if supports_evidence_requests:
+        functions.append(EvidenceLifecycleControlTool.request_evidence)
     if execution_mode == "persistent_context":
         functions.extend(
             [
@@ -1213,7 +1312,15 @@ def _lifecycle_tool_schema(execution_mode: str) -> list[dict[str, str]]:
     return [
         {
             "name": function.__name__,
-            "signature": str(inspect.signature(function)),
+            "signature": str(
+                inspect.signature(function).replace(
+                    parameters=[
+                        parameter
+                        for name, parameter in inspect.signature(function).parameters.items()
+                        if name != "self"
+                    ]
+                )
+            ),
             "description": inspect.getdoc(function) or "",
         }
         for function in functions

--- a/src/aec_bench/meta_harness/evidence_lifecycle_state.py
+++ b/src/aec_bench/meta_harness/evidence_lifecycle_state.py
@@ -4,9 +4,10 @@
 from __future__ import annotations
 
 from enum import StrEnum
+from pathlib import PurePosixPath
 from typing import Literal
 
-from pydantic import Field, PositiveInt, field_validator, model_validator
+from pydantic import Field, NonNegativeInt, PositiveInt, field_validator, model_validator
 
 from aec_bench.contracts.validators import NonEmptyStr, StrictModel
 from aec_bench.meta_harness.evidence_lifecycle_metrics import LifecycleSemanticMetrics
@@ -33,9 +34,98 @@ class CheckpointAttemptStatus(StrEnum):
 
 class LifecycleTransitionKind(StrEnum):
     BRANCH = "branch"
+    EVIDENCE_REQUEST = "evidence_request"
     RELEASE = "release"
     SUBMIT = "submit"
     REVISIT = "revisit"
+
+
+class EvidenceRequestOutcome(StrEnum):
+    RELEASED = "released"
+    ALREADY_RELEASED = "already_released"
+    REJECTED = "rejected"
+
+
+class EvidenceRequestRejection(StrEnum):
+    INACTIVE_CHECKPOINT = "inactive_checkpoint"
+    UNKNOWN_REQUEST = "unknown_request"
+    PREREQUISITES_INCOMPLETE = "prerequisites_incomplete"
+    BUDGET_EXHAUSTED = "budget_exhausted"
+    NOT_SUPPORTED = "not_supported"
+
+
+class ReleasedEvidenceArtifact(StrictModel):
+    path: NonEmptyStr
+    workspace_path: NonEmptyStr
+    sha256: NonEmptyStr
+
+    @field_validator("sha256")
+    @classmethod
+    def validate_sha256(cls, value: str) -> str:
+        if len(value) != 64 or any(character not in "0123456789abcdef" for character in value):
+            raise ValueError("sha256 must contain 64 lowercase hexadecimal characters")
+        return value
+
+    @model_validator(mode="after")
+    def validate_paths(self) -> ReleasedEvidenceArtifact:
+        canonical = PurePosixPath(self.path)
+        workspace = PurePosixPath(self.workspace_path)
+        if canonical.is_absolute() or ".." in canonical.parts or canonical.parts[:1] != ("evidence_requests",):
+            raise ValueError("released evidence artifact path must stay under evidence_requests/")
+        if workspace.is_absolute() or ".." in workspace.parts or workspace.parts[:1] != ("inbox",):
+            raise ValueError("released evidence workspace path must stay under inbox/")
+        return self
+
+
+class EvidenceRequestActionRecord(StrictModel):
+    action_id: NonEmptyStr
+    sequence: PositiveInt
+    checkpoint_id: NonEmptyStr
+    requested_checkpoint_id: NonEmptyStr
+    request_id: NonEmptyStr
+    reason: NonEmptyStr
+    session_id: NonEmptyStr
+    attempt_id: NonEmptyStr
+    outcome: EvidenceRequestOutcome
+    rejection: EvidenceRequestRejection | None = None
+    pre_action_state_sha256: NonEmptyStr
+    post_action_state_sha256: NonEmptyStr
+    released_artifacts: tuple[ReleasedEvidenceArtifact, ...] = ()
+    budget_before: NonNegativeInt
+    budget_consumed: Literal[0, 1]
+    budget_after: NonNegativeInt
+    inherited_from_parent: bool = False
+
+    @field_validator("pre_action_state_sha256", "post_action_state_sha256")
+    @classmethod
+    def validate_state_sha256(cls, value: str) -> str:
+        if len(value) != 64 or any(character not in "0123456789abcdef" for character in value):
+            raise ValueError("action state sha256 must contain 64 lowercase hexadecimal characters")
+        return value
+
+    @model_validator(mode="after")
+    def validate_outcome_and_budget(self) -> EvidenceRequestActionRecord:
+        if self.budget_after != self.budget_before - self.budget_consumed:
+            raise ValueError("evidence request budget arithmetic is inconsistent")
+        if self.outcome == EvidenceRequestOutcome.RELEASED:
+            if (
+                self.requested_checkpoint_id != self.checkpoint_id
+                or self.rejection is not None
+                or self.budget_consumed != 1
+                or not self.released_artifacts
+            ):
+                raise ValueError("released evidence request must consume budget and record artifacts")
+        elif self.outcome == EvidenceRequestOutcome.ALREADY_RELEASED:
+            if (
+                self.requested_checkpoint_id != self.checkpoint_id
+                or self.rejection is not None
+                or self.budget_consumed != 0
+                or not self.released_artifacts
+            ):
+                raise ValueError("already-released evidence request must preserve its artifacts")
+        elif self.rejection is None or self.budget_consumed != 0 or self.released_artifacts:
+            raise ValueError("rejected evidence request must record only its rejection")
+        return self
 
 
 class CheckpointAttemptRecord(StrictModel):
@@ -47,6 +137,7 @@ class CheckpointAttemptRecord(StrictModel):
     resumed_from_attempt_id: str | None = None
     failure_kind: str | None = None
     episode_request_sha256: str | None = None
+    inherited_from_parent: bool = False
 
     @field_validator("episode_request_sha256")
     @classmethod
@@ -63,6 +154,9 @@ class CheckpointRunRecord(StrictModel):
     submission_path: str | None = None
     submission_sha256: str | None = None
     attempts: list[CheckpointAttemptRecord] = Field(default_factory=list)
+    evidence_request_budget: NonNegativeInt = 0
+    evidence_request_budget_remaining: NonNegativeInt = 0
+    evidence_request_actions: list[EvidenceRequestActionRecord] = Field(default_factory=list)
     inherited_from_parent: bool = False
 
     @model_validator(mode="after")
@@ -76,6 +170,17 @@ class CheckpointRunRecord(StrictModel):
         sequences = [attempt.sequence for attempt in self.attempts]
         if sequences != list(range(1, len(sequences) + 1)):
             raise ValueError("checkpoint attempt sequences must be contiguous")
+        if self.evidence_request_budget_remaining > self.evidence_request_budget:
+            raise ValueError("remaining evidence request budget cannot exceed its initial budget")
+        remaining = self.evidence_request_budget
+        for action in self.evidence_request_actions:
+            if action.checkpoint_id != self.checkpoint_id:
+                raise ValueError("evidence request action checkpoint must match its run record")
+            if action.budget_before != remaining:
+                raise ValueError("evidence request action budget chain is inconsistent")
+            remaining = action.budget_after
+        if remaining != self.evidence_request_budget_remaining:
+            raise ValueError("remaining evidence request budget must match the action history")
         return self
 
     @property
@@ -110,11 +215,19 @@ class LifecycleBranchRecord(StrictModel):
     parent_run_dir: NonEmptyStr
     branched_from_checkpoint_id: NonEmptyStr
     parent_submission_sha256: NonEmptyStr
+    parent_action_state_sha256: str | None = None
     reason: NonEmptyStr
+
+    @field_validator("parent_action_state_sha256")
+    @classmethod
+    def validate_parent_action_state_sha256(cls, value: str | None) -> str | None:
+        if value is not None and (len(value) != 64 or any(character not in "0123456789abcdef" for character in value)):
+            raise ValueError("parent action state sha256 must contain 64 lowercase hexadecimal characters")
+        return value
 
 
 class EvidenceLifecycleRunState(StrictModel):
-    schema_version: Literal["3"] = "3"
+    schema_version: Literal["3", "4"] = "4"
     lifecycle_id: NonEmptyStr
     world_id: NonEmptyStr
     lifecycle_spec_sha256: NonEmptyStr
@@ -155,6 +268,15 @@ class EvidenceLifecycleRunState(StrictModel):
             raise ValueError("checkpoint statuses must follow submitted, active, then pending order")
         if self.branch is not None and self.branch.branched_from_checkpoint_id not in checkpoint_ids:
             raise ValueError("branch checkpoint must exist in lifecycle state")
+        if self.schema_version == "4" and self.branch is not None and self.branch.parent_action_state_sha256 is None:
+            raise ValueError("v4 branch state requires a parent action state sha256")
+        actions = [action for checkpoint in self.checkpoint_runs for action in checkpoint.evidence_request_actions]
+        for expected_sequence, action in enumerate(actions, start=1):
+            expected_action_id = f"evidence-request-{expected_sequence:06d}"
+            if action.sequence != expected_sequence or action.action_id != expected_action_id:
+                raise ValueError(
+                    "evidence request action identities must be contiguous and globally ordered across the run"
+                )
         return self
 
     def checkpoint(self, checkpoint_id: str) -> CheckpointRunRecord:

--- a/src/aec_bench/meta_harness/evidence_lifecycle_transfer.py
+++ b/src/aec_bench/meta_harness/evidence_lifecycle_transfer.py
@@ -15,16 +15,30 @@ from aec_bench.contracts.evaluation_result import ValidityCheck
 from aec_bench.contracts.task_definition import Visibility
 from aec_bench.contracts.trial_record import ArtifactReference, Completeness, TrialRecord
 from aec_bench.contracts.validators import NonEmptyStr, StrictModel
+from aec_bench.meta_harness.evidence_lifecycle import (
+    EvidenceLifecycleError,
+    evidence_request_catalog_payload,
+    evidence_request_protocol_identity,
+    validate_evidence_request_run_state,
+)
 from aec_bench.meta_harness.evidence_lifecycle_episode import (
     LifecycleExecutionMode,
     LifecycleVisibilityPolicy,
 )
-from aec_bench.meta_harness.evidence_lifecycle_experiment import LifecycleExperimentManifest
+from aec_bench.meta_harness.evidence_lifecycle_experiment import (
+    LifecycleExperimentManifest,
+    LifecycleExperimentMetrics,
+)
 from aec_bench.meta_harness.evidence_lifecycle_metrics import LifecycleSemanticMetrics
 from aec_bench.meta_harness.evidence_lifecycle_state import (
     EvidenceLifecycleRunState,
     LifecycleVerificationResult,
 )
+from aec_bench.meta_harness.evidence_request_protocol import (
+    expected_evidence_request_run_artifact_paths,
+    is_evidence_request_run_artifact_path,
+)
+from aec_bench.task_world_templates.contracts import EvidenceLifecycleSpec
 
 
 class LifecycleTransferRecordReference(StrictModel):
@@ -334,7 +348,9 @@ def _snapshot_record_reasons(
     if provenance is None or execution is None:
         return ()
     verification_reference = _artifact_by_kind(record, "lifecycle_verification")
+    metrics_reference = _artifact_by_kind(record, "lifecycle_metrics")
     state_reference = _artifact_by_kind(record, "lifecycle_state")
+    lifecycle_spec_reference = _artifact_by_suffix(record, "/package/lifecycle.json")
     if verification_reference is None or state_reference is None or provenance.invocation_index is None:
         return ("snapshot_contract_missing",)
     try:
@@ -342,11 +358,27 @@ def _snapshot_record_reasons(
         invocation_index = _read_artifact_object(artifacts, provenance.invocation_index)
         verification = _read_artifact_object(artifacts, verification_reference)
         state = _read_artifact_object(artifacts, state_reference)
+        if _v3_state_contains_evidence_request_fields(state):
+            return ("snapshot_contract_invalid",)
         manifest = LifecycleExperimentManifest.model_validate(manifest).model_dump(mode="json")
         verification_result = LifecycleVerificationResult.model_validate(verification)
         state_result = EvidenceLifecycleRunState.model_validate(state)
-    except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError, EvidenceLifecycleError):
         return ("snapshot_contract_invalid",)
+
+    metrics_result: LifecycleExperimentMetrics | None = None
+    lifecycle_spec_result: EvidenceLifecycleSpec | None = None
+    if state_result.schema_version == "4":
+        if metrics_reference is None or lifecycle_spec_reference is None:
+            return ("snapshot_contract_missing",)
+        try:
+            metrics = _read_artifact_object(artifacts, metrics_reference)
+            lifecycle_spec = _read_artifact_object(artifacts, lifecycle_spec_reference)
+            metrics_result = LifecycleExperimentMetrics.model_validate(metrics)
+            lifecycle_spec_result = EvidenceLifecycleSpec.model_validate(lifecycle_spec)
+            validate_evidence_request_run_state(state_result, lifecycle_spec_result)
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError, EvidenceLifecycleError):
+            return ("snapshot_contract_invalid",)
 
     lifecycle = manifest.get("lifecycle")
     repository = manifest.get("repository")
@@ -384,6 +416,11 @@ def _snapshot_record_reasons(
         or manifest_sweep.get("planned_trial_id") != record.trial_id
     ):
         return ("snapshot_record_mismatch",)
+    if metrics_reference is not None and (
+        outputs.get("metrics.json") != metrics_reference.sha256
+        or declared_artifacts.get("metrics.json") != metrics_reference.sha256
+    ):
+        return ("snapshot_record_mismatch",)
     try:
         runtime_distributions = _string_tuple(runtime.get("distributions"))
         resolved_models = tuple(sorted(_string_tuple(model.get("resolved_models"))))
@@ -411,6 +448,20 @@ def _snapshot_record_reasons(
         or state_checkpoint_ids != session_checkpoint_ids
     ):
         return ("snapshot_record_mismatch",)
+
+    if state_result.schema_version == "4":
+        assert lifecycle_spec_result is not None
+        assert metrics_result is not None
+        evidence_request_reasons = _evidence_request_snapshot_reasons(
+            record,
+            artifacts=artifacts,
+            state=state_result,
+            spec=lifecycle_spec_result,
+            manifest=manifest,
+            metrics=metrics_result,
+        )
+        if evidence_request_reasons:
+            return evidence_request_reasons
 
     output_structurally_valid = state_result.status.value == "complete"
     verifier_completed = verification_result.overall != "incomplete"
@@ -505,8 +556,178 @@ def _snapshot_record_reasons(
     return ()
 
 
+def _v3_state_contains_evidence_request_fields(state: dict[str, object]) -> bool:
+    if state.get("schema_version") != "3":
+        return False
+    checkpoint_runs = state.get("checkpoint_runs")
+    if not isinstance(checkpoint_runs, list):
+        return False
+    forbidden = {
+        "evidence_request_budget",
+        "evidence_request_budget_remaining",
+        "evidence_request_actions",
+    }
+    return any(isinstance(checkpoint, dict) and not forbidden.isdisjoint(checkpoint) for checkpoint in checkpoint_runs)
+
+
+def _evidence_request_snapshot_reasons(
+    record: TrialRecord,
+    *,
+    artifacts: dict[str, bytes],
+    state: EvidenceLifecycleRunState,
+    spec: EvidenceLifecycleSpec,
+    manifest: dict[str, object],
+    metrics: LifecycleExperimentMetrics,
+) -> tuple[str, ...]:
+    actions = [action for checkpoint in state.checkpoint_runs for action in checkpoint.evidence_request_actions]
+    action_capable = any(checkpoint.conditional_evidence is not None for checkpoint in spec.checkpoints)
+    interaction = manifest.get("interaction")
+    if not isinstance(interaction, dict):
+        return ("snapshot_contract_invalid",)
+    if not action_capable:
+        return ("snapshot_contract_invalid",) if actions else ()
+    if _record_evidence_request_run_artifact_paths(record) != expected_evidence_request_run_artifact_paths(
+        state,
+        spec,
+    ):
+        return ("snapshot_contract_invalid",)
+
+    protocol = interaction.get("evidence_request_protocol")
+    tool_schema = interaction.get("tool_schema")
+    if not isinstance(protocol, dict) or not isinstance(tool_schema, list):
+        return ("snapshot_contract_invalid",)
+    expected_protocol = evidence_request_protocol_identity()
+    encoded_tool_schema = json.dumps(
+        tool_schema,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    if (
+        protocol.get("schema_version") != expected_protocol["schema_version"]
+        or protocol.get("sha256") != expected_protocol["sha256"]
+        or protocol.get("tool_schema_sha256") != hashlib.sha256(encoded_tool_schema).hexdigest()
+        or not any(isinstance(tool, dict) and tool.get("name") == "request_evidence" for tool in tool_schema)
+    ):
+        return ("snapshot_contract_invalid",)
+
+    expected_metrics = {
+        "evidence_request_calls": len(actions),
+        "accepted_evidence_requests": sum(action.outcome.value == "released" for action in actions),
+        "already_released_evidence_requests": sum(action.outcome.value == "already_released" for action in actions),
+        "rejected_evidence_requests": sum(action.outcome.value == "rejected" for action in actions),
+        "evidence_request_budget_consumed": sum(action.budget_consumed for action in actions),
+        "evidence_request_artifacts_released": sum(
+            len(action.released_artifacts) for action in actions if action.outcome.value == "released"
+        ),
+    }
+    metrics_payload = metrics.model_dump(mode="json")
+    if any(metrics_payload.get(field) != value for field, value in expected_metrics.items()):
+        return ("snapshot_record_mismatch",)
+    breakdown = record.evaluation.breakdown if isinstance(record.evaluation.breakdown, dict) else {}
+    operational = dict(metrics_payload)
+    operational.pop("semantic_transition", None)
+    if breakdown.get("operational_metrics") != operational:
+        return ("snapshot_record_mismatch",)
+
+    checkpoint_specs = {checkpoint.checkpoint_id: checkpoint for checkpoint in spec.checkpoints}
+    for checkpoint in state.checkpoint_runs:
+        expected_catalog = evidence_request_catalog_payload(
+            checkpoint_specs[checkpoint.checkpoint_id],
+            checkpoint,
+        )
+        catalog_relative = f"workspace/checkpoints/{checkpoint.checkpoint_id}/evidence-requests.json"
+        catalog_content = _run_artifact_content(
+            record,
+            artifacts=artifacts,
+            relative=catalog_relative,
+        )
+        catalog_was_released = expected_catalog is not None and checkpoint.status.value != "pending"
+        if not catalog_was_released:
+            if catalog_content is not None:
+                return ("snapshot_contract_invalid",)
+        else:
+            try:
+                actual_catalog = json.loads(catalog_content.decode("utf-8")) if catalog_content else None
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                return ("snapshot_contract_invalid",)
+            if actual_catalog != expected_catalog:
+                return ("snapshot_contract_invalid",)
+
+        for action in checkpoint.evidence_request_actions:
+            action_content = _run_artifact_content(
+                record,
+                artifacts=artifacts,
+                relative=f"evidence_requests/{action.action_id}/action.json",
+            )
+            committed_content = _run_artifact_content(
+                record,
+                artifacts=artifacts,
+                relative=f"evidence_requests/{action.action_id}/committed.json",
+            )
+            try:
+                persisted_action = json.loads(action_content.decode("utf-8")) if action_content else None
+                committed = json.loads(committed_content.decode("utf-8")) if committed_content else None
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                return ("snapshot_contract_invalid",)
+            if persisted_action != action.model_dump(mode="json") or committed != {
+                "action_id": action.action_id,
+                "status": "committed",
+            }:
+                return ("snapshot_contract_invalid",)
+            for artifact in action.released_artifacts:
+                canonical = _run_artifact_content(
+                    record,
+                    artifacts=artifacts,
+                    relative=artifact.path,
+                )
+                projection = _run_artifact_content(
+                    record,
+                    artifacts=artifacts,
+                    relative=f"workspace/{artifact.workspace_path}",
+                )
+                if (
+                    canonical is None
+                    or projection is None
+                    or hashlib.sha256(canonical).hexdigest() != artifact.sha256
+                    or hashlib.sha256(projection).hexdigest() != artifact.sha256
+                ):
+                    return ("snapshot_contract_invalid",)
+    return ()
+
+
+def _record_evidence_request_run_artifact_paths(record: TrialRecord) -> frozenset[str]:
+    paths: set[str] = set()
+    for artifact in record.outputs.artifacts or ():
+        normalized = f"/{artifact.path.lstrip('/')}"
+        marker = "/run/"
+        if marker not in normalized:
+            continue
+        relative = normalized.rsplit(marker, maxsplit=1)[1]
+        if is_evidence_request_run_artifact_path(relative):
+            paths.add(relative)
+    return frozenset(paths)
+
+
+def _run_artifact_content(
+    record: TrialRecord,
+    *,
+    artifacts: dict[str, bytes],
+    relative: str,
+) -> bytes | None:
+    suffix = f"/run/{relative}"
+    matches = [artifact for artifact in record.outputs.artifacts or () if artifact.path.endswith(suffix)]
+    if len(matches) != 1:
+        return None
+    return artifacts.get(matches[0].path)
+
+
 def _artifact_by_kind(record: TrialRecord, kind: str) -> ArtifactReference | None:
     matches = [artifact for artifact in record.outputs.artifacts or () if artifact.kind == kind]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _artifact_by_suffix(record: TrialRecord, suffix: str) -> ArtifactReference | None:
+    matches = [artifact for artifact in record.outputs.artifacts or () if artifact.path.endswith(suffix)]
     return matches[0] if len(matches) == 1 else None
 
 

--- a/src/aec_bench/meta_harness/evidence_lifecycle_trial_record.py
+++ b/src/aec_bench/meta_harness/evidence_lifecycle_trial_record.py
@@ -49,7 +49,10 @@ from aec_bench.ledger.durability import (
 )
 from aec_bench.ledger.writer import DuplicateTrialRecordError, write_trial_record
 from aec_bench.meta_harness.evidence_lifecycle import (
+    evidence_request_catalog_payload,
+    load_evidence_lifecycle_spec,
     read_evidence_lifecycle_state,
+    validate_evidence_request_run_state,
     validate_lifecycle_verification,
 )
 from aec_bench.meta_harness.evidence_lifecycle_ablation_plan import (
@@ -63,7 +66,15 @@ from aec_bench.meta_harness.evidence_lifecycle_experiment import (
     LifecycleExperimentManifest,
     LifecycleExperimentMetrics,
 )
-from aec_bench.meta_harness.evidence_lifecycle_state import EvidenceLifecycleRunState
+from aec_bench.meta_harness.evidence_lifecycle_state import (
+    EvidenceLifecycleRunState,
+    EvidenceRequestActionRecord,
+)
+from aec_bench.meta_harness.evidence_request_protocol import (
+    expected_evidence_request_run_artifact_paths,
+    is_evidence_request_run_artifact_path,
+)
+from aec_bench.task_world_templates.contracts import EvidenceLifecycleSpec
 from aec_bench.task_world_templates.lifecycles import lifecycle_package_variant
 
 
@@ -121,7 +132,7 @@ def _build_lifecycle_trial_record(
     if require_planned_paths:
         read_evidence_lifecycle_state(package, run)
     else:
-        _validate_snapshotted_lifecycle_state(run)
+        _validate_snapshotted_lifecycle_state(package, run)
     state = _read_json(run / "state.json")
     variant = lifecycle_package_variant(package)
     if variant is None or variant.get("variant_id") != trial.variant_id:
@@ -929,11 +940,44 @@ def _validate_declared_run_artifacts(run_dir: Path, experiment: dict[str, Any]) 
             raise ValueError(f"trajectory hash does not match declared run artifact: {relative}")
 
 
-def _validate_snapshotted_lifecycle_state(run_dir: Path) -> None:
+def _validate_snapshotted_lifecycle_state(package_dir: Path, run_dir: Path) -> None:
     state = EvidenceLifecycleRunState.model_validate(_read_json(run_dir / "state.json"))
+    spec = load_evidence_lifecycle_spec(package_dir)
+    validate_evidence_request_run_state(state, spec)
     if state.branch is not None:
         raise ValueError("branched lifecycle snapshots are not supported by ablation finalization")
     for checkpoint in state.checkpoint_runs:
+        checkpoint_spec = next(item for item in spec.checkpoints if item.checkpoint_id == checkpoint.checkpoint_id)
+        expected_catalog = evidence_request_catalog_payload(checkpoint_spec, checkpoint)
+        catalog_path = run_dir / "workspace" / "checkpoints" / checkpoint.checkpoint_id / "evidence-requests.json"
+        catalog_was_released = expected_catalog is not None and checkpoint.status.value != "pending"
+        if not catalog_was_released:
+            if catalog_path.exists():
+                raise ValueError("snapshot contains an unreleased or undeclared evidence request catalogue")
+        elif not catalog_path.is_file() or _read_json(catalog_path) != expected_catalog:
+            raise ValueError("snapshotted evidence request catalogue does not match lifecycle state")
+        for action in checkpoint.evidence_request_actions:
+            transaction = run_dir / "evidence_requests" / action.action_id
+            action_path = transaction / "action.json"
+            committed_path = transaction / "committed.json"
+            if not action_path.is_file() or not committed_path.is_file():
+                raise ValueError(f"snapshotted evidence request transaction is incomplete: {action.action_id}")
+            persisted_action = EvidenceRequestActionRecord.model_validate(_read_json(action_path))
+            if persisted_action != action:
+                raise ValueError("snapshotted evidence request action does not match lifecycle state")
+            committed = _read_json(committed_path)
+            if committed != {"action_id": action.action_id, "status": "committed"}:
+                raise ValueError("snapshotted evidence request transaction is not committed")
+            for artifact in action.released_artifacts:
+                canonical = run_dir / artifact.path
+                workspace = run_dir / "workspace" / artifact.workspace_path
+                if (
+                    not canonical.is_file()
+                    or _sha256(canonical) != artifact.sha256
+                    or not workspace.is_file()
+                    or _sha256(workspace) != artifact.sha256
+                ):
+                    raise ValueError("snapshotted requested evidence artifact hash mismatch")
         if checkpoint.status.value != "submitted":
             continue
         if checkpoint.submission_sha256 is None:
@@ -941,6 +985,32 @@ def _validate_snapshotted_lifecycle_state(run_dir: Path) -> None:
         path = run_dir / "episodes" / checkpoint.checkpoint_id / "submission.json"
         if not path.is_file() or _sha256(path) != checkpoint.submission_sha256:
             raise ValueError(f"snapshotted checkpoint submission hash mismatch: {checkpoint.checkpoint_id}")
+    if any(checkpoint.conditional_evidence is not None for checkpoint in spec.checkpoints):
+        _validate_evidence_request_artifact_inventory(run_dir, state, spec)
+
+
+def _validate_evidence_request_artifact_inventory(
+    run_dir: Path,
+    state: EvidenceLifecycleRunState,
+    spec: EvidenceLifecycleSpec,
+) -> None:
+    expected = expected_evidence_request_run_artifact_paths(state, spec)
+    actual: set[str] = set()
+    for path in sorted(run_dir.rglob("*")):
+        relative = path.relative_to(run_dir).as_posix()
+        if not is_evidence_request_run_artifact_path(relative):
+            continue
+        if path.is_symlink():
+            raise ValueError(f"snapshotted evidence request artifact is a symlink: {relative}")
+        if path.is_file():
+            actual.add(relative)
+    if actual != expected:
+        missing = ", ".join(sorted(expected - actual)) or "none"
+        unexpected = ", ".join(sorted(actual - expected)) or "none"
+        raise ValueError(
+            "snapshotted evidence request artifact inventory does not match lifecycle state: "
+            f"missing={missing}; unexpected={unexpected}"
+        )
 
 
 def _validate_metrics_against_run(
@@ -960,6 +1030,13 @@ def _validate_metrics_against_run(
         for attempt in checkpoint.get("attempts", [])
         if isinstance(attempt, dict)
     ]
+    evidence_request_actions = [
+        action
+        for checkpoint in checkpoint_runs
+        if isinstance(checkpoint, dict)
+        for action in checkpoint.get("evidence_request_actions", [])
+        if isinstance(action, dict)
+    ]
     expected = {
         "checkpoint_count": sum(
             isinstance(checkpoint, dict) and checkpoint.get("status") == "submitted" for checkpoint in checkpoint_runs
@@ -971,6 +1048,29 @@ def _validate_metrics_against_run(
         ),
         "failures": sum(attempt.get("status") == "failed" for attempt in attempts),
     }
+    if state.get("schema_version") == "4":
+        expected.update(
+            {
+                "evidence_request_calls": len(evidence_request_actions),
+                "accepted_evidence_requests": sum(
+                    action.get("outcome") == "released" for action in evidence_request_actions
+                ),
+                "already_released_evidence_requests": sum(
+                    action.get("outcome") == "already_released" for action in evidence_request_actions
+                ),
+                "rejected_evidence_requests": sum(
+                    action.get("outcome") == "rejected" for action in evidence_request_actions
+                ),
+                "evidence_request_budget_consumed": sum(
+                    int(action.get("budget_consumed", 0)) for action in evidence_request_actions
+                ),
+                "evidence_request_artifacts_released": sum(
+                    len(action.get("released_artifacts", []))
+                    for action in evidence_request_actions
+                    if action.get("outcome") == "released"
+                ),
+            }
+        )
     for field, value in expected.items():
         if metrics.get(field) != value:
             raise ValueError(f"lifecycle {field} does not match run state")
@@ -1092,6 +1192,16 @@ def _artifact_kind(relative: Path) -> str:
         return "agent_result"
     if path.endswith("/agent_result.corrupt.json"):
         return "corrupt_agent_result"
+    if path.startswith("run/evidence_requests/") and path.endswith("/action.json"):
+        return "evidence_request_action"
+    if path.startswith("run/evidence_requests/") and path.endswith("/committed.json"):
+        return "evidence_request_commit"
+    if path.startswith("run/evidence_requests/") and "/artifacts/" in path:
+        return "requested_evidence"
+    if path.endswith("/evidence-requests.json"):
+        return "evidence_request_catalog"
+    if path.startswith("run/workspace/inbox/") and "/requests/" in path:
+        return "requested_evidence_projection"
     if path.endswith("/submission.json") or "/submissions/" in path:
         return "checkpoint_submission"
     if path == "run/state.json":

--- a/src/aec_bench/meta_harness/evidence_request_protocol.py
+++ b/src/aec_bench/meta_harness/evidence_request_protocol.py
@@ -1,0 +1,415 @@
+# ABOUTME: Defines conditional-evidence request contracts, catalogue projections, and state validation.
+# ABOUTME: Keeps protocol identity and action-history rules independent from lifecycle execution and storage.
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Sequence
+from pathlib import PurePosixPath
+from typing import Any, Literal
+
+from pydantic import Field, model_validator
+
+from aec_bench.contracts.validators import NonEmptyStr, StrictModel
+from aec_bench.meta_harness.evidence_lifecycle_state import (
+    CheckpointRunRecord,
+    CheckpointRunStatus,
+    EvidenceLifecycleRunState,
+    EvidenceRequestActionRecord,
+    EvidenceRequestOutcome,
+    EvidenceRequestRejection,
+    LifecycleTransitionKind,
+    LifecycleTransitionRecord,
+)
+from aec_bench.task_world_templates.contracts import EvidenceCheckpointSpec, EvidenceLifecycleSpec
+
+
+class EvidenceLifecycleError(RuntimeError):
+    """Raised when a lifecycle package or checkpoint transition is invalid."""
+
+
+class EvidenceRequestResolution(StrictModel):
+    checkpoint_id: NonEmptyStr
+    request_id: NonEmptyStr
+    source_path: NonEmptyStr
+
+    @model_validator(mode="after")
+    def validate_source_path(self) -> EvidenceRequestResolution:
+        path = PurePosixPath(self.source_path)
+        expected = ("hidden", "evidence_requests", self.checkpoint_id, self.request_id)
+        if path.is_absolute() or ".." in path.parts or path.parts != expected:
+            raise ValueError("evidence request source path must match its hidden request identity")
+        return self
+
+
+class EvidenceRequestResolutionManifest(StrictModel):
+    schema_version: Literal["1"] = "1"
+    lifecycle_id: NonEmptyStr
+    resolutions: tuple[EvidenceRequestResolution, ...] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def validate_unique_resolutions(self) -> EvidenceRequestResolutionManifest:
+        identities = [(item.checkpoint_id, item.request_id) for item in self.resolutions]
+        if len(identities) != len(set(identities)):
+            raise ValueError("evidence request resolutions must have unique identities")
+        return self
+
+
+_EVIDENCE_REQUEST_PROTOCOL = {
+    "schema_version": "1",
+    "tool": {
+        "name": "request_evidence",
+        "arguments": ["checkpoint_id", "request_id", "reason"],
+    },
+    "catalog_path": "workspace/checkpoints/<checkpoint_id>/evidence-requests.json",
+    "canonical_transaction_path": "evidence_requests/<action_id>",
+    "workspace_release_path": "workspace/inbox/<checkpoint_id>/requests/<request_id>",
+    "budget_rule": "first_successful_unique_request_consumes_one",
+    "duplicate_rule": "already_released_consumes_zero",
+    "rejection_rule": "rejections_consume_zero_and_release_nothing",
+    "call_validation_rule": "malformed_or_blank_arguments_fail_without_lifecycle_action",
+    "rejection_codes": [rejection.value for rejection in EvidenceRequestRejection],
+    "state_projection": "catalog_identity_budget_and_released_artifact_hashes",
+}
+
+
+def evidence_request_protocol_identity() -> dict[str, str]:
+    """Return the versioned hash of model-visible conditional evidence semantics."""
+    encoded = json.dumps(
+        _EVIDENCE_REQUEST_PROTOCOL,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return {
+        "schema_version": str(_EVIDENCE_REQUEST_PROTOCOL["schema_version"]),
+        "sha256": hashlib.sha256(encoded).hexdigest(),
+    }
+
+
+def validate_evidence_request_run_state(
+    state: EvidenceLifecycleRunState,
+    spec: EvidenceLifecycleSpec,
+) -> None:
+    """Validate action history against its public catalogue without mutating a run."""
+    if state.schema_version == "3" and any(checkpoint.evidence_request_actions for checkpoint in state.checkpoint_runs):
+        raise EvidenceLifecycleError("v3 lifecycle state cannot contain evidence request actions")
+    _validate_evidence_request_state_contract(state, spec)
+
+
+def evidence_request_catalog_payload(
+    checkpoint: EvidenceCheckpointSpec,
+    checkpoint_run: CheckpointRunRecord,
+) -> dict[str, Any] | None:
+    """Build the model-visible conditional evidence catalogue for one checkpoint."""
+    return _evidence_request_catalog(checkpoint, checkpoint_run)
+
+
+def expected_evidence_request_run_artifact_paths(
+    state: EvidenceLifecycleRunState,
+    spec: EvidenceLifecycleSpec,
+) -> frozenset[str]:
+    """Return every canonical, catalogue, and projection file justified by state."""
+    checkpoint_specs = {checkpoint.checkpoint_id: checkpoint for checkpoint in spec.checkpoints}
+    expected: set[str] = set()
+    for checkpoint in state.checkpoint_runs:
+        checkpoint_spec = checkpoint_specs[checkpoint.checkpoint_id]
+        if checkpoint_spec.conditional_evidence is not None and checkpoint.status is not CheckpointRunStatus.PENDING:
+            expected.add(f"workspace/checkpoints/{checkpoint.checkpoint_id}/evidence-requests.json")
+        for action in checkpoint.evidence_request_actions:
+            expected.add(f"evidence_requests/{action.action_id}/action.json")
+            expected.add(f"evidence_requests/{action.action_id}/committed.json")
+            for artifact in action.released_artifacts:
+                expected.add(artifact.path)
+                expected.add(f"workspace/{artifact.workspace_path}")
+    return frozenset(expected)
+
+
+def is_evidence_request_run_artifact_path(raw_path: str) -> bool:
+    """Identify files in namespaces reserved for conditional-evidence provenance."""
+    path = PurePosixPath(raw_path)
+    parts = path.parts
+    if path.is_absolute() or ".." in parts:
+        return False
+    if parts[:1] == ("evidence_requests",):
+        return True
+    if len(parts) >= 4 and parts[:2] == ("workspace", "inbox") and parts[3] == "requests":
+        return True
+    return len(parts) >= 4 and parts[:2] == ("workspace", "checkpoints") and path.name == "evidence-requests.json"
+
+
+def _validate_evidence_request_state_contract(
+    state: EvidenceLifecycleRunState,
+    spec: EvidenceLifecycleSpec,
+) -> None:
+    checkpoint_specs = {checkpoint.checkpoint_id: checkpoint for checkpoint in spec.checkpoints}
+    for checkpoint_run in state.checkpoint_runs:
+        checkpoint_spec = checkpoint_specs[checkpoint_run.checkpoint_id]
+        conditional = checkpoint_spec.conditional_evidence
+        expected_budget = conditional.request_budget if conditional is not None else 0
+        if checkpoint_run.evidence_request_budget != expected_budget:
+            raise EvidenceLifecycleError("evidence request budget does not match the lifecycle contract")
+
+        public_requests = (
+            {request.request_id: request for request in conditional.requests} if conditional is not None else {}
+        )
+        remaining = expected_budget
+        history: list[EvidenceRequestActionRecord] = []
+        released: dict[str, EvidenceRequestActionRecord] = {}
+        for action in checkpoint_run.evidence_request_actions:
+            owner = next(
+                (
+                    attempt
+                    for attempt in checkpoint_run.attempts
+                    if attempt.attempt_id == action.attempt_id and attempt.session_id == action.session_id
+                ),
+                None,
+            )
+            if owner is None:
+                raise EvidenceLifecycleError("evidence request action owner is not present in checkpoint attempts")
+            pre_state = _evidence_request_projection_sha256(
+                state,
+                checkpoint_id=checkpoint_run.checkpoint_id,
+                evidence_request_budget=expected_budget,
+                evidence_request_budget_remaining=remaining,
+                actions=history,
+            )
+            if action.pre_action_state_sha256 != pre_state or action.budget_before != remaining:
+                raise EvidenceLifecycleError("evidence request action pre-state does not match its history")
+
+            request = public_requests.get(action.request_id)
+            released_ids = set(released)
+            if action.outcome == EvidenceRequestOutcome.RELEASED:
+                if action.requested_checkpoint_id != checkpoint_run.checkpoint_id or request is None:
+                    raise EvidenceLifecycleError("released evidence request is not declared by its checkpoint")
+                if action.request_id in released:
+                    raise EvidenceLifecycleError("evidence request cannot be released more than once")
+                if not set(request.prerequisite_request_ids).issubset(released_ids):
+                    raise EvidenceLifecycleError("released evidence request prerequisites are incomplete")
+                if remaining < 1:
+                    raise EvidenceLifecycleError("released evidence request exceeds its checkpoint budget")
+                _validate_released_evidence_artifact_paths(action)
+                remaining -= 1
+                released[action.request_id] = action
+            elif action.outcome == EvidenceRequestOutcome.ALREADY_RELEASED:
+                prior = released.get(action.request_id)
+                if prior is None or action.released_artifacts != prior.released_artifacts:
+                    raise EvidenceLifecycleError("already-released request does not match its original release")
+            else:
+                _validate_evidence_request_rejection(
+                    action,
+                    checkpoint_id=checkpoint_run.checkpoint_id,
+                    request=request,
+                    released_ids=released_ids,
+                    remaining_budget=remaining,
+                    supports_requests=conditional is not None,
+                )
+
+            history.append(action)
+            post_state = _evidence_request_projection_sha256(
+                state,
+                checkpoint_id=checkpoint_run.checkpoint_id,
+                evidence_request_budget=expected_budget,
+                evidence_request_budget_remaining=remaining,
+                actions=history,
+            )
+            if action.post_action_state_sha256 != post_state or action.budget_after != remaining:
+                raise EvidenceLifecycleError("evidence request action post-state does not match its history")
+        if checkpoint_run.evidence_request_budget_remaining != remaining:
+            raise EvidenceLifecycleError("evidence request remaining budget does not match its history")
+
+
+def _evidence_request_catalog(
+    checkpoint: EvidenceCheckpointSpec,
+    checkpoint_run: CheckpointRunRecord,
+) -> dict[str, Any] | None:
+    conditional = checkpoint.conditional_evidence
+    if conditional is None:
+        return None
+    released_ids = {
+        action.request_id
+        for action in checkpoint_run.evidence_request_actions
+        if action.outcome == EvidenceRequestOutcome.RELEASED
+    }
+    requests = []
+    for request in conditional.requests:
+        if request.request_id in released_ids:
+            status = "released"
+        elif not set(request.prerequisite_request_ids).issubset(released_ids):
+            status = "prerequisites_incomplete"
+        elif checkpoint_run.evidence_request_budget_remaining == 0:
+            status = "budget_exhausted"
+        else:
+            status = "available"
+        requests.append(
+            {
+                "request_id": request.request_id,
+                "title": request.title,
+                "description": request.description,
+                "prerequisite_request_ids": list(request.prerequisite_request_ids),
+                "status": status,
+            }
+        )
+    return {
+        "schema_version": "1",
+        "checkpoint_id": checkpoint.checkpoint_id,
+        "request_budget": checkpoint_run.evidence_request_budget,
+        "remaining_budget": checkpoint_run.evidence_request_budget_remaining,
+        "requests": requests,
+    }
+
+
+def _validate_released_evidence_artifact_paths(action: EvidenceRequestActionRecord) -> None:
+    canonical_prefix = PurePosixPath("evidence_requests") / action.action_id / "artifacts"
+    workspace_prefix = PurePosixPath("inbox") / action.checkpoint_id / "requests" / action.request_id
+    for artifact in action.released_artifacts:
+        canonical = PurePosixPath(artifact.path)
+        workspace = PurePosixPath(artifact.workspace_path)
+        try:
+            canonical_relative = canonical.relative_to(canonical_prefix)
+            workspace_relative = workspace.relative_to(workspace_prefix)
+        except ValueError as exc:
+            raise EvidenceLifecycleError("released evidence artifact path does not match its action") from exc
+        if canonical_relative == PurePosixPath(".") or canonical_relative != workspace_relative:
+            raise EvidenceLifecycleError("released evidence artifact projections do not match")
+
+
+def _validate_evidence_request_rejection(
+    action: EvidenceRequestActionRecord,
+    *,
+    checkpoint_id: str,
+    request: Any,
+    released_ids: set[str],
+    remaining_budget: int,
+    supports_requests: bool,
+) -> None:
+    rejection = action.rejection
+    valid = False
+    if rejection == EvidenceRequestRejection.INACTIVE_CHECKPOINT:
+        valid = action.requested_checkpoint_id != checkpoint_id
+    elif rejection == EvidenceRequestRejection.NOT_SUPPORTED:
+        valid = action.requested_checkpoint_id == checkpoint_id and not supports_requests
+    elif rejection == EvidenceRequestRejection.UNKNOWN_REQUEST:
+        valid = action.requested_checkpoint_id == checkpoint_id and supports_requests and request is None
+    elif rejection == EvidenceRequestRejection.PREREQUISITES_INCOMPLETE:
+        valid = (
+            action.requested_checkpoint_id == checkpoint_id
+            and request is not None
+            and not set(request.prerequisite_request_ids).issubset(released_ids)
+        )
+    elif rejection == EvidenceRequestRejection.BUDGET_EXHAUSTED:
+        valid = (
+            action.requested_checkpoint_id == checkpoint_id
+            and request is not None
+            and request.request_id not in released_ids
+            and set(request.prerequisite_request_ids).issubset(released_ids)
+            and remaining_budget == 0
+        )
+    if not valid:
+        raise EvidenceLifecycleError("evidence request rejection does not match the action state")
+
+
+def _evidence_request_state_sha256(
+    state: EvidenceLifecycleRunState,
+    checkpoint_id: str,
+) -> str:
+    checkpoint = state.checkpoint(checkpoint_id)
+    return _evidence_request_projection_sha256(
+        state,
+        checkpoint_id=checkpoint_id,
+        evidence_request_budget=checkpoint.evidence_request_budget,
+        evidence_request_budget_remaining=checkpoint.evidence_request_budget_remaining,
+        actions=checkpoint.evidence_request_actions,
+    )
+
+
+def _evidence_request_projection_sha256(
+    state: EvidenceLifecycleRunState,
+    *,
+    checkpoint_id: str,
+    evidence_request_budget: int,
+    evidence_request_budget_remaining: int,
+    actions: Sequence[EvidenceRequestActionRecord],
+) -> str:
+    released = [
+        {
+            "request_id": action.request_id,
+            "released_artifacts": [artifact.model_dump(mode="json") for artifact in action.released_artifacts],
+            "budget_after": action.budget_after,
+        }
+        for action in actions
+        if action.outcome == EvidenceRequestOutcome.RELEASED
+    ]
+    payload = {
+        "schema_version": "1",
+        "lifecycle_id": state.lifecycle_id,
+        "package_sha256": state.package_sha256,
+        "checkpoint_id": checkpoint_id,
+        "evidence_request_budget": evidence_request_budget,
+        "evidence_request_budget_remaining": evidence_request_budget_remaining,
+        "released_requests": released,
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _branch_action_state_sha256(
+    state: EvidenceLifecycleRunState,
+    *,
+    branch_index: int,
+    inherited_only: bool,
+) -> str:
+    checkpoints = []
+    for checkpoint in state.checkpoint_runs[: branch_index + 1]:
+        actions = [
+            action
+            for action in checkpoint.evidence_request_actions
+            if not inherited_only or action.inherited_from_parent
+        ]
+        normalized_actions = []
+        for action in actions:
+            payload = action.model_dump(mode="json")
+            payload.pop("inherited_from_parent")
+            normalized_actions.append(payload)
+        checkpoints.append(
+            {
+                "checkpoint_id": checkpoint.checkpoint_id,
+                "evidence_request_budget": checkpoint.evidence_request_budget,
+                "inherited_budget_after": (actions[-1].budget_after if actions else checkpoint.evidence_request_budget),
+                "actions": normalized_actions,
+            }
+        )
+    payload = {
+        "schema_version": "1",
+        "lifecycle_id": state.lifecycle_id,
+        "package_sha256": state.package_sha256,
+        "checkpoints": checkpoints,
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _checkpoint(spec: EvidenceLifecycleSpec, checkpoint_id: str) -> EvidenceCheckpointSpec:
+    for checkpoint in spec.checkpoints:
+        if checkpoint.checkpoint_id == checkpoint_id:
+            return checkpoint
+    raise EvidenceLifecycleError(f"unknown checkpoint in lifecycle state: {checkpoint_id}")
+
+
+def _append_transition(
+    state: EvidenceLifecycleRunState,
+    *,
+    kind: LifecycleTransitionKind,
+    from_checkpoint_id: str | None,
+    to_checkpoint_id: str | None,
+    reason: str,
+) -> None:
+    state.transitions.append(
+        LifecycleTransitionRecord(
+            transition_id=f"transition-{len(state.transitions) + 1:03d}",
+            kind=kind,
+            from_checkpoint_id=from_checkpoint_id,
+            to_checkpoint_id=to_checkpoint_id,
+            reason=reason,
+        )
+    )

--- a/src/aec_bench/meta_harness/evidence_request_store.py
+++ b/src/aec_bench/meta_harness/evidence_request_store.py
@@ -1,0 +1,643 @@
+# ABOUTME: Persists conditional-evidence transactions, workspace projections, recovery, and ledgers.
+# ABOUTME: Provides the shared durable file primitives used by the lifecycle executor.
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import tempfile
+from pathlib import Path, PurePosixPath
+from typing import Any, Literal
+
+from pydantic import ValidationError
+
+from aec_bench.ledger.durability import fsync_directory, fsync_tree, mkdir_durable
+from aec_bench.meta_harness.evidence_lifecycle_state import (
+    CheckpointRunRecord,
+    CheckpointRunStatus,
+    EvidenceLifecycleRunState,
+    EvidenceRequestActionRecord,
+    EvidenceRequestOutcome,
+    EvidenceRequestRejection,
+    LifecycleTransitionKind,
+    ReleasedEvidenceArtifact,
+)
+from aec_bench.meta_harness.evidence_request_protocol import (
+    EvidenceLifecycleError,
+    EvidenceRequestResolution,
+    EvidenceRequestResolutionManifest,
+    _append_transition,
+    _checkpoint,
+    _evidence_request_catalog,
+    _evidence_request_state_sha256,
+    _validate_evidence_request_state_contract,
+)
+from aec_bench.meta_harness.ledger import append_ledger_entry, read_ledger
+from aec_bench.task_world_templates.contracts import EvidenceCheckpointSpec, EvidenceLifecycleSpec
+
+
+def _load_evidence_request_resolutions(
+    package_dir: Path,
+    spec: EvidenceLifecycleSpec,
+) -> dict[tuple[str, str], EvidenceRequestResolution]:
+    expected = {
+        (checkpoint.checkpoint_id, request.request_id)
+        for checkpoint in spec.checkpoints
+        if checkpoint.conditional_evidence is not None
+        for request in checkpoint.conditional_evidence.requests
+    }
+    if not expected:
+        return {}
+
+    manifest_path = package_dir / "hidden" / "evidence-request-resolutions.json"
+    if not manifest_path.is_file() or manifest_path.is_symlink():
+        raise EvidenceLifecycleError(f"evidence request resolution manifest not found: {manifest_path}")
+    try:
+        manifest = EvidenceRequestResolutionManifest.model_validate(_read_json(manifest_path))
+    except ValidationError as exc:
+        raise EvidenceLifecycleError(f"invalid evidence request resolution manifest: {manifest_path}") from exc
+    if manifest.lifecycle_id != spec.lifecycle_id:
+        raise EvidenceLifecycleError("evidence request resolution manifest lifecycle does not match")
+
+    resolutions = {(resolution.checkpoint_id, resolution.request_id): resolution for resolution in manifest.resolutions}
+    if set(resolutions) != expected:
+        raise EvidenceLifecycleError("evidence request resolutions do not match the public request catalogue")
+    for resolution in resolutions.values():
+        source = package_dir / resolution.source_path
+        if not source.is_dir() or source.is_symlink():
+            raise EvidenceLifecycleError(f"evidence request source not found: {source}")
+    return resolutions
+
+
+def _write_evidence_request_catalog(
+    run_dir: Path,
+    checkpoint: EvidenceCheckpointSpec,
+    checkpoint_run: CheckpointRunRecord,
+) -> None:
+    catalog = _evidence_request_catalog(checkpoint, checkpoint_run)
+    if catalog is None:
+        return
+    destination = _workspace(run_dir) / "checkpoints" / checkpoint.checkpoint_id / "evidence-requests.json"
+    if checkpoint_run.status == CheckpointRunStatus.PENDING:
+        if destination.exists():
+            raise EvidenceLifecycleError("pending checkpoint cannot publish an evidence request catalogue")
+        return
+    _write_json_atomic_durable(destination, catalog)
+
+
+def _record_evidence_request_action(
+    run_dir: Path,
+    spec: EvidenceLifecycleSpec,
+    state: EvidenceLifecycleRunState,
+    *,
+    requested_checkpoint_id: str,
+    request_id: str,
+    reason: str,
+    session_id: str,
+    outcome: EvidenceRequestOutcome,
+    rejection: EvidenceRequestRejection | None = None,
+    released_artifacts: tuple[ReleasedEvidenceArtifact, ...] = (),
+    release_source: Path | None = None,
+) -> dict[str, Any]:
+    active_checkpoint_id = state.active_checkpoint_id
+    if active_checkpoint_id is None:
+        raise EvidenceLifecycleError("no checkpoint is active")
+    checkpoint_run = state.checkpoint(active_checkpoint_id)
+    attempt = checkpoint_run.active_attempt
+    if attempt is None or attempt.session_id != session_id:
+        raise EvidenceLifecycleError("evidence request action has no matching active attempt")
+
+    sequence = 1 + sum(len(item.evidence_request_actions) for item in state.checkpoint_runs)
+    action_id = f"evidence-request-{sequence:06d}"
+    transaction_root = run_dir / "evidence_requests"
+    mkdir_durable(transaction_root)
+    staging = Path(tempfile.mkdtemp(prefix=f".{action_id}.tmp-", dir=transaction_root))
+    transaction = transaction_root / action_id
+    if transaction.exists():
+        shutil.rmtree(staging, ignore_errors=True)
+        raise EvidenceLifecycleError(f"evidence request transaction already exists: {action_id}")
+
+    if outcome == EvidenceRequestOutcome.RELEASED:
+        if release_source is None or released_artifacts:
+            shutil.rmtree(staging, ignore_errors=True)
+            raise EvidenceLifecycleError("released evidence request requires one canonical source")
+        artifact_root = staging / "artifacts"
+        released_files = _copy_release(release_source, artifact_root)
+        if not released_files:
+            shutil.rmtree(staging, ignore_errors=True)
+            raise EvidenceLifecycleError("evidence request source must contain at least one file")
+        destination = _workspace(run_dir) / "inbox" / active_checkpoint_id / "requests" / request_id
+        released_artifacts = tuple(
+            ReleasedEvidenceArtifact(
+                path=(Path("evidence_requests") / action_id / "artifacts" / relative).as_posix(),
+                workspace_path=(destination / relative).relative_to(_workspace(run_dir)).as_posix(),
+                sha256=_sha256(artifact_root / relative),
+            )
+            for relative in released_files
+        )
+    elif release_source is not None:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise EvidenceLifecycleError("only released evidence requests may publish canonical artifacts")
+
+    budget_before = checkpoint_run.evidence_request_budget_remaining
+    budget_consumed: Literal[0, 1] = 1 if outcome == EvidenceRequestOutcome.RELEASED else 0
+    pre_action_state_sha256 = _evidence_request_state_sha256(state, active_checkpoint_id)
+    checkpoint_run.evidence_request_budget_remaining -= budget_consumed
+    action = EvidenceRequestActionRecord(
+        action_id=action_id,
+        sequence=sequence,
+        checkpoint_id=active_checkpoint_id,
+        requested_checkpoint_id=requested_checkpoint_id,
+        request_id=request_id,
+        reason=reason,
+        session_id=session_id,
+        attempt_id=attempt.attempt_id,
+        outcome=outcome,
+        rejection=rejection,
+        pre_action_state_sha256=pre_action_state_sha256,
+        post_action_state_sha256="0" * 64,
+        released_artifacts=released_artifacts,
+        budget_before=budget_before,
+        budget_consumed=budget_consumed,
+        budget_after=checkpoint_run.evidence_request_budget_remaining,
+    )
+    checkpoint_run.evidence_request_actions.append(action)
+    action.post_action_state_sha256 = _evidence_request_state_sha256(state, active_checkpoint_id)
+    try:
+        _write_json(staging / "action.json", action.model_dump(mode="json"))
+        fsync_tree(staging)
+        staging.replace(transaction)
+        fsync_directory(transaction_root)
+        if outcome == EvidenceRequestOutcome.RELEASED:
+            _materialize_evidence_request_projection(run_dir, action)
+        _write_evidence_request_catalog(
+            run_dir,
+            _checkpoint(spec, active_checkpoint_id),
+            checkpoint_run,
+        )
+        _append_transition(
+            state,
+            kind=LifecycleTransitionKind.EVIDENCE_REQUEST,
+            from_checkpoint_id=active_checkpoint_id,
+            to_checkpoint_id=active_checkpoint_id,
+            reason=f"Conditional evidence request {outcome.value}.",
+        )
+        _write_state(run_dir, state)
+        _sync_transition_ledger(run_dir, state)
+        _sync_evidence_request_ledger(run_dir, state)
+        _write_json_atomic_durable(
+            transaction / "committed.json",
+            {"action_id": action_id, "status": "committed"},
+        )
+        fsync_tree(transaction)
+        fsync_directory(transaction_root)
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+    return action.model_dump(mode="json")
+
+
+def _assert_evidence_request_artifacts_unchanged(
+    run_dir: Path,
+    action: EvidenceRequestActionRecord,
+) -> None:
+    first = action.released_artifacts[0]
+    canonical_path = PurePosixPath(first.path)
+    canonical_prefix = PurePosixPath(*canonical_path.parts[:3])
+    workspace_prefix = PurePosixPath("inbox") / action.checkpoint_id / "requests" / action.request_id
+    expected_canonical = {
+        PurePosixPath(artifact.path).relative_to(canonical_prefix).as_posix(): artifact.sha256
+        for artifact in action.released_artifacts
+    }
+    expected_workspace = {
+        PurePosixPath(artifact.workspace_path).relative_to(workspace_prefix).as_posix(): artifact.sha256
+        for artifact in action.released_artifacts
+    }
+    if len(expected_canonical) != len(action.released_artifacts) or len(expected_workspace) != len(
+        action.released_artifacts
+    ):
+        raise EvidenceLifecycleError("released evidence request artifact paths are not unique")
+
+    canonical_root = run_dir / canonical_prefix
+    workspace_root = _workspace(run_dir) / workspace_prefix
+    actual_canonical = _artifact_tree_inventory(canonical_root, confined_to=run_dir)
+    actual_workspace = _artifact_tree_inventory(
+        workspace_root,
+        confined_to=_workspace(run_dir),
+    )
+    if set(actual_canonical) != set(expected_canonical) or set(actual_workspace) != set(expected_workspace):
+        raise EvidenceLifecycleError(f"released evidence request artifact file set changed: {action.action_id}")
+    for artifact in action.released_artifacts:
+        canonical_relative = PurePosixPath(artifact.path).relative_to(canonical_prefix).as_posix()
+        workspace_relative = PurePosixPath(artifact.workspace_path).relative_to(workspace_prefix).as_posix()
+        if (
+            actual_canonical[canonical_relative] != artifact.sha256
+            or actual_workspace[workspace_relative] != artifact.sha256
+        ):
+            raise EvidenceLifecycleError(f"released evidence request artifact changed: {artifact.path}")
+
+
+def _artifact_tree_inventory(root: Path, *, confined_to: Path) -> dict[str, str]:
+    try:
+        relative_root = root.relative_to(confined_to)
+    except ValueError as exc:
+        raise EvidenceLifecycleError(f"evidence request artifact tree escapes its run: {root}") from exc
+    cursor = confined_to
+    for part in relative_root.parts:
+        cursor /= part
+        if cursor.is_symlink():
+            raise EvidenceLifecycleError(f"evidence request artifact tree may not contain symlinks: {cursor}")
+    if not root.is_dir():
+        raise EvidenceLifecycleError(f"evidence request artifact tree is missing: {root}")
+
+    inventory: dict[str, str] = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_symlink():
+            raise EvidenceLifecycleError(f"evidence request artifact tree may not contain symlinks: {path}")
+        if path.is_dir():
+            continue
+        if not path.is_file():
+            raise EvidenceLifecycleError(f"evidence request artifact tree contains a non-file: {path}")
+        inventory[path.relative_to(root).as_posix()] = _sha256(path)
+    return inventory
+
+
+def _recover_evidence_request_transactions(
+    run_dir: Path,
+    spec: EvidenceLifecycleSpec,
+    state: EvidenceLifecycleRunState,
+) -> None:
+    transaction_root = run_dir / "evidence_requests"
+    actions = [action for checkpoint in state.checkpoint_runs for action in checkpoint.evidence_request_actions]
+    if not transaction_root.exists():
+        if actions:
+            raise EvidenceLifecycleError("evidence request state is missing its canonical transactions")
+        return
+
+    for staging in transaction_root.glob(".*.tmp-*"):
+        if staging.is_dir():
+            shutil.rmtree(staging)
+
+    by_id = {action.action_id: action for action in actions}
+    changed = False
+    pending_commits: list[tuple[Path, str]] = []
+    transactions = sorted(
+        path for path in transaction_root.iterdir() if path.is_dir() and not path.name.startswith(".")
+    )
+    for transaction in transactions:
+        action_path = transaction / "action.json"
+        if not action_path.is_file() or action_path.is_symlink():
+            raise EvidenceLifecycleError(f"invalid evidence request transaction: {transaction}")
+        try:
+            action = EvidenceRequestActionRecord.model_validate(_read_json(action_path))
+        except ValidationError as exc:
+            raise EvidenceLifecycleError(f"invalid evidence request action: {action_path}") from exc
+        if action.action_id != transaction.name:
+            raise EvidenceLifecycleError("evidence request action id does not match its transaction")
+
+        existing = by_id.get(action.action_id)
+        if existing is None:
+            expected_sequence = 1 + sum(
+                len(checkpoint.evidence_request_actions) for checkpoint in state.checkpoint_runs
+            )
+            if action.sequence != expected_sequence:
+                raise EvidenceLifecycleError("evidence request recovery sequence is not contiguous")
+            checkpoint_run = state.checkpoint(action.checkpoint_id)
+            owner = next(
+                (
+                    attempt
+                    for attempt in checkpoint_run.attempts
+                    if attempt.attempt_id == action.attempt_id and attempt.session_id == action.session_id
+                ),
+                None,
+            )
+            if owner is None:
+                raise EvidenceLifecycleError("evidence request action owner is not present in checkpoint attempts")
+            if checkpoint_run.evidence_request_budget_remaining != action.budget_before:
+                raise EvidenceLifecycleError("evidence request recovery budget does not match state")
+            if _evidence_request_state_sha256(state, action.checkpoint_id) != action.pre_action_state_sha256:
+                raise EvidenceLifecycleError("evidence request recovery pre-state hash does not match")
+
+            if action.outcome == EvidenceRequestOutcome.RELEASED:
+                _materialize_evidence_request_projection(run_dir, action)
+            elif action.outcome == EvidenceRequestOutcome.ALREADY_RELEASED:
+                _assert_evidence_request_artifacts_unchanged(run_dir, action)
+            checkpoint_run.evidence_request_budget_remaining = action.budget_after
+            checkpoint_run.evidence_request_actions.append(action)
+            if _evidence_request_state_sha256(state, action.checkpoint_id) != action.post_action_state_sha256:
+                raise EvidenceLifecycleError("evidence request recovery post-state hash does not match")
+            _append_transition(
+                state,
+                kind=LifecycleTransitionKind.EVIDENCE_REQUEST,
+                from_checkpoint_id=action.checkpoint_id,
+                to_checkpoint_id=action.checkpoint_id,
+                reason=f"Conditional evidence request {action.outcome.value}.",
+            )
+            by_id[action.action_id] = action
+            changed = True
+        elif existing.model_dump(mode="json") != action.model_dump(mode="json"):
+            raise EvidenceLifecycleError("evidence request state does not match its canonical transaction")
+
+        if action.outcome == EvidenceRequestOutcome.RELEASED:
+            _materialize_evidence_request_projection(run_dir, action)
+        elif action.outcome == EvidenceRequestOutcome.ALREADY_RELEASED:
+            _assert_evidence_request_artifacts_unchanged(run_dir, action)
+        committed = transaction / "committed.json"
+        if not committed.exists():
+            pending_commits.append((committed, action.action_id))
+        elif committed.is_symlink() or _read_json(committed) != {
+            "action_id": action.action_id,
+            "status": "committed",
+        }:
+            raise EvidenceLifecycleError("evidence request transaction commit marker is invalid")
+
+    transaction_ids = {transaction.name for transaction in transactions}
+    missing = sorted(set(by_id) - transaction_ids)
+    if missing:
+        raise EvidenceLifecycleError(f"evidence request state is missing canonical transactions: {', '.join(missing)}")
+    if changed:
+        _validate_evidence_request_state_contract(state, spec)
+        for checkpoint in spec.checkpoints:
+            _write_evidence_request_catalog(
+                run_dir,
+                checkpoint,
+                state.checkpoint(checkpoint.checkpoint_id),
+            )
+        _write_state(run_dir, state)
+        _sync_transition_ledger(run_dir, state)
+        _sync_evidence_request_ledger(run_dir, state)
+    for committed, action_id in pending_commits:
+        _write_json_atomic_durable(
+            committed,
+            {"action_id": action_id, "status": "committed"},
+        )
+    if pending_commits:
+        fsync_directory(transaction_root)
+
+
+def _materialize_evidence_request_projection(
+    run_dir: Path,
+    action: EvidenceRequestActionRecord,
+) -> None:
+    if action.outcome != EvidenceRequestOutcome.RELEASED:
+        return
+    source = run_dir / "evidence_requests" / action.action_id / "artifacts"
+    destination = _workspace(run_dir) / "inbox" / action.checkpoint_id / "requests" / action.request_id
+    if destination.exists():
+        _assert_evidence_request_artifacts_unchanged(run_dir, action)
+        return
+
+    staging_root = _workspace(run_dir) / ".staging" / "evidence_requests" / action.action_id
+    staging_release = staging_root / "release"
+    if staging_root.exists():
+        shutil.rmtree(staging_root)
+    try:
+        copied = _copy_release(source, staging_release)
+        destination_relative = destination.relative_to(_workspace(run_dir))
+        expected = [
+            Path(artifact.workspace_path).relative_to(destination_relative).as_posix()
+            for artifact in action.released_artifacts
+        ]
+        if copied != expected:
+            raise EvidenceLifecycleError("canonical evidence request artifacts do not match the action record")
+        fsync_tree(staging_release)
+        mkdir_durable(destination.parent)
+        staging_release.replace(destination)
+        fsync_directory(destination.parent)
+        _assert_evidence_request_artifacts_unchanged(run_dir, action)
+    finally:
+        shutil.rmtree(staging_root, ignore_errors=True)
+
+
+def _inherit_evidence_request_transactions(
+    parent_run: Path,
+    branch_run: Path,
+    state: EvidenceLifecycleRunState,
+) -> None:
+    inherited_actions = sorted(
+        (
+            action
+            for checkpoint in state.checkpoint_runs
+            for action in checkpoint.evidence_request_actions
+            if action.inherited_from_parent
+        ),
+        key=lambda action: action.sequence,
+    )
+    if not inherited_actions:
+        return
+    destination_root = branch_run / "evidence_requests"
+    destination_root.mkdir(parents=True, exist_ok=True)
+    for action in inherited_actions:
+        source = parent_run / "evidence_requests" / action.action_id
+        destination = destination_root / action.action_id
+        _copy_release(source, destination)
+        _write_json(destination / "action.json", action.model_dump(mode="json"))
+        _write_json(
+            destination / "committed.json",
+            {"action_id": action.action_id, "status": "committed"},
+        )
+    fsync_tree(destination_root)
+
+
+def _copy_release(source: Path, destination: Path) -> list[str]:
+    if not source.is_dir() or source.is_symlink():
+        raise EvidenceLifecycleError(f"checkpoint release not found: {source}")
+    destination.mkdir(parents=True, exist_ok=False)
+    released: list[str] = []
+    for source_path in sorted(source.rglob("*")):
+        if source_path.is_symlink():
+            raise EvidenceLifecycleError(f"checkpoint releases may not contain symlinks: {source_path}")
+        relative = source_path.relative_to(source)
+        destination_path = destination / relative
+        if source_path.is_dir():
+            destination_path.mkdir(parents=True, exist_ok=True)
+            continue
+        destination_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source_path, destination_path)
+        released.append(relative.as_posix())
+    return released
+
+
+def _copy_file_atomic(source: Path, destination: Path) -> None:
+    if not source.is_file():
+        raise EvidenceLifecycleError(f"branch source artifact not found: {source}")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_suffix(destination.suffix + ".tmp")
+    shutil.copy2(source, temporary)
+    temporary.replace(destination)
+
+
+def _sync_transition_ledger(run_dir: Path, state: EvidenceLifecycleRunState) -> None:
+    ledger_path = _ledger_path(run_dir)
+    recorded = _ledger_entries_by_summary_id(
+        ledger_path,
+        stage="lifecycle_transition",
+        identity_field="transition_id",
+        label="lifecycle transition",
+    )
+    expected_ids = {transition.transition_id for transition in state.transitions}
+    unexpected = sorted(set(recorded) - expected_ids)
+    if unexpected:
+        raise EvidenceLifecycleError(
+            "lifecycle transition ledger contains entries absent from state: " + ", ".join(unexpected)
+        )
+    for transition in state.transitions:
+        summary = transition.model_dump(mode="json")
+        existing = recorded.get(transition.transition_id)
+        if existing is not None:
+            _assert_ledger_entry_matches(
+                existing,
+                process_id=state.lifecycle_id,
+                status=transition.kind.value,
+                summary=summary,
+                artifact_refs=[],
+                label="lifecycle transition",
+            )
+            continue
+        append_ledger_entry(
+            ledger_path,
+            process_id=state.lifecycle_id,
+            stage="lifecycle_transition",
+            status=transition.kind.value,
+            summary=summary,
+            artifact_refs=[],
+        )
+
+
+def _sync_evidence_request_ledger(
+    run_dir: Path,
+    state: EvidenceLifecycleRunState,
+) -> None:
+    ledger_path = _ledger_path(run_dir)
+    recorded = _ledger_entries_by_summary_id(
+        ledger_path,
+        stage="evidence_request",
+        identity_field="action_id",
+        label="evidence request",
+    )
+    actions = sorted(
+        (action for checkpoint in state.checkpoint_runs for action in checkpoint.evidence_request_actions),
+        key=lambda action: action.sequence,
+    )
+    expected_ids = {action.action_id for action in actions}
+    unexpected = sorted(set(recorded) - expected_ids)
+    if unexpected:
+        raise EvidenceLifecycleError(
+            f"evidence request ledger contains entries absent from state: {', '.join(unexpected)}"
+        )
+    for action in actions:
+        summary = action.model_dump(mode="json")
+        artifact_refs = [artifact.path for artifact in action.released_artifacts]
+        existing = recorded.get(action.action_id)
+        if existing is not None:
+            _assert_ledger_entry_matches(
+                existing,
+                process_id=state.lifecycle_id,
+                status=action.outcome.value,
+                summary=summary,
+                artifact_refs=artifact_refs,
+                label="evidence request",
+            )
+            continue
+        append_ledger_entry(
+            ledger_path,
+            process_id=state.lifecycle_id,
+            stage="evidence_request",
+            status=action.outcome.value,
+            summary=summary,
+            artifact_refs=artifact_refs,
+        )
+
+
+def _ledger_entries_by_summary_id(
+    ledger_path: Path,
+    *,
+    stage: str,
+    identity_field: str,
+    label: str,
+) -> dict[str, dict[str, Any]]:
+    recorded: dict[str, dict[str, Any]] = {}
+    for entry in read_ledger(ledger_path):
+        if entry.get("stage") != stage:
+            continue
+        summary = entry.get("summary")
+        identity = summary.get(identity_field) if isinstance(summary, dict) else None
+        if not isinstance(identity, str) or not identity:
+            raise EvidenceLifecycleError(f"{label} ledger entry is missing its canonical identity")
+        if identity in recorded:
+            raise EvidenceLifecycleError(f"{label} ledger contains duplicate entry: {identity}")
+        recorded[identity] = entry
+    return recorded
+
+
+def _assert_ledger_entry_matches(
+    entry: dict[str, Any],
+    *,
+    process_id: str,
+    status: str,
+    summary: dict[str, Any],
+    artifact_refs: list[str],
+    label: str,
+) -> None:
+    if (
+        entry.get("process_id") != process_id
+        or entry.get("status") != status
+        or entry.get("summary") != summary
+        or entry.get("artifact_refs") != artifact_refs
+    ):
+        raise EvidenceLifecycleError(f"{label} ledger entry conflicts with canonical state")
+
+
+def _workspace(run_dir: Path) -> Path:
+    return run_dir / "workspace"
+
+
+def _state_path(run_dir: Path) -> Path:
+    return run_dir / "state.json"
+
+
+def _ledger_path(run_dir: Path) -> Path:
+    return run_dir / "lifecycle_ledger.jsonl"
+
+
+def _write_state(run_dir: Path, state: EvidenceLifecycleRunState) -> None:
+    path = _state_path(run_dir)
+    _write_json_atomic_durable(path, state.model_dump(mode="json"))
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise EvidenceLifecycleError(f"invalid JSON artifact: {path}") from exc
+    if not isinstance(payload, dict):
+        raise EvidenceLifecycleError(f"JSON artifact must contain an object: {path}")
+    return payload
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _write_json_atomic_durable(path: Path, payload: dict[str, Any]) -> None:
+    mkdir_durable(path.parent)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    _write_json(temporary, payload)
+    descriptor = os.open(temporary, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+    temporary.replace(path)
+    fsync_directory(path.parent)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(64 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/src/aec_bench/prime_lab/lifecycle_environment.py
+++ b/src/aec_bench/prime_lab/lifecycle_environment.py
@@ -13,6 +13,7 @@ from typing import Any, cast
 from aec_bench.meta_harness.evidence_lifecycle import (
     evidence_lifecycle_package_identity,
     fail_checkpoint_attempt,
+    load_evidence_lifecycle_spec,
     open_checkpoint_attempt,
     prepare_evidence_checkpoint,
     read_evidence_lifecycle_state,
@@ -60,10 +61,14 @@ def load_local_lifecycle_environment(
     manifest = load_prime_lifecycle_manifest(Path(manifest_path))
     _assert_source_provenance(manifest.source)
     records = _select_records(manifest, variant=variant, num_examples=num_examples, seed=seed)
+    supports_evidence_requests = _records_support_evidence_requests(records)
     dataset = _build_dataset(records)
     vf = importlib.import_module("verifiers")
     rubric = _build_lifecycle_rubric(vf)
-    environment_type = _build_environment_type(vf)
+    environment_type = _build_environment_type(
+        vf,
+        supports_evidence_requests=supports_evidence_requests,
+    )
     return environment_type(
         manifest=manifest,
         records=records,
@@ -89,6 +94,20 @@ def write_checkpoint_submission(
 ) -> str:
     """Write the active checkpoint JSON through the host-confined workspace tool."""
     return _workspace_tool(state).write_checkpoint_submission(checkpoint_id, content)
+
+
+def request_evidence(
+    checkpoint_id: str,
+    request_id: str,
+    reason: str,
+    state: dict[str, Any] | None = None,
+) -> str:
+    """Request one declared evidence packet through the session-bound host tool."""
+    return _control_tool(_required_state(state)).request_evidence(
+        checkpoint_id,
+        request_id,
+        reason,
+    )
 
 
 def submit_checkpoint(checkpoint_id: str, state: dict[str, Any] | None = None) -> str:
@@ -139,7 +158,11 @@ async def aec_bench_lifecycle_reward(state: dict[str, Any]) -> float:
     return reward
 
 
-def _build_environment_type(vf: Any) -> type[Any]:
+def _build_environment_type(
+    vf: Any,
+    *,
+    supports_evidence_requests: bool,
+) -> type[Any]:
     class AecBenchLifecycleEnv(vf.StatefulToolEnv):  # type: ignore[misc]
         execution_mode = "persistent_context"
         memory_visibility_policy = "persistent_context"
@@ -154,21 +177,29 @@ def _build_environment_type(vf: Any) -> type[Any]:
         ) -> None:
             self.lifecycle_manifest = manifest
             self.lifecycle_records = records
+            system_prompt = _SYSTEM_PROMPT
+            if supports_evidence_requests:
+                system_prompt += (
+                    " Inspect the active checkpoint evidence-requests.json catalogue and use request_evidence "
+                    "only when additional declared evidence is needed within its finite budget."
+                )
             super().__init__(
                 tools=[],
                 max_turns=manifest.max_turns,
                 dataset=dataset,
                 eval_dataset=dataset,
                 rubric=rubric,
-                system_prompt=_SYSTEM_PROMPT,
+                system_prompt=system_prompt,
             )
-            for tool in (
+            tools = [
                 list_workspace,
                 read_workspace_file,
                 write_checkpoint_submission,
-                submit_checkpoint,
-                revisit_checkpoint,
-            ):
+            ]
+            if supports_evidence_requests:
+                tools.append(request_evidence)
+            tools.extend([submit_checkpoint, revisit_checkpoint])
+            for tool in tools:
                 self.add_tool(tool, args_to_skip=["state"])
 
         async def setup_state(self, state: dict[str, Any]) -> None:
@@ -287,6 +318,21 @@ def _select_records(
     if not records:
         raise ValueError("lifecycle selection is empty")
     return tuple(records)
+
+
+def _records_support_evidence_requests(
+    records: tuple[PrimeLifecyclePackageRecord, ...],
+) -> bool:
+    capabilities = {
+        any(
+            checkpoint.conditional_evidence is not None
+            for checkpoint in load_evidence_lifecycle_spec(Path(record.package_dir)).checkpoints
+        )
+        for record in records
+    }
+    if len(capabilities) != 1:
+        raise ValueError("selected lifecycle packages must share one conditional evidence capability")
+    return capabilities.pop()
 
 
 def _assert_source_provenance(expected: PrimeLifecycleSourceProvenance) -> None:

--- a/src/aec_bench/task_world_templates/contracts.py
+++ b/src/aec_bench/task_world_templates/contracts.py
@@ -7,7 +7,7 @@ import re
 from pathlib import PurePosixPath
 from typing import Any
 
-from pydantic import Field, model_validator
+from pydantic import Field, PositiveInt, model_validator
 
 from aec_bench.contracts.task_world import (
     AgenticReviewProfile,
@@ -80,6 +80,83 @@ class DataGapSpec(StrictModel):
     severity: NonEmptyStr = "medium"
 
 
+class EvidenceRequestSpec(StrictModel):
+    request_id: NonEmptyStr
+    title: NonEmptyStr
+    description: NonEmptyStr
+    prerequisite_request_ids: tuple[NonEmptyStr, ...] = ()
+
+    @model_validator(mode="after")
+    def validate_request_id(self) -> EvidenceRequestSpec:
+        if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", self.request_id) is None:
+            raise ValueError("request_id must be a safe path segment")
+        if len(self.prerequisite_request_ids) != len(set(self.prerequisite_request_ids)):
+            raise ValueError("evidence request prerequisites must be unique")
+        if self.request_id in self.prerequisite_request_ids:
+            raise ValueError("evidence request cannot depend on itself")
+        return self
+
+
+class ConditionalEvidenceSpec(StrictModel):
+    request_budget: PositiveInt
+    requests: tuple[EvidenceRequestSpec, ...] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def validate_request_graph(self) -> ConditionalEvidenceSpec:
+        request_ids = [request.request_id for request in self.requests]
+        if len(request_ids) != len(set(request_ids)):
+            raise ValueError("evidence request ids must be unique per checkpoint")
+        if self.request_budget > len(request_ids):
+            raise ValueError("evidence request budget cannot exceed the number of requests")
+
+        known = set(request_ids)
+        prerequisites = {request.request_id: set(request.prerequisite_request_ids) for request in self.requests}
+        for request_id, dependencies in prerequisites.items():
+            unknown = dependencies - known
+            if unknown:
+                names = ", ".join(sorted(unknown))
+                raise ValueError(f"evidence request prerequisites are unknown for {request_id}: {names}")
+
+        visiting: set[str] = set()
+        visited: set[str] = set()
+
+        def visit(request_id: str) -> None:
+            if request_id in visiting:
+                raise ValueError("evidence request prerequisites must not contain cycles")
+            if request_id in visited:
+                return
+            visiting.add(request_id)
+            for dependency in prerequisites[request_id]:
+                visit(dependency)
+            visiting.remove(request_id)
+            visited.add(request_id)
+
+        for request_id in request_ids:
+            visit(request_id)
+
+        prerequisite_closures: dict[str, set[str]] = {}
+
+        def prerequisite_closure(request_id: str) -> set[str]:
+            cached = prerequisite_closures.get(request_id)
+            if cached is not None:
+                return cached
+            closure: set[str] = set()
+            for dependency in prerequisites[request_id]:
+                closure.add(dependency)
+                closure.update(prerequisite_closure(dependency))
+            prerequisite_closures[request_id] = closure
+            return closure
+
+        for request_id in request_ids:
+            required_budget = len(prerequisite_closure(request_id)) + 1
+            if required_budget > self.request_budget:
+                raise ValueError(
+                    f"evidence request budget cannot satisfy prerequisites for {request_id}: "
+                    f"requires {required_budget} requests"
+                )
+        return self
+
+
 class EvidenceCheckpointSpec(StrictModel):
     checkpoint_id: NonEmptyStr
     title: NonEmptyStr
@@ -88,6 +165,7 @@ class EvidenceCheckpointSpec(StrictModel):
     submission_path: NonEmptyStr
     depends_on: list[NonEmptyStr] = Field(default_factory=list)
     required_submission_fields: list[NonEmptyStr] = Field(default_factory=lambda: ["checkpoint_id"])
+    conditional_evidence: ConditionalEvidenceSpec | None = None
 
     @model_validator(mode="after")
     def validate_package_paths(self) -> EvidenceCheckpointSpec:

--- a/tests/meta_harness/test_evidence_lifecycle.py
+++ b/tests/meta_harness/test_evidence_lifecycle.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 import json
 import subprocess
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from threading import Event, Thread
 from types import SimpleNamespace
 from typing import Any, Never
 
@@ -15,6 +17,8 @@ from pydantic import ValidationError
 
 import aec_bench.meta_harness.evidence_lifecycle as lifecycle_runtime
 import aec_bench.meta_harness.evidence_lifecycle_local as lifecycle_local_runtime
+import aec_bench.meta_harness.evidence_request_protocol as evidence_request_protocol_runtime
+import aec_bench.meta_harness.evidence_request_store as evidence_request_store_runtime
 from aec_bench.meta_harness.evidence_lifecycle import (
     EvidenceLifecycleError,
     branch_evidence_lifecycle,
@@ -105,6 +109,156 @@ def test_lifecycle_contract_rejects_duplicate_submission_paths() -> None:
             world_id="world.demo",
             checkpoints=[initial, response],
         )
+
+
+def test_conditional_evidence_contract_rejects_ambiguous_request_graphs() -> None:
+    payload = _checkpoint("initial_review").model_dump(mode="json")
+    payload["conditional_evidence"] = {
+        "request_budget": 1,
+        "requests": [
+            {
+                "request_id": "survey_revision",
+                "title": "Survey revision",
+                "description": "Obtain the revised survey.",
+                "prerequisite_request_ids": ["outlet_inspection"],
+            },
+            {
+                "request_id": "outlet_inspection",
+                "title": "Outlet inspection",
+                "description": "Obtain the outlet inspection.",
+                "prerequisite_request_ids": ["survey_revision"],
+            },
+        ],
+    }
+
+    with pytest.raises(ValidationError, match="must not contain cycles"):
+        EvidenceCheckpointSpec.model_validate(payload)
+
+    payload["conditional_evidence"]["requests"][1]["request_id"] = "survey_revision"
+    payload["conditional_evidence"]["requests"][1]["prerequisite_request_ids"] = []
+    with pytest.raises(ValidationError, match="ids must be unique"):
+        EvidenceCheckpointSpec.model_validate(payload)
+
+
+@pytest.mark.parametrize(
+    ("request_budget", "requests", "unreachable_request_id"),
+    [
+        (
+            1,
+            [
+                {
+                    "request_id": "survey_revision",
+                    "title": "Survey revision",
+                    "description": "Obtain the revised survey.",
+                },
+                {
+                    "request_id": "outlet_inspection",
+                    "title": "Outlet inspection",
+                    "description": "Obtain the outlet inspection.",
+                    "prerequisite_request_ids": ["survey_revision"],
+                },
+            ],
+            "outlet_inspection",
+        ),
+        (
+            2,
+            [
+                {
+                    "request_id": "survey_revision",
+                    "title": "Survey revision",
+                    "description": "Obtain the revised survey.",
+                },
+                {
+                    "request_id": "outlet_inspection",
+                    "title": "Outlet inspection",
+                    "description": "Obtain the outlet inspection.",
+                    "prerequisite_request_ids": ["survey_revision"],
+                },
+                {
+                    "request_id": "model_reconciliation",
+                    "title": "Model reconciliation",
+                    "description": "Obtain the reconciled model record.",
+                    "prerequisite_request_ids": ["outlet_inspection"],
+                },
+            ],
+            "model_reconciliation",
+        ),
+    ],
+)
+def test_conditional_evidence_contract_rejects_requests_unreachable_within_budget(
+    request_budget: int,
+    requests: list[dict[str, Any]],
+    unreachable_request_id: str,
+) -> None:
+    payload = _checkpoint("initial_review").model_dump(mode="json")
+    payload["conditional_evidence"] = {
+        "request_budget": request_budget,
+        "requests": requests,
+    }
+
+    with pytest.raises(
+        ValidationError,
+        match=f"budget cannot satisfy prerequisites for {unreachable_request_id}",
+    ):
+        EvidenceCheckpointSpec.model_validate(payload)
+
+
+def test_conditional_evidence_contract_accepts_every_request_reachable_within_budget() -> None:
+    payload = _checkpoint("initial_review").model_dump(mode="json")
+    payload["conditional_evidence"] = {
+        "request_budget": 2,
+        "requests": [
+            {
+                "request_id": "survey_revision",
+                "title": "Survey revision",
+                "description": "Obtain the revised survey.",
+            },
+            {
+                "request_id": "outlet_inspection",
+                "title": "Outlet inspection",
+                "description": "Obtain the outlet inspection.",
+                "prerequisite_request_ids": ["survey_revision"],
+            },
+            {
+                "request_id": "model_reconciliation",
+                "title": "Model reconciliation",
+                "description": "Obtain the reconciled model record.",
+            },
+        ],
+    }
+
+    checkpoint = EvidenceCheckpointSpec.model_validate(payload)
+
+    assert checkpoint.conditional_evidence is not None
+    assert checkpoint.conditional_evidence.request_budget == 2
+
+
+def test_public_conditional_evidence_contract_rejects_hidden_resolution_paths() -> None:
+    payload = _checkpoint("initial_review").model_dump(mode="json")
+    payload["conditional_evidence"] = {
+        "request_budget": 1,
+        "requests": [
+            {
+                "request_id": "survey_revision",
+                "title": "Survey revision",
+                "description": "Obtain the revised survey.",
+                "source_path": "hidden/evidence_requests/initial_review/survey_revision",
+            }
+        ],
+    }
+
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        EvidenceCheckpointSpec.model_validate(payload)
+
+
+def test_conditional_release_reserves_requests_workspace_namespace(tmp_path: Path) -> None:
+    package = _write_conditional_package(tmp_path / "package")
+    reserved = package / "releases/initial_review/requests/preexisting.txt"
+    reserved.parent.mkdir()
+    reserved.write_text("collision\n", encoding="utf-8")
+
+    with pytest.raises(EvidenceLifecycleError, match="reserved requests namespace"):
+        prepare_evidence_checkpoint(package, tmp_path / "run")
 
 
 def test_lifecycle_state_rejects_contradictory_active_and_complete_state() -> None:
@@ -219,6 +373,653 @@ def test_prepare_releases_only_the_active_checkpoint(tmp_path: Path) -> None:
     assert "initial review" in (workspace / "instruction.md").read_text().lower()
 
 
+def test_request_evidence_releases_only_selected_request_and_records_budget(
+    tmp_path: Path,
+) -> None:
+    package = _write_conditional_package(tmp_path / "package")
+
+    run_dir = tmp_path / "run"
+    prepared = prepare_evidence_checkpoint(package, run_dir)
+    catalog_path = run_dir / "workspace/checkpoints/initial_review/evidence-requests.json"
+    initial_catalog = _load_json(catalog_path)
+    assert prepared["evidence_request_catalog"] == initial_catalog
+    assert initial_catalog["remaining_budget"] == 1
+    assert [request["status"] for request in initial_catalog["requests"]] == [
+        "available",
+        "available",
+    ]
+    assert "source_path" not in json.dumps(initial_catalog)
+    assert "hidden" not in json.dumps(initial_catalog)
+    attempt = open_checkpoint_attempt(
+        package,
+        run_dir,
+        session_id="session-001",
+        execution_mode="fresh_context",
+    )
+
+    result = lifecycle_runtime.request_evidence_checkpoint(
+        package,
+        run_dir,
+        checkpoint_id="initial_review",
+        request_id="survey_revision",
+        reason="Resolve the source revision discrepancy.",
+        session_id="session-001",
+    )
+
+    assert result["outcome"] == "released"
+    assert result["attempt_id"] == attempt["attempt_id"]
+    assert result["session_id"] == "session-001"
+    assert result["budget_before"] == 1
+    assert result["budget_consumed"] == 1
+    assert result["budget_after"] == 0
+    assert len(result["pre_action_state_sha256"]) == 64
+    assert len(result["post_action_state_sha256"]) == 64
+    assert result["released_artifacts"][0]["sha256"]
+    requested = run_dir / "workspace/inbox/initial_review/requests"
+    assert (requested / "survey_revision" / "survey-rev-b.txt").read_text(encoding="utf-8") == "revision B\n"
+    assert not (requested / "outlet_inspection").exists()
+
+    state = _load_json(run_dir / "state.json")
+    checkpoint = state["checkpoint_runs"][0]
+    assert checkpoint["evidence_request_budget"] == 1
+    assert checkpoint["evidence_request_budget_remaining"] == 0
+    assert checkpoint["evidence_request_actions"] == [result]
+    updated_catalog = _load_json(catalog_path)
+    assert updated_catalog["remaining_budget"] == 0
+    assert [request["status"] for request in updated_catalog["requests"]] == [
+        "released",
+        "budget_exhausted",
+    ]
+
+
+def test_evidence_request_catalog_preserves_unmet_prerequisite_status_after_budget_exhaustion(
+    tmp_path: Path,
+) -> None:
+    package = _write_prerequisite_conditional_package(tmp_path / "package")
+    run_dir = tmp_path / "run"
+    prepare_evidence_checkpoint(package, run_dir)
+    open_checkpoint_attempt(
+        package,
+        run_dir,
+        session_id="session-001",
+        execution_mode="persistent_context",
+    )
+    for request_id in ("alternative_c", "alternative_d"):
+        lifecycle_runtime.request_evidence_checkpoint(
+            package,
+            run_dir,
+            checkpoint_id="initial_review",
+            request_id=request_id,
+            reason=f"Inspect {request_id}.",
+            session_id="session-001",
+        )
+
+    catalog = _load_json(run_dir / "workspace/checkpoints/initial_review/evidence-requests.json")
+    outlet_status = next(
+        request["status"] for request in catalog["requests"] if request["request_id"] == "outlet_inspection"
+    )
+    rejected = lifecycle_runtime.request_evidence_checkpoint(
+        package,
+        run_dir,
+        checkpoint_id="initial_review",
+        request_id="outlet_inspection",
+        reason="Inspect the outlet evidence.",
+        session_id="session-001",
+    )
+
+    assert outlet_status == "prerequisites_incomplete"
+    assert rejected["rejection"] == "prerequisites_incomplete"
+    assert rejected["budget_after"] == 0
+
+
+def test_repeated_evidence_request_is_idempotent_and_consumes_no_budget(
+    tmp_path: Path,
+) -> None:
+    package = _write_conditional_package(tmp_path / "package")
+    run_dir = tmp_path / "run"
+    prepare_evidence_checkpoint(package, run_dir)
+    open_checkpoint_attempt(
+        package,
+        run_dir,
+        session_id="session-001",
+        execution_mode="persistent_context",
+    )
+    first = lifecycle_runtime.request_evidence_checkpoint(
+        package,
+        run_dir,
+        checkpoint_id="initial_review",
+        request_id="survey_revision",
+        reason="Resolve the source revision discrepancy.",
+        session_id="session-001",
+    )
+
+    repeated = lifecycle_runtime.request_evidence_checkpoint(
+        package,
+        run_dir,
+        checkpoint_id="initial_review",
+        request_id="survey_revision",
+        reason="Recover the result after a lost response.",
+        session_id="session-001",
+    )
+
+    assert repeated["outcome"] == "already_released"
+    assert repeated["budget_before"] == 0
+    assert repeated["budget_consumed"] == 0
+    assert repeated["budget_after"] == 0
+    assert repeated["released_artifacts"] == first["released_artifacts"]
+    assert repeated["pre_action_state_sha256"] == repeated["post_action_state_sha256"]
+    checkpoint = _load_json(run_dir / "state.json")["checkpoint_runs"][0]
+    assert [action["outcome"] for action in checkpoint["evidence_request_actions"]] == [
+        "released",
+        "already_released",
+    ]
+
+
+def test_invalid_evidence_requests_are_recorded_without_leaking_alternatives(
+    tmp_path: Path,
+) -> None:
+    package = _write_conditional_package(tmp_path / "package")
+    run_dir = tmp_path / "run"
+    prepare_evidence_checkpoint(package, run_dir)
+    open_checkpoint_attempt(
+        package,
+        run_dir,
+        session_id="session-001",
+        execution_mode="persistent_context",
+    )
+
+    rejected = lifecycle_runtime.request_evidence_checkpoint(
+        package,
+        run_dir,
+        checkpoint_id="initial_review",
+        request_id="invented_request",
+        reason="Try an undeclared source.",
+        session_id="session-001",
+    )
+
+    assert rejected["outcome"] == "rejected"
+    assert rejected["rejection"] == "unknown_request"
+    assert rejected["budget_before"] == 1
+    assert rejected["budget_consumed"] == 0
+    assert rejected["budget_after"] == 1
+    assert rejected["released_artifacts"] == []
+    assert "survey_revision" not in json.dumps(rejected)
+    assert "outlet_inspection" not in json.dumps(rejected)
+    assert not (run_dir / "workspace/inbox/initial_review/requests").exists()
+
+
+def test_evidence_request_recovers_once_after_release_before_state_commit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package = _write_conditional_package(tmp_path / "package")
+    run_dir = tmp_path / "run"
+    prepare_evidence_checkpoint(package, run_dir)
+    open_checkpoint_attempt(
+        package,
+        run_dir,
+        session_id="session-001",
+        execution_mode="persistent_context",
+    )
+    original_write_state = evidence_request_store_runtime._write_state
+    failed = False
+
+    def fail_action_state_commit(
+        target_run: Path,
+        state: EvidenceLifecycleRunState,
+    ) -> None:
+        nonlocal failed
+        has_action = any(checkpoint.evidence_request_actions for checkpoint in state.checkpoint_runs)
+        if has_action and not failed:
+            failed = True
+            raise RuntimeError("simulated action state commit failure")
+        original_write_state(target_run, state)
+
+    monkeypatch.setattr(evidence_request_store_runtime, "_write_state", fail_action_state_commit)
+    with pytest.raises(RuntimeError, match="simulated action state commit failure"):
+        lifecycle_runtime.request_evidence_checkpoint(
+            package,
+            run_dir,
+            checkpoint_id="initial_review",
+            request_id="survey_revision",
+            reason="Resolve the source revision discrepancy.",
+            session_id="session-001",
+        )
+
+    monkeypatch.setattr(evidence_request_store_runtime, "_write_state", original_write_state)
+    recovered = read_evidence_lifecycle_state(package, run_dir)
+    checkpoint = recovered["checkpoint_runs"][0]
+
+    assert checkpoint["evidence_request_budget_remaining"] == 0
+    assert [action["outcome"] for action in checkpoint["evidence_request_actions"]] == ["released"]
+    assert (run_dir / "workspace/inbox/initial_review/requests/survey_revision/survey-rev-b.txt").read_text(
+        encoding="utf-8"
+    ) == "revision B\n"
+    action_dir = run_dir / "evidence_requests/evidence-request-000001"
+    assert (action_dir / "action.json").is_file()
+    assert (action_dir / "committed.json").is_file()
+
+
+def test_evidence_request_recovery_does_not_publish_pending_checkpoint_catalog(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package = _write_all_conditional_package(tmp_path / "package")
+    run_dir = tmp_path / "run"
+    prepare_evidence_checkpoint(package, run_dir)
+    pending_catalog = run_dir / "workspace/checkpoints/response_review/evidence-requests.json"
+    assert not pending_catalog.exists()
+    open_checkpoint_attempt(
+        package,
+        run_dir,
+        session_id="session-001",
+        execution_mode="persistent_context",
+    )
+    original_write_state = evidence_request_store_runtime._write_state
+    failed = False
+
+    def fail_action_state_commit(
+        target_run: Path,
+        state: EvidenceLifecycleRunState,
+    ) -> None:
+        nonlocal failed
+        has_action = any(checkpoint.evidence_request_actions for checkpoint in state.checkpoint_runs)
+        if has_action and not failed:
+            failed = True
+            raise RuntimeError("simulated action state commit failure")
+        original_write_state(target_run, state)
+
+    monkeypatch.setattr(evidence_request_store_runtime, "_write_state", fail_action_state_commit)
+    with pytest.raises(RuntimeError, match="simulated action state commit failure"):
+        lifecycle_runtime.request_evidence_checkpoint(
+            package,
+            run_dir,
+            checkpoint_id="initial_review",
+            request_id="survey_revision",
+            reason="Resolve the source revision discrepancy.",
+            session_id="session-001",
+        )
+
+    monkeypatch.setattr(evidence_request_store_runtime, "_write_state", original_write_state)
+    recovered = read_evidence_lifecycle_state(package, run_dir)
+
+    assert recovered["checkpoint_runs"][0]["evidence_request_budget_remaining"] == 0
+    assert not pending_catalog.exists()
+
+
+def test_evidence_request_repairs_action_ledger_after_state_commit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package = _write_conditional_package(tmp_path / "package")
+    run_dir = tmp_path / "run"
+    prepare_evidence_checkpoint(package, run_dir)
+    open_checkpoint_attempt(
+        package,
+        run_dir,
+        session_id="session-001",
+        execution_mode="persistent_context",
+    )
+    original_append = evidence_request_store_runtime.append_ledger_entry
+
+    def fail_action_ledger(*args: Any, **kwargs: Any) -> None:
+        if kwargs.get("stage") == "evidence_request":
+            raise RuntimeError("simulated action ledger failure")
+        original_append(*args, **kwargs)
+
+    monkeypatch.setattr(evidence_request_store_runtime, "append_ledger_entry", fail_action_ledger)
+    with pytest.raises(RuntimeError, match="simulated action ledger failure"):
+        lifecycle_runtime.request_evidence_checkpoint(
+            package,
+            run_dir,
+            checkpoint_id="initial_review",
+            request_id="survey_revision",
+            reason="Resolve the source revision discrepancy.",
+            session_id="session-001",
+        )
+
+    monkeypatch.setattr(evidence_request_store_runtime, "append_ledger_entry", original_append)
+    recovered = read_evidence_lifecycle_state(package, run_dir)
+    action_entries = [
+        json.loads(line)
+        for line in (run_dir / "lifecycle_ledger.jsonl").read_text(encoding="utf-8").splitlines()
+        if json.loads(line)["stage"] == "evidence_request"
+    ]
+
+    assert len(recovered["checkpoint_runs"][0]["evidence_request_actions"]) == 1
+    assert len(action_entries) == 1
+    assert action_entries[0]["summary"]["action_id"] == "evidence-request-000001"
+    assert (run_dir / "evidence_requests/evidence-request-000001/committed.json").is_file()
+
+
+def test_evidence_request_recovers_torn_atomic_commit_marker_publish(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package = _write_conditional_package(tmp_path / "package")
+    run_dir = tmp_path / "run"
+    prepare_evidence_checkpoint(package, run_dir)
+    open_checkpoint_attempt(
+        package,
+        run_dir,
+        session_id="session-001",
+        execution_mode="persistent_context",
+    )
+    original_write_atomic = evidence_request_store_runtime._write_json_atomic_durable
+    interrupted = False
+
+    def interrupt_commit_marker(path: Path, payload: dict[str, Any]) -> None:
+        nonlocal interrupted
+        if path.name == "committed.json" and not interrupted:
+            interrupted = True
+            path.with_suffix(".json.tmp").write_text("{", encoding="utf-8")
+            raise RuntimeError("simulated commit marker publication death")
+        original_write_atomic(path, payload)
+
+    monkeypatch.setattr(
+        evidence_request_store_runtime,
+        "_write_json_atomic_durable",
+        interrupt_commit_marker,
+    )
+    with pytest.raises(RuntimeError, match="simulated commit marker publication death"):
+        lifecycle_runtime.request_evidence_checkpoint(
+            package,
+            run_dir,
+            checkpoint_id="initial_review",
+            request_id="survey_revision",
+            reason="Resolve the source revision discrepancy.",
+            session_id="session-001",
+        )
+
+    monkeypatch.setattr(
+        evidence_request_store_runtime,
+        "_write_json_atomic_durable",
+        original_write_atomic,
+    )
+    recovered = read_evidence_lifecycle_state(package, run_dir)
+    transaction = run_dir / "evidence_requests/evidence-request-000001"
+
+    assert len(recovered["checkpoint_runs"][0]["evidence_request_actions"]) == 1
+    assert _load_json(transaction / "committed.json") == {
+        "action_id": "evidence-request-000001",
+        "status": "committed",
+    }
+    assert not (transaction / "committed.json.tmp").exists()
+
+
+def test_concurrent_evidence_requests_preserve_sequence_and_budget(tmp_path: Path) -> None:
+    package = _write_conditional_package(tmp_path / "package")
+    run_dir = tmp_path / "run"
+    prepare_evidence_checkpoint(package, run_dir)
+    open_checkpoint_attempt(
+        package,
+        run_dir,
+        session_id="session-001",
+        execution_mode="persistent_context",
+    )
+
+    def request(request_id: str) -> dict[str, Any]:
+        return lifecycle_runtime.request_evidence_checkpoint(
+            package,
+            run_dir,
+            checkpoint_id="initial_review",
+            request_id=request_id,
+            reason=f"Inspect {request_id}.",
+            session_id="session-001",
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(request, ["survey_revision", "outlet_inspection"]))
+
+    assert sorted(result["outcome"] for result in results) == ["rejected", "released"]
+    rejected = next(result for result in results if result["outcome"] == "rejected")
+    assert rejected["rejection"] == "budget_exhausted"
+    checkpoint = _load_json(run_dir / "state.json")["checkpoint_runs"][0]
+    assert [action["sequence"] for action in checkpoint["evidence_request_actions"]] == [1, 2]
+    assert checkpoint["evidence_request_budget_remaining"] == 0
+    assert len(list((run_dir / "evidence_requests").glob("evidence-request-*"))) == 2
+
+
+def test_concurrent_submission_cannot_overwrite_an_evidence_request_transition(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package = _write_conditional_package(tmp_path / "package")
+    run_dir = tmp_path / "run"
+    prepared = prepare_evidence_checkpoint(package, run_dir)
+    open_checkpoint_attempt(
+        package,
+        run_dir,
+        session_id="session-001",
+        execution_mode="persistent_context",
+    )
+    _write_json(Path(prepared["submission_path"]), {"checkpoint_id": "initial_review"})
+    submission_ready = Event()
+    release_submission = Event()
+    request_entered = Event()
+    original_write_state = lifecycle_runtime._write_state
+    original_record_action = lifecycle_runtime._record_evidence_request_action
+
+    def pause_submission_publish(
+        target_run: Path,
+        state: EvidenceLifecycleRunState,
+    ) -> None:
+        initial = state.checkpoint("initial_review")
+        if (
+            state.active_checkpoint_id is None
+            and initial.status == CheckpointRunStatus.SUBMITTED
+            and not submission_ready.is_set()
+        ):
+            submission_ready.set()
+            if not release_submission.wait(timeout=5):
+                raise AssertionError("submission concurrency barrier timed out")
+        original_write_state(target_run, state)
+
+    def note_request_entry(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        request_entered.set()
+        return original_record_action(*args, **kwargs)
+
+    monkeypatch.setattr(lifecycle_runtime, "_write_state", pause_submission_publish)
+    monkeypatch.setattr(lifecycle_runtime, "_record_evidence_request_action", note_request_entry)
+    submit_errors: list[Exception] = []
+    request_errors: list[Exception] = []
+
+    def submit() -> None:
+        try:
+            submit_evidence_checkpoint(package, run_dir)
+        except Exception as exc:  # pragma: no cover - asserted below
+            submit_errors.append(exc)
+
+    def request() -> None:
+        try:
+            lifecycle_runtime.request_evidence_checkpoint(
+                package,
+                run_dir,
+                checkpoint_id="initial_review",
+                request_id="survey_revision",
+                reason="Resolve the source revision discrepancy.",
+                session_id="session-001",
+            )
+        except Exception as exc:
+            request_errors.append(exc)
+
+    submit_thread = Thread(target=submit)
+    submit_thread.start()
+    assert submission_ready.wait(timeout=5)
+    request_thread = Thread(target=request)
+    request_thread.start()
+    request_entered.wait(timeout=1)
+    release_submission.set()
+    submit_thread.join(timeout=5)
+    request_thread.join(timeout=5)
+
+    assert not submit_thread.is_alive()
+    assert not request_thread.is_alive()
+    assert submit_errors == []
+    assert len(request_errors) == 1
+    assert isinstance(request_errors[0], EvidenceLifecycleError)
+    assert "no checkpoint is active" in str(request_errors[0])
+    state = read_evidence_lifecycle_state(package, run_dir)
+    state_transitions = {transition["transition_id"]: transition for transition in state["transitions"]}
+    ledger_transitions = {
+        entry["summary"]["transition_id"]: entry["summary"]
+        for entry in _load_jsonl(run_dir / "lifecycle_ledger.jsonl")
+        if entry["stage"] == "lifecycle_transition"
+    }
+    assert ledger_transitions == state_transitions
+
+
+@pytest.mark.parametrize("tamper", ["status", "summary", "artifact_refs"])
+def test_evidence_request_ledger_rejects_conflicting_existing_action_entry(
+    tmp_path: Path,
+    tamper: str,
+) -> None:
+    package = _write_conditional_package(tmp_path / "package")
+    run_dir = tmp_path / "run"
+    prepare_evidence_checkpoint(package, run_dir)
+    open_checkpoint_attempt(
+        package,
+        run_dir,
+        session_id="session-001",
+        execution_mode="persistent_context",
+    )
+    lifecycle_runtime.request_evidence_checkpoint(
+        package,
+        run_dir,
+        checkpoint_id="initial_review",
+        request_id="survey_revision",
+        reason="Resolve the source revision discrepancy.",
+        session_id="session-001",
+    )
+    ledger_path = run_dir / "lifecycle_ledger.jsonl"
+    entries = _load_jsonl(ledger_path)
+    action_entry = next(entry for entry in entries if entry["stage"] == "evidence_request")
+    if tamper == "status":
+        action_entry["status"] = "rejected"
+    elif tamper == "summary":
+        action_entry["summary"]["reason"] = "Forged reason."
+    else:
+        action_entry["artifact_refs"] = []
+    _write_jsonl(ledger_path, entries)
+
+    with pytest.raises(EvidenceLifecycleError, match="evidence request ledger entry conflicts"):
+        read_evidence_lifecycle_state(package, run_dir)
+
+
+def test_transition_ledger_rejects_conflicting_existing_transition_entry(tmp_path: Path) -> None:
+    package = _write_package(tmp_path / "package")
+    run_dir = tmp_path / "run"
+    prepare_evidence_checkpoint(package, run_dir)
+    ledger_path = run_dir / "lifecycle_ledger.jsonl"
+    entries = _load_jsonl(ledger_path)
+    transition_entry = next(entry for entry in entries if entry["stage"] == "lifecycle_transition")
+    transition_entry["status"] = "submit"
+    _write_jsonl(ledger_path, entries)
+
+    with pytest.raises(EvidenceLifecycleError, match="lifecycle transition ledger entry conflicts"):
+        read_evidence_lifecycle_state(package, run_dir)
+
+
+def test_requested_evidence_rejects_unbound_projection_files(tmp_path: Path) -> None:
+    package = _write_conditional_package(tmp_path / "package")
+    run_dir = tmp_path / "run"
+    prepare_evidence_checkpoint(package, run_dir)
+    open_checkpoint_attempt(
+        package,
+        run_dir,
+        session_id="session-001",
+        execution_mode="persistent_context",
+    )
+    lifecycle_runtime.request_evidence_checkpoint(
+        package,
+        run_dir,
+        checkpoint_id="initial_review",
+        request_id="survey_revision",
+        reason="Resolve the source revision discrepancy.",
+        session_id="session-001",
+    )
+    unexpected = run_dir / "workspace/inbox/initial_review/requests/survey_revision/unbound.txt"
+    unexpected.write_text("unbound evidence\n", encoding="utf-8")
+
+    with pytest.raises(EvidenceLifecycleError, match="artifact file set changed"):
+        read_evidence_lifecycle_state(package, run_dir)
+
+
+def test_lifecycle_state_rejects_cross_checkpoint_action_identity_reordering(
+    tmp_path: Path,
+) -> None:
+    package = _write_conditional_package(tmp_path / "package")
+    lifecycle_path = package / "lifecycle.json"
+    lifecycle = _load_json(lifecycle_path)
+    lifecycle["checkpoints"][1]["conditional_evidence"] = {
+        "request_budget": 1,
+        "requests": [
+            {
+                "request_id": "response_support",
+                "title": "Response support",
+                "description": "Obtain the response-stage support record.",
+            }
+        ],
+    }
+    _write_json(lifecycle_path, lifecycle)
+    resolution_path = package / "hidden/evidence-request-resolutions.json"
+    resolutions = _load_json(resolution_path)
+    resolutions["resolutions"].append(
+        {
+            "checkpoint_id": "response_review",
+            "request_id": "response_support",
+            "source_path": "hidden/evidence_requests/response_review/response_support",
+        }
+    )
+    _write_json(resolution_path, resolutions)
+    support = package / "hidden/evidence_requests/response_review/response_support/support.txt"
+    support.parent.mkdir(parents=True)
+    support.write_text("response support\n", encoding="utf-8")
+
+    run_dir = tmp_path / "run"
+    prepared = prepare_evidence_checkpoint(package, run_dir)
+    open_checkpoint_attempt(
+        package,
+        run_dir,
+        session_id="session-001",
+        execution_mode="persistent_context",
+    )
+    lifecycle_runtime.request_evidence_checkpoint(
+        package,
+        run_dir,
+        checkpoint_id="initial_review",
+        request_id="survey_revision",
+        reason="Resolve the source revision discrepancy.",
+        session_id="session-001",
+    )
+    _write_json(Path(prepared["submission_path"]), {"checkpoint_id": "initial_review"})
+    submit_evidence_checkpoint(package, run_dir)
+    prepared = prepare_evidence_checkpoint(package, run_dir)
+    open_checkpoint_attempt(
+        package,
+        run_dir,
+        session_id="session-002",
+        execution_mode="persistent_context",
+    )
+    lifecycle_runtime.request_evidence_checkpoint(
+        package,
+        run_dir,
+        checkpoint_id="response_review",
+        request_id="response_support",
+        reason="Inspect the response-stage support record.",
+        session_id="session-002",
+    )
+
+    state = _load_json(run_dir / "state.json")
+    first = state["checkpoint_runs"][0]["evidence_request_actions"][0]
+    second = state["checkpoint_runs"][1]["evidence_request_actions"][0]
+    first["sequence"], second["sequence"] = second["sequence"], first["sequence"]
+    first["action_id"], second["action_id"] = second["action_id"], first["action_id"]
+
+    with pytest.raises(ValidationError, match="globally ordered"):
+        EvidenceLifecycleRunState.model_validate(state)
+
+
 def test_lifecycle_state_persists_first_class_checkpoint_records(tmp_path: Path) -> None:
     package = _write_package(tmp_path / "package")
     run_dir = tmp_path / "run"
@@ -226,7 +1027,7 @@ def test_lifecycle_state_persists_first_class_checkpoint_records(tmp_path: Path)
     prepare_evidence_checkpoint(package, run_dir)
     state = json.loads((run_dir / "state.json").read_text(encoding="utf-8"))
 
-    assert state["schema_version"] == "3"
+    assert state["schema_version"] == "4"
     assert state["lifecycle_spec_sha256"]
     assert state["package_sha256"]
     assert state["status"] == "awaiting_checkpoint_submission"
@@ -278,7 +1079,7 @@ def test_lifecycle_state_migrates_legacy_dictionary_shape(tmp_path: Path) -> Non
     persisted = json.loads((run_dir / "state.json").read_text(encoding="utf-8"))
 
     assert state["active_checkpoint_id"] == "response_review"
-    assert persisted["schema_version"] == "3"
+    assert persisted["schema_version"] == "4"
     assert [item["status"] for item in persisted["checkpoint_runs"]] == ["submitted", "active"]
 
 
@@ -301,8 +1102,171 @@ def test_lifecycle_state_migrates_v2_records_without_losing_attempts(tmp_path: P
 
     migrated = read_evidence_lifecycle_state(package, run_dir)
 
-    assert _load_json(state_path)["schema_version"] == "3"
+    assert _load_json(state_path)["schema_version"] == "4"
     assert migrated["checkpoint_runs"][0]["attempts"][0]["session_id"] == "session-001"
+
+
+def test_lifecycle_state_migrates_v2_branch_with_action_lineage_hash(tmp_path: Path) -> None:
+    package = _write_package(tmp_path / "package")
+    parent_run = tmp_path / "parent"
+    branch_run = tmp_path / "branch"
+    _complete_demo_lifecycle(package, parent_run)
+    branch_evidence_lifecycle(
+        package,
+        parent_run,
+        branch_run,
+        checkpoint_id="initial_review",
+        branch_id="branch.v2-lineage",
+        reason="Resume a branch persisted before action lineage hashes.",
+    )
+    state_path = branch_run / "state.json"
+    state = _load_json(state_path)
+    state["schema_version"] = "2"
+    state.pop("lifecycle_spec_sha256")
+    state.pop("package_sha256")
+    state["branch"].pop("parent_action_state_sha256")
+    for checkpoint in state["checkpoint_runs"]:
+        checkpoint.pop("evidence_request_budget")
+        checkpoint.pop("evidence_request_budget_remaining")
+        checkpoint.pop("evidence_request_actions")
+        for attempt in checkpoint["attempts"]:
+            attempt.pop("inherited_from_parent")
+    _write_json(state_path, state)
+
+    migrated = read_evidence_lifecycle_state(package, branch_run)
+    persisted = _load_json(state_path)
+
+    assert persisted["schema_version"] == "4"
+    assert migrated["branch"]["parent_action_state_sha256"]
+    assert migrated["branch"]["branched_from_checkpoint_id"] == "initial_review"
+
+
+def test_lifecycle_state_migrates_v3_to_v4_without_inventing_actions(tmp_path: Path) -> None:
+    package = _write_package(tmp_path / "package")
+    run_dir = tmp_path / "run"
+    prepare_evidence_checkpoint(package, run_dir)
+    state_path = run_dir / "state.json"
+    state = _load_json(state_path)
+    state["schema_version"] = "3"
+    for checkpoint in state["checkpoint_runs"]:
+        checkpoint.pop("evidence_request_budget")
+        checkpoint.pop("evidence_request_budget_remaining")
+        checkpoint.pop("evidence_request_actions")
+    _write_json(state_path, state)
+
+    migrated = read_evidence_lifecycle_state(package, run_dir)
+
+    assert migrated["checkpoint_runs"][0]["evidence_request_actions"] == []
+    assert _load_json(state_path)["schema_version"] == "4"
+
+
+def test_v3_branch_rejects_attempts_on_inherited_checkpoint_records(tmp_path: Path) -> None:
+    package = _write_package(tmp_path / "package")
+    parent_run = tmp_path / "parent"
+    branch_run = tmp_path / "branch"
+    _complete_demo_lifecycle(package, parent_run)
+    branch_evidence_lifecycle(
+        package,
+        parent_run,
+        branch_run,
+        checkpoint_id="response_review",
+        branch_id="branch.impossible-v3-lineage",
+        reason="Construct an impossible v3 inherited-attempt payload.",
+    )
+    state_path = branch_run / "state.json"
+    state = _load_json(state_path)
+    state["schema_version"] = "3"
+    state["branch"].pop("parent_action_state_sha256")
+    for checkpoint in state["checkpoint_runs"]:
+        checkpoint.pop("evidence_request_budget")
+        checkpoint.pop("evidence_request_budget_remaining")
+        checkpoint.pop("evidence_request_actions")
+        for attempt in checkpoint["attempts"]:
+            attempt.pop("inherited_from_parent")
+    _write_json(state_path, state)
+
+    with pytest.raises(EvidenceLifecycleError, match="v3 inherited checkpoint cannot contain attempts"):
+        read_evidence_lifecycle_state(package, branch_run)
+
+
+def test_v3_branch_migration_preserves_branch_local_attempts(tmp_path: Path) -> None:
+    package = _write_package(tmp_path / "package")
+    parent_run = tmp_path / "parent"
+    branch_run = tmp_path / "branch"
+    _complete_demo_lifecycle(package, parent_run)
+    branch_evidence_lifecycle(
+        package,
+        parent_run,
+        branch_run,
+        checkpoint_id="response_review",
+        branch_id="branch.legacy-local-attempt",
+        reason="Match the attempt lineage emitted by the PR16 v3 branch runtime.",
+    )
+    state_path = branch_run / "state.json"
+    state = _load_json(state_path)
+    for checkpoint in state["checkpoint_runs"]:
+        checkpoint["attempts"] = []
+    _write_json(state_path, state)
+    open_checkpoint_attempt(
+        package,
+        branch_run,
+        session_id="branch-session-001",
+        execution_mode="fresh_context",
+    )
+    state = _load_json(state_path)
+    state["schema_version"] = "3"
+    state["branch"].pop("parent_action_state_sha256")
+    for checkpoint in state["checkpoint_runs"]:
+        checkpoint.pop("evidence_request_budget")
+        checkpoint.pop("evidence_request_budget_remaining")
+        checkpoint.pop("evidence_request_actions")
+        for attempt in checkpoint["attempts"]:
+            attempt.pop("inherited_from_parent")
+    _write_json(state_path, state)
+
+    migrated = read_evidence_lifecycle_state(package, branch_run)
+
+    assert migrated["checkpoint_runs"][0]["attempts"] == []
+    assert migrated["checkpoint_runs"][1]["attempts"] == [
+        {
+            "attempt_id": "response_review.attempt-001",
+            "session_id": "branch-session-001",
+            "sequence": 1,
+            "execution_mode": "fresh_context",
+            "status": "active",
+            "resumed_from_attempt_id": None,
+            "failure_kind": None,
+            "episode_request_sha256": None,
+            "inherited_from_parent": False,
+        }
+    ]
+
+
+def test_v3_state_cannot_smuggle_conditional_evidence_fields(tmp_path: Path) -> None:
+    package = _write_package(tmp_path / "package")
+    run_dir = tmp_path / "run"
+    prepare_evidence_checkpoint(package, run_dir)
+    state_path = run_dir / "state.json"
+    state = _load_json(state_path)
+    state["schema_version"] = "3"
+    _write_json(state_path, state)
+
+    with pytest.raises(EvidenceLifecycleError, match="v3 lifecycle state cannot contain"):
+        read_evidence_lifecycle_state(package, run_dir)
+
+
+def test_lifecycle_state_budget_must_match_conditional_contract(tmp_path: Path) -> None:
+    package = _write_conditional_package(tmp_path / "package")
+    run_dir = tmp_path / "run"
+    prepare_evidence_checkpoint(package, run_dir)
+    state_path = run_dir / "state.json"
+    state = _load_json(state_path)
+    state["checkpoint_runs"][0]["evidence_request_budget"] = 2
+    state["checkpoint_runs"][0]["evidence_request_budget_remaining"] = 2
+    _write_json(state_path, state)
+
+    with pytest.raises(EvidenceLifecycleError, match="budget does not match"):
+        read_evidence_lifecycle_state(package, run_dir)
 
 
 def test_open_checkpoint_attempt_marks_abandoned_attempt_interrupted(tmp_path: Path) -> None:
@@ -329,6 +1293,101 @@ def test_open_checkpoint_attempt_marks_abandoned_attempt_interrupted(tmp_path: P
     assert second["attempt_id"] == "initial_review.attempt-002"
     assert [attempt["status"] for attempt in attempts] == ["interrupted", "active"]
     assert second["resumed_from_attempt_id"] == first["attempt_id"]
+
+
+def test_requested_evidence_and_budget_survive_failed_attempt_retry(tmp_path: Path) -> None:
+    package = _write_conditional_package(tmp_path / "package")
+    run_dir = tmp_path / "run"
+    prepare_evidence_checkpoint(package, run_dir)
+    first_attempt = open_checkpoint_attempt(
+        package,
+        run_dir,
+        session_id="session-001",
+        execution_mode="fresh_context",
+    )
+    lifecycle_runtime.request_evidence_checkpoint(
+        package,
+        run_dir,
+        checkpoint_id="initial_review",
+        request_id="survey_revision",
+        reason="Resolve the source revision discrepancy.",
+        session_id="session-001",
+    )
+    fail_checkpoint_attempt(
+        package,
+        run_dir,
+        session_id="session-001",
+        failure_kind="provider_error",
+    )
+    second_attempt = open_checkpoint_attempt(
+        package,
+        run_dir,
+        session_id="session-002",
+        execution_mode="fresh_context",
+    )
+
+    repeated = lifecycle_runtime.request_evidence_checkpoint(
+        package,
+        run_dir,
+        checkpoint_id="initial_review",
+        request_id="survey_revision",
+        reason="Confirm the evidence acquired by the failed attempt remains available.",
+        session_id="session-002",
+    )
+
+    assert repeated["outcome"] == "already_released"
+    assert repeated["attempt_id"] == second_attempt["attempt_id"]
+    assert repeated["budget_after"] == 0
+    checkpoint = _load_json(run_dir / "state.json")["checkpoint_runs"][0]
+    assert [attempt["status"] for attempt in checkpoint["attempts"]] == ["failed", "active"]
+    assert checkpoint["evidence_request_actions"][0]["attempt_id"] == first_attempt["attempt_id"]
+    assert (run_dir / "workspace/inbox/initial_review/requests/survey_revision/survey-rev-b.txt").is_file()
+
+
+def test_fresh_retry_episode_request_binds_acquired_conditional_evidence(tmp_path: Path) -> None:
+    package = _write_conditional_package(tmp_path / "package")
+    run_dir = tmp_path / "run"
+    prepare_evidence_checkpoint(package, run_dir)
+    open_checkpoint_attempt(
+        package,
+        run_dir,
+        session_id="session-001",
+        execution_mode="fresh_context",
+    )
+    lifecycle_runtime.request_evidence_checkpoint(
+        package,
+        run_dir,
+        checkpoint_id="initial_review",
+        request_id="survey_revision",
+        reason="Resolve the source revision discrepancy.",
+        session_id="session-001",
+    )
+    fail_checkpoint_attempt(
+        package,
+        run_dir,
+        session_id="session-001",
+        failure_kind="provider_error",
+    )
+    context = LifecycleEpisodeContext.from_runtime_context(
+        prepare_evidence_checkpoint(package, run_dir),
+        visibility_policy=LifecycleVisibilityPolicy.ARTIFACT_MEMORY,
+    )
+
+    request = lifecycle_runtime._build_episode_request(
+        context,
+        _FunctionEpisodeEnvironment(lambda _request: {}),
+        attempt_id="initial_review.attempt-002",
+        session_id="session-002",
+    )
+
+    assert request.schema_version == "2"
+    assert request.evidence_request_catalog is not None
+    assert request.evidence_request_catalog.remaining_budget == 0
+    assert len(request.released_evidence_artifacts) == 1
+    artifact = request.released_evidence_artifacts[0]
+    assert artifact.workspace_path == ("inbox/initial_review/requests/survey_revision/survey-rev-b.txt")
+    assert len(artifact.sha256) == 64
+    assert "hidden" not in request.model_dump_json()
 
 
 def test_failed_checkpoint_attempt_is_closed_and_resumed_explicitly(tmp_path: Path) -> None:
@@ -456,6 +1515,49 @@ def test_branch_reopens_selected_checkpoint_without_mutating_parent(tmp_path: Pa
         "checkpoint_id": "initial_review"
     }
     assert branch["transitions"][0]["kind"] == "branch"
+
+
+def test_branch_inherits_requested_evidence_actions_and_consumed_budget(tmp_path: Path) -> None:
+    package = _write_conditional_package(tmp_path / "package")
+    parent_run = tmp_path / "parent"
+    branch_run = tmp_path / "branch"
+    prepared = prepare_evidence_checkpoint(package, parent_run)
+    open_checkpoint_attempt(
+        package,
+        parent_run,
+        session_id="session-001",
+        execution_mode="persistent_context",
+    )
+    lifecycle_runtime.request_evidence_checkpoint(
+        package,
+        parent_run,
+        checkpoint_id="initial_review",
+        request_id="survey_revision",
+        reason="Resolve the source revision discrepancy.",
+        session_id="session-001",
+    )
+    _write_json(Path(prepared["submission_path"]), {"checkpoint_id": "initial_review"})
+    submit_evidence_checkpoint(package, parent_run)
+
+    branch = branch_evidence_lifecycle(
+        package,
+        parent_run,
+        branch_run,
+        checkpoint_id="initial_review",
+        branch_id="branch.conditional-evidence",
+        reason="Reconsider the review without unseeing acquired evidence.",
+    )
+
+    checkpoint = branch["checkpoint_runs"][0]
+    assert checkpoint["evidence_request_budget"] == 1
+    assert checkpoint["evidence_request_budget_remaining"] == 0
+    assert len(checkpoint["evidence_request_actions"]) == 1
+    assert checkpoint["evidence_request_actions"][0]["inherited_from_parent"] is True
+    assert branch["branch"]["parent_action_state_sha256"]
+    assert (branch_run / "workspace/inbox/initial_review/requests/survey_revision/survey-rev-b.txt").read_text(
+        encoding="utf-8"
+    ) == "revision B\n"
+    assert (branch_run / "evidence_requests/evidence-request-000001/artifacts/survey-rev-b.txt").is_file()
 
 
 def test_branch_rejects_package_drift_from_parent_run(tmp_path: Path) -> None:
@@ -680,7 +1782,7 @@ def test_prepare_reconciles_transition_ledger_after_append_failure(
 ) -> None:
     package = _write_package(tmp_path / "package")
     run_dir = tmp_path / "run"
-    original_append = lifecycle_runtime.append_ledger_entry
+    original_append = evidence_request_store_runtime.append_ledger_entry
     calls = 0
 
     def fail_first_append(*args, **kwargs):
@@ -690,11 +1792,11 @@ def test_prepare_reconciles_transition_ledger_after_append_failure(
             raise RuntimeError("simulated ledger append failure")
         return original_append(*args, **kwargs)
 
-    monkeypatch.setattr(lifecycle_runtime, "append_ledger_entry", fail_first_append)
+    monkeypatch.setattr(evidence_request_store_runtime, "append_ledger_entry", fail_first_append)
     with pytest.raises(RuntimeError, match="simulated ledger append failure"):
         prepare_evidence_checkpoint(package, run_dir)
 
-    monkeypatch.setattr(lifecycle_runtime, "append_ledger_entry", original_append)
+    monkeypatch.setattr(evidence_request_store_runtime, "append_ledger_entry", original_append)
     prepared = prepare_evidence_checkpoint(package, run_dir)
     entries = [
         json.loads(line) for line in (run_dir / "lifecycle_ledger.jsonl").read_text(encoding="utf-8").splitlines()
@@ -878,6 +1980,29 @@ def test_local_episode_environment_builds_fresh_adapters_in_one_workspace(tmp_pa
     assert {
         attempt["execution_mode"] for checkpoint in state["checkpoint_runs"] for attempt in checkpoint["attempts"]
     } == {"fresh_context"}
+
+
+def test_fresh_local_environment_exposes_session_bound_conditional_request_tool(
+    tmp_path: Path,
+) -> None:
+    package = _write_conditional_package(tmp_path / "package")
+    run_dir = tmp_path / "run"
+    registry = _ConditionalWritingRegistry()
+    environment = build_local_evidence_lifecycle_episode_environment(
+        package_dir=package,
+        model="test-model",
+        adapter_kind="tool_loop",
+        registry=registry,
+    )
+
+    result = run_evidence_lifecycle(package, run_dir, episode_environment=environment)
+
+    assert result["status"] == "complete"
+    assert all("request_evidence" in names for names in registry.native_tool_names)
+    assert all("request_evidence" in names for names in registry.request_tool_names)
+    action = _load_json(run_dir / "state.json")["checkpoint_runs"][0]["evidence_request_actions"][0]
+    assert action["session_id"] == "initial_review.session-001"
+    assert action["attempt_id"] == "initial_review.attempt-001"
 
 
 def test_local_episode_environment_marks_provider_failure_immediately(tmp_path: Path) -> None:
@@ -1267,6 +2392,96 @@ def test_lifecycle_control_tool_rejects_wrong_checkpoint_without_advancing(tmp_p
     assert not (run_dir / "workspace" / "inbox" / "response_review").exists()
 
 
+def test_control_tool_requests_conditional_evidence_without_exposing_host_identity(
+    tmp_path: Path,
+) -> None:
+    package = _write_conditional_package(tmp_path / "package")
+    run_dir = tmp_path / "run"
+    prepare_evidence_checkpoint(package, run_dir)
+    open_checkpoint_attempt(
+        package,
+        run_dir,
+        session_id="session-001",
+        execution_mode="persistent_context",
+    )
+    tool = EvidenceLifecycleControlTool(
+        package_dir=package,
+        run_dir=run_dir,
+        session_id="session-001",
+    )
+
+    response = json.loads(
+        tool.request_evidence(
+            "initial_review",
+            "survey_revision",
+            "Resolve the source revision discrepancy.",
+        )
+    )
+
+    assert response == {
+        "status": "released",
+        "checkpoint_id": "initial_review",
+        "request_id": "survey_revision",
+        "remaining_budget": 0,
+        "released_files": ["inbox/initial_review/requests/survey_revision/survey-rev-b.txt"],
+    }
+    assert "session" not in json.dumps(response)
+    assert "attempt" not in json.dumps(response)
+    assert "sha256" not in json.dumps(response)
+
+
+def test_control_tool_rejects_blank_evidence_request_without_recording_an_action(
+    tmp_path: Path,
+) -> None:
+    package = _write_conditional_package(tmp_path / "package")
+    run_dir = tmp_path / "run"
+    prepare_evidence_checkpoint(package, run_dir)
+    open_checkpoint_attempt(
+        package,
+        run_dir,
+        session_id="session-001",
+        execution_mode="fresh_context",
+    )
+    tool = EvidenceLifecycleControlTool(
+        package_dir=package,
+        run_dir=run_dir,
+        session_id="session-001",
+    )
+
+    response = json.loads(tool.request_evidence("initial_review", "survey_revision", "  "))
+
+    assert response == {
+        "status": "rejected",
+        "error": "evidence request arguments must not be blank",
+    }
+    assert _load_json(run_dir / "state.json")["checkpoint_runs"][0]["evidence_request_actions"] == []
+    assert not (run_dir / "evidence_requests").exists()
+    assert "hidden" not in json.dumps(response)
+
+
+def test_fresh_context_prompt_explains_conditional_evidence_boundary() -> None:
+    prompt = lifecycle_local_runtime._workspace_policy(
+        {
+            "branch": None,
+            "evidence_request_catalog": {
+                "checkpoint_id": "initial_review",
+                "remaining_budget": 1,
+            },
+        },
+        persistent=False,
+        visibility_policy=LifecycleVisibilityPolicy.ARTIFACT_MEMORY,
+        supports_evidence_requests=True,
+    )
+
+    assert "Declared within-checkpoint evidence is released only by request_evidence." in prompt
+
+
+def test_evidence_request_protocol_binds_host_call_validation_boundary() -> None:
+    assert evidence_request_protocol_runtime._EVIDENCE_REQUEST_PROTOCOL["call_validation_rule"] == (
+        "malformed_or_blank_arguments_fail_without_lifecycle_action"
+    )
+
+
 def test_lifecycle_workspace_tool_confines_reads_and_submission_writes(tmp_path: Path) -> None:
     package = _write_package(tmp_path / "package")
     run_dir = tmp_path / "run"
@@ -1329,6 +2544,45 @@ def test_lifecycle_workspace_visibility_policies_control_model_reads_without_del
     assert json.loads(current_release.list_workspace("inbox"))["entries"] == ["response_review"]
     assert "submissions" not in json.loads(current_release.list_workspace("."))["entries"]
     assert (run_dir / "workspace" / "submissions" / "initial_review.json").is_file()
+
+
+def test_requested_evidence_obeys_lifecycle_visibility_policies(tmp_path: Path) -> None:
+    package = _write_conditional_package(tmp_path / "package")
+    run_dir = tmp_path / "run"
+    initial = prepare_evidence_checkpoint(package, run_dir)
+    open_checkpoint_attempt(
+        package,
+        run_dir,
+        session_id="session-001",
+        execution_mode="persistent_context",
+    )
+    lifecycle_runtime.request_evidence_checkpoint(
+        package,
+        run_dir,
+        checkpoint_id="initial_review",
+        request_id="survey_revision",
+        reason="Resolve the source revision discrepancy.",
+        session_id="session-001",
+    )
+    requested_path = "inbox/initial_review/requests/survey_revision/survey-rev-b.txt"
+    current = EvidenceLifecycleWorkspaceTool(
+        package_dir=package,
+        run_dir=run_dir,
+        visibility_policy=LifecycleVisibilityPolicy.CURRENT_RELEASE_ONLY,
+    )
+    assert json.loads(current.read_workspace_file(requested_path))["status"] == "ok"
+
+    _write_json(Path(initial["submission_path"]), {"checkpoint_id": "initial_review"})
+    submit_evidence_checkpoint(package, run_dir)
+    prepare_evidence_checkpoint(package, run_dir)
+    raw = EvidenceLifecycleWorkspaceTool(
+        package_dir=package,
+        run_dir=run_dir,
+        visibility_policy=LifecycleVisibilityPolicy.RAW_EVIDENCE_ONLY,
+    )
+
+    assert json.loads(current.read_workspace_file(requested_path))["status"] == "rejected"
+    assert json.loads(raw.read_workspace_file(requested_path))["status"] == "ok"
 
 
 def test_execution_modes_reject_incompatible_visibility_policies(tmp_path: Path) -> None:
@@ -1422,6 +2676,87 @@ def test_local_session_builds_one_adapter_for_all_checkpoints(tmp_path: Path) ->
     assert task_run["evidence"]["score"] == {"reward": 0.75, "passed": False}
     assert (run_dir / "sessions" / "session-001" / "agent_result.json").exists()
     assert (run_dir / "sessions" / "session-001" / "conversation.jsonl").exists()
+
+
+def test_persistent_local_session_exposes_conditional_request_tool_only_for_capable_package(
+    tmp_path: Path,
+) -> None:
+    package = _write_conditional_package(tmp_path / "package")
+    run_dir = tmp_path / "run"
+    registry = _ConditionalLifecycleSessionRegistry(package=package, run_dir=run_dir)
+
+    task_run = run_local_evidence_lifecycle_session(
+        package_dir=package,
+        run_dir=run_dir,
+        model="test-model",
+        registry=registry,
+        verifier=lambda _package, _run: {
+            "lifecycle_id": "lifecycle.demo",
+            "reward": 1.0,
+            "overall": "pass",
+            "passed": True,
+            "gates": {"continuity": {"passed": True, "score": 1.0, "failures": []}},
+        },
+    )
+
+    assert registry.tool_names == [
+        "list_workspace",
+        "read_workspace_file",
+        "write_checkpoint_submission",
+        "request_evidence",
+        "submit_checkpoint",
+        "revisit_checkpoint",
+    ]
+    assert registry.request_tool_names == registry.tool_names
+    action = task_run["evidence"]["lifecycle"]["checkpoint_runs"][0]["evidence_request_actions"][0]
+    assert action["session_id"] == "session-001"
+    manifest = _load_json(run_dir / "experiment-manifest.json")
+    metrics = _load_json(run_dir / "metrics.json")
+    tool_schema_names = [item["name"] for item in manifest["interaction"]["tool_schema"]]
+    assert "request_evidence" in tool_schema_names
+    request_schema = next(item for item in manifest["interaction"]["tool_schema"] if item["name"] == "request_evidence")
+    assert "self" not in request_schema["signature"]
+    assert "session_id" not in request_schema["signature"]
+    assert metrics["evidence_request_calls"] == 1
+    assert metrics["accepted_evidence_requests"] == 1
+    assert metrics["already_released_evidence_requests"] == 0
+    assert metrics["rejected_evidence_requests"] == 0
+    assert metrics["evidence_request_budget_consumed"] == 1
+    assert manifest["interaction"]["evidence_request_protocol"]["sha256"]
+    assert manifest["interaction"]["evidence_request_protocol"]["tool_schema_sha256"]
+    artifact_paths = set(manifest["outputs"]["artifacts"])
+    assert "evidence_requests/evidence-request-000001/action.json" in artifact_paths
+    assert "evidence_requests/evidence-request-000001/committed.json" in artifact_paths
+    assert "evidence_requests/evidence-request-000001/artifacts/survey-rev-b.txt" in artifact_paths
+    assert "workspace/inbox/initial_review/requests/survey_revision/survey-rev-b.txt" in artifact_paths
+    assert "workspace/checkpoints/initial_review/evidence-requests.json" in artifact_paths
+
+
+def test_persistent_session_guidance_uses_package_capability_when_only_later_checkpoint_is_conditional(
+    tmp_path: Path,
+) -> None:
+    package = _write_later_checkpoint_conditional_package(tmp_path / "package")
+    run_dir = tmp_path / "run"
+    registry = _LifecycleSessionRegistry(package=package, run_dir=run_dir)
+
+    task_run = run_local_evidence_lifecycle_session(
+        package_dir=package,
+        run_dir=run_dir,
+        model="test-model",
+        registry=registry,
+        verifier=lambda _package, _run: {
+            "lifecycle_id": "lifecycle.demo",
+            "reward": 1.0,
+            "overall": "pass",
+            "passed": True,
+            "gates": {"continuity": {"passed": True, "score": 1.0, "failures": []}},
+        },
+    )
+
+    assert task_run["evidence"]["lifecycle"]["status"] == "complete"
+    assert "request_evidence" in registry.tool_names
+    assert "Declared within-checkpoint evidence is released only by request_evidence." in registry.system_prompt
+    assert "inspect checkpoints/<checkpoint_id>/evidence-requests.json" in registry.instruction
 
 
 def test_local_session_continues_branch_with_editable_active_draft(tmp_path: Path) -> None:
@@ -1601,6 +2936,154 @@ def _write_package(package: Path) -> Path:
     return package
 
 
+def _write_conditional_package(package: Path) -> Path:
+    package = _write_package(package)
+    lifecycle_path = package / "lifecycle.json"
+    lifecycle = _load_json(lifecycle_path)
+    lifecycle["checkpoints"][0]["conditional_evidence"] = {
+        "request_budget": 1,
+        "requests": [
+            {
+                "request_id": "survey_revision",
+                "title": "Revised survey",
+                "description": "Obtain the revised survey source.",
+            },
+            {
+                "request_id": "outlet_inspection",
+                "title": "Outlet inspection",
+                "description": "Obtain the outlet inspection record.",
+            },
+        ],
+    }
+    _write_json(lifecycle_path, lifecycle)
+    _write_json(
+        package / "hidden" / "evidence-request-resolutions.json",
+        {
+            "schema_version": "1",
+            "lifecycle_id": "lifecycle.demo",
+            "resolutions": [
+                {
+                    "checkpoint_id": "initial_review",
+                    "request_id": "survey_revision",
+                    "source_path": "hidden/evidence_requests/initial_review/survey_revision",
+                },
+                {
+                    "checkpoint_id": "initial_review",
+                    "request_id": "outlet_inspection",
+                    "source_path": "hidden/evidence_requests/initial_review/outlet_inspection",
+                },
+            ],
+        },
+    )
+    survey = package / "hidden/evidence_requests/initial_review/survey_revision/survey-rev-b.txt"
+    survey.parent.mkdir(parents=True)
+    survey.write_text("revision B\n", encoding="utf-8")
+    inspection = package / "hidden/evidence_requests/initial_review/outlet_inspection/inspection.txt"
+    inspection.parent.mkdir(parents=True)
+    inspection.write_text("inspection\n", encoding="utf-8")
+    return package
+
+
+def _write_prerequisite_conditional_package(package: Path) -> Path:
+    package = _write_conditional_package(package)
+    lifecycle_path = package / "lifecycle.json"
+    lifecycle = _load_json(lifecycle_path)
+    conditional = lifecycle["checkpoints"][0]["conditional_evidence"]
+    conditional["request_budget"] = 2
+    conditional["requests"][1]["prerequisite_request_ids"] = ["survey_revision"]
+
+    resolution_path = package / "hidden" / "evidence-request-resolutions.json"
+    resolutions = _load_json(resolution_path)
+    for request_id in ("alternative_c", "alternative_d"):
+        conditional["requests"].append(
+            {
+                "request_id": request_id,
+                "title": request_id.replace("_", " ").title(),
+                "description": f"Obtain {request_id.replace('_', ' ')} evidence.",
+            }
+        )
+        source_path = f"hidden/evidence_requests/initial_review/{request_id}"
+        resolutions["resolutions"].append(
+            {
+                "checkpoint_id": "initial_review",
+                "request_id": request_id,
+                "source_path": source_path,
+            }
+        )
+        evidence = package / source_path / f"{request_id}.txt"
+        evidence.parent.mkdir(parents=True)
+        evidence.write_text(f"{request_id}\n", encoding="utf-8")
+    _write_json(lifecycle_path, lifecycle)
+    _write_json(resolution_path, resolutions)
+    return package
+
+
+def _write_later_checkpoint_conditional_package(package: Path) -> Path:
+    package = _write_package(package)
+    lifecycle_path = package / "lifecycle.json"
+    lifecycle = _load_json(lifecycle_path)
+    lifecycle["checkpoints"][1]["conditional_evidence"] = {
+        "request_budget": 1,
+        "requests": [
+            {
+                "request_id": "response_support",
+                "title": "Response support",
+                "description": "Obtain the response-stage support record.",
+            }
+        ],
+    }
+    _write_json(lifecycle_path, lifecycle)
+    _write_json(
+        package / "hidden" / "evidence-request-resolutions.json",
+        {
+            "schema_version": "1",
+            "lifecycle_id": "lifecycle.demo",
+            "resolutions": [
+                {
+                    "checkpoint_id": "response_review",
+                    "request_id": "response_support",
+                    "source_path": "hidden/evidence_requests/response_review/response_support",
+                }
+            ],
+        },
+    )
+    support = package / "hidden/evidence_requests/response_review/response_support/support.txt"
+    support.parent.mkdir(parents=True)
+    support.write_text("response support\n", encoding="utf-8")
+    return package
+
+
+def _write_all_conditional_package(package: Path) -> Path:
+    package = _write_conditional_package(package)
+    lifecycle_path = package / "lifecycle.json"
+    lifecycle = _load_json(lifecycle_path)
+    lifecycle["checkpoints"][1]["conditional_evidence"] = {
+        "request_budget": 1,
+        "requests": [
+            {
+                "request_id": "response_support",
+                "title": "Response support",
+                "description": "Obtain the response-stage support record.",
+            }
+        ],
+    }
+    _write_json(lifecycle_path, lifecycle)
+    resolutions_path = package / "hidden" / "evidence-request-resolutions.json"
+    resolutions = _load_json(resolutions_path)
+    resolutions["resolutions"].append(
+        {
+            "checkpoint_id": "response_review",
+            "request_id": "response_support",
+            "source_path": "hidden/evidence_requests/response_review/response_support",
+        }
+    )
+    _write_json(resolutions_path, resolutions)
+    support = package / "hidden/evidence_requests/response_review/response_support/support.txt"
+    support.parent.mkdir(parents=True)
+    support.write_text("response support\n", encoding="utf-8")
+    return package
+
+
 def _write_json(path: Path, payload: dict) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
@@ -1608,6 +3091,17 @@ def _write_json(path: Path, payload: dict) -> None:
 
 def _load_json(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def _write_jsonl(path: Path, entries: list[dict[str, Any]]) -> None:
+    path.write_text(
+        "".join(f"{json.dumps(entry, sort_keys=True)}\n" for entry in entries),
+        encoding="utf-8",
+    )
 
 
 class _FunctionEpisodeEnvironment:
@@ -1676,6 +3170,50 @@ class _WritingRegistry:
         self.build_count += 1
         self.workspaces.append(workspace)
         return _WritingAdapter()
+
+
+class _ConditionalWritingRegistry:
+    def __init__(self) -> None:
+        self.native_tool_names: list[list[str]] = []
+        self.request_tool_names: list[list[str]] = []
+
+    def build(self, *, native_tools, **_kwargs):
+        self.native_tool_names.append([tool.__name__ for tool in native_tools])
+        request_evidence = next(
+            (tool for tool in native_tools if tool.__name__ == "request_evidence"),
+            None,
+        )
+        registry = self
+
+        class _ConditionalWritingAdapter:
+            def execute(self, request):
+                registry.request_tool_names.append([tool.name for tool in request.tools])
+                output_path = Path(request.output_path)
+                checkpoint_id = output_path.stem
+                if checkpoint_id == "initial_review":
+                    assert request_evidence is not None
+                    response = json.loads(
+                        request_evidence(
+                            checkpoint_id,
+                            "survey_revision",
+                            "Resolve the source revision discrepancy.",
+                        )
+                    )
+                    assert response["status"] == "released"
+                _write_json(output_path, {"checkpoint_id": checkpoint_id})
+                return SimpleNamespace(
+                    agent_output=SimpleNamespace(status=SimpleNamespace(value="completed")),
+                    transcript=[],
+                    raw_output_text=None,
+                    provider_error=None,
+                    failure_kind=None,
+                    usage_input_tokens=10,
+                    usage_output_tokens=2,
+                    usage_cache_read_tokens=0,
+                    usage_cache_write_tokens=0,
+                )
+
+        return _ConditionalWritingAdapter()
 
 
 class _WritingAdapter:
@@ -1766,6 +3304,7 @@ class _LifecycleSessionRegistry:
         self.build_count = 0
         self.execute_count = 0
         self.tool_names: list[str] = []
+        self.instruction = ""
         self.system_prompt = ""
         self.enable_bash: bool | None = None
         self.request_tool_names: list[str] = []
@@ -1780,6 +3319,7 @@ class _LifecycleSessionRegistry:
         class _SessionAdapter:
             def execute(self, request):
                 registry.execute_count += 1
+                registry.instruction = request.instruction
                 registry.system_prompt = request.system_prompt
                 registry.request_tool_names = [tool.name for tool in request.tools]
                 while True:
@@ -1807,6 +3347,60 @@ class _LifecycleSessionRegistry:
                 )
 
         return _SessionAdapter()
+
+
+class _ConditionalLifecycleSessionRegistry:
+    def __init__(self, *, package: Path, run_dir: Path) -> None:
+        self.package = package
+        self.run_dir = run_dir
+        self.tool_names: list[str] = []
+        self.request_tool_names: list[str] = []
+
+    def build(self, *, native_tools, **_kwargs):
+        self.tool_names = [tool.__name__ for tool in native_tools]
+        request_evidence = next(tool for tool in native_tools if tool.__name__ == "request_evidence")
+        submit_checkpoint = next(tool for tool in native_tools if tool.__name__ == "submit_checkpoint")
+        registry = self
+
+        class _ConditionalSessionAdapter:
+            def execute(self, request):
+                registry.request_tool_names = [tool.name for tool in request.tools]
+                requested = False
+                while True:
+                    state = read_evidence_lifecycle_state(registry.package, registry.run_dir)
+                    checkpoint_id = state["active_checkpoint_id"]
+                    if checkpoint_id is None:
+                        break
+                    if checkpoint_id == "initial_review" and not requested:
+                        response = json.loads(
+                            request_evidence(
+                                checkpoint_id,
+                                "survey_revision",
+                                "Resolve the source revision discrepancy.",
+                            )
+                        )
+                        assert response["status"] == "released"
+                        requested = True
+                    _write_json(
+                        registry.run_dir / "workspace" / "submissions" / f"{checkpoint_id}.json",
+                        {"checkpoint_id": checkpoint_id},
+                    )
+                    response = json.loads(submit_checkpoint(checkpoint_id))
+                    if response["status"] == "complete":
+                        break
+                return SimpleNamespace(
+                    agent_output=SimpleNamespace(status=SimpleNamespace(value="completed")),
+                    transcript=[],
+                    raw_output_text="Lifecycle complete.",
+                    provider_error=None,
+                    failure_kind=None,
+                    usage_input_tokens=30,
+                    usage_output_tokens=6,
+                    usage_cache_read_tokens=0,
+                    usage_cache_write_tokens=0,
+                )
+
+        return _ConditionalSessionAdapter()
 
 
 class _CrashingRegistry:

--- a/tests/meta_harness/test_evidence_lifecycle_ablation.py
+++ b/tests/meta_harness/test_evidence_lifecycle_ablation.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import inspect
 import json
 import platform
@@ -19,10 +20,11 @@ import aec_bench.ledger.writer as ledger_writer
 import aec_bench.meta_harness.evidence_lifecycle_ablation as ablation_runtime
 import aec_bench.meta_harness.evidence_lifecycle_ablation_plan as ablation_plan_runtime
 import aec_bench.meta_harness.evidence_lifecycle_experiment as experiment_runtime
+import aec_bench.meta_harness.evidence_lifecycle_transfer as transfer_runtime
 import aec_bench.meta_harness.evidence_lifecycle_trial_record as trial_record_runtime
 from aec_bench.contracts.experiment_manifest import AgentConfig
 from aec_bench.contracts.task_definition import Visibility
-from aec_bench.contracts.trial_record import Completeness, TrialRecord
+from aec_bench.contracts.trial_record import ArtifactReference, Completeness, TrialRecord
 from aec_bench.ledger.writer import DuplicateTrialRecordError
 from aec_bench.meta_harness.evidence_lifecycle import (
     open_checkpoint_attempt,
@@ -64,6 +66,7 @@ from aec_bench.meta_harness.evidence_lifecycle_trial_record import (
     validate_historical_lifecycle_ablation_record,
 )
 from aec_bench.task_world_templates.catalogue import get_template
+from aec_bench.task_world_templates.contracts import CompositeTaskWorldTemplate
 from aec_bench.task_world_templates.lifecycles import registered_lifecycle_verifier
 from aec_bench.task_world_templates.materializer import (
     materialize_template_lifecycle,
@@ -594,6 +597,101 @@ def test_finalize_lifecycle_trial_record_snapshots_artifacts_and_writes_once(tmp
             run_dir=run_dir,
         )
     assert record_path.read_bytes() == original_record
+
+
+def test_conditional_evidence_transactions_are_declared_and_snapshot_validated(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest, trial, package, run_dir = _conditional_recorded_trial(tmp_path, monkeypatch)
+    invocation = json.loads((run_dir / "experiment-manifest.json").read_text(encoding="utf-8"))
+    artifacts = invocation["outputs"]["artifacts"]
+
+    action_path = "evidence_requests/evidence-request-000001/action.json"
+    commit_path = "evidence_requests/evidence-request-000001/committed.json"
+    requested_path = "evidence_requests/evidence-request-000001/artifacts/survey-rev-b.txt"
+    projection_path = "workspace/inbox/initial_review/requests/survey_revision/survey-rev-b.txt"
+    catalog_path = "workspace/checkpoints/initial_review/evidence-requests.json"
+    assert {action_path, commit_path, requested_path, projection_path, catalog_path}.issubset(artifacts)
+    assert trial_record_runtime._artifact_kind(Path(f"run/{action_path}")) == "evidence_request_action"
+    assert trial_record_runtime._artifact_kind(Path(f"run/{commit_path}")) == "evidence_request_commit"
+    assert trial_record_runtime._artifact_kind(Path(f"run/{requested_path}")) == "requested_evidence"
+    assert trial_record_runtime._artifact_kind(Path(f"run/{projection_path}")) == "requested_evidence_projection"
+    assert trial_record_runtime._artifact_kind(Path(f"run/{catalog_path}")) == "evidence_request_catalog"
+    trial_record_runtime._validate_declared_run_artifacts(run_dir, invocation)
+    trial_record_runtime._validate_snapshotted_lifecycle_state(package, run_dir)
+    for unexpected_relative in (
+        "evidence_requests/evidence-request-000001/untracked.txt",
+        "workspace/inbox/initial_review/requests/untracked/evidence.txt",
+        "workspace/checkpoints/initial_review/untracked/evidence-requests.json",
+    ):
+        unexpected = run_dir / unexpected_relative
+        unexpected.parent.mkdir(parents=True, exist_ok=True)
+        unexpected.write_text("not bound to an action\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="evidence request artifact inventory"):
+            trial_record_runtime._validate_snapshotted_lifecycle_state(package, run_dir)
+        unexpected.unlink()
+
+    record_path = finalize_lifecycle_trial_record(
+        manifest=manifest,
+        trial=trial,
+        package_dir=package,
+        run_dir=run_dir,
+    )
+    record = TrialRecord.model_validate_json(record_path.read_bytes())
+    validate_historical_lifecycle_ablation_record(
+        record,
+        manifest,
+        build_lifecycle_ablation_plan(manifest),
+        trial,
+    )
+    reference = LifecycleTransferRecordReference(
+        experiment_id=record.experiment_id,
+        trial_id=record.trial_id,
+        ledger_path=str(record_path),
+        sha256=_sha256(record_path),
+    )
+    loaded = transfer_runtime._load_record(reference)
+    assert loaded.record == record
+    assert loaded.reasons == ()
+    loaded_artifacts = transfer_runtime._load_artifacts(
+        record,
+        ledger_root=Path(manifest.ledger_root),
+    )
+    assert loaded_artifacts.reasons == ()
+    state_reference = next(
+        artifact for artifact in record.outputs.artifacts or () if artifact.kind == "lifecycle_state"
+    )
+    snapshot_prefix, marker, _ = state_reference.path.rpartition("/run/")
+    assert marker
+    extra_content = b"not bound to an action\n"
+    extra_path = f"{snapshot_prefix}/run/workspace/inbox/initial_review/requests/untracked/evidence.txt"
+    extra_reference = ArtifactReference(
+        kind="requested_evidence_projection",
+        path=extra_path,
+        sha256=hashlib.sha256(extra_content).hexdigest(),
+        media_type="text/plain",
+    )
+    record_with_extra_projection = record.model_copy(
+        update={
+            "outputs": record.outputs.model_copy(
+                update={"artifacts": [*(record.outputs.artifacts or ()), extra_reference]}
+            )
+        }
+    )
+    artifacts_with_extra_projection = dict(loaded_artifacts.content_by_path)
+    artifacts_with_extra_projection[extra_path] = extra_content
+    assert transfer_runtime._snapshot_record_reasons(
+        record_with_extra_projection,
+        artifacts=artifacts_with_extra_projection,
+    ) == ("snapshot_contract_invalid",)
+
+    requested_reference = next(
+        artifact for artifact in record.outputs.artifacts or () if artifact.kind == "requested_evidence"
+    )
+    requested_snapshot = Path(manifest.ledger_root) / requested_reference.path
+    requested_snapshot.write_text("tampered\n", encoding="utf-8")
+    assert transfer_runtime._load_record(reference).reasons == ("artifact_sha256_mismatch",)
 
 
 def test_historical_lifecycle_record_without_visibility_still_validates_but_is_not_backfilled(
@@ -1604,6 +1702,93 @@ def test_run_lifecycle_ablation_records_provider_failure_as_immutable_trial(tmp_
     assert second.skipped_trials == 1
 
 
+def test_provider_failure_before_later_conditional_checkpoint_preserves_pending_catalog_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def materialize_later_conditional_lifecycle(
+        template: CompositeTaskWorldTemplate,
+        output_dir: Path,
+        *,
+        variant_id: str | None = None,
+    ) -> Path:
+        package = materialize_template_lifecycle(
+            template,
+            output_dir,
+            variant_id=variant_id,
+        )
+        _add_later_conditional_evidence(package)
+        return package
+
+    monkeypatch.setattr(
+        ablation_plan_runtime,
+        "materialize_template_lifecycle",
+        materialize_later_conditional_lifecycle,
+    )
+    monkeypatch.setattr(
+        ablation_runtime,
+        "materialize_template_lifecycle",
+        materialize_later_conditional_lifecycle,
+    )
+    manifest = _single_manifest(tmp_path).model_copy(
+        update={"experiment_id": "ssc03-later-conditional-provider-failure"}
+    )
+
+    result = run_lifecycle_ablation(
+        manifest,
+        registry_factory=lambda _trial, _package, _run: _FailedRegistry(),
+    )
+
+    assert result.executed_trials == 1
+    assert result.failed_trials == 1
+    record_path = Path(result.record_paths[0])
+    record = TrialRecord.model_validate_json(record_path.read_bytes())
+    assert not any(
+        artifact.path.endswith("/run/workspace/checkpoints/response_review/evidence-requests.json")
+        for artifact in record.outputs.artifacts or ()
+    )
+    loaded = transfer_runtime._load_artifacts(
+        record,
+        ledger_root=Path(manifest.ledger_root),
+    )
+    assert loaded.reasons == ()
+    assert record.lifecycle_provenance is not None
+    state_reference = next(
+        artifact for artifact in record.outputs.artifacts or () if artifact.kind == "lifecycle_state"
+    )
+    metrics_reference = next(
+        artifact for artifact in record.outputs.artifacts or () if artifact.kind == "lifecycle_metrics"
+    )
+    lifecycle_reference = next(
+        artifact for artifact in record.outputs.artifacts or () if artifact.path.endswith("/package/lifecycle.json")
+    )
+    invocation_reference = record.lifecycle_provenance.invocation_manifest
+    state = transfer_runtime.EvidenceLifecycleRunState.model_validate(
+        json.loads(loaded.content_by_path[state_reference.path])
+    )
+    metrics = transfer_runtime.LifecycleExperimentMetrics.model_validate(
+        json.loads(loaded.content_by_path[metrics_reference.path])
+    )
+    lifecycle = transfer_runtime.EvidenceLifecycleSpec.model_validate(
+        json.loads(loaded.content_by_path[lifecycle_reference.path])
+    )
+    invocation = transfer_runtime.LifecycleExperimentManifest.model_validate(
+        json.loads(loaded.content_by_path[invocation_reference.path])
+    ).model_dump(mode="json")
+
+    assert (
+        transfer_runtime._evidence_request_snapshot_reasons(
+            record,
+            artifacts=loaded.content_by_path,
+            state=state,
+            spec=lifecycle,
+            manifest=invocation,
+            metrics=metrics,
+        )
+        == ()
+    )
+
+
 def test_run_lifecycle_ablation_normalizes_empty_agent_output_as_failed(tmp_path: Path) -> None:
     manifest = _single_manifest(tmp_path).model_copy(update={"experiment_id": "ssc03-empty-output"})
 
@@ -1949,7 +2134,7 @@ def _recorded_trial(
         run_dir=run_dir,
         model=trial.agent.model,
         adapter_kind=trial.agent.adapter,
-        max_turns=20,
+        max_turns=trial.max_turns_per_session,
         registry=_GoldFreshRegistry(package, resolved_model=trial.agent.model),
         verifier=verify_template_lifecycle,
         visibility_policy=trial.memory_visibility_policy,
@@ -1962,6 +2147,148 @@ def _recorded_trial(
         ),
     )
     return manifest, trial, package, run_dir
+
+
+def _conditional_recorded_trial(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[LifecycleAblationManifest, LifecycleAblationTrial, Path, Path]:
+    def materialize_conditional_lifecycle(
+        template: CompositeTaskWorldTemplate,
+        output_dir: Path,
+        *,
+        variant_id: str | None = None,
+    ) -> Path:
+        package = materialize_template_lifecycle(
+            template,
+            output_dir,
+            variant_id=variant_id,
+        )
+        _add_conditional_evidence(package)
+        return package
+
+    monkeypatch.setattr(
+        ablation_plan_runtime,
+        "materialize_template_lifecycle",
+        materialize_conditional_lifecycle,
+    )
+    manifest = _single_manifest(tmp_path).model_copy(update={"experiment_id": "ssc03-conditional-import"})
+    plan = build_lifecycle_ablation_plan(manifest)
+    trial = plan.trials[0]
+    package = materialize_conditional_lifecycle(
+        get_template(TEMPLATE_ID),
+        Path(trial.package_dir),
+        variant_id=trial.variant_id,
+    )
+    run_dir = Path(trial.run_dir)
+    run_local_evidence_lifecycle_fresh_context(
+        package_dir=package,
+        run_dir=run_dir,
+        model=trial.agent.model,
+        adapter_kind=trial.agent.adapter,
+        max_turns=trial.max_turns_per_session,
+        registry=_ConditionalGoldFreshRegistry(package),
+        verifier=verify_template_lifecycle,
+        visibility_policy=trial.memory_visibility_policy,
+        sweep_context=LifecycleExperimentSweepContext(
+            sweep_experiment_id=manifest.experiment_id,
+            planned_trial_id=trial.trial_id,
+            plan_sha256=plan.plan_sha256,
+            condition_id=f"{trial.execution_mode.value}__{trial.memory_visibility_policy.value}",
+            repetition=trial.repetition,
+        ),
+    )
+    return manifest, trial, package, run_dir
+
+
+def _add_conditional_evidence(package: Path) -> None:
+    lifecycle_path = package / "lifecycle.json"
+    template_path = package / "template.json"
+    lifecycle = json.loads(lifecycle_path.read_text(encoding="utf-8"))
+    template = json.loads(template_path.read_text(encoding="utf-8"))
+    checkpoint_id = lifecycle["checkpoints"][0]["checkpoint_id"]
+    conditional = {
+        "request_budget": 1,
+        "requests": [
+            {
+                "request_id": "survey_revision",
+                "title": "Revised survey",
+                "description": "Obtain the revised survey source.",
+                "prerequisite_request_ids": [],
+            }
+        ],
+    }
+    lifecycle["checkpoints"][0]["conditional_evidence"] = conditional
+    template["evidence_lifecycle"]["checkpoints"][0]["conditional_evidence"] = conditional
+    lifecycle_path.write_text(json.dumps(lifecycle, indent=2, sort_keys=True), encoding="utf-8")
+    template_path.write_text(json.dumps(template, indent=2, sort_keys=True), encoding="utf-8")
+    resolution = package / "hidden" / "evidence-request-resolutions.json"
+    resolution.write_text(
+        json.dumps(
+            {
+                "schema_version": "1",
+                "lifecycle_id": lifecycle["lifecycle_id"],
+                "resolutions": [
+                    {
+                        "checkpoint_id": checkpoint_id,
+                        "request_id": "survey_revision",
+                        "source_path": (f"hidden/evidence_requests/{checkpoint_id}/survey_revision"),
+                    }
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    evidence = package / "hidden" / "evidence_requests" / checkpoint_id / "survey_revision"
+    evidence.mkdir(parents=True)
+    (evidence / "survey-rev-b.txt").write_text("revision B\n", encoding="utf-8")
+
+
+def _add_later_conditional_evidence(package: Path) -> None:
+    lifecycle_path = package / "lifecycle.json"
+    template_path = package / "template.json"
+    lifecycle = json.loads(lifecycle_path.read_text(encoding="utf-8"))
+    template = json.loads(template_path.read_text(encoding="utf-8"))
+    checkpoint_id = lifecycle["checkpoints"][1]["checkpoint_id"]
+    conditional = {
+        "request_budget": 1,
+        "requests": [
+            {
+                "request_id": "response_support",
+                "title": "Response support",
+                "description": "Obtain the response-stage support record.",
+                "prerequisite_request_ids": [],
+            }
+        ],
+    }
+    lifecycle["checkpoints"][1]["conditional_evidence"] = conditional
+    template["evidence_lifecycle"]["checkpoints"][1]["conditional_evidence"] = conditional
+    lifecycle_path.write_text(json.dumps(lifecycle, indent=2, sort_keys=True), encoding="utf-8")
+    template_path.write_text(json.dumps(template, indent=2, sort_keys=True), encoding="utf-8")
+    resolution = package / "hidden" / "evidence-request-resolutions.json"
+    resolution.write_text(
+        json.dumps(
+            {
+                "schema_version": "1",
+                "lifecycle_id": lifecycle["lifecycle_id"],
+                "resolutions": [
+                    {
+                        "checkpoint_id": checkpoint_id,
+                        "request_id": "response_support",
+                        "source_path": (f"hidden/evidence_requests/{checkpoint_id}/response_support"),
+                    }
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    evidence = package / "hidden" / "evidence_requests" / checkpoint_id / "response_support"
+    evidence.mkdir(parents=True)
+    (evidence / "support.txt").write_text("response support\n", encoding="utf-8")
 
 
 def _terminal_persistent_state(
@@ -2047,6 +2374,28 @@ class _GoldFreshRegistry:
                 )
 
         return _GoldAdapter()
+
+
+class _ConditionalGoldFreshRegistry(_GoldFreshRegistry):
+    def build(self, *, native_tools: list[object], **kwargs: object) -> object:
+        adapter = super().build(native_tools=native_tools, **kwargs)
+        request_evidence = next(tool for tool in native_tools if getattr(tool, "__name__", "") == "request_evidence")
+
+        class _ConditionalGoldAdapter:
+            def execute(self, request: object) -> object:
+                output_path = Path(request.output_path)
+                if output_path.stem == "initial_review":
+                    response = json.loads(
+                        request_evidence(
+                            "initial_review",
+                            "survey_revision",
+                            "Resolve the source revision discrepancy.",
+                        )
+                    )
+                    assert response["status"] == "released"
+                return adapter.execute(request)
+
+        return _ConditionalGoldAdapter()
 
 
 class _InvalidSchemaRegistry(_GoldFreshRegistry):

--- a/tests/meta_harness/test_evidence_lifecycle_episode.py
+++ b/tests/meta_harness/test_evidence_lifecycle_episode.py
@@ -188,6 +188,69 @@ def test_retry_adopts_identical_request_left_before_attempt_publication(
     assert state["checkpoint_runs"][0]["attempts"][0]["status"] == "submitted"
 
 
+def test_retry_adopts_v1_request_left_before_attempt_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package = _write_package(tmp_path / "package")
+    run_dir = tmp_path / "run"
+    environment = _RecordingEnvironment()
+    original_open_attempt = lifecycle_runtime.open_checkpoint_attempt
+
+    def interrupt_before_publication(*_args: Any, **_kwargs: Any) -> Never:
+        raise KeyboardInterrupt("simulated pre-publication interruption")
+
+    monkeypatch.setattr(lifecycle_runtime, "open_checkpoint_attempt", interrupt_before_publication)
+    with pytest.raises(KeyboardInterrupt, match="simulated pre-publication interruption"):
+        run_evidence_lifecycle(package, run_dir, episode_environment=environment)
+
+    request_path = run_dir / "episodes" / "initial_review" / "initial_review.session-001" / "episode_request.json"
+    _downgrade_episode_request_and_state(request_path, run_dir / "state.json")
+    request_bytes = request_path.read_bytes()
+
+    monkeypatch.setattr(lifecycle_runtime, "open_checkpoint_attempt", original_open_attempt)
+    result = run_evidence_lifecycle(package, run_dir, episode_environment=environment)
+
+    assert result["status"] == "complete"
+    assert request_path.read_bytes() == request_bytes
+    assert environment.requests[0].schema_version == "1"
+
+
+def test_recovery_accepts_v1_request_for_interrupted_v3_attempt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package = _write_package(tmp_path / "package")
+    run_dir = tmp_path / "run"
+    environment = _RecordingEnvironment()
+    original_open_attempt = lifecycle_runtime.open_checkpoint_attempt
+
+    def interrupt_after_publication(*args: Any, **kwargs: Any) -> Never:
+        original_open_attempt(*args, **kwargs)
+        raise KeyboardInterrupt("simulated publication interruption")
+
+    monkeypatch.setattr(lifecycle_runtime, "open_checkpoint_attempt", interrupt_after_publication)
+    with pytest.raises(KeyboardInterrupt, match="simulated publication interruption"):
+        run_evidence_lifecycle(package, run_dir, episode_environment=environment)
+
+    request_path = run_dir / "episodes" / "initial_review" / "initial_review.session-001" / "episode_request.json"
+    _downgrade_episode_request_and_state(request_path, run_dir / "state.json")
+
+    monkeypatch.setattr(lifecycle_runtime, "open_checkpoint_attempt", original_open_attempt)
+    result = run_evidence_lifecycle(package, run_dir, episode_environment=environment)
+
+    assert result["status"] == "complete"
+    interrupted_result = _read_json(request_path.with_name("episode_result.json"))
+    assert interrupted_result["status"] == "failed"
+    assert interrupted_result["failure_kind"] == "interrupted"
+    state = _read_json(run_dir / "state.json")
+    assert state["schema_version"] == "4"
+    assert [attempt["status"] for attempt in state["checkpoint_runs"][0]["attempts"]] == [
+        "interrupted",
+        "submitted",
+    ]
+
+
 def test_recovery_rejects_tampered_active_attempt_request(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -743,6 +806,27 @@ def _checkpoint(checkpoint_id: str) -> EvidenceCheckpointSpec:
 def _write_json(path: Path, payload: dict[str, object]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _downgrade_episode_request_and_state(request_path: Path, state_path: Path) -> None:
+    request = _read_json(request_path)
+    request["schema_version"] = "1"
+    request.pop("evidence_request_catalog")
+    request.pop("released_evidence_artifacts")
+    request_path.write_text(json.dumps(request, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    state = _read_json(state_path)
+    state["schema_version"] = "3"
+    for checkpoint in state["checkpoint_runs"]:
+        checkpoint.pop("evidence_request_budget")
+        checkpoint.pop("evidence_request_budget_remaining")
+        checkpoint.pop("evidence_request_actions")
+        for attempt in checkpoint["attempts"]:
+            attempt.pop("inherited_from_parent")
+    attempts = state["checkpoint_runs"][0]["attempts"]
+    if attempts:
+        attempts[0]["episode_request_sha256"] = lifecycle_runtime._sha256(request_path)
+    _write_json(state_path, state)
 
 
 def _read_json(path: Path) -> dict[str, Any]:

--- a/tests/meta_harness/test_evidence_lifecycle_episode_visibility.py
+++ b/tests/meta_harness/test_evidence_lifecycle_episode_visibility.py
@@ -1,0 +1,175 @@
+# ABOUTME: Tests visibility-aware conditional-evidence binding at the lifecycle episode boundary.
+# ABOUTME: Ensures fresh episode identity hashes every requested artifact the model can read.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from aec_bench.meta_harness.evidence_lifecycle import _build_episode_request
+from aec_bench.meta_harness.evidence_lifecycle_episode import (
+    LifecycleEpisodeContext,
+    LifecycleVisibilityPolicy,
+)
+
+
+@pytest.mark.parametrize(
+    "visibility_policy",
+    [
+        LifecycleVisibilityPolicy.ARTIFACT_MEMORY,
+        LifecycleVisibilityPolicy.RAW_EVIDENCE_ONLY,
+    ],
+)
+def test_cumulative_episode_visibility_binds_prior_and_active_requested_evidence(
+    visibility_policy: LifecycleVisibilityPolicy,
+) -> None:
+    context = LifecycleEpisodeContext.from_runtime_context(
+        _runtime_context(),
+        visibility_policy=visibility_policy,
+    )
+
+    request = _build_episode_request(
+        context,
+        _environment(visibility_policy),
+        attempt_id="response_review.attempt-001",
+        session_id="response_review.session-001",
+    )
+
+    assert [artifact.workspace_path for artifact in request.released_evidence_artifacts] == [
+        "inbox/initial_review/requests/survey_revision/survey-rev-b.txt",
+        "inbox/response_review/requests/outlet_inspection/inspection.txt",
+    ]
+
+
+def test_current_release_only_episode_visibility_excludes_prior_requested_evidence() -> None:
+    context = LifecycleEpisodeContext.from_runtime_context(
+        _runtime_context(),
+        visibility_policy=LifecycleVisibilityPolicy.CURRENT_RELEASE_ONLY,
+    )
+
+    request = _build_episode_request(
+        context,
+        _environment(LifecycleVisibilityPolicy.CURRENT_RELEASE_ONLY),
+        attempt_id="response_review.attempt-001",
+        session_id="response_review.session-001",
+    )
+
+    assert [artifact.workspace_path for artifact in request.released_evidence_artifacts] == [
+        "inbox/response_review/requests/outlet_inspection/inspection.txt",
+    ]
+
+
+def _environment(visibility_policy: LifecycleVisibilityPolicy) -> SimpleNamespace:
+    return SimpleNamespace(
+        execution_mode="fresh_context",
+        memory_visibility_policy=visibility_policy.value,
+        requested_adapter="tool_loop",
+        requested_model="test-model",
+        max_turns_per_session=20,
+    )
+
+
+def _runtime_context() -> dict[str, object]:
+    return {
+        "lifecycle_id": "lifecycle.demo",
+        "world_id": "world.demo",
+        "lifecycle_spec_sha256": "1" * 64,
+        "package_sha256": "2" * 64,
+        "status": "awaiting_checkpoint_submission",
+        "active_checkpoint_id": "response_review",
+        "checkpoint_id": "response_review",
+        "title": "Response review",
+        "workspace": "/tmp/run/workspace",
+        "run_dir": "/tmp/run",
+        "instruction": "Review the response.",
+        "instruction_path": "/tmp/run/workspace/checkpoints/response_review/instruction.md",
+        "submission_path": "/tmp/run/workspace/submissions/response_review.json",
+        "released_files": ("response.txt",),
+        "evidence_request_catalog": None,
+        "completed_checkpoints": (
+            {
+                "checkpoint_id": "initial_review",
+                "submission_path": "submissions/initial_review.json",
+                "submission_sha256": "3" * 64,
+                "released_files": ("initial.txt",),
+            },
+        ),
+        "checkpoint_runs": (
+            _checkpoint_run(
+                checkpoint_id="initial_review",
+                status="submitted",
+                action_id="evidence-request-000001",
+                sequence=1,
+                request_id="survey_revision",
+                artifact_path=("evidence_requests/evidence-request-000001/artifacts/survey-rev-b.txt"),
+                workspace_path=("inbox/initial_review/requests/survey_revision/survey-rev-b.txt"),
+                artifact_sha256="4" * 64,
+                submission_path="submissions/initial_review.json",
+                submission_sha256="3" * 64,
+            ),
+            _checkpoint_run(
+                checkpoint_id="response_review",
+                status="active",
+                action_id="evidence-request-000002",
+                sequence=2,
+                request_id="outlet_inspection",
+                artifact_path=("evidence_requests/evidence-request-000002/artifacts/inspection.txt"),
+                workspace_path=("inbox/response_review/requests/outlet_inspection/inspection.txt"),
+                artifact_sha256="5" * 64,
+            ),
+        ),
+    }
+
+
+def _checkpoint_run(
+    *,
+    checkpoint_id: str,
+    status: str,
+    action_id: str,
+    sequence: int,
+    request_id: str,
+    artifact_path: str,
+    workspace_path: str,
+    artifact_sha256: str,
+    submission_path: str | None = None,
+    submission_sha256: str | None = None,
+) -> dict[str, object]:
+    return {
+        "checkpoint_id": checkpoint_id,
+        "status": status,
+        "released_files": [],
+        "submission_path": submission_path,
+        "submission_sha256": submission_sha256,
+        "attempts": [],
+        "evidence_request_budget": 1,
+        "evidence_request_budget_remaining": 0,
+        "evidence_request_actions": [
+            {
+                "action_id": action_id,
+                "sequence": sequence,
+                "checkpoint_id": checkpoint_id,
+                "requested_checkpoint_id": checkpoint_id,
+                "request_id": request_id,
+                "reason": "Inspect the declared evidence.",
+                "session_id": f"{checkpoint_id}.session-001",
+                "attempt_id": f"{checkpoint_id}.attempt-001",
+                "outcome": "released",
+                "rejection": None,
+                "pre_action_state_sha256": "6" * 64,
+                "post_action_state_sha256": "7" * 64,
+                "released_artifacts": [
+                    {
+                        "path": artifact_path,
+                        "workspace_path": workspace_path,
+                        "sha256": artifact_sha256,
+                    }
+                ],
+                "budget_before": 1,
+                "budget_consumed": 1,
+                "budget_after": 0,
+                "inherited_from_parent": False,
+            }
+        ],
+        "inherited_from_parent": False,
+    }

--- a/tests/meta_harness/test_evidence_lifecycle_transfer.py
+++ b/tests/meta_harness/test_evidence_lifecycle_transfer.py
@@ -418,6 +418,41 @@ def test_tampered_record_or_snapshot_artifact_is_not_evaluable(tmp_path: Path, t
     assert result.mean_target_reward is None
 
 
+def test_v3_snapshot_cannot_smuggle_v4_evidence_request_fields(tmp_path: Path) -> None:
+    condition = _condition()
+    calibration = _write_record(
+        tmp_path,
+        experiment_id="calibration",
+        trial_id="calibration-001",
+        visibility=Visibility.PUBLIC,
+        package_sha256="a" * 64,
+        reward=1.0,
+        condition=condition,
+        state_checkpoint_updates={
+            "evidence_request_budget": 1,
+            "evidence_request_budget_remaining": 1,
+            "evidence_request_actions": [],
+        },
+    )
+    target = _write_record(
+        tmp_path,
+        experiment_id="target",
+        trial_id="target-001",
+        visibility=Visibility.HOLDOUT,
+        package_sha256="b" * 64,
+        reward=1.0,
+        condition=condition,
+    )
+
+    result = build_lifecycle_transfer_evaluation(
+        _spec(condition=condition, calibration=(calibration.reference,), targets=(target.reference,))
+    )
+
+    assert result.status == "not_evaluable"
+    assert result.calibration_results[0].reasons == ("snapshot_contract_invalid",)
+    assert result.target_results[0].reasons == ("no_public_calibration_support",)
+
+
 @pytest.mark.parametrize(
     "tampered_field",
     ["reward", "validity_errors", "completeness", "visibility", "package_sha256"],
@@ -902,6 +937,7 @@ def _write_record(
     verification_overall: str | None = None,
     verification_lifecycle_id: str | None = None,
     verification_template_id: str = "drainage-model-evidence-lifecycle-review",
+    state_checkpoint_updates: dict[str, object] | None = None,
 ) -> _WrittenRecord:
     ledger_root = tmp_path / "ledger"
     artifact_root = ledger_root / experiment_id / "_artifacts" / trial_id
@@ -930,31 +966,28 @@ def _write_record(
         sha256=_sha256(snapshot_path),
         media_type="application/json",
     )
-    state_path = artifact_root / "state.json"
-    state_path.write_text(
-        json.dumps(
+    checkpoint_updates = state_checkpoint_updates or {}
+    state_payload = {
+        "schema_version": "3",
+        "lifecycle_id": f"lifecycle-{trial_id}",
+        "world_id": f"world-{trial_id}",
+        "lifecycle_spec_sha256": "3" * 64,
+        "package_sha256": package_sha256,
+        "status": "complete",
+        "active_checkpoint_id": None,
+        "checkpoint_runs": [
             {
-                "schema_version": "3",
-                "lifecycle_id": f"lifecycle-{trial_id}",
-                "world_id": f"world-{trial_id}",
-                "lifecycle_spec_sha256": "3" * 64,
-                "package_sha256": package_sha256,
-                "status": "complete",
-                "active_checkpoint_id": None,
-                "checkpoint_runs": [
-                    {
-                        "checkpoint_id": checkpoint_id,
-                        "status": "submitted",
-                        "submission_path": f"episodes/{checkpoint_id}/submission.json",
-                        "submission_sha256": "7" * 64,
-                    }
-                    for checkpoint_id in ("initial", "corrected")
-                ],
-            },
-            sort_keys=True,
-        ),
-        encoding="utf-8",
-    )
+                "checkpoint_id": checkpoint_id,
+                "status": "submitted",
+                "submission_path": f"episodes/{checkpoint_id}/submission.json",
+                "submission_sha256": "7" * 64,
+                **checkpoint_updates,
+            }
+            for checkpoint_id in ("initial", "corrected")
+        ],
+    }
+    state_path = artifact_root / "state.json"
+    state_path.write_text(json.dumps(state_payload, sort_keys=True), encoding="utf-8")
     state_reference = ArtifactReference(
         kind="lifecycle_state",
         path=state_path.relative_to(ledger_root).as_posix(),

--- a/tests/prime_lab/test_lifecycle_exporter.py
+++ b/tests/prime_lab/test_lifecycle_exporter.py
@@ -17,6 +17,7 @@ import pytest
 from typer.testing import CliRunner
 
 from aec_bench.cli.main import app
+from aec_bench.prime_lab.lifecycle_environment import load_local_lifecycle_environment
 from aec_bench.prime_lab.lifecycle_exporter import (
     PrimeLifecycleExportConfig,
     export_prime_lifecycle_environment,
@@ -170,6 +171,22 @@ def test_lifecycle_export_rejects_empty_duplicate_and_unregistered_packages(tmp_
                 output_dir=tmp_path / "unregistered-output",
             )
         )
+
+
+def test_local_lifecycle_environment_rejects_mixed_request_capabilities(tmp_path: Path) -> None:
+    legacy = _materialize(tmp_path / "legacy", PUBLIC_VARIANTS[0])
+    conditional = _materialize(tmp_path / "conditional", PUBLIC_VARIANTS[1])
+    _add_conditional_evidence(conditional)
+    result = export_prime_lifecycle_environment(
+        PrimeLifecycleExportConfig(
+            name="mixed-capabilities",
+            package_dirs=(legacy, conditional),
+            output_dir=tmp_path / "environments",
+        )
+    )
+
+    with pytest.raises(ValueError, match="share one conditional evidence capability"):
+        load_local_lifecycle_environment(manifest_path=result.manifest_path)
 
 
 def test_lifecycle_export_rejects_destination_overlap_without_mutating_packages(tmp_path: Path) -> None:
@@ -327,6 +344,77 @@ def test_generated_lifecycle_rollout_advances_all_checkpoints_in_one_persistent_
     assert lifecycle["status"] == "complete"
     assert [attempt["status"] for attempt in attempts] == ["submitted", "submitted", "submitted"]
     assert {attempt["session_id"] for attempt in attempts} == {"gold-rollout"}
+
+
+def test_generated_lifecycle_rollout_exposes_conditional_evidence_only_for_capable_package(
+    tmp_path: Path,
+) -> None:
+    package = _materialize(tmp_path / "package", PUBLIC_VARIANTS[0])
+    _add_conditional_evidence(package)
+    result = export_prime_lifecycle_environment(
+        PrimeLifecycleExportConfig(
+            name="ssc03-conditional-lifecycle",
+            package_dirs=(package,),
+            output_dir=tmp_path / "environments",
+        )
+    )
+    gold = _read_json(package / "hidden" / "gold-submissions.json")
+    checkpoint_ids = [item["checkpoint_id"] for item in _read_json(package / "lifecycle.json")["checkpoints"]]
+    actions: list[dict[str, Any]] = [
+        {
+            "name": "request_evidence",
+            "arguments": {
+                "checkpoint_id": checkpoint_ids[0],
+                "request_id": "survey_revision",
+                "reason": "Resolve the source revision discrepancy.",
+            },
+        }
+    ]
+    for checkpoint_id in checkpoint_ids:
+        actions.extend(
+            [
+                {
+                    "name": "write_checkpoint_submission",
+                    "arguments": {
+                        "checkpoint_id": checkpoint_id,
+                        "content": json.dumps(gold[checkpoint_id]),
+                    },
+                },
+                {"name": "submit_checkpoint", "arguments": {"checkpoint_id": checkpoint_id}},
+            ]
+        )
+
+    probe = _run_generated_probe(
+        result.package_dir,
+        result.environment_id,
+        tmp_path / "outside-conditional",
+        {"trajectory_id": "conditional-rollout", "actions": actions},
+    )
+
+    assert probe["tool_names"] == [
+        "list_workspace",
+        "read_workspace_file",
+        "write_checkpoint_submission",
+        "request_evidence",
+        "submit_checkpoint",
+        "revisit_checkpoint",
+    ]
+    request_response = next(
+        response
+        for response in cast(list[dict[str, Any]], probe["responses"])
+        if response["name"] == "request_evidence"
+    )
+    assert request_response["payload"] == {
+        "status": "released",
+        "checkpoint_id": checkpoint_ids[0],
+        "request_id": "survey_revision",
+        "remaining_budget": 0,
+        "released_files": [f"inbox/{checkpoint_ids[0]}/requests/survey_revision/survey-rev-b.txt"],
+    }
+    action = cast(dict[str, Any], probe["lifecycle"])["checkpoint_runs"][0]["evidence_request_actions"][0]
+    assert action["session_id"] == "conditional-rollout"
+    request_parameters = probe["tool_parameters"][probe["tool_names"].index("request_evidence")]
+    assert set(request_parameters["properties"]) == {"checkpoint_id", "request_id", "reason"}
 
 
 def test_lifecycle_reward_is_task_owned_and_only_runs_at_terminal_state(tmp_path: Path) -> None:
@@ -507,6 +595,46 @@ def test_prime_export_lifecycle_cli_writes_local_only_manifest(tmp_path: Path) -
 
 def _materialize(path: Path, variant_id: str) -> Path:
     return materialize_template_lifecycle(get_template(TEMPLATE_ID), path, variant_id=variant_id)
+
+
+def _add_conditional_evidence(package: Path) -> None:
+    lifecycle_path = package / "lifecycle.json"
+    template_path = package / "template.json"
+    lifecycle = _read_json(lifecycle_path)
+    template = _read_json(template_path)
+    checkpoint_id = lifecycle["checkpoints"][0]["checkpoint_id"]
+    conditional = {
+        "request_budget": 1,
+        "requests": [
+            {
+                "request_id": "survey_revision",
+                "title": "Revised survey",
+                "description": "Obtain the revised survey source.",
+                "prerequisite_request_ids": [],
+            }
+        ],
+    }
+    lifecycle["checkpoints"][0]["conditional_evidence"] = conditional
+    template["evidence_lifecycle"]["checkpoints"][0]["conditional_evidence"] = conditional
+    _write_json(lifecycle_path, lifecycle)
+    _write_json(template_path, template)
+    _write_json(
+        package / "hidden" / "evidence-request-resolutions.json",
+        {
+            "schema_version": "1",
+            "lifecycle_id": lifecycle["lifecycle_id"],
+            "resolutions": [
+                {
+                    "checkpoint_id": checkpoint_id,
+                    "request_id": "survey_revision",
+                    "source_path": f"hidden/evidence_requests/{checkpoint_id}/survey_revision",
+                }
+            ],
+        },
+    )
+    evidence = package / "hidden" / "evidence_requests" / checkpoint_id / "survey_revision"
+    evidence.mkdir(parents=True)
+    (evidence / "survey-rev-b.txt").write_text("revision B\n", encoding="utf-8")
 
 
 def _run_generated_probe(


### PR DESCRIPTION
## Summary

Adds the PR17 action-conditioned evidence contract on top of PR16's evidence-only transfer evaluator.

- lets a checkpoint declare a finite public evidence-request catalogue with prerequisites while keeping hidden resolution paths task-owned
- records each boundary-valid request as a globally ordered, session/attempt-owned, sequence-addressed and hash-bound transaction
- publishes only the selected packet into the model-visible workspace and preserves budget/evidence across retries and branch inheritance
- exposes the same model-visible request tool in persistent local, fresh-context, and local Prime execution while leaving legacy package tool sets unchanged
- binds visible requested evidence into typed episode requests, manifests, reward-independent metrics, immutable TrialRecords, and PR16 transfer validation
- preserves exact v1/v2/v3 recovery and migration behavior while introducing the v4 action state

## Why

SSC-03 needs to become richer than a longer static prompt. This is the first bounded interaction step: a model-visible action can condition subsequent model-visible evidence, while the host retains release, provenance, verification, and reward authority.

The protocol deliberately does not claim hydraulic consequences, useful model selection, model performance, transfer, learning across runs, or continual learning.

## Reliability and audit boundaries

- one shared per-run lock covers every state mutation from load through durable persistence
- action publication is staged, atomic, fsync-durable, crash-recoverable, and exactly reconciled with lifecycle/action ledger rows
- malformed tool calls fail without becoming lifecycle actions; typed semantic rejections consume zero budget and leak no valid alternatives
- pending future catalogues remain absent, and reserved action/catalogue/projection namespaces must exactly match state
- immutable snapshots validate canonical transactions, commit markers, public catalogues, released bytes, workspace projections, metrics, and protocol/tool-schema fingerprints
- the conditional-evidence subsystem is split into protocol and durable-store modules rather than extending the lifecycle orchestrator indefinitely

## Validation

- full suite: **5,369 passed, 20 skipped, 5 known warnings**
- repository-wide Ruff check: clean
- repository-wide Ruff format check: clean
- declared contracts mypy gate: clean (33 source files)
- changed-source mypy gate: clean (11 source files)
- `git diff --check`: clean
- three independent final reviews: no remaining P0-P2 findings

## Stack

- Base: PR #16 / `feat/ssc03-evidence-transfer-evaluator`
- This PR requires no provider credentials and executes no hosted model.
- The next planned layer is an executable deterministic hydraulic world; see `docs/ssc03-richer-interaction-roadmap.md`.
