### PR TITLE
Add model-selectable hydraulic intervention lifecycle

### DIFF
--- a/docs/meta-harness-guide.md
+++ b/docs/meta-harness-guide.md
@@ -77,6 +77,14 @@ Every boundary-valid call becomes a canonical transaction before its workspace p
 
 The public SSC-03 interaction family uses these operations for two scenarios across a baseline, one declared revision, and closeout. Four revisions exercise an administrative no-op, a major-event rainfall change, an outlet-geometry change, and a tailwater change. The task verifier checks the resulting selective recomputation and document lineage independently of action efficiency. See [the interactive hydraulic lifecycle guide](ssc03-interactive-hydraulic-lifecycle.md).
 
+The separate SSC-03 design-response successor adds a model-selected source transition without changing the PR21
+calibration family. A prior checkpoint archives exactly one bounded intervention ID. The later
+`source-intervention.selected` operation binds that submission hash to one immutable option package, after which
+unchanged hydrology is reusable and outlet-dependent calculations become stale. The verifier scores honest evidence
+handling separately from whether the chosen intervention resolves every criterion. Registered public tasks with a
+smoke environment can execute the complete credential-free host path through `task composite-template
+run-lifecycle-smoke`. See [the model-selected intervention guide](ssc03-model-selected-intervention.md).
+
 ### Sealed external lifecycles
 
 A private holdout lifecycle is supplied by one explicit `SealedLifecycleProvider` instance rather than another registry. The host writes a generic `holdout` receipt, binds the provider to the exact package path and hash, and resolves its operation logic and task verifier only while the package-scoped mount is active. Copying the package or leaving the mount context removes that authority; a new process must explicitly bind the provider again.

--- a/docs/ssc03-model-selected-intervention.md
+++ b/docs/ssc03-model-selected-intervention.md
@@ -1,0 +1,138 @@
+# ABOUTME: Explains the SSC-03 successor lifecycle where a model-selected intervention changes the hydraulic source.
+# ABOUTME: Separates deterministic task evidence from model performance, post-training, and continual learning claims.
+
+# SSC-03 Model-Selected Hydraulic Intervention
+
+## The short version
+
+The PR19 task lets a model run declared calculations after the host issues a source revision. The source changes, but
+the model does not choose that change.
+
+This successor task adds one missing step: the model must choose one of two bounded design responses before seeing its
+calculated outcome. That archived choice controls which exact hydraulic source becomes active. Later calculations,
+decisions, and the closeout memo must all follow the chosen source.
+
+This is a richer fixed-model environment. It is not post-training or continual learning.
+
+## The four checkpoints
+
+| Checkpoint | Plain-language job |
+| --- | --- |
+| `problem_analysis` | Run both scenarios and diagnose the issued major-rainfall problem. |
+| `intervention_selection` | Read two public intervention descriptions and commit to exactly one. |
+| `intervention_analysis` | Activate only that archived choice, reuse unchanged hydrology, and recompute the affected calculations. |
+| `closeout_review` | Carry the selected option, current source, runs, reports, decisions, and readiness into one final record. |
+
+The selection checkpoint deliberately exposes the declared physical changes but not their calculated outcomes. The
+host archives the submission before it releases the intervention-analysis checkpoint. Changing the archived choice
+later is rejected.
+
+## The issued problem
+
+The task starts from the public major-rainfall revision. The design event passes. The major event has two coupled
+problems:
+
+- minimum freeboard is `0.289305 m`, below the declared `0.30 m` minimum; and
+- peak structured outflow is `1.620433 m³/s`, slightly above the first pipe's capacity.
+
+The reviewer therefore needs to consider both the basin and the downstream network. Fixing only the most visible local
+symptom may move the problem elsewhere.
+
+## The bounded choices
+
+| Intervention | Declared physical change | Deterministic consequence after selection |
+| --- | --- | --- |
+| `controlled_orifice_resize` | Increase the controlled-orifice diameter from `0.42 m` to `0.48 m`. | Both scenarios satisfy every declared screening criterion. |
+| `emergency_weir_enlargement` | Increase the emergency-weir length from `4.2 m` to `5.5 m`. | Major-event freeboard passes, but the greater downstream flow still exceeds pipe capacity. |
+
+The second option is intentionally plausible. It improves the basin result, but the coupled network calculation exposes
+the remaining consequence. The task is not asking the model to avoid an obviously silly answer.
+
+## What the host records
+
+The model still uses the existing bounded operation call:
+
+```text
+execute_operation(
+  checkpoint_id,
+  operation_id,
+  visible_source_state_sha256,
+  reason
+)
+```
+
+At intervention analysis, `source-intervention.selected` is the only source-changing operation. The resolver reads the
+immutable selection submission, rejects undeclared option IDs, and binds all of the following into the activation:
+
+- the selected intervention ID;
+- the selection-submission hash;
+- the problem-source fingerprints;
+- the selected option-source fingerprints; and
+- the resulting model-visible source identity.
+
+Neither the model nor the CLI can supply arbitrary outlet geometry, source paths, or expected answers.
+
+Because both options change only the outlet section, the dependency behavior is exact:
+
+```text
+hydrology                    -> already current, zero budget
+detention and outlet         -> recomputed
+downstream HGL and capacity  -> recomputed
+```
+
+## Honest failure and task completion are separate
+
+The verifier has a distinct `intervention_effectiveness` gate.
+
+If the reviewer selects the larger emergency weir and accurately reports the remaining pipe-capacity failure, its
+source grounding, calculations, decisions, readiness, and closeout can all be correct. Those gates pass. The task still
+does not pass overall because the selected intervention did not solve every declared criterion. Its scalar reward is
+capped at `0.5`, so correct paperwork around an ineffective intervention cannot look nearly equivalent to task success.
+
+This prevents two bad incentives:
+
+- pretending that a physically inadequate option succeeded; and
+- treating an honest diagnosis as though it completed the design-response objective.
+
+## Run the complete credential-free task proof
+
+From the repository root:
+
+```bash
+uv run aec-bench --json task composite-template materialize-lifecycle \
+  hydraulic-design-response-lifecycle-review \
+  --output /tmp/ssc03-intervention-package
+
+uv run aec-bench --json task composite-template run-lifecycle-smoke \
+  /tmp/ssc03-intervention-package \
+  --run-dir /tmp/ssc03-intervention-run
+```
+
+The second command runs the default feasible policy through the real lifecycle host, operation store, deterministic
+hydraulic engine, immutable submissions, and task-owned verifier. It makes no provider call and is not model-performance
+evidence.
+
+A real fixed-model run can use the same package through `lifecycle-run-local` or the local Prime lifecycle export. That
+later run requires the separately approved provider configuration and must be reported as a pilot or campaign result,
+not inferred from the deterministic smoke.
+
+## What this establishes
+
+- A model-controlled bounded choice can select a different physical source state.
+- Two runs from the same problem can produce divergent, attributable hydraulic consequences.
+- The prior selection cannot be changed after submission.
+- Dependency-aware reuse and recomputation continue to work after the model-selected transition.
+- The task verifier can distinguish correct reporting from successful intervention choice.
+
+## What it does not establish
+
+- that a real language model chooses the feasible option reliably;
+- project design quality or authority approval;
+- SWMM equivalence;
+- transfer to a distinct target;
+- an effect of post-training; or
+- continual learning across encounters.
+
+The next richer mechanic should add a scarce diagnostic choice before intervention selection, or introduce explicit
+time-evolving world state for stepwise control. The latter needs a separate world-state protocol rather than pretending
+that runtime storage and flow are static source files.

--- a/docs/ssc03-richer-interaction-roadmap.md
+++ b/docs/ssc03-richer-interaction-roadmap.md
@@ -25,6 +25,8 @@ This is a substrate for ordinary post-training and evaluation first. It is not y
 | PR19 | Bounded hydraulic operations, source revision, selective recomputation, and closeout verification |
 | PR20 | Explicit sealed-provider mounting without public target registration or export |
 | PR21 | Preregistered public calibration, write-once condition selection, and a successful fixed-contract model pilot |
+| PR22 | Target-bound private one-shot execution, recovery, immutable audit evidence, and an allowlisted aggregate receipt |
+| PR23 | A successor task where the model selects a bounded physical intervention before seeing its consequences |
 
 ## PR17: action-conditioned evidence protocol
 
@@ -118,10 +120,37 @@ The sealed PR16 entry point requires exactly one target record plus its explicit
 
 Still pending are the real public campaign, its immutable selected-condition freeze, a real private target execution, and the final stacked audit. The allowed result remains descriptive holdout generalization, not causal transfer or continual learning. Global one-shot enforcement against deletion or restoration by the filesystem owner would require external write-once storage or a transparency service.
 
+## PR23: model-selected physical intervention
+
+PR23 leaves the preregistered PR21 family and PR22 audit contract unchanged. It adds a distinct successor lifecycle for
+task-design work, because changing the calibrated family in place would rewrite the identity of the evidence already
+collected around it.
+
+The successor starts from the public major-rainfall problem source. After diagnosing both scenarios, the model sees two
+bounded intervention descriptions but not their calculated outcomes. It must archive exactly one selection. At the next
+checkpoint, one common `source-intervention.selected` operation reads that immutable submission and activates only the
+corresponding source package. The activation binds the selection hash and both source identities; arbitrary geometry,
+paths, and hidden answers remain unavailable to the model.
+
+Both options change only the outlet section. Hydrology therefore remains current, while detention/outlet and HGL
+evidence must be recomputed. The controlled-orifice option satisfies all declared criteria. The larger emergency-weir
+option resolves the local freeboard problem but leaves a downstream pipe-capacity failure. Its honest record can pass
+every evidence and readiness gate while failing the separate intervention-effectiveness gate. That failure caps scalar
+reward at `0.5`, preserving diagnostic credit without making an ineffective design response look almost successful.
+
+A registered CLI smoke command now runs the complete four-checkpoint task through the production host and task verifier
+without credentials. Two deterministic policies prove the same initial source can lead to different selected source
+hashes, hydraulic results, and terminal outcomes. This is task-mechanics evidence, not language-model performance.
+
+See [the plain-language model-selected intervention guide](ssc03-model-selected-intervention.md).
+
 ## Inputs still needed
 
 Provider credentials have been used only for the two explicitly approved public pilots. The public campaign and any later private-target transmission remain separately gated.
 
-Engineering review is needed for plausible parameter ranges, coupled scenarios, tolerances, dependency invalidation, equivalent information requests, closure policy, pump curves, NPSH, wet-well behavior, and operating rules. Infrastructure work is needed for the controlled solver matrix, private package storage, access-controlled ledgers, and redacted reporting.
+Engineering review is needed for plausible parameter ranges, intervention constructability, coupled scenarios,
+tolerances, equivalent information requests, closure policy, pump curves, NPSH, wet-well behavior, and operating rules.
+Infrastructure work is needed for the controlled solver matrix, private package storage, access-controlled ledgers, and
+redacted reporting.
 
 The progression is deliberate: first make actions observable and auditable, then make them physically consequential, then hide a structurally distinct target, and only then spend model budget.

--- a/src/aec_bench/cli/commands/task_world_templates.py
+++ b/src/aec_bench/cli/commands/task_world_templates.py
@@ -10,8 +10,13 @@ from pathlib import Path
 import typer
 
 from aec_bench.cli.output import emit, print_table
+from aec_bench.meta_harness.evidence_lifecycle import run_evidence_lifecycle
+from aec_bench.meta_harness.evidence_request_protocol import EvidenceLifecycleError
 from aec_bench.task_world_templates.catalogue import get_template, list_templates
-from aec_bench.task_world_templates.lifecycles import lifecycle_variant_ids
+from aec_bench.task_world_templates.lifecycles import (
+    lifecycle_variant_ids,
+    registered_lifecycle_smoke_environment,
+)
 from aec_bench.task_world_templates.materializer import (
     materialize_template_example,
     materialize_template_lifecycle,
@@ -136,12 +141,53 @@ def verify_lifecycle_command(
     emit("task composite-template verify-lifecycle", result, start_time=start)
 
 
+@app.command("run-lifecycle-smoke")
+def run_lifecycle_smoke_command(
+    package_dir: Path = typer.Argument(..., help="Materialized public lifecycle package directory"),
+    run_dir: Path = typer.Option(..., "--run-dir", help="Empty output directory for the deterministic run"),
+) -> None:
+    """Run and verify one registered credential-free lifecycle task proof."""
+    start = time.monotonic()
+    try:
+        template_id = _package_template_id(package_dir)
+        environment = registered_lifecycle_smoke_environment(template_id, package_dir)
+        if environment is None:
+            raise ValueError(f"lifecycle template {template_id!r} does not declare a smoke environment")
+        lifecycle = run_evidence_lifecycle(package_dir, run_dir, episode_environment=environment)
+        verification = verify_template_lifecycle(package_dir, run_dir)
+    except (EvidenceLifecycleError, json.JSONDecodeError, KeyError, OSError, ValueError) as exc:
+        emit("task composite-template run-lifecycle-smoke", None, errors=[str(exc)], start_time=start)
+        return
+    emit(
+        "task composite-template run-lifecycle-smoke",
+        {
+            "template_id": template_id,
+            "package_dir": str(package_dir),
+            "run_dir": str(run_dir),
+            "lifecycle_status": lifecycle["status"],
+            "overall": verification["overall"],
+            "passed": verification["passed"],
+            "reward": verification["reward"],
+            "gates": verification["gates"],
+        },
+        start_time=start,
+    )
+
+
 def _materialized_variant_id(package_dir: Path) -> str | None:
     path = package_dir / "hidden" / "variant.json"
     if not path.is_file():
         return None
     payload = json.loads(path.read_text(encoding="utf-8"))
     return str(payload["variant_id"])
+
+
+def _package_template_id(package_dir: Path) -> str:
+    payload = json.loads((Path(package_dir) / "template.json").read_text(encoding="utf-8"))
+    template_id = payload.get("template_id") if isinstance(payload, dict) else None
+    if not isinstance(template_id, str) or not template_id:
+        raise ValueError("lifecycle package template identity is invalid")
+    return template_id
 
 
 def _render_templates(data: dict[str, object]) -> None:

--- a/src/aec_bench/meta_harness/evidence_lifecycle.py
+++ b/src/aec_bench/meta_harness/evidence_lifecycle.py
@@ -450,6 +450,7 @@ def execute_lifecycle_operation(
     with _lifecycle_state_lock(run):
         spec = load_evidence_lifecycle_spec(package)
         state = _load_state(package, run, spec, lock_held=True)
+        _assert_prior_submissions_unchanged(run, state)
         return _execute_lifecycle_operation_locked(
             package,
             run,

--- a/src/aec_bench/task_world_templates/catalogue.py
+++ b/src/aec_bench/task_world_templates/catalogue.py
@@ -32,6 +32,44 @@ def get_template(template_id: str) -> CompositeTaskWorldTemplate:
     raise KeyError(msg)
 
 
+def _hydraulic_calculation_operations(
+    *,
+    source_prerequisites: tuple[str, ...] = (),
+) -> list[LifecycleOperationSpec]:
+    operations: list[LifecycleOperationSpec] = []
+    for scenario_id, title in (("design-10yr", "design"), ("major-100yr", "major")):
+        operations.append(
+            LifecycleOperationSpec(
+                operation_id=f"hydrology.{scenario_id}",
+                kind="run_hydrology",
+                title=f"Run {title}-scenario hydrology",
+                description="Calculate bounded Rational Method hydrology for the declared scenario.",
+                prerequisite_operation_ids=source_prerequisites,
+            )
+        )
+    for scenario_id, title in (("design-10yr", "design"), ("major-100yr", "major")):
+        operations.append(
+            LifecycleOperationSpec(
+                operation_id=f"detention-outlet.{scenario_id}.declared-outlet",
+                kind="run_detention_outlet",
+                title=f"Run {title}-scenario coupled detention and outlet analysis",
+                description="Execute the declared coupled basin, outlet, and downstream network calculation.",
+                prerequisite_operation_ids=source_prerequisites + (f"hydrology.{scenario_id}",),
+            )
+        )
+    for scenario_id, title in (("design-10yr", "design"), ("major-100yr", "major")):
+        operations.append(
+            LifecycleOperationSpec(
+                operation_id=f"network-hgl.{scenario_id}.declared-tailwater",
+                kind="run_network_hgl",
+                title=f"Project {title}-scenario network HGL",
+                description="Project HGL evidence from the exact coupled run at the declared boundary.",
+                prerequisite_operation_ids=source_prerequisites + (f"detention-outlet.{scenario_id}.declared-outlet",),
+            )
+        )
+    return operations
+
+
 def _hydraulic_operations(*, include_revision: bool) -> ConditionalOperationSpec:
     operations: list[LifecycleOperationSpec] = []
     revision_prerequisite: tuple[str, ...] = ()
@@ -45,36 +83,24 @@ def _hydraulic_operations(*, include_revision: bool) -> ConditionalOperationSpec
             )
         )
         revision_prerequisite = ("source-revision.current",)
-    for scenario_id, title in (("design-10yr", "design"), ("major-100yr", "major")):
-        operations.append(
-            LifecycleOperationSpec(
-                operation_id=f"hydrology.{scenario_id}",
-                kind="run_hydrology",
-                title=f"Run {title}-scenario hydrology",
-                description="Calculate bounded Rational Method hydrology for the declared scenario.",
-                prerequisite_operation_ids=revision_prerequisite,
-            )
-        )
-    for scenario_id, title in (("design-10yr", "design"), ("major-100yr", "major")):
-        operations.append(
-            LifecycleOperationSpec(
-                operation_id=f"detention-outlet.{scenario_id}.declared-outlet",
-                kind="run_detention_outlet",
-                title=f"Run {title}-scenario coupled detention and outlet analysis",
-                description="Execute the declared coupled basin, outlet, and downstream network calculation.",
-                prerequisite_operation_ids=revision_prerequisite + (f"hydrology.{scenario_id}",),
-            )
-        )
-    for scenario_id, title in (("design-10yr", "design"), ("major-100yr", "major")):
-        operations.append(
-            LifecycleOperationSpec(
-                operation_id=f"network-hgl.{scenario_id}.declared-tailwater",
-                kind="run_network_hgl",
-                title=f"Project {title}-scenario network HGL",
-                description="Project HGL evidence from the exact coupled run at the declared boundary.",
-                prerequisite_operation_ids=revision_prerequisite + (f"detention-outlet.{scenario_id}.declared-outlet",),
-            )
-        )
+    operations.extend(_hydraulic_calculation_operations(source_prerequisites=revision_prerequisite))
+    return ConditionalOperationSpec(
+        operation_budget=len(operations),
+        operations=tuple(operations),
+    )
+
+
+def _hydraulic_intervention_operations() -> ConditionalOperationSpec:
+    operation_id = "source-intervention.selected"
+    operations = [
+        LifecycleOperationSpec(
+            operation_id=operation_id,
+            kind="activate_source_intervention",
+            title="Activate the selected source intervention",
+            description="Activate only the bounded intervention archived at the prior selection checkpoint.",
+        ),
+        *_hydraulic_calculation_operations(source_prerequisites=(operation_id,)),
+    ]
     return ConditionalOperationSpec(
         operation_budget=len(operations),
         operations=tuple(operations),
@@ -6105,6 +6131,298 @@ _TEMPLATES = [
                     depends_on=["revision_analysis"],
                     required_submission_fields=[
                         "checkpoint_id",
+                        "visible_source_state_sha256",
+                        "selected_operations",
+                        "run_reference",
+                        "report_reference",
+                        "memo",
+                        "accepted_decisions",
+                        "supersession_lineage",
+                        "readiness_decision",
+                        "claim_boundary",
+                    ],
+                    allow_additional_submission_fields=False,
+                ),
+            ],
+        ),
+        projection_axes=["source_pack", "stage_graph", "verifier_gates", "evidence_lifecycle"],
+    ),
+    CompositeTaskWorldTemplate(
+        template_id="hydraulic-design-response-lifecycle-review",
+        name="Hydraulic Design Response Lifecycle Review",
+        summary=(
+            "Successor SSC-03 lifecycle where the reviewer selects one bounded physical intervention, "
+            "activates its exact source state, and carries the resulting hydraulic consequences to closeout."
+        ),
+        pattern=(
+            "issued hydraulic problem -> source-bound diagnosis -> bounded intervention selection -> "
+            "selective recomputation -> consequence-aware closeout"
+        ),
+        discipline_scope=["civil", "hydrology", "hydraulics", "design-review"],
+        source_artifacts=[
+            _source(
+                "issued_hydraulic_problem",
+                "typed-source-state",
+                "The immutable major-rainfall source whose coupled screening criteria require a design response.",
+                ["catchments", "scenarios", "basin", "outlet", "network", "criteria"],
+            ),
+            _source(
+                "public_intervention_catalogue",
+                "bounded-design-options",
+                "Two public source interventions described without their calculated outcomes.",
+                ["intervention_identity", "declared_change", "delivery_class"],
+            ),
+            _source(
+                "operation_transactions",
+                "lifecycle-action-evidence",
+                "Immutable intervention activation, calculation, reuse, and artifact lineage.",
+                ["action_identity", "source_identity", "calculation_identity"],
+            ),
+        ],
+        stages=[
+            _stage(
+                "problem_analysis",
+                "Diagnose the issued hydraulic problem",
+                "civil",
+                ["detention-outlet-hgl-package"],
+                ["issued_hydraulic_problem"],
+                ["problem_run_evidence", "problem_decisions"],
+                ["checkpoint_contract", "operation_evidence_integrity"],
+            ),
+            _stage(
+                "intervention_selection",
+                "Select one bounded design response",
+                "civil",
+                ["detention-outlet-hgl-package"],
+                ["problem_run_evidence", "public_intervention_catalogue"],
+                ["selected_intervention"],
+                ["selection_grounding"],
+                ["bounded_intervention"],
+            ),
+            _stage(
+                "intervention_analysis",
+                "Activate and assess the selected intervention",
+                "civil",
+                ["detention-outlet-hgl-package"],
+                ["problem_decisions", "selected_intervention"],
+                ["intervention_run_evidence", "supersession_lineage"],
+                ["selective_recomputation", "decision_update", "intervention_effectiveness"],
+            ),
+            _stage(
+                "closeout_review",
+                "Reconcile the selected intervention and its consequences",
+                "civil",
+                ["detention-outlet-hgl-package"],
+                ["intervention_run_evidence", "supersession_lineage"],
+                ["final_design_response", "final_readiness"],
+                ["run_propagation", "report_propagation", "memo_propagation", "final_readiness"],
+            ),
+        ],
+        handoffs=[
+            _handoff(
+                "problem_evidence_chain",
+                "Source-bound diagnosis carried into intervention selection.",
+                "sha256-chain",
+                "problem_analysis",
+                ["intervention_selection", "intervention_analysis"],
+                "operation-000001",
+            ),
+            _handoff(
+                "selected_intervention",
+                "The bounded option whose archived selection controls the later source transition.",
+                "intervention-id",
+                "intervention_selection",
+                ["intervention_analysis", "closeout_review"],
+                "controlled_orifice_resize",
+            ),
+            _handoff(
+                "final_readiness_state",
+                "Readiness derived from the activated intervention's complete current evidence.",
+                "state",
+                "closeout_review",
+                [],
+                "ready_or_not_ready",
+            ),
+        ],
+        branch_decisions=[
+            _branch(
+                "bounded_intervention",
+                "Select exactly one declared intervention before its calculated consequences are exposed.",
+                ["controlled_orifice_resize", "emergency_weir_enlargement"],
+                "controlled_orifice_resize",
+                "selected_intervention_id",
+            )
+        ],
+        verifier_gates=[
+            _gate(
+                "checkpoint_contract",
+                "handoff_consistency",
+                "Every checkpoint provides the exact cumulative design-response record.",
+                ["lifecycle.checkpoints"],
+                "The interaction record is incomplete.",
+            ),
+            _gate(
+                "selection_grounding",
+                "source_grounding",
+                "The archived bounded selection alone controls the activated source intervention.",
+                ["lifecycle.selection", "hydraulic.source_state"],
+                "The intervention selection and source transition do not reconcile.",
+            ),
+            _gate(
+                "operation_evidence_integrity",
+                "source_grounding",
+                "Every selected operation reconciles to its canonical transaction and hydraulic evidence.",
+                ["lifecycle.operations"],
+                "Operation evidence cannot govern.",
+            ),
+            _gate(
+                "selective_recomputation",
+                "handoff_consistency",
+                "Unchanged hydrology is retained while outlet-dependent calculations are recomputed.",
+                ["lifecycle.operation_dependencies"],
+                "Selected engineering evidence is stale or needlessly replaced.",
+            ),
+            _gate(
+                "decision_update",
+                "handoff_consistency",
+                "Both source-bound decisions are superseded by the selected intervention evidence.",
+                ["lifecycle.accepted_decisions"],
+                "A decision does not follow the activated intervention.",
+            ),
+            _gate(
+                "intervention_effectiveness",
+                "calculation",
+                "The selected intervention satisfies every declared current screening criterion.",
+                ["lifecycle.accepted_decisions"],
+                "The selected intervention leaves a declared screening criterion unresolved.",
+            ),
+            _gate(
+                "run_propagation",
+                "source_grounding",
+                "The selected runs reference the activated intervention source.",
+                ["lifecycle.final_run"],
+                "The selected run is stale.",
+            ),
+            _gate(
+                "report_propagation",
+                "deliverable",
+                "The selected reports come from the selected intervention runs.",
+                ["lifecycle.final_report"],
+                "The report does not match the intervention run.",
+            ),
+            _gate(
+                "memo_propagation",
+                "deliverable",
+                "The closeout memo cites the selection, source, runs, reports, decisions, and lineage.",
+                ["lifecycle.final_memo"],
+                "The memo is stale or assertion-only.",
+            ),
+            _gate(
+                "final_readiness",
+                "deliverable",
+                "Readiness honestly follows the selected intervention's complete criteria state.",
+                ["lifecycle.final_readiness"],
+                "The readiness decision is inconsistent.",
+            ),
+            _gate(
+                "claim_boundary",
+                "source_grounding",
+                "The review preserves the synthetic screening and non-learning claim boundary.",
+                ["lifecycle.claim_boundary"],
+                "The lifecycle overstates its evidence or authority.",
+            ),
+        ],
+        deliverables=[
+            _deliverable(
+                "hydraulic_design_response_closeout",
+                "deliverables/hydraulic-design-response-closeout.json",
+                "Cumulative selection, source, operation, decision, report, memo, and readiness evidence.",
+            )
+        ],
+        data_gaps=[
+            _gap(
+                "project_hydraulic_inputs",
+                "Real work requires accepted project rainfall, survey, network, and outlet inputs.",
+                "high",
+            ),
+            _gap(
+                "intervention_feasibility",
+                "The synthetic intervention geometry and delivery classes require project engineering review.",
+                "high",
+            ),
+            _gap(
+                "native_solver_fidelity",
+                "The deterministic screening kernel is not SWMM-equivalent simulation.",
+                "medium",
+            ),
+        ],
+        evidence_lifecycle=EvidenceLifecycleSpec(
+            lifecycle_id="ssc03.hydraulic-design-response-lifecycle",
+            world_id="aec.task_world.composite.hydraulic-design-response-lifecycle-review",
+            checkpoints=[
+                EvidenceCheckpointSpec(
+                    checkpoint_id="problem_analysis",
+                    title="Issued hydraulic problem analysis",
+                    release_path="releases/problem_analysis",
+                    instruction_path="instructions/problem_analysis.md",
+                    submission_path="submissions/problem_analysis.json",
+                    required_submission_fields=[
+                        "checkpoint_id",
+                        "visible_source_state_sha256",
+                        "selected_operations",
+                        "accepted_decisions",
+                        "readiness_decision",
+                        "claim_boundary",
+                    ],
+                    allow_additional_submission_fields=False,
+                    conditional_operations=_hydraulic_operations(include_revision=False),
+                ),
+                EvidenceCheckpointSpec(
+                    checkpoint_id="intervention_selection",
+                    title="Bounded intervention selection",
+                    release_path="releases/intervention_selection",
+                    instruction_path="instructions/intervention_selection.md",
+                    submission_path="submissions/intervention_selection.json",
+                    depends_on=["problem_analysis"],
+                    required_submission_fields=[
+                        "checkpoint_id",
+                        "visible_source_state_sha256",
+                        "selected_intervention_id",
+                        "selection_basis",
+                        "claim_boundary",
+                    ],
+                    allow_additional_submission_fields=False,
+                ),
+                EvidenceCheckpointSpec(
+                    checkpoint_id="intervention_analysis",
+                    title="Selected intervention analysis",
+                    release_path="releases/intervention_analysis",
+                    instruction_path="instructions/intervention_analysis.md",
+                    submission_path="submissions/intervention_analysis.json",
+                    depends_on=["intervention_selection"],
+                    required_submission_fields=[
+                        "checkpoint_id",
+                        "selected_intervention_id",
+                        "visible_source_state_sha256",
+                        "selected_operations",
+                        "accepted_decisions",
+                        "supersession_lineage",
+                        "readiness_decision",
+                        "claim_boundary",
+                    ],
+                    allow_additional_submission_fields=False,
+                    conditional_operations=_hydraulic_intervention_operations(),
+                ),
+                EvidenceCheckpointSpec(
+                    checkpoint_id="closeout_review",
+                    title="Hydraulic design-response closeout",
+                    release_path="releases/closeout_review",
+                    instruction_path="instructions/closeout_review.md",
+                    submission_path="submissions/closeout_review.json",
+                    depends_on=["intervention_analysis"],
+                    required_submission_fields=[
+                        "checkpoint_id",
+                        "selected_intervention_id",
                         "visible_source_state_sha256",
                         "selected_operations",
                         "run_reference",

--- a/src/aec_bench/task_world_templates/hydraulics/intervention_operations.py
+++ b/src/aec_bench/task_world_templates/hydraulics/intervention_operations.py
@@ -1,0 +1,136 @@
+# ABOUTME: Resolves the SSC-03 model-selected intervention against immutable source packages.
+# ABOUTME: Reuses the shared hydraulic calculation graph after a selection-bound source transition.
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from aec_bench.meta_harness.evidence_lifecycle_state import (
+    LifecycleOperationActionRecord,
+    LifecycleOperationDisposition,
+    LifecycleOperationOutcome,
+)
+from aec_bench.meta_harness.evidence_request_protocol import EvidenceLifecycleError
+from aec_bench.meta_harness.lifecycle_operation_protocol import (
+    LifecycleOperationPlan,
+    LifecycleOperationSourceContext,
+)
+from aec_bench.task_world_templates.contracts import LifecycleOperationSpec
+from aec_bench.task_world_templates.hydraulics.identity import canonical_json_sha256
+from aec_bench.task_world_templates.hydraulics.operations import (
+    Ssc03HydraulicOperationResolver,
+    _read_json,
+    _source_context,
+    _source_identity_payload,
+    _write_json,
+)
+
+_SELECTION_CHECKPOINT_ID = "intervention_selection"
+_SOURCE_OPERATION_ID = "source-intervention.selected"
+
+
+class Ssc03HydraulicInterventionResolver(Ssc03HydraulicOperationResolver):
+    """Resolve one archived bounded selection into the active hydraulic source."""
+
+    def _configure_source_packages(self) -> None:
+        self._problem = self.package_dir / str(self._manifest["problem_package_path"])
+        raw_paths = self._manifest["intervention_package_paths"]
+        if not isinstance(raw_paths, dict) or not raw_paths:
+            raise EvidenceLifecycleError("intervention package paths are absent from the resolver manifest")
+        self._interventions = {
+            str(intervention_id): self.package_dir / str(path) for intervention_id, path in raw_paths.items()
+        }
+
+    def _source_packages(self) -> tuple[Path, ...]:
+        return (self._problem, *(self._interventions[key] for key in sorted(self._interventions)))
+
+    def _source_transition_operation_ids(self) -> frozenset[str]:
+        return frozenset({_SOURCE_OPERATION_ID})
+
+    def _source_transition_kinds(self) -> frozenset[str]:
+        return frozenset({"activate_source_intervention"})
+
+    def current_source(
+        self,
+        actions: Sequence[LifecycleOperationActionRecord],
+    ) -> LifecycleOperationSourceContext:
+        activated = next(
+            (
+                action
+                for action in reversed(actions)
+                if action.operation_id == _SOURCE_OPERATION_ID
+                and action.operation_kind == "activate_source_intervention"
+                and action.outcome == LifecycleOperationOutcome.COMPLETED
+            ),
+            None,
+        )
+        if activated is None:
+            return _source_context(self._problem, revision_id="problem")
+        intervention_id, _selection_sha256 = self._validated_selection()
+        return _source_context(self._interventions[intervention_id], revision_id=intervention_id)
+
+    def _plan_source_transition(
+        self,
+        operation: LifecycleOperationSpec,
+        resolution: dict[str, Any],
+        actions: Sequence[LifecycleOperationActionRecord],
+        *,
+        source_before: LifecycleOperationSourceContext,
+    ) -> LifecycleOperationPlan:
+        del actions
+        if resolution.get("selection_checkpoint_id") != _SELECTION_CHECKPOINT_ID:
+            raise EvidenceLifecycleError("intervention operation does not bind the selection checkpoint")
+        intervention_id, selection_sha256 = self._validated_selection()
+        source_after = _source_context(self._interventions[intervention_id], revision_id=intervention_id)
+        payload = {
+            "schema_version": "1",
+            "operation_id": operation.operation_id,
+            "kind": operation.kind,
+            "selected_intervention_id": intervention_id,
+            "selection_checkpoint_id": _SELECTION_CHECKPOINT_ID,
+            "selection_submission_sha256": selection_sha256,
+            "source_after": source_after.visible_source_state_sha256,
+            "physical_source_after": source_after.physical_source_state_sha256,
+        }
+        return LifecycleOperationPlan(
+            operation_id=operation.operation_id,
+            operation_kind=operation.kind,
+            disposition=LifecycleOperationDisposition.ACTIVATED,
+            source_before=source_before,
+            source_after=source_after,
+            input_projection_sha256=canonical_json_sha256(payload),
+            prerequisite_action_ids=(),
+            model_visible_artifact_paths=("source-identity.json", "source-state.json"),
+            payload=payload,
+        )
+
+    def _write_source_transition_artifacts(self, plan: LifecycleOperationPlan, artifact_dir: Path) -> None:
+        _write_json(artifact_dir / "source-state.json", plan.source_after.source_state)
+        identity = _source_identity_payload(plan.source_after)
+        identity.update(
+            {
+                "selected_intervention_id": plan.payload["selected_intervention_id"],
+                "selection_checkpoint_id": plan.payload["selection_checkpoint_id"],
+                "selection_submission_sha256": plan.payload["selection_submission_sha256"],
+            }
+        )
+        _write_json(artifact_dir / "source-identity.json", identity)
+
+    def _validated_selection(self) -> tuple[str, str]:
+        selection_path = self.run_dir / "episodes" / _SELECTION_CHECKPOINT_ID / "submission.json"
+        if not selection_path.is_file():
+            raise EvidenceLifecycleError("archived intervention selection is unavailable")
+        selection = _read_json(selection_path)
+        intervention_id = selection.get("selected_intervention_id")
+        if not isinstance(intervention_id, str) or intervention_id not in self._interventions:
+            raise EvidenceLifecycleError("archived intervention selection is not declared")
+        selection_basis = selection.get("selection_basis")
+        if not isinstance(selection_basis, str) or not selection_basis.strip():
+            raise EvidenceLifecycleError("archived intervention selection basis is blank")
+        problem = _source_context(self._problem, revision_id="problem")
+        if selection.get("visible_source_state_sha256") != problem.visible_source_state_sha256:
+            raise EvidenceLifecycleError("archived intervention selection does not bind the problem source")
+        return intervention_id, hashlib.sha256(selection_path.read_bytes()).hexdigest()

--- a/src/aec_bench/task_world_templates/hydraulics/interventions.py
+++ b/src/aec_bench/task_world_templates/hydraulics/interventions.py
@@ -1,0 +1,106 @@
+# ABOUTME: Defines bounded public source interventions for the SSC-03 design-response lifecycle.
+# ABOUTME: Builds deterministic option sources from the issued major-rainfall problem state.
+
+from __future__ import annotations
+
+from typing import Literal
+
+from aec_bench.contracts.validators import NonEmptyStr, StrictModel
+from aec_bench.task_world_templates.hydraulics.contracts import (
+    HydraulicSourcePayload,
+    HydraulicSourceState,
+    SectionName,
+    build_source_state_contract,
+)
+from aec_bench.task_world_templates.hydraulics.revisions import build_hydraulic_revision_source_state
+
+HydraulicInterventionId = Literal[
+    "controlled_orifice_resize",
+    "emergency_weir_enlargement",
+]
+
+
+class HydraulicInterventionSpec(StrictModel):
+    schema_version: Literal["1"] = "1"
+    intervention_id: HydraulicInterventionId
+    title: NonEmptyStr
+    description: NonEmptyStr
+    visibility: Literal["public"] = "public"
+    delivery_class: Literal["controlled_outlet_works", "emergency_outlet_works"]
+    changed_sections: tuple[SectionName, ...]
+
+
+_INTERVENTIONS: dict[HydraulicInterventionId, HydraulicInterventionSpec] = {
+    "controlled_orifice_resize": HydraulicInterventionSpec(
+        intervention_id="controlled_orifice_resize",
+        title="Resize the controlled outlet",
+        description=(
+            "Increase the declared orifice diameter from 0.42 m to 0.48 m while retaining the emergency weir."
+        ),
+        delivery_class="controlled_outlet_works",
+        changed_sections=("outlet",),
+    ),
+    "emergency_weir_enlargement": HydraulicInterventionSpec(
+        intervention_id="emergency_weir_enlargement",
+        title="Enlarge the emergency weir",
+        description=(
+            "Increase the declared emergency-weir length from 4.2 m to 5.5 m while retaining the controlled outlet."
+        ),
+        delivery_class="emergency_outlet_works",
+        changed_sections=("outlet",),
+    ),
+}
+
+
+def list_hydraulic_intervention_ids() -> tuple[str, ...]:
+    """Return the stable public intervention IDs in lexical order."""
+    return tuple(sorted(_INTERVENTIONS))
+
+
+def get_hydraulic_intervention(intervention_id: str) -> HydraulicInterventionSpec:
+    """Return a defensive copy of one declared public intervention."""
+    try:
+        return _INTERVENTIONS[intervention_id].model_copy(deep=True)  # type: ignore[index]
+    except KeyError as exc:
+        known = ", ".join(list_hydraulic_intervention_ids())
+        raise KeyError(f"unknown hydraulic intervention {intervention_id!r}; expected one of: {known}") from exc
+
+
+def build_hydraulic_problem_source_state() -> HydraulicSourceState:
+    """Return the issued major-rainfall source that requires a design response."""
+    return build_hydraulic_revision_source_state("major_idf_revision")
+
+
+def build_hydraulic_intervention_source_state(intervention_id: str) -> HydraulicSourceState:
+    """Build the exact physical source activated by one bounded intervention."""
+    intervention = get_hydraulic_intervention(intervention_id)
+    problem = build_hydraulic_problem_source_state()
+    payload_data = problem.payload.model_dump(mode="json")
+
+    if intervention.intervention_id == "controlled_orifice_resize":
+        orifice = problem.payload.outlet.orifice.model_copy(update={"diameter_m": 0.48})
+        outlet = problem.payload.outlet.model_copy(update={"orifice": orifice})
+    elif intervention.intervention_id == "emergency_weir_enlargement":
+        emergency_weir = problem.payload.outlet.emergency_weir.model_copy(update={"length_m": 5.5})
+        outlet = problem.payload.outlet.model_copy(update={"emergency_weir": emergency_weir})
+    else:  # pragma: no cover - the typed registry makes this unreachable
+        raise AssertionError(f"unhandled hydraulic intervention: {intervention.intervention_id}")
+    payload_data["outlet"] = outlet.model_dump(mode="json")
+    payload = HydraulicSourcePayload.model_validate(payload_data)
+
+    section_revisions = {
+        section.section_name: (
+            section.source_id,
+            "Rev C" if section.section_name in intervention.changed_sections else section.revision,
+        )
+        for section in problem.sections
+    }
+    return build_source_state_contract(
+        world_id=problem.world_id,
+        title=problem.title,
+        description=problem.description,
+        claim_boundary=problem.claim_boundary,
+        reference=problem.reference,
+        payload=payload,
+        section_revisions=section_revisions,
+    )

--- a/src/aec_bench/task_world_templates/hydraulics/operations.py
+++ b/src/aec_bench/task_world_templates/hydraulics/operations.py
@@ -43,6 +43,10 @@ _NETWORK_CRITERION_IDS = {
     "pipe_capacity",
     "pipe_velocity",
 }
+_SOURCE_TRANSITION_KINDS = {
+    "activate_source_intervention",
+    "request_source_revision",
+}
 
 
 class Ssc03HydraulicOperationResolver:
@@ -56,10 +60,26 @@ class Ssc03HydraulicOperationResolver:
         self._operation_specs = _load_operation_specs(self.package_dir / "lifecycle.json")
         if set(self._resolutions) != set(self._operation_specs):
             raise EvidenceLifecycleError("operation resolver does not match the public operation catalogue")
+        self._configure_source_packages()
+        for hydraulic_package in self._source_packages():
+            build_hydraulic_run_request(hydraulic_package, scenario_id="design-10yr")
+
+    def _configure_source_packages(self) -> None:
+        """Bind the fixed baseline and revision packages for the calibration lifecycle."""
         self._baseline = self.package_dir / str(self._manifest["baseline_package_path"])
         self._revision = self.package_dir / str(self._manifest["revision_package_path"])
-        for hydraulic_package in (self._baseline, self._revision):
-            build_hydraulic_run_request(hydraulic_package, scenario_id="design-10yr")
+
+    def _source_packages(self) -> tuple[Path, ...]:
+        """Return every immutable source package the resolver may activate."""
+        return (self._baseline, self._revision)
+
+    def _source_transition_operation_ids(self) -> frozenset[str]:
+        """Return operation IDs that change the current source without calculation recursion."""
+        return frozenset({"source-revision.current"})
+
+    def _source_transition_kinds(self) -> frozenset[str]:
+        """Return operation kinds handled by the task-specific source transition hook."""
+        return frozenset({"request_source_revision"})
 
     def current_source(
         self,
@@ -90,6 +110,45 @@ class Ssc03HydraulicOperationResolver:
             resolving=(),
         )
 
+    def _plan_source_transition(
+        self,
+        operation: LifecycleOperationSpec,
+        resolution: dict[str, Any],
+        actions: Sequence[LifecycleOperationActionRecord],
+        *,
+        source_before: LifecycleOperationSourceContext,
+    ) -> LifecycleOperationPlan:
+        """Plan the calibration lifecycle's one fixed source revision."""
+        del actions
+        source_after = _source_context(self._revision, revision_id=str(self._manifest["variant_id"]))
+        payload = {
+            "schema_version": "1",
+            "operation_id": operation.operation_id,
+            "kind": operation.kind,
+            "revision_id": resolution["revision_id"],
+            "source_after": source_after.visible_source_state_sha256,
+            "physical_source_after": source_after.physical_source_state_sha256,
+        }
+        return LifecycleOperationPlan(
+            operation_id=operation.operation_id,
+            operation_kind=operation.kind,
+            disposition=LifecycleOperationDisposition.ACTIVATED,
+            source_before=source_before,
+            source_after=source_after,
+            input_projection_sha256=canonical_json_sha256(payload),
+            prerequisite_action_ids=(),
+            model_visible_artifact_paths=("source-identity.json", "source-state.json"),
+            payload=payload,
+        )
+
+    def _write_source_transition_artifacts(self, plan: LifecycleOperationPlan, artifact_dir: Path) -> None:
+        """Publish the selected source state and its bounded visible identity."""
+        _write_json(artifact_dir / "source-state.json", plan.source_after.source_state)
+        _write_json(
+            artifact_dir / "source-identity.json",
+            _source_identity_payload(plan.source_after),
+        )
+
     def _plan_operation(
         self,
         operation: LifecycleOperationSpec,
@@ -103,10 +162,17 @@ class Ssc03HydraulicOperationResolver:
         resolution = self._resolutions.get(operation.operation_id)
         if resolution is None or resolution.get("kind") != operation.kind:
             raise EvidenceLifecycleError("operation resolver does not match the public operation catalogue")
+        if operation.kind in self._source_transition_kinds():
+            return self._plan_source_transition(
+                operation,
+                resolution,
+                actions,
+                source_before=source_before,
+            )
         calculation_prerequisites = tuple(
             prerequisite_id
             for prerequisite_id in operation.prerequisite_operation_ids
-            if prerequisite_id != "source-revision.current"
+            if prerequisite_id not in self._source_transition_operation_ids()
         )
         prerequisite_action_ids_list: list[str] = []
         visible_artifacts: tuple[str, ...]
@@ -125,19 +191,7 @@ class Ssc03HydraulicOperationResolver:
                 raise LifecycleOperationPrerequisiteError("operation prerequisites are incomplete")
             prerequisite_action_ids_list.append(prerequisite_action.action_id)
         prerequisite_action_ids = tuple(prerequisite_action_ids_list)
-        if operation.kind == "request_source_revision":
-            source_after = _source_context(self._revision, revision_id=str(self._manifest["variant_id"]))
-            payload = {
-                "schema_version": "1",
-                "operation_id": operation.operation_id,
-                "kind": operation.kind,
-                "revision_id": resolution["revision_id"],
-                "source_after": source_after.visible_source_state_sha256,
-                "physical_source_after": source_after.physical_source_state_sha256,
-            }
-            disposition = LifecycleOperationDisposition.ACTIVATED
-            visible_artifacts = ("source-identity.json", "source-state.json")
-        elif operation.kind == "run_hydrology":
+        if operation.kind == "run_hydrology":
             source_after = source_before
             scenario_id = str(resolution["scenario_id"])
             scenario = _selected_scenario(source_before.source_state, scenario_id)
@@ -204,15 +258,8 @@ class Ssc03HydraulicOperationResolver:
 
     def execute(self, plan: LifecycleOperationPlan, artifact_dir: Path) -> None:
         artifact_dir.mkdir(parents=True, exist_ok=True)
-        if plan.operation_kind == "request_source_revision":
-            _write_json(
-                artifact_dir / "source-state.json",
-                plan.source_after.source_state,
-            )
-            _write_json(
-                artifact_dir / "source-identity.json",
-                _source_identity_payload(plan.source_after),
-            )
+        if plan.operation_kind in self._source_transition_kinds():
+            self._write_source_transition_artifacts(plan, artifact_dir)
             return
         if plan.operation_kind == "run_hydrology":
             scenario = plan.payload["scenario"]
@@ -330,28 +377,33 @@ def _action_by_id(
 
 def _load_operation_specs(path: Path) -> dict[str, LifecycleOperationSpec]:
     lifecycle = EvidenceLifecycleSpec.model_validate(_read_json(path))
+    declared_operations = [
+        operation
+        for checkpoint in lifecycle.checkpoints
+        if checkpoint.conditional_operations is not None
+        for operation in checkpoint.conditional_operations.operations
+    ]
+    source_transition_ids = {
+        operation.operation_id for operation in declared_operations if operation.kind in _SOURCE_TRANSITION_KINDS
+    }
     operation_specs: dict[str, LifecycleOperationSpec] = {}
-    for checkpoint in lifecycle.checkpoints:
-        conditional = checkpoint.conditional_operations
-        if conditional is None:
-            continue
-        for operation in conditional.operations:
-            calculation_prerequisites = tuple(
-                prerequisite_id
-                for prerequisite_id in operation.prerequisite_operation_ids
-                if prerequisite_id != "source-revision.current"
-            )
-            normalized = operation.model_copy(
-                update={"prerequisite_operation_ids": calculation_prerequisites},
-                deep=True,
-            )
-            existing = operation_specs.get(operation.operation_id)
-            if existing is not None and (
-                existing.kind != normalized.kind
-                or existing.prerequisite_operation_ids != normalized.prerequisite_operation_ids
-            ):
-                raise EvidenceLifecycleError("operation definition changes across public checkpoints")
-            operation_specs[operation.operation_id] = normalized
+    for operation in declared_operations:
+        calculation_prerequisites = tuple(
+            prerequisite_id
+            for prerequisite_id in operation.prerequisite_operation_ids
+            if prerequisite_id not in source_transition_ids
+        )
+        normalized = operation.model_copy(
+            update={"prerequisite_operation_ids": calculation_prerequisites},
+            deep=True,
+        )
+        existing = operation_specs.get(operation.operation_id)
+        if existing is not None and (
+            existing.kind != normalized.kind
+            or existing.prerequisite_operation_ids != normalized.prerequisite_operation_ids
+        ):
+            raise EvidenceLifecycleError("operation definition changes across public checkpoints")
+        operation_specs[operation.operation_id] = normalized
     return operation_specs
 
 

--- a/src/aec_bench/task_world_templates/lifecycles/__init__.py
+++ b/src/aec_bench/task_world_templates/lifecycles/__init__.py
@@ -91,6 +91,15 @@ _LIFECYCLES = {
             smoke_module_name=("aec_bench.task_world_templates.lifecycles.ssc03_hydraulic_interaction_smoke"),
             smoke_environment_name="build_ssc03_hydraulic_smoke_environment",
         ),
+        LifecycleTemplateRegistration(
+            template_id="hydraulic-design-response-lifecycle-review",
+            module_name="aec_bench.task_world_templates.lifecycles.ssc03_hydraulic_intervention",
+            materializer_name="materialize_ssc03_hydraulic_intervention_lifecycle",
+            verifier_name="verify_ssc03_hydraulic_intervention_lifecycle",
+            operation_resolver_name="build_ssc03_hydraulic_intervention_resolver",
+            smoke_module_name=("aec_bench.task_world_templates.lifecycles.ssc03_hydraulic_intervention_smoke"),
+            smoke_environment_name="build_ssc03_hydraulic_intervention_smoke_environment",
+        ),
     ]
 }
 

--- a/src/aec_bench/task_world_templates/lifecycles/ssc03_hydraulic_interaction_verifier.py
+++ b/src/aec_bench/task_world_templates/lifecycles/ssc03_hydraulic_interaction_verifier.py
@@ -637,14 +637,35 @@ def _verify_scenario_evidence(
 
 
 def _package_for_physical_source(package: Path, source_sha256: str) -> Path:
-    candidates = (
-        package / "hidden" / "hydraulic" / "packages" / "baseline",
-        package / "hidden" / "hydraulic" / "packages" / "revision",
-    )
+    candidates = _declared_hydraulic_packages(package)
     for candidate in candidates:
         if _sha256(candidate / "source" / "source-state.json") == source_sha256:
             return candidate
     raise ValueError("operation physical source does not match an embedded PR18 package")
+
+
+def _declared_hydraulic_packages(package: Path) -> tuple[Path, ...]:
+    manifest = _read_json(package / "hidden" / "lifecycle-operation-resolutions.json")
+    raw_paths: list[str] = []
+    for key in ("baseline_package_path", "revision_package_path", "problem_package_path"):
+        value = manifest.get(key)
+        if value is not None:
+            if not isinstance(value, str):
+                raise ValueError("hydraulic package path is invalid")
+            raw_paths.append(value)
+    intervention_paths = manifest.get("intervention_package_paths", {})
+    if not isinstance(intervention_paths, dict) or any(
+        not isinstance(value, str) for value in intervention_paths.values()
+    ):
+        raise ValueError("hydraulic intervention package paths are invalid")
+    raw_paths.extend(str(intervention_paths[key]) for key in sorted(intervention_paths))
+    if not raw_paths or len(raw_paths) != len(set(raw_paths)):
+        raise ValueError("hydraulic package paths are absent or duplicated")
+    package_root = package.resolve()
+    candidates = tuple(package / raw_path for raw_path in raw_paths)
+    if any(not candidate.resolve().is_relative_to(package_root) for candidate in candidates):
+        raise ValueError("hydraulic package path escapes the lifecycle package")
+    return candidates
 
 
 def _expected_decisions(

--- a/src/aec_bench/task_world_templates/lifecycles/ssc03_hydraulic_intervention.py
+++ b/src/aec_bench/task_world_templates/lifecycles/ssc03_hydraulic_intervention.py
@@ -1,0 +1,278 @@
+# ABOUTME: Materializes and validates the public SSC-03 model-selected intervention lifecycle.
+# ABOUTME: Binds a prior structured selection to one exact hydraulic source transition.
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from aec_bench.task_world_templates.catalogue import get_template
+from aec_bench.task_world_templates.contracts import CompositeTaskWorldTemplate, EvidenceCheckpointSpec
+from aec_bench.task_world_templates.hydraulics import build_hydraulic_run_request, materialize_hydraulic_world
+from aec_bench.task_world_templates.hydraulics.contracts import HydraulicSourceState
+from aec_bench.task_world_templates.hydraulics.interventions import (
+    build_hydraulic_intervention_source_state,
+    build_hydraulic_problem_source_state,
+    get_hydraulic_intervention,
+    list_hydraulic_intervention_ids,
+)
+
+TEMPLATE_ID = "hydraulic-design-response-lifecycle-review"
+LIFECYCLE_ID = "ssc03.hydraulic-design-response-lifecycle"
+
+
+def build_ssc03_hydraulic_intervention_resolver(package_dir: Path, run_dir: Path) -> Any:
+    """Build the task-owned resolver for one validated design-response package."""
+    from aec_bench.task_world_templates.hydraulics.intervention_operations import (
+        Ssc03HydraulicInterventionResolver,
+    )
+
+    validated_ssc03_hydraulic_intervention_package(package_dir)
+    return Ssc03HydraulicInterventionResolver(package_dir, run_dir)
+
+
+def materialize_ssc03_hydraulic_intervention_lifecycle(
+    output_dir: Path,
+    *,
+    template: CompositeTaskWorldTemplate | None = None,
+) -> Path:
+    """Materialize one deterministic four-checkpoint design-response package."""
+    output = Path(output_dir)
+    template = template or get_template(TEMPLATE_ID)
+    if template.template_id != TEMPLATE_ID or template.evidence_lifecycle is None:
+        raise ValueError(f"unexpected hydraulic intervention template: {template.template_id}")
+    if output.exists() and (not output.is_dir() or any(output.iterdir())):
+        raise ValueError(f"output directory must be empty: {output}")
+
+    _write_json(output / "template.json", template.model_dump(mode="json"))
+    _write_json(output / "world.json", template.compile_task_world_payload())
+    _write_json(output / "lifecycle.json", template.evidence_lifecycle.model_dump(mode="json"))
+    (output / "README.md").parent.mkdir(parents=True, exist_ok=True)
+    (output / "README.md").write_text(_readme(), encoding="utf-8")
+    for checkpoint_id, instruction in _instructions(template).items():
+        path = output / "instructions" / f"{checkpoint_id}.md"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(instruction, encoding="utf-8")
+    for checkpoint_id, notice in _release_notices().items():
+        path = output / "releases" / checkpoint_id / "notice.md"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(notice, encoding="utf-8")
+
+    public_catalogue = _public_intervention_catalogue()
+    _write_json(
+        output / "releases" / "intervention_selection" / "interventions.json",
+        public_catalogue,
+    )
+    problem = build_hydraulic_problem_source_state()
+    materialize_hydraulic_world(
+        problem.world_id,
+        output / "hidden" / "hydraulic" / "packages" / "problem",
+        source_state=problem,
+    )
+    for intervention_id in list_hydraulic_intervention_ids():
+        source = build_hydraulic_intervention_source_state(intervention_id)
+        materialize_hydraulic_world(
+            source.world_id,
+            output / "hidden" / "hydraulic" / "packages" / "interventions" / intervention_id,
+            source_state=source,
+        )
+    _write_json(
+        output / "hidden" / "lifecycle-operation-resolutions.json",
+        _resolution_manifest(public_catalogue),
+    )
+    return output
+
+
+def validated_ssc03_hydraulic_intervention_package(package_dir: Path) -> dict[str, Any]:
+    """Validate the public catalogue, operation map, and every immutable source package."""
+    package = Path(package_dir)
+    intervention_ids = list_hydraulic_intervention_ids()
+    try:
+        template = get_template(TEMPLATE_ID)
+        if _read_json(package / "template.json") != template.model_dump(mode="json"):
+            raise ValueError("template mismatch")
+        assert template.evidence_lifecycle is not None
+        if _read_json(package / "lifecycle.json") != template.evidence_lifecycle.model_dump(mode="json"):
+            raise ValueError("lifecycle mismatch")
+        public_catalogue = _read_json(package / "releases" / "intervention_selection" / "interventions.json")
+        if public_catalogue != _public_intervention_catalogue():
+            raise ValueError("public intervention catalogue mismatch")
+        problem_package = package / "hidden" / "hydraulic" / "packages" / "problem"
+        build_hydraulic_run_request(problem_package, scenario_id="design-10yr")
+        problem = HydraulicSourceState.model_validate(_read_json(problem_package / "source" / "source-state.json"))
+        if problem != build_hydraulic_problem_source_state():
+            raise ValueError("problem source mismatch")
+        for intervention_id in intervention_ids:
+            option_package = package / "hidden" / "hydraulic" / "packages" / "interventions" / intervention_id
+            build_hydraulic_run_request(option_package, scenario_id="design-10yr")
+            source = HydraulicSourceState.model_validate(_read_json(option_package / "source" / "source-state.json"))
+            if source != build_hydraulic_intervention_source_state(intervention_id):
+                raise ValueError("intervention source mismatch")
+        if _read_json(package / "hidden" / "lifecycle-operation-resolutions.json") != _resolution_manifest(
+            public_catalogue
+        ):
+            raise ValueError("operation resolution mismatch")
+    except (OSError, ValueError, json.JSONDecodeError, KeyError, AssertionError) as exc:
+        raise ValueError("hydraulic intervention package identity does not match materialized content") from exc
+    return {
+        "schema_version": "1",
+        "template_id": TEMPLATE_ID,
+        "lifecycle_id": LIFECYCLE_ID,
+        "intervention_ids": list(intervention_ids),
+        "public_catalogue_sha256": _canonical_json_sha256(public_catalogue),
+    }
+
+
+def verify_ssc03_hydraulic_intervention_lifecycle(package_dir: Path, run_dir: Path) -> dict[str, Any]:
+    """Verify selection, source transition, calculations, decisions, and closeout."""
+    from aec_bench.task_world_templates.lifecycles.ssc03_hydraulic_intervention_verifier import (
+        verify_hydraulic_intervention_lifecycle,
+    )
+
+    validated_ssc03_hydraulic_intervention_package(package_dir)
+    return verify_hydraulic_intervention_lifecycle(package_dir, run_dir)
+
+
+def _public_intervention_catalogue() -> dict[str, Any]:
+    return {
+        "schema_version": "1",
+        "selection_rule": (
+            "Select exactly one declared intervention from the issued descriptions before its calculated "
+            "hydraulic consequences are exposed."
+        ),
+        "interventions": [
+            get_hydraulic_intervention(intervention_id).model_dump(mode="json")
+            for intervention_id in list_hydraulic_intervention_ids()
+        ],
+    }
+
+
+def _resolution_manifest(public_catalogue: dict[str, Any]) -> dict[str, Any]:
+    operations: list[dict[str, Any]] = [
+        {
+            "operation_id": "source-intervention.selected",
+            "kind": "activate_source_intervention",
+            "selection_checkpoint_id": "intervention_selection",
+        }
+    ]
+    for scenario_id in ("design-10yr", "major-100yr"):
+        operations.extend(
+            [
+                {
+                    "operation_id": f"hydrology.{scenario_id}",
+                    "kind": "run_hydrology",
+                    "scenario_id": scenario_id,
+                },
+                {
+                    "operation_id": f"detention-outlet.{scenario_id}.declared-outlet",
+                    "kind": "run_detention_outlet",
+                    "scenario_id": scenario_id,
+                    "option_id": "selected-intervention-outlet",
+                },
+                {
+                    "operation_id": f"network-hgl.{scenario_id}.declared-tailwater",
+                    "kind": "run_network_hgl",
+                    "scenario_id": scenario_id,
+                    "boundary_id": "declared-tailwater",
+                },
+            ]
+        )
+    return {
+        "schema_version": "1",
+        "lifecycle_id": LIFECYCLE_ID,
+        "problem_package_path": "hidden/hydraulic/packages/problem",
+        "intervention_package_paths": {
+            intervention_id: f"hidden/hydraulic/packages/interventions/{intervention_id}"
+            for intervention_id in list_hydraulic_intervention_ids()
+        },
+        "public_catalogue_sha256": _canonical_json_sha256(public_catalogue),
+        "operations": sorted(operations, key=lambda item: item["operation_id"]),
+    }
+
+
+def _instructions(template: CompositeTaskWorldTemplate) -> dict[str, str]:
+    assert template.evidence_lifecycle is not None
+    checkpoints = {checkpoint.checkpoint_id: checkpoint for checkpoint in template.evidence_lifecycle.checkpoints}
+    claim = (
+        "Do not describe these synthetic screening calculations as SWMM, authority approval, standards "
+        "compliance, project design evidence, model transfer, post-training, or continual learning."
+    )
+    return {
+        "problem_analysis": (
+            "# Issued hydraulic problem\n\nRun both declared scenario chains and diagnose the current physical "
+            "criteria. "
+            f"{claim}\n\n{_submission_contract(checkpoints['problem_analysis'])}"
+        ),
+        "intervention_selection": (
+            "# Bounded intervention selection\n\nRead `interventions.json` and select exactly one intervention before "
+            "its calculated outcomes are available. Preserve the current source hash and give a concise engineering "
+            f"basis for the selection. {claim}\n\n{_submission_contract(checkpoints['intervention_selection'])}"
+        ),
+        "intervention_analysis": (
+            "# Selected intervention analysis\n\nActivate the archived selection, retain current hydrology, recompute "
+            "outlet-dependent evidence, and replace both source-bound decisions. Report failure honestly if the "
+            f"selected option remains inadequate. {claim}\n\n"
+            f"{_submission_contract(checkpoints['intervention_analysis'])}"
+        ),
+        "closeout_review": (
+            "# Design-response closeout\n\nExecute no new operations. Reconcile the selected intervention, source, "
+            "runs, reports, decisions, replacement lineage, readiness, and claim boundary in the final memo. "
+            f"{claim}\n\n{_submission_contract(checkpoints['closeout_review'])}"
+        ),
+    }
+
+
+def _submission_contract(checkpoint: EvidenceCheckpointSpec) -> str:
+    fields = "\n".join(f"- `{field}`" for field in checkpoint.required_submission_fields)
+    return f"""## Structured submission contract
+
+Use exactly these top-level keys and no others:
+
+{fields}
+
+Use the exact IDs and source hashes exposed by the host. `selection_basis` is a non-empty concise explanation, not
+an authority claim. `accepted_decisions` contains exactly the design and major scenarios. Use `screening_ready` only
+when all current criteria pass; otherwise use `not_screening_ready`. The closeout `memo` must repeat the selected
+intervention, source, run and report references, decision IDs, supersession lineage, readiness, and claim boundary.
+"""
+
+
+def _release_notices() -> dict[str, str]:
+    return {
+        "problem_analysis": "The issued major-rainfall source is active. Diagnose it before selecting a response.\n",
+        "intervention_selection": (
+            "The public intervention catalogue is available. Calculated option outcomes remain unavailable.\n"
+        ),
+        "intervention_analysis": "The host can now activate only the intervention archived at selection.\n",
+        "closeout_review": "No new hydraulic operation is permitted at closeout.\n",
+    }
+
+
+def _readme() -> str:
+    return """# SSC-03 Hydraulic Design Response Lifecycle
+
+This public successor task starts from a checked hydraulic problem, asks the reviewer to choose one of two bounded
+source interventions, and makes that selection control the later physical source. The model cannot supply arbitrary
+geometry or hidden paths. A task-owned verifier independently checks the resulting calculations and closeout.
+
+This is a deterministic synthetic screening task, not project design evidence, post-training, or continual learning.
+"""
+
+
+def _canonical_json_sha256(value: Any) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return payload

--- a/src/aec_bench/task_world_templates/lifecycles/ssc03_hydraulic_intervention_smoke.py
+++ b/src/aec_bench/task_world_templates/lifecycles/ssc03_hydraulic_intervention_smoke.py
@@ -1,0 +1,237 @@
+# ABOUTME: Drives both bounded intervention policies through the real four-checkpoint lifecycle.
+# ABOUTME: Provides credential-free task proofs with production operations and immutable submissions.
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from typing import Any, cast
+
+from aec_bench.meta_harness.evidence_lifecycle_episode import (
+    InProcessLifecycleEpisodeEnvironment,
+    LifecycleEpisodeEnvironment,
+    LifecycleEpisodeRequest,
+    LifecycleEpisodeResult,
+    LifecycleEpisodeUsage,
+)
+from aec_bench.task_world_templates.hydraulics.interventions import get_hydraulic_intervention
+from aec_bench.task_world_templates.lifecycles.ssc03_hydraulic_interaction_smoke import (
+    _CLAIM_BOUNDARY,
+    _decision,
+    _execute_calculation_operations,
+    _execute_operation,
+    _read_json,
+    _readiness,
+    _run_references,
+    _selected_operations,
+    _visible_source_sha256,
+    _write_json,
+)
+from aec_bench.task_world_templates.lifecycles.ssc03_hydraulic_interaction_verifier import SCENARIO_IDS
+from aec_bench.task_world_templates.lifecycles.ssc03_hydraulic_intervention import (
+    validated_ssc03_hydraulic_intervention_package,
+)
+
+
+def build_ssc03_hydraulic_intervention_smoke_environment(
+    package_dir: Path,
+    *,
+    selected_intervention_id: str = "controlled_orifice_resize",
+) -> LifecycleEpisodeEnvironment:
+    """Build a credential-free environment for one declared intervention policy."""
+    package = Path(package_dir)
+    validated_ssc03_hydraulic_intervention_package(package)
+    intervention = get_hydraulic_intervention(selected_intervention_id)
+
+    def execute(request: LifecycleEpisodeRequest) -> LifecycleEpisodeResult:
+        write_ssc03_hydraulic_intervention_smoke_submission(
+            package,
+            Path(request.run_dir),
+            request.checkpoint_id,
+            request.session_id,
+            Path(request.submission_path),
+            selected_intervention_id=intervention.intervention_id,
+        )
+        return LifecycleEpisodeResult(
+            episode_id=request.episode_id,
+            attempt_id=request.attempt_id,
+            session_id=request.session_id,
+            checkpoint_ids=request.checkpoint_ids,
+            execution_mode=request.execution_mode,
+            memory_visibility_policy=request.memory_visibility_policy,
+            status="completed",
+            requested_adapter=request.requested_adapter,
+            requested_model=request.requested_model,
+            max_turns_per_session=request.max_turns_per_session,
+            adapter="in_process",
+            resolved_model=f"hydraulic-intervention-smoke:{intervention.intervention_id}",
+            configuration={
+                "source": "registered_task_smoke",
+                "selected_intervention_id": intervention.intervention_id,
+            },
+            usage=LifecycleEpisodeUsage(),
+        )
+
+    return InProcessLifecycleEpisodeEnvironment(
+        executor=execute,
+        requested_model=f"hydraulic-intervention-smoke:{intervention.intervention_id}",
+    )
+
+
+def write_ssc03_hydraulic_intervention_smoke_submission(
+    package_dir: Path,
+    run_dir: Path,
+    checkpoint_id: str,
+    session_id: str,
+    submission_path: Path,
+    *,
+    selected_intervention_id: str,
+) -> None:
+    """Write one deterministic task submission without advancing the host checkpoint."""
+    package = Path(package_dir)
+    run = Path(run_dir)
+    validated_ssc03_hydraulic_intervention_package(package)
+    intervention = get_hydraulic_intervention(selected_intervention_id)
+    if checkpoint_id == "problem_analysis":
+        submission = _problem_submission(package, run, session_id=session_id)
+    elif checkpoint_id == "intervention_selection":
+        submission = _selection_submission(run, intervention.intervention_id)
+    elif checkpoint_id == "intervention_analysis":
+        submission = _intervention_submission(
+            package,
+            run,
+            session_id=session_id,
+            intervention_id=intervention.intervention_id,
+        )
+    elif checkpoint_id == "closeout_review":
+        submission = _closeout_submission(package, run, intervention.intervention_id)
+    else:
+        raise ValueError(f"unsupported hydraulic intervention smoke checkpoint: {checkpoint_id}")
+    _write_json(Path(submission_path), submission)
+
+
+def _problem_submission(package: Path, run: Path, *, session_id: str) -> dict[str, Any]:
+    actions = _execute_calculation_operations(
+        package,
+        run,
+        checkpoint_id="problem_analysis",
+        session_id=session_id,
+    )
+    decisions = [
+        _phase_decision(run, actions, scenario_id=scenario_id, phase="problem") for scenario_id in SCENARIO_IDS
+    ]
+    return {
+        "checkpoint_id": "problem_analysis",
+        "visible_source_state_sha256": _visible_source_sha256(run),
+        "selected_operations": _selected_operations(actions),
+        "accepted_decisions": decisions,
+        "readiness_decision": _readiness(decisions),
+        "claim_boundary": copy.deepcopy(_CLAIM_BOUNDARY),
+    }
+
+
+def _selection_submission(run: Path, intervention_id: str) -> dict[str, Any]:
+    return {
+        "checkpoint_id": "intervention_selection",
+        "visible_source_state_sha256": _visible_source_sha256(run),
+        "selected_intervention_id": intervention_id,
+        "selection_basis": (
+            "Select one bounded outlet intervention before its calculated consequences are exposed, then verify "
+            "both basin and downstream criteria."
+        ),
+        "claim_boundary": copy.deepcopy(_CLAIM_BOUNDARY),
+    }
+
+
+def _intervention_submission(
+    package: Path,
+    run: Path,
+    *,
+    session_id: str,
+    intervention_id: str,
+) -> dict[str, Any]:
+    problem = _read_json(run / "episodes" / "problem_analysis" / "submission.json")
+    problem_decisions = cast(list[dict[str, Any]], problem["accepted_decisions"])
+    activation = _execute_operation(
+        package,
+        run,
+        checkpoint_id="intervention_analysis",
+        operation_id="source-intervention.selected",
+        session_id=session_id,
+    )
+    actions = _execute_calculation_operations(
+        package,
+        run,
+        checkpoint_id="intervention_analysis",
+        session_id=session_id,
+    )
+    decisions = [
+        _phase_decision(run, actions, scenario_id=scenario_id, phase="intervention") for scenario_id in SCENARIO_IDS
+    ]
+    problem_by_scenario = {str(item["scenario_id"]): item for item in problem_decisions}
+    supersession = [
+        {
+            "scenario_id": scenario_id,
+            "superseded_decision_id": str(problem_by_scenario[scenario_id]["decision_id"]),
+            "replacement_decision_id": f"decision.{scenario_id}.intervention",
+        }
+        for scenario_id in SCENARIO_IDS
+    ]
+    return {
+        "checkpoint_id": "intervention_analysis",
+        "selected_intervention_id": intervention_id,
+        "visible_source_state_sha256": _visible_source_sha256(run),
+        "selected_operations": {
+            **_selected_operations(actions),
+            "source-intervention.selected": str(activation["action_id"]),
+        },
+        "accepted_decisions": decisions,
+        "supersession_lineage": supersession,
+        "readiness_decision": _readiness(decisions),
+        "claim_boundary": copy.deepcopy(_CLAIM_BOUNDARY),
+    }
+
+
+def _closeout_submission(package: Path, run: Path, intervention_id: str) -> dict[str, Any]:
+    intervention = _read_json(run / "episodes" / "intervention_analysis" / "submission.json")
+    selected_operations = cast(dict[str, str], intervention["selected_operations"])
+    decisions = cast(list[dict[str, Any]], intervention["accepted_decisions"])
+    supersession = cast(list[dict[str, str]], intervention["supersession_lineage"])
+    visible_source = str(intervention["visible_source_state_sha256"])
+    readiness = str(intervention["readiness_decision"])
+    run_reference, report_reference = _run_references(package, run, selected_operations)
+    memo = {
+        "selected_intervention_id": intervention_id,
+        "visible_source_state_sha256": visible_source,
+        "run_reference": copy.deepcopy(run_reference),
+        "report_reference": copy.deepcopy(report_reference),
+        "decision_ids": {str(item["scenario_id"]): str(item["decision_id"]) for item in decisions},
+        "supersession_lineage": supersession,
+        "readiness_decision": readiness,
+        "claim_boundary": copy.deepcopy(_CLAIM_BOUNDARY),
+    }
+    return {
+        "checkpoint_id": "closeout_review",
+        "selected_intervention_id": intervention_id,
+        "visible_source_state_sha256": visible_source,
+        "selected_operations": selected_operations,
+        "run_reference": run_reference,
+        "report_reference": report_reference,
+        "memo": memo,
+        "accepted_decisions": decisions,
+        "supersession_lineage": supersession,
+        "readiness_decision": readiness,
+        "claim_boundary": copy.deepcopy(_CLAIM_BOUNDARY),
+    }
+
+
+def _phase_decision(
+    run: Path,
+    actions: dict[str, dict[str, Any]],
+    *,
+    scenario_id: str,
+    phase: str,
+) -> dict[str, Any]:
+    decision = _decision(run, actions, scenario_id=scenario_id, revision=phase != "problem")
+    decision["decision_id"] = f"decision.{scenario_id}.{phase}"
+    return decision

--- a/src/aec_bench/task_world_templates/lifecycles/ssc03_hydraulic_intervention_verifier.py
+++ b/src/aec_bench/task_world_templates/lifecycles/ssc03_hydraulic_intervention_verifier.py
@@ -1,0 +1,515 @@
+# ABOUTME: Verifies the SSC-03 intervention choice from archived selection through hydraulic closeout.
+# ABOUTME: Scores honest evidence handling separately from whether the chosen intervention solves the problem.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import ValidationError
+
+from aec_bench.contracts.validators import NonEmptyStr, StrictModel
+from aec_bench.meta_harness.evidence_lifecycle import (
+    load_validated_lifecycle_submissions,
+    read_evidence_lifecycle_state,
+)
+from aec_bench.meta_harness.evidence_lifecycle_state import (
+    LifecycleOperationActionRecord,
+    LifecycleOperationDisposition,
+    LifecycleOperationOutcome,
+)
+from aec_bench.task_world_templates.hydraulics.interventions import (
+    HydraulicInterventionId,
+    list_hydraulic_intervention_ids,
+)
+from aec_bench.task_world_templates.lifecycles.ssc03_hydraulic_interaction_verifier import (
+    CALCULATION_OPERATION_IDS,
+    SCENARIO_IDS,
+    ClaimBoundary,
+    DecisionSupersession,
+    ReadinessDecision,
+    ReportReference,
+    RunReference,
+    ScenarioDecision,
+    ScenarioEvidence,
+    _expected_readiness,
+    _gate,
+    _mapping_failures,
+    _read_json,
+    _scenario_evidence,
+    _selected_actions,
+    _sha256,
+    _transaction_failures,
+)
+
+SOURCE_INTERVENTION_OPERATION_ID = "source-intervention.selected"
+GATE_IDS = (
+    "checkpoint_contract",
+    "selection_grounding",
+    "operation_evidence_integrity",
+    "selective_recomputation",
+    "decision_update",
+    "intervention_effectiveness",
+    "run_propagation",
+    "report_propagation",
+    "memo_propagation",
+    "final_readiness",
+    "claim_boundary",
+)
+
+
+class ProblemSubmission(StrictModel):
+    checkpoint_id: Literal["problem_analysis"]
+    visible_source_state_sha256: NonEmptyStr
+    selected_operations: dict[NonEmptyStr, NonEmptyStr]
+    accepted_decisions: tuple[ScenarioDecision, ...]
+    readiness_decision: ReadinessDecision
+    claim_boundary: ClaimBoundary
+
+
+class SelectionSubmission(StrictModel):
+    checkpoint_id: Literal["intervention_selection"]
+    visible_source_state_sha256: NonEmptyStr
+    selected_intervention_id: HydraulicInterventionId
+    selection_basis: NonEmptyStr
+    claim_boundary: ClaimBoundary
+
+
+class InterventionSubmission(StrictModel):
+    checkpoint_id: Literal["intervention_analysis"]
+    selected_intervention_id: HydraulicInterventionId
+    visible_source_state_sha256: NonEmptyStr
+    selected_operations: dict[NonEmptyStr, NonEmptyStr]
+    accepted_decisions: tuple[ScenarioDecision, ...]
+    supersession_lineage: tuple[DecisionSupersession, ...]
+    readiness_decision: ReadinessDecision
+    claim_boundary: ClaimBoundary
+
+
+class InterventionCloseoutMemo(StrictModel):
+    selected_intervention_id: HydraulicInterventionId
+    visible_source_state_sha256: NonEmptyStr
+    run_reference: dict[NonEmptyStr, RunReference]
+    report_reference: dict[NonEmptyStr, ReportReference]
+    decision_ids: dict[NonEmptyStr, NonEmptyStr]
+    supersession_lineage: tuple[DecisionSupersession, ...]
+    readiness_decision: ReadinessDecision
+    claim_boundary: ClaimBoundary
+
+
+class InterventionCloseoutSubmission(StrictModel):
+    checkpoint_id: Literal["closeout_review"]
+    selected_intervention_id: HydraulicInterventionId
+    visible_source_state_sha256: NonEmptyStr
+    selected_operations: dict[NonEmptyStr, NonEmptyStr]
+    run_reference: dict[NonEmptyStr, RunReference]
+    report_reference: dict[NonEmptyStr, ReportReference]
+    memo: InterventionCloseoutMemo
+    accepted_decisions: tuple[ScenarioDecision, ...]
+    supersession_lineage: tuple[DecisionSupersession, ...]
+    readiness_decision: ReadinessDecision
+    claim_boundary: ClaimBoundary
+
+
+def verify_hydraulic_intervention_lifecycle(package_dir: Path, run_dir: Path) -> dict[str, Any]:
+    """Verify the complete design response from problem diagnosis through closeout."""
+    package = Path(package_dir)
+    run = Path(run_dir)
+    raw = load_validated_lifecycle_submissions(package, run)
+    try:
+        problem = ProblemSubmission.model_validate(raw["problem_analysis"])
+        selection = SelectionSubmission.model_validate(raw["intervention_selection"])
+        intervention = InterventionSubmission.model_validate(raw["intervention_analysis"])
+        closeout = InterventionCloseoutSubmission.model_validate(raw["closeout_review"])
+    except (KeyError, ValidationError) as exc:
+        return _invalid_contract_result(str(exc))
+
+    state = read_evidence_lifecycle_state(package, run)
+    actions = {
+        action.action_id: action
+        for checkpoint in state["checkpoint_runs"]
+        for action in (LifecycleOperationActionRecord.model_validate(item) for item in checkpoint["operation_actions"])
+    }
+    problem_selected, problem_selection_failures = _selected_actions(
+        problem.selected_operations,
+        actions,
+        checkpoint_id="problem_analysis",
+        expected_operation_ids=set(CALCULATION_OPERATION_IDS),
+    )
+    intervention_selected, intervention_selection_failures = _selected_actions(
+        intervention.selected_operations,
+        actions,
+        checkpoint_id="intervention_analysis",
+        expected_operation_ids=set(CALCULATION_OPERATION_IDS) | {SOURCE_INTERVENTION_OPERATION_ID},
+    )
+
+    checkpoint_failures = _checkpoint_failures(problem, selection, intervention, closeout)
+    selection_failures = _selection_failures(
+        package,
+        run,
+        problem,
+        selection,
+        intervention,
+        closeout,
+        intervention_selected,
+    )
+    operation_failures = problem_selection_failures + intervention_selection_failures
+    operation_failures.extend(_transaction_failures(run, actions.values()))
+    selective_failures = _selective_recomputation_failures(problem_selected, intervention_selected)
+
+    problem_evidence, problem_evidence_failures = _scenario_evidence(package, run, problem_selected)
+    intervention_evidence, intervention_evidence_failures = _scenario_evidence(
+        package,
+        run,
+        intervention_selected,
+    )
+    operation_failures.extend(problem_evidence_failures)
+    operation_failures.extend(intervention_evidence_failures)
+
+    expected_problem_decisions = _expected_phase_decisions(problem_evidence, phase="problem")
+    expected_intervention_decisions = _expected_phase_decisions(
+        intervention_evidence,
+        phase="intervention",
+    )
+    expected_lineage = tuple(
+        DecisionSupersession(
+            scenario_id=scenario_id,
+            superseded_decision_id=f"decision.{scenario_id}.problem",
+            replacement_decision_id=f"decision.{scenario_id}.intervention",
+        )
+        for scenario_id in SCENARIO_IDS
+    )
+    decision_failures = _decision_failures(
+        problem,
+        intervention,
+        expected_problem_decisions,
+        expected_intervention_decisions,
+        expected_lineage,
+    )
+    effectiveness_failures = _effectiveness_failures(
+        selection.selected_intervention_id,
+        intervention_evidence,
+    )
+
+    expected_runs = {scenario_id: evidence.run_reference for scenario_id, evidence in intervention_evidence.items()}
+    expected_reports = {
+        scenario_id: evidence.report_reference for scenario_id, evidence in intervention_evidence.items()
+    }
+    run_failures = _scenario_mapping_failures("run_reference", closeout.run_reference, expected_runs)
+    report_failures = _scenario_mapping_failures("report_reference", closeout.report_reference, expected_reports)
+    readiness = _expected_readiness(expected_intervention_decisions)
+    memo_failures = _memo_failures(
+        closeout,
+        expected_runs,
+        expected_reports,
+        expected_intervention_decisions,
+        expected_lineage,
+        readiness,
+    )
+    readiness_failures = _readiness_failures(
+        problem,
+        intervention,
+        closeout,
+        expected_problem_decisions,
+        expected_intervention_decisions,
+    )
+    claim_failures = _claim_failures(problem, selection, intervention, closeout)
+
+    gates = {
+        "checkpoint_contract": _gate(checkpoint_failures),
+        "selection_grounding": _gate(selection_failures),
+        "operation_evidence_integrity": _gate(operation_failures),
+        "selective_recomputation": _gate(selective_failures),
+        "decision_update": _gate(decision_failures),
+        "intervention_effectiveness": _gate(effectiveness_failures),
+        "run_propagation": _gate(run_failures),
+        "report_propagation": _gate(report_failures),
+        "memo_propagation": _gate(memo_failures),
+        "final_readiness": _gate(readiness_failures),
+        "claim_boundary": _gate(claim_failures),
+    }
+    passed = all(gate["passed"] for gate in gates.values())
+    reward = _reward(gates)
+    return {
+        "template_id": "hydraulic-design-response-lifecycle-review",
+        "lifecycle_id": "ssc03.hydraulic-design-response-lifecycle",
+        "overall": "pass" if passed else "fail",
+        "passed": passed,
+        "reward": reward,
+        "gates": gates,
+    }
+
+
+def _invalid_contract_result(message: str) -> dict[str, Any]:
+    gates = {
+        gate_id: _gate([message if gate_id == "checkpoint_contract" else "checkpoint contract unavailable"])
+        for gate_id in GATE_IDS
+    }
+    return {
+        "template_id": "hydraulic-design-response-lifecycle-review",
+        "lifecycle_id": "ssc03.hydraulic-design-response-lifecycle",
+        "overall": "fail",
+        "passed": False,
+        "reward": 0.0,
+        "gates": gates,
+    }
+
+
+def _reward(gates: dict[str, dict[str, Any]]) -> float:
+    mean_gate_score = sum(float(gate["score"]) for gate in gates.values()) / len(gates)
+    if not gates["intervention_effectiveness"]["passed"]:
+        mean_gate_score = min(mean_gate_score, 0.5)
+    return round(mean_gate_score, 4)
+
+
+def _checkpoint_failures(
+    problem: ProblemSubmission,
+    selection: SelectionSubmission,
+    intervention: InterventionSubmission,
+    closeout: InterventionCloseoutSubmission,
+) -> list[str]:
+    failures: list[str] = []
+    for checkpoint_id, decisions in (
+        ("problem_analysis", problem.accepted_decisions),
+        ("intervention_analysis", intervention.accepted_decisions),
+        ("closeout_review", closeout.accepted_decisions),
+    ):
+        if len(decisions) != len(SCENARIO_IDS) or {item.scenario_id for item in decisions} != set(SCENARIO_IDS):
+            failures.append(f"{checkpoint_id}.accepted_decisions.scenarios")
+    if not selection.selection_basis.strip():
+        failures.append("intervention_selection.selection_basis")
+    if closeout.selected_operations != intervention.selected_operations:
+        failures.append("closeout_review.selected_operations")
+    if closeout.accepted_decisions != intervention.accepted_decisions:
+        failures.append("closeout_review.accepted_decisions")
+    if closeout.supersession_lineage != intervention.supersession_lineage:
+        failures.append("closeout_review.supersession_lineage")
+    return failures
+
+
+def _selection_failures(
+    package: Path,
+    run: Path,
+    problem: ProblemSubmission,
+    selection: SelectionSubmission,
+    intervention: InterventionSubmission,
+    closeout: InterventionCloseoutSubmission,
+    selected_actions: dict[str, LifecycleOperationActionRecord],
+) -> list[str]:
+    failures: list[str] = []
+    source_action = selected_actions.get(SOURCE_INTERVENTION_OPERATION_ID)
+    if source_action is None:
+        return ["intervention_analysis.source_intervention_action"]
+    intervention_id = selection.selected_intervention_id
+    if intervention_id not in set(list_hydraulic_intervention_ids()):
+        failures.append("intervention_selection.selected_intervention_id")
+    if intervention.selected_intervention_id != intervention_id:
+        failures.append("intervention_analysis.selected_intervention_id")
+    if closeout.selected_intervention_id != intervention_id:
+        failures.append("closeout_review.selected_intervention_id")
+    if problem.visible_source_state_sha256 != source_action.visible_source_state_before_sha256:
+        failures.append("problem_analysis.visible_source_state_sha256")
+    if selection.visible_source_state_sha256 != problem.visible_source_state_sha256:
+        failures.append("intervention_selection.visible_source_state_sha256")
+    if intervention.visible_source_state_sha256 != source_action.visible_source_state_after_sha256:
+        failures.append("intervention_analysis.visible_source_state_sha256")
+    if closeout.visible_source_state_sha256 != intervention.visible_source_state_sha256:
+        failures.append("closeout_review.visible_source_state_sha256")
+
+    problem_source = package / "hidden" / "hydraulic" / "packages" / "problem" / "source" / "source-state.json"
+    option_source = (
+        package
+        / "hidden"
+        / "hydraulic"
+        / "packages"
+        / "interventions"
+        / intervention_id
+        / "source"
+        / "source-state.json"
+    )
+    if source_action.physical_source_state_before_sha256 != _sha256(problem_source):
+        failures.append("intervention_analysis.physical_source_before")
+    if source_action.physical_source_state_after_sha256 != _sha256(option_source):
+        failures.append("intervention_analysis.physical_source_after")
+    if (
+        source_action.outcome != LifecycleOperationOutcome.COMPLETED
+        or source_action.disposition != LifecycleOperationDisposition.ACTIVATED
+        or source_action.budget_consumed != 1
+    ):
+        failures.append("intervention_analysis.source_intervention_activation")
+    identity = _read_json(run / "lifecycle_operations" / source_action.action_id / "artifacts" / "source-identity.json")
+    selection_path = run / "episodes" / "intervention_selection" / "submission.json"
+    if identity.get("selected_intervention_id") != intervention_id:
+        failures.append("intervention_analysis.source_identity.intervention")
+    if identity.get("selection_submission_sha256") != _sha256(selection_path):
+        failures.append("intervention_analysis.source_identity.selection")
+    return failures
+
+
+def _selective_recomputation_failures(
+    problem: dict[str, LifecycleOperationActionRecord],
+    intervention: dict[str, LifecycleOperationActionRecord],
+) -> list[str]:
+    failures: list[str] = []
+    for operation_id in CALCULATION_OPERATION_IDS:
+        problem_action = problem.get(operation_id)
+        current_action = intervention.get(operation_id)
+        if problem_action is None or current_action is None:
+            failures.append(f"intervention_analysis.{operation_id}.missing")
+            continue
+        if operation_id.startswith("hydrology."):
+            if (
+                current_action.outcome != LifecycleOperationOutcome.ALREADY_CURRENT
+                or current_action.disposition != LifecycleOperationDisposition.REUSED
+                or current_action.retained_from_action_id != problem_action.action_id
+                or current_action.input_projection_sha256 != problem_action.input_projection_sha256
+                or current_action.budget_consumed != 0
+            ):
+                failures.append(f"intervention_analysis.{operation_id}.reuse")
+        elif (
+            current_action.outcome != LifecycleOperationOutcome.COMPLETED
+            or current_action.disposition != LifecycleOperationDisposition.COMPUTED
+            or current_action.retained_from_action_id is not None
+            or current_action.input_projection_sha256 == problem_action.input_projection_sha256
+            or current_action.budget_consumed != 1
+        ):
+            failures.append(f"intervention_analysis.{operation_id}.recompute")
+    return failures
+
+
+def _expected_phase_decisions(
+    evidence: dict[str, ScenarioEvidence],
+    *,
+    phase: str,
+) -> dict[str, ScenarioDecision]:
+    return {
+        scenario_id: ScenarioDecision(
+            decision_id=f"decision.{scenario_id}.{phase}",
+            scenario_id=evidence_item.scenario_id,
+            hydrology_action_id=evidence_item.hydrology_action_id,
+            detention_action_id=evidence_item.detention_action_id,
+            hgl_action_id=evidence_item.hgl_action_id,
+            hydraulic_run_id=evidence_item.hydraulic_run_id,
+            screening_outcome=("criteria_not_met" if evidence_item.failed_criteria else "criteria_met"),
+            failed_criteria=evidence_item.failed_criteria,
+        )
+        for scenario_id, evidence_item in evidence.items()
+    }
+
+
+def _decision_failures(
+    problem: ProblemSubmission,
+    intervention: InterventionSubmission,
+    expected_problem: dict[str, ScenarioDecision],
+    expected_intervention: dict[str, ScenarioDecision],
+    expected_lineage: tuple[DecisionSupersession, ...],
+) -> list[str]:
+    actual_problem = {item.scenario_id: item for item in problem.accepted_decisions}
+    actual_intervention = {item.scenario_id: item for item in intervention.accepted_decisions}
+    failures = [
+        f"problem_analysis.accepted_decisions.{scenario_id}"
+        for scenario_id in SCENARIO_IDS
+        if actual_problem.get(scenario_id) != expected_problem.get(scenario_id)
+    ]
+    failures.extend(
+        f"intervention_analysis.accepted_decisions.{scenario_id}"
+        for scenario_id in SCENARIO_IDS
+        if actual_intervention.get(scenario_id) != expected_intervention.get(scenario_id)
+    )
+    if intervention.supersession_lineage != expected_lineage:
+        failures.append("intervention_analysis.supersession_lineage")
+    return failures
+
+
+def _effectiveness_failures(
+    intervention_id: HydraulicInterventionId,
+    evidence: dict[str, ScenarioEvidence],
+) -> list[str]:
+    failures: list[str] = []
+    for scenario_id in SCENARIO_IDS:
+        scenario = evidence.get(scenario_id)
+        if scenario is None:
+            failures.append(f"{intervention_id}.{scenario_id}.evidence_missing")
+            continue
+        failures.extend(f"{intervention_id}.{scenario_id}.{criterion_id}" for criterion_id in scenario.failed_criteria)
+    return failures
+
+
+def _scenario_mapping_failures(
+    label: str,
+    actual: dict[str, Any],
+    expected: dict[str, Any],
+) -> list[str]:
+    failures: list[str] = []
+    if set(actual) != set(SCENARIO_IDS):
+        failures.append(f"closeout_review.{label}.scenarios")
+    failures.extend(_mapping_failures(label, actual, expected))
+    return failures
+
+
+def _memo_failures(
+    closeout: InterventionCloseoutSubmission,
+    runs: dict[str, RunReference],
+    reports: dict[str, ReportReference],
+    decisions: dict[str, ScenarioDecision],
+    lineage: tuple[DecisionSupersession, ...],
+    readiness: ReadinessDecision,
+) -> list[str]:
+    failures: list[str] = []
+    for label, mapping in (
+        ("run_reference", closeout.memo.run_reference),
+        ("report_reference", closeout.memo.report_reference),
+        ("decision_ids", closeout.memo.decision_ids),
+    ):
+        if set(mapping) != set(SCENARIO_IDS):
+            failures.append(f"closeout_review.memo.{label}.scenarios")
+    expected = InterventionCloseoutMemo(
+        selected_intervention_id=closeout.selected_intervention_id,
+        visible_source_state_sha256=closeout.visible_source_state_sha256,
+        run_reference=runs,
+        report_reference=reports,
+        decision_ids={scenario_id: decision.decision_id for scenario_id, decision in decisions.items()},
+        supersession_lineage=lineage,
+        readiness_decision=readiness,
+        claim_boundary=closeout.claim_boundary,
+    )
+    if closeout.memo != expected:
+        failures.append("closeout_review.memo")
+    return failures
+
+
+def _readiness_failures(
+    problem: ProblemSubmission,
+    intervention: InterventionSubmission,
+    closeout: InterventionCloseoutSubmission,
+    problem_decisions: dict[str, ScenarioDecision],
+    intervention_decisions: dict[str, ScenarioDecision],
+) -> list[str]:
+    failures: list[str] = []
+    if set(problem_decisions) != set(SCENARIO_IDS):
+        failures.append("problem_analysis.readiness_evidence.scenarios")
+    if set(intervention_decisions) != set(SCENARIO_IDS):
+        failures.append("intervention_analysis.readiness_evidence.scenarios")
+    if problem.readiness_decision != _expected_readiness(problem_decisions):
+        failures.append("problem_analysis.readiness_decision")
+    expected_intervention = _expected_readiness(intervention_decisions)
+    if intervention.readiness_decision != expected_intervention:
+        failures.append("intervention_analysis.readiness_decision")
+    if closeout.readiness_decision != expected_intervention:
+        failures.append("closeout_review.readiness_decision")
+    return failures
+
+
+def _claim_failures(
+    problem: ProblemSubmission,
+    selection: SelectionSubmission,
+    intervention: InterventionSubmission,
+    closeout: InterventionCloseoutSubmission,
+) -> list[str]:
+    claims = (
+        problem.claim_boundary,
+        selection.claim_boundary,
+        intervention.claim_boundary,
+        closeout.claim_boundary,
+    )
+    return [] if len(set(claim.model_dump_json() for claim in claims)) == 1 else ["claim_boundary"]

--- a/tests/cli/test_task_world_templates.py
+++ b/tests/cli/test_task_world_templates.py
@@ -21,10 +21,14 @@ def test_task_composite_template_list_command_emits_template_catalogue() -> None
     assert result.exit_code == 0, result.output
     envelope = json.loads(result.output)
     assert envelope["command"] == "task composite-template list"
-    assert envelope["data"]["count"] == 28
+    assert envelope["data"]["count"] == 29
     assert envelope["data"]["templates"][0]["template_id"] == "stormwater-drainage-package"
     assert any(
         template["template_id"] == "hydraulic-interaction-lifecycle-review"
+        for template in envelope["data"]["templates"]
+    )
+    assert any(
+        template["template_id"] == "hydraulic-design-response-lifecycle-review"
         for template in envelope["data"]["templates"]
     )
     assert envelope["data"]["templates"][-1]["template_id"] == "drainage-model-evidence-lifecycle-review"
@@ -200,6 +204,44 @@ def test_task_composite_template_hydraulic_interaction_variants_materialize(tmp_
     assert json.loads((package / "hidden" / "variant.json").read_text(encoding="utf-8"))["variant_id"] == (
         "tailwater_revision"
     )
+
+
+def test_task_composite_template_runs_intervention_smoke_end_to_end(tmp_path: Path) -> None:
+    package = tmp_path / "intervention-package"
+    run_dir = tmp_path / "intervention-run"
+    materialized = runner.invoke(
+        app,
+        [
+            "--json",
+            "task",
+            "composite-template",
+            "materialize-lifecycle",
+            "hydraulic-design-response-lifecycle-review",
+            "--output",
+            str(package),
+        ],
+    )
+    executed = runner.invoke(
+        app,
+        [
+            "--json",
+            "task",
+            "composite-template",
+            "run-lifecycle-smoke",
+            str(package),
+            "--run-dir",
+            str(run_dir),
+        ],
+    )
+
+    assert materialized.exit_code == 0, materialized.output
+    assert executed.exit_code == 0, executed.output
+    assert json.loads(materialized.output)["data"]["checkpoint_count"] == 4
+    data = json.loads(executed.output)["data"]
+    assert data["template_id"] == "hydraulic-design-response-lifecycle-review"
+    assert data["lifecycle_status"] == "complete"
+    assert data["overall"] == "pass"
+    assert data["reward"] == 1.0
 
 
 def test_task_composite_template_materialize_lifecycle_rejects_unknown_variant(tmp_path: Path) -> None:

--- a/tests/task_world_templates/hydraulics/test_intervention_operations.py
+++ b/tests/task_world_templates/hydraulics/test_intervention_operations.py
@@ -1,0 +1,250 @@
+# ABOUTME: Tests that an archived intervention selection controls the later hydraulic source transition.
+# ABOUTME: Proves hydrology is reused while outlet-dependent evidence recomputes against the chosen option.
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from aec_bench.meta_harness.evidence_lifecycle import (
+    execute_lifecycle_operation,
+    open_checkpoint_attempt,
+    prepare_evidence_checkpoint,
+    read_evidence_lifecycle_state,
+    submit_evidence_checkpoint,
+)
+from aec_bench.meta_harness.evidence_request_protocol import EvidenceLifecycleError
+from aec_bench.task_world_templates.catalogue import get_template
+from aec_bench.task_world_templates.lifecycles import materialize_lifecycle_template
+from aec_bench.task_world_templates.lifecycles.ssc03_hydraulic_intervention import TEMPLATE_ID
+
+SCENARIO_IDS = ("design-10yr", "major-100yr")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return cast(dict[str, Any], payload)
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _visible_source_sha256(run: Path) -> str:
+    return str(_read_json(run / "workspace" / "hydraulics" / "current-source.json")["visible_source_state_sha256"])
+
+
+def _execute(
+    package: Path,
+    run: Path,
+    *,
+    checkpoint_id: str,
+    operation_id: str,
+    session_id: str,
+) -> dict[str, Any]:
+    return execute_lifecycle_operation(
+        package,
+        run,
+        checkpoint_id=checkpoint_id,
+        operation_id=operation_id,
+        visible_source_state_sha256=_visible_source_sha256(run),
+        reason=f"Exercise {operation_id} against the declared source.",
+        session_id=session_id,
+    )
+
+
+def _execute_scenario_chains(
+    package: Path,
+    run: Path,
+    *,
+    checkpoint_id: str,
+    session_id: str,
+) -> dict[str, dict[str, Any]]:
+    actions: dict[str, dict[str, Any]] = {}
+    for scenario_id in SCENARIO_IDS:
+        for operation_id in (
+            f"hydrology.{scenario_id}",
+            f"detention-outlet.{scenario_id}.declared-outlet",
+            f"network-hgl.{scenario_id}.declared-tailwater",
+        ):
+            actions[operation_id] = _execute(
+                package,
+                run,
+                checkpoint_id=checkpoint_id,
+                operation_id=operation_id,
+                session_id=session_id,
+            )
+    return actions
+
+
+def _archive_problem_analysis(package: Path, run: Path) -> dict[str, dict[str, Any]]:
+    context = prepare_evidence_checkpoint(package, run)
+    assert context["checkpoint_id"] == "problem_analysis"
+    session_id = "problem.session-001"
+    open_checkpoint_attempt(package, run, session_id=session_id, execution_mode="fresh_context")
+    actions = _execute_scenario_chains(
+        package,
+        run,
+        checkpoint_id="problem_analysis",
+        session_id=session_id,
+    )
+    _write_json(
+        run / "workspace" / "submissions" / "problem_analysis.json",
+        {
+            "checkpoint_id": "problem_analysis",
+            "visible_source_state_sha256": _visible_source_sha256(run),
+            "selected_operations": {key: value["action_id"] for key, value in actions.items()},
+            "accepted_decisions": [],
+            "readiness_decision": "not_screening_ready",
+            "claim_boundary": {},
+        },
+    )
+    submit_evidence_checkpoint(package, run)
+    return actions
+
+
+def _archive_selection(package: Path, run: Path, intervention_id: str) -> str:
+    context = prepare_evidence_checkpoint(package, run)
+    assert context["checkpoint_id"] == "intervention_selection"
+    submission = run / "workspace" / "submissions" / "intervention_selection.json"
+    _write_json(
+        submission,
+        {
+            "checkpoint_id": "intervention_selection",
+            "visible_source_state_sha256": _visible_source_sha256(run),
+            "selected_intervention_id": intervention_id,
+            "selection_basis": "Select the bounded outlet response for coupled verification.",
+            "claim_boundary": {},
+        },
+    )
+    submit_evidence_checkpoint(package, run)
+    archived = run / "episodes" / "intervention_selection" / "submission.json"
+    return hashlib.sha256(archived.read_bytes()).hexdigest()
+
+
+@pytest.mark.parametrize(
+    "intervention_id",
+    ["controlled_orifice_resize", "emergency_weir_enlargement"],
+)
+def test_archived_selection_controls_source_and_selective_recomputation(
+    tmp_path: Path,
+    intervention_id: str,
+) -> None:
+    package = materialize_lifecycle_template(get_template(TEMPLATE_ID), tmp_path / "package")
+    run = tmp_path / "run"
+    problem_actions = _archive_problem_analysis(package, run)
+    selection_sha256 = _archive_selection(package, run, intervention_id)
+    context = prepare_evidence_checkpoint(package, run)
+    assert context["checkpoint_id"] == "intervention_analysis"
+    problem_source_sha256 = str(
+        _read_json(run / "workspace" / "hydraulics" / "current-source.json")["physical_source_state_sha256"]
+    )
+    session_id = "intervention.session-001"
+    open_checkpoint_attempt(package, run, session_id=session_id, execution_mode="fresh_context")
+
+    activation = _execute(
+        package,
+        run,
+        checkpoint_id="intervention_analysis",
+        operation_id="source-intervention.selected",
+        session_id=session_id,
+    )
+    option_source = (
+        package
+        / "hidden"
+        / "hydraulic"
+        / "packages"
+        / "interventions"
+        / intervention_id
+        / "source"
+        / "source-state.json"
+    )
+
+    assert activation["outcome"] == "completed"
+    assert activation["disposition"] == "activated"
+    assert activation["physical_source_state_before_sha256"] == problem_source_sha256
+    assert activation["physical_source_state_after_sha256"] == hashlib.sha256(option_source.read_bytes()).hexdigest()
+    source_identity = _read_json(
+        run / "lifecycle_operations" / str(activation["action_id"]) / "artifacts" / "source-identity.json"
+    )
+    assert source_identity["revision_id"] == intervention_id
+    assert source_identity["selection_submission_sha256"] == selection_sha256
+
+    current_actions = _execute_scenario_chains(
+        package,
+        run,
+        checkpoint_id="intervention_analysis",
+        session_id=session_id,
+    )
+    for scenario_id in SCENARIO_IDS:
+        hydrology = current_actions[f"hydrology.{scenario_id}"]
+        detention = current_actions[f"detention-outlet.{scenario_id}.declared-outlet"]
+        hgl = current_actions[f"network-hgl.{scenario_id}.declared-tailwater"]
+        assert hydrology["outcome"] == "already_current"
+        assert hydrology["retained_from_action_id"] == problem_actions[f"hydrology.{scenario_id}"]["action_id"]
+        assert hydrology["budget_consumed"] == 0
+        assert detention["outcome"] == "completed"
+        assert detention["budget_consumed"] == 1
+        assert hgl["outcome"] == "completed"
+        assert hgl["budget_consumed"] == 1
+
+
+def test_undeclared_archived_selection_fails_before_intervention_release(tmp_path: Path) -> None:
+    package = materialize_lifecycle_template(get_template(TEMPLATE_ID), tmp_path / "package")
+    run = tmp_path / "run"
+    _archive_problem_analysis(package, run)
+    _archive_selection(package, run, "invented_outlet_option")
+
+    with pytest.raises(EvidenceLifecycleError, match="selection is not declared"):
+        prepare_evidence_checkpoint(package, run)
+
+
+def test_archived_selection_cannot_be_changed_after_submission(tmp_path: Path) -> None:
+    package = materialize_lifecycle_template(get_template(TEMPLATE_ID), tmp_path / "package")
+    run = tmp_path / "run"
+    _archive_problem_analysis(package, run)
+    _archive_selection(package, run, "controlled_orifice_resize")
+    archived = run / "episodes" / "intervention_selection" / "submission.json"
+    payload = _read_json(archived)
+    payload["selection_basis"] = "Change the archived choice after submission."
+    _write_json(archived, payload)
+
+    with pytest.raises(EvidenceLifecycleError, match="archived checkpoint submission changed"):
+        prepare_evidence_checkpoint(package, run)
+
+
+def test_selection_tampering_after_checkpoint_release_cannot_activate_an_option(tmp_path: Path) -> None:
+    package = materialize_lifecycle_template(get_template(TEMPLATE_ID), tmp_path / "package")
+    run = tmp_path / "run"
+    _archive_problem_analysis(package, run)
+    _archive_selection(package, run, "controlled_orifice_resize")
+    context = prepare_evidence_checkpoint(package, run)
+    assert context["checkpoint_id"] == "intervention_analysis"
+    session_id = "intervention.session-001"
+    open_checkpoint_attempt(package, run, session_id=session_id, execution_mode="fresh_context")
+    archived = run / "episodes" / "intervention_selection" / "submission.json"
+    original = archived.read_bytes()
+    payload = _read_json(archived)
+    payload["selected_intervention_id"] = "emergency_weir_enlargement"
+    _write_json(archived, payload)
+
+    with pytest.raises(EvidenceLifecycleError, match="archived checkpoint submission changed"):
+        _execute(
+            package,
+            run,
+            checkpoint_id="intervention_analysis",
+            operation_id="source-intervention.selected",
+            session_id=session_id,
+        )
+
+    archived.write_bytes(original)
+    state = read_evidence_lifecycle_state(package, run)
+    checkpoint = next(item for item in state["checkpoint_runs"] if item["checkpoint_id"] == "intervention_analysis")
+    assert checkpoint["operation_actions"] == []
+    assert checkpoint["operation_budget_remaining"] == 7

--- a/tests/task_world_templates/hydraulics/test_intervention_package.py
+++ b/tests/task_world_templates/hydraulics/test_intervention_package.py
@@ -1,0 +1,98 @@
+# ABOUTME: Tests the public SSC-03 design-response lifecycle package and operation contract.
+# ABOUTME: Keeps model-selected interventions separate from the PR21 calibration family.
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from aec_bench.task_world_templates.catalogue import get_template
+from aec_bench.task_world_templates.hydraulics import build_hydraulic_run_request
+from aec_bench.task_world_templates.hydraulics.interventions import list_hydraulic_intervention_ids
+from aec_bench.task_world_templates.lifecycles import (
+    materialize_lifecycle_template,
+    registered_lifecycle_template_ids,
+)
+from aec_bench.task_world_templates.lifecycles.ssc03_hydraulic_intervention import (
+    TEMPLATE_ID,
+    validated_ssc03_hydraulic_intervention_package,
+)
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return cast(dict[str, Any], payload)
+
+
+def test_intervention_lifecycle_has_a_distinct_four_checkpoint_contract() -> None:
+    template = get_template(TEMPLATE_ID)
+    assert template.evidence_lifecycle is not None
+    checkpoints = template.evidence_lifecycle.checkpoints
+
+    assert TEMPLATE_ID in registered_lifecycle_template_ids()
+    assert template.evidence_lifecycle.lifecycle_id == "ssc03.hydraulic-design-response-lifecycle"
+    assert [checkpoint.checkpoint_id for checkpoint in checkpoints] == [
+        "problem_analysis",
+        "intervention_selection",
+        "intervention_analysis",
+        "closeout_review",
+    ]
+    assert checkpoints[1].conditional_operations is None
+    assert checkpoints[3].conditional_operations is None
+    assert checkpoints[0].conditional_operations is not None
+    assert checkpoints[2].conditional_operations is not None
+    assert checkpoints[0].conditional_operations.operation_budget == 6
+    assert checkpoints[2].conditional_operations.operation_budget == 7
+    assert {operation.operation_id for operation in checkpoints[2].conditional_operations.operations} == {
+        "source-intervention.selected",
+        "hydrology.design-10yr",
+        "hydrology.major-100yr",
+        "detention-outlet.design-10yr.declared-outlet",
+        "detention-outlet.major-100yr.declared-outlet",
+        "network-hgl.design-10yr.declared-tailwater",
+        "network-hgl.major-100yr.declared-tailwater",
+    }
+
+
+def test_materialized_package_exposes_options_without_outcomes(tmp_path: Path) -> None:
+    package = materialize_lifecycle_template(get_template(TEMPLATE_ID), tmp_path / "package")
+
+    validated = validated_ssc03_hydraulic_intervention_package(package)
+    public_catalogue = _read_json(package / "releases" / "intervention_selection" / "interventions.json")
+    encoded_catalogue = json.dumps(public_catalogue, sort_keys=True)
+
+    assert validated["intervention_ids"] == list(list_hydraulic_intervention_ids())
+    assert [item["intervention_id"] for item in public_catalogue["interventions"]] == list(
+        list_hydraulic_intervention_ids()
+    )
+    assert "expected" not in encoded_catalogue
+    assert "failed_criteria" not in encoded_catalogue
+    assert "screening_ready" not in encoded_catalogue
+
+    problem = package / "hidden" / "hydraulic" / "packages" / "problem"
+    build_hydraulic_run_request(problem, scenario_id="major-100yr")
+    for intervention_id in list_hydraulic_intervention_ids():
+        option = package / "hidden" / "hydraulic" / "packages" / "interventions" / intervention_id
+        build_hydraulic_run_request(option, scenario_id="major-100yr")
+
+
+def test_materialized_package_rejects_option_tampering(tmp_path: Path) -> None:
+    package = materialize_lifecycle_template(get_template(TEMPLATE_ID), tmp_path / "package")
+    source = (
+        package
+        / "hidden"
+        / "hydraulic"
+        / "packages"
+        / "interventions"
+        / "controlled_orifice_resize"
+        / "source"
+        / "source-state.json"
+    )
+    source.write_text(source.read_text(encoding="utf-8").replace("0.48", "0.49"), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="intervention package identity"):
+        validated_ssc03_hydraulic_intervention_package(package)

--- a/tests/task_world_templates/hydraulics/test_intervention_verifier.py
+++ b/tests/task_world_templates/hydraulics/test_intervention_verifier.py
@@ -1,0 +1,272 @@
+# ABOUTME: Tests complete task-owned verification of both SSC-03 intervention trajectories.
+# ABOUTME: Separates honest evidence handling from whether the selected design response solves the problem.
+
+from __future__ import annotations
+
+import copy
+import json
+import shutil
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from aec_bench.meta_harness.evidence_lifecycle import read_evidence_lifecycle_state, run_evidence_lifecycle
+from aec_bench.task_world_templates.catalogue import get_template
+from aec_bench.task_world_templates.lifecycles import (
+    materialize_lifecycle_template,
+    verify_lifecycle_template,
+)
+from aec_bench.task_world_templates.lifecycles.ssc03_hydraulic_interaction_smoke import (
+    _run_references,
+)
+from aec_bench.task_world_templates.lifecycles.ssc03_hydraulic_intervention import TEMPLATE_ID
+from aec_bench.task_world_templates.lifecycles.ssc03_hydraulic_intervention_smoke import (
+    build_ssc03_hydraulic_intervention_smoke_environment,
+    write_ssc03_hydraulic_intervention_smoke_submission,
+)
+from aec_bench.task_world_templates.lifecycles.ssc03_hydraulic_intervention_verifier import (
+    _invalid_contract_result,
+)
+from tests.support.lifecycle_episode import deterministic_episode_environment
+
+EXPECTED_GATES = {
+    "checkpoint_contract",
+    "selection_grounding",
+    "operation_evidence_integrity",
+    "selective_recomputation",
+    "decision_update",
+    "intervention_effectiveness",
+    "run_propagation",
+    "report_propagation",
+    "memo_propagation",
+    "final_readiness",
+    "claim_boundary",
+}
+
+
+def test_invalid_submission_contract_returns_a_zero_reward_failure() -> None:
+    result = _invalid_contract_result("invalid intervention submission")
+
+    assert result["passed"] is False
+    assert result["overall"] == "fail"
+    assert result["reward"] == 0.0
+    assert result["gates"]["checkpoint_contract"]["failures"] == ["invalid intervention submission"]
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return cast(dict[str, Any], payload)
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _run_policy(tmp_path: Path, intervention_id: str) -> tuple[Path, Path, dict[str, Any]]:
+    package = materialize_lifecycle_template(get_template(TEMPLATE_ID), tmp_path / f"package-{intervention_id}")
+    run = tmp_path / f"run-{intervention_id}"
+    environment = build_ssc03_hydraulic_intervention_smoke_environment(
+        package,
+        selected_intervention_id=intervention_id,
+    )
+
+    lifecycle = run_evidence_lifecycle(package, run, episode_environment=environment)
+    verification = verify_lifecycle_template(package, run)
+
+    assert lifecycle["status"] == "complete"
+    return package, run, verification
+
+
+def test_feasible_intervention_completes_the_real_lifecycle(tmp_path: Path) -> None:
+    _package, run, result = _run_policy(tmp_path, "controlled_orifice_resize")
+
+    state = read_evidence_lifecycle_state(_package, run)
+    actions = [action for checkpoint in state["checkpoint_runs"] for action in checkpoint["operation_actions"]]
+    closeout = _read_json(run / "episodes" / "closeout_review" / "submission.json")
+
+    assert result["passed"] is True
+    assert result["overall"] == "pass"
+    assert result["reward"] == 1.0
+    assert set(result["gates"]) == EXPECTED_GATES
+    assert all(gate["passed"] for gate in result["gates"].values())
+    assert len(actions) == 13
+    assert closeout["selected_intervention_id"] == "controlled_orifice_resize"
+    assert closeout["readiness_decision"] == "screening_ready"
+
+
+def test_infeasible_intervention_is_honestly_recorded_but_does_not_solve_the_task(tmp_path: Path) -> None:
+    _package, run, result = _run_policy(tmp_path, "emergency_weir_enlargement")
+    closeout = _read_json(run / "episodes" / "closeout_review" / "submission.json")
+
+    assert result["passed"] is False
+    assert result["overall"] == "fail"
+    assert result["reward"] == 0.5
+    assert set(result["gates"]) == EXPECTED_GATES
+    assert result["gates"]["intervention_effectiveness"]["passed"] is False
+    assert result["gates"]["intervention_effectiveness"]["failures"] == [
+        "emergency_weir_enlargement.major-100yr.pipe_capacity"
+    ]
+    assert all(gate["passed"] for gate_id, gate in result["gates"].items() if gate_id != "intervention_effectiveness")
+    assert closeout["selected_intervention_id"] == "emergency_weir_enlargement"
+    assert closeout["readiness_decision"] == "not_screening_ready"
+
+
+def test_two_bounded_policies_diverge_from_the_same_problem_source(tmp_path: Path) -> None:
+    _feasible_package, feasible_run, _feasible_result = _run_policy(tmp_path, "controlled_orifice_resize")
+    _infeasible_package, infeasible_run, _infeasible_result = _run_policy(
+        tmp_path,
+        "emergency_weir_enlargement",
+    )
+
+    feasible_state = read_evidence_lifecycle_state(_feasible_package, feasible_run)
+    infeasible_state = read_evidence_lifecycle_state(_infeasible_package, infeasible_run)
+    feasible_actions = {
+        action["operation_id"]: action
+        for checkpoint in feasible_state["checkpoint_runs"]
+        for action in checkpoint["operation_actions"]
+        if checkpoint["checkpoint_id"] == "intervention_analysis"
+    }
+    infeasible_actions = {
+        action["operation_id"]: action
+        for checkpoint in infeasible_state["checkpoint_runs"]
+        for action in checkpoint["operation_actions"]
+        if checkpoint["checkpoint_id"] == "intervention_analysis"
+    }
+    feasible_activation = feasible_actions["source-intervention.selected"]
+    infeasible_activation = infeasible_actions["source-intervention.selected"]
+    feasible_major = _read_json(
+        feasible_run
+        / "lifecycle_operations"
+        / feasible_actions["detention-outlet.major-100yr.declared-outlet"]["action_id"]
+        / "artifacts"
+        / "detention-outlet.json"
+    )
+    infeasible_major = _read_json(
+        infeasible_run
+        / "lifecycle_operations"
+        / infeasible_actions["detention-outlet.major-100yr.declared-outlet"]["action_id"]
+        / "artifacts"
+        / "detention-outlet.json"
+    )
+
+    assert (
+        feasible_activation["physical_source_state_before_sha256"]
+        == infeasible_activation["physical_source_state_before_sha256"]
+    )
+    assert (
+        feasible_activation["physical_source_state_after_sha256"]
+        != infeasible_activation["physical_source_state_after_sha256"]
+    )
+    assert feasible_major["peak_structured_outflow_m3_s"] == pytest.approx(1.617686, abs=1e-6)
+    assert infeasible_major["peak_structured_outflow_m3_s"] == pytest.approx(1.626967, abs=1e-6)
+
+
+def test_undeclared_duplicate_package_cannot_hijack_verifier_lookup(tmp_path: Path) -> None:
+    package = materialize_lifecycle_template(get_template(TEMPLATE_ID), tmp_path / "package")
+    declared = package / "hidden" / "hydraulic" / "packages" / "interventions" / "controlled_orifice_resize"
+    undeclared = package / "hidden" / "hydraulic" / "packages" / "aaa"
+    shutil.copytree(declared, undeclared)
+    (undeclared / "engine" / "identity.json").unlink()
+    run = tmp_path / "run"
+    environment = build_ssc03_hydraulic_intervention_smoke_environment(
+        package,
+        selected_intervention_id="controlled_orifice_resize",
+    )
+
+    run_evidence_lifecycle(package, run, episode_environment=environment)
+    result = verify_lifecycle_template(package, run)
+
+    assert result["passed"] is True
+    assert result["reward"] == 1.0
+
+
+def test_omitting_the_failing_major_chain_cannot_bypass_the_reward_cap(tmp_path: Path) -> None:
+    package = materialize_lifecycle_template(get_template(TEMPLATE_ID), tmp_path / "package")
+    run = tmp_path / "run"
+    full_selected: dict[str, str] = {}
+
+    def execute(context: dict[str, Any]) -> dict[str, str]:
+        checkpoint_id = str(context["checkpoint_id"])
+        submission_path = Path(str(context["submission_path"]))
+        if checkpoint_id != "closeout_review":
+            write_ssc03_hydraulic_intervention_smoke_submission(
+                package,
+                run,
+                checkpoint_id,
+                str(context["session_id"]),
+                submission_path,
+                selected_intervention_id="emergency_weir_enlargement",
+            )
+            if checkpoint_id == "intervention_analysis":
+                submission = _read_json(submission_path)
+                selected = cast(dict[str, str], submission["selected_operations"])
+                full_selected.update(selected)
+                submission["selected_operations"] = {
+                    key: value for key, value in selected.items() if "major-100yr" not in key
+                }
+                submission["readiness_decision"] = "screening_ready"
+                _write_json(submission_path, submission)
+            return {"status": "completed"}
+
+        intervention = _read_json(run / "episodes" / "intervention_analysis" / "submission.json")
+        run_reference, report_reference = _run_references(package, run, full_selected)
+        run_reference = {"design-10yr": run_reference["design-10yr"]}
+        report_reference = {"design-10yr": report_reference["design-10yr"]}
+        selected_operations = cast(dict[str, str], intervention["selected_operations"])
+        decisions = cast(list[dict[str, Any]], intervention["accepted_decisions"])
+        lineage = cast(list[dict[str, str]], intervention["supersession_lineage"])
+        claim = cast(dict[str, str], intervention["claim_boundary"])
+        visible_source = str(intervention["visible_source_state_sha256"])
+        memo = {
+            "selected_intervention_id": "emergency_weir_enlargement",
+            "visible_source_state_sha256": visible_source,
+            "run_reference": copy.deepcopy(run_reference),
+            "report_reference": copy.deepcopy(report_reference),
+            "decision_ids": {"design-10yr": "decision.design-10yr.intervention"},
+            "supersession_lineage": copy.deepcopy(lineage),
+            "readiness_decision": "screening_ready",
+            "claim_boundary": copy.deepcopy(claim),
+        }
+        _write_json(
+            submission_path,
+            {
+                "checkpoint_id": "closeout_review",
+                "selected_intervention_id": "emergency_weir_enlargement",
+                "visible_source_state_sha256": visible_source,
+                "selected_operations": selected_operations,
+                "run_reference": run_reference,
+                "report_reference": report_reference,
+                "memo": memo,
+                "accepted_decisions": decisions,
+                "supersession_lineage": lineage,
+                "readiness_decision": "screening_ready",
+                "claim_boundary": claim,
+            },
+        )
+        return {"status": "completed"}
+
+    run_evidence_lifecycle(
+        package,
+        run,
+        episode_environment=deterministic_episode_environment(execute),
+    )
+    result = verify_lifecycle_template(package, run)
+
+    assert result["reward"] <= 0.5
+    for gate_id in (
+        "operation_evidence_integrity",
+        "selective_recomputation",
+        "decision_update",
+        "intervention_effectiveness",
+        "run_propagation",
+        "report_propagation",
+        "memo_propagation",
+        "final_readiness",
+    ):
+        assert result["gates"][gate_id]["passed"] is False
+    assert result["gates"]["intervention_effectiveness"]["failures"] == [
+        "emergency_weir_enlargement.major-100yr.evidence_missing"
+    ]

--- a/tests/task_world_templates/hydraulics/test_interventions.py
+++ b/tests/task_world_templates/hydraulics/test_interventions.py
@@ -1,0 +1,124 @@
+# ABOUTME: Tests the bounded public intervention choices for the SSC-03 design-response lifecycle.
+# ABOUTME: Proves each option changes declared source sections and produces distinct checked consequences.
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from aec_bench.task_world_templates.hydraulics import (
+    build_hydraulic_run_request,
+    execute_hydraulic_world,
+    materialize_hydraulic_world,
+)
+from aec_bench.task_world_templates.hydraulics.interventions import (
+    build_hydraulic_intervention_source_state,
+    build_hydraulic_problem_source_state,
+    get_hydraulic_intervention,
+    list_hydraulic_intervention_ids,
+)
+
+INTERVENTION_IDS = (
+    "controlled_orifice_resize",
+    "emergency_weir_enlargement",
+)
+
+
+def _section_hashes(state: object) -> dict[str, str]:
+    return {section.section_name: section.content_sha256 for section in state.sections}  # type: ignore[attr-defined]
+
+
+def _run_result(tmp_path: Path, intervention_id: str, scenario_id: str) -> dict[str, Any]:
+    source = build_hydraulic_intervention_source_state(intervention_id)
+    package = materialize_hydraulic_world(source.world_id, tmp_path / intervention_id, source_state=source)
+    request = build_hydraulic_run_request(package, scenario_id=scenario_id)
+    run = execute_hydraulic_world(package, tmp_path / f"{intervention_id}-{scenario_id}", request)
+    payload = json.loads((run / "results.json").read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return cast(dict[str, Any], payload)
+
+
+def test_intervention_registry_is_exact_public_and_answer_free() -> None:
+    assert list_hydraulic_intervention_ids() == INTERVENTION_IDS
+
+    for intervention_id in INTERVENTION_IDS:
+        first = get_hydraulic_intervention(intervention_id)
+        second = get_hydraulic_intervention(intervention_id)
+        payload = first.model_dump(mode="json")
+
+        assert first == second
+        assert first is not second
+        assert first.visibility == "public"
+        assert "expected" not in json.dumps(payload)
+        assert "pass" not in json.dumps(payload)
+
+
+@pytest.mark.parametrize(
+    ("intervention_id", "changed_sections"),
+    [
+        ("controlled_orifice_resize", {"outlet"}),
+        ("emergency_weir_enlargement", {"outlet"}),
+    ],
+)
+def test_intervention_changes_only_declared_source_sections(
+    intervention_id: str,
+    changed_sections: set[str],
+) -> None:
+    problem = build_hydraulic_problem_source_state()
+    intervention = get_hydraulic_intervention(intervention_id)
+    revised = build_hydraulic_intervention_source_state(intervention_id)
+    actual_changed = {
+        section_name
+        for section_name, content_hash in _section_hashes(problem).items()
+        if _section_hashes(revised)[section_name] != content_hash
+    }
+
+    assert set(intervention.changed_sections) == changed_sections
+    assert actual_changed == changed_sections
+    assert revised.world_id == problem.world_id
+
+
+@pytest.mark.parametrize(
+    ("intervention_id", "scenario_id", "peak_outflow", "minimum_freeboard", "failed_criteria"),
+    [
+        ("controlled_orifice_resize", "design-10yr", 0.392365, 0.914051, set()),
+        ("controlled_orifice_resize", "major-100yr", 1.617686, 0.303073, set()),
+        ("emergency_weir_enlargement", "design-10yr", 0.321368, 0.834846, set()),
+        (
+            "emergency_weir_enlargement",
+            "major-100yr",
+            1.626967,
+            0.337831,
+            {"pipe_capacity"},
+        ),
+    ],
+)
+def test_intervention_scenario_matrix_has_distinct_physical_consequences(
+    tmp_path: Path,
+    intervention_id: str,
+    scenario_id: str,
+    peak_outflow: float,
+    minimum_freeboard: float,
+    failed_criteria: set[str],
+) -> None:
+    result = _run_result(tmp_path, intervention_id, scenario_id)
+
+    assert result["peak_structured_outflow_m3_s"] == pytest.approx(peak_outflow, abs=1e-6)
+    assert result["minimum_freeboard_m"] == pytest.approx(minimum_freeboard, abs=1e-6)
+    assert {criterion_id for criterion_id, passed in result["criteria"].items() if not passed} == failed_criteria
+
+
+def test_problem_source_requires_an_intervention_for_the_major_event(tmp_path: Path) -> None:
+    source = build_hydraulic_problem_source_state()
+    package = materialize_hydraulic_world(source.world_id, tmp_path / "problem", source_state=source)
+    request = build_hydraulic_run_request(package, scenario_id="major-100yr")
+    run = execute_hydraulic_world(package, tmp_path / "problem-run", request)
+    result = json.loads((run / "results.json").read_text(encoding="utf-8"))
+
+    assert {criterion_id for criterion_id, passed in result["criteria"].items() if not passed} == {
+        "freeboard",
+        "pipe_capacity",
+    }

--- a/tests/task_world_templates/test_products.py
+++ b/tests/task_world_templates/test_products.py
@@ -40,6 +40,7 @@ def test_builtin_catalogue_covers_composite_task_world_templates() -> None:
         "drainage-model-run-provenance-issue-review-package",
         "level-crossing-warning-issue-review-package",
         "hydraulic-interaction-lifecycle-review",
+        "hydraulic-design-response-lifecycle-review",
         "drainage-model-evidence-lifecycle-review",
     ]
     assert all(template.data_gaps for template in templates)


### PR DESCRIPTION
## Summary

- Add a successor SSC-03 lifecycle in which the model must archive one bounded physical intervention before its consequences are revealed.
- Preserve the PR21 calibration family and PR22 sealed-audit identity unchanged; this is a separate successor task.
- Bind the archived choice to the exact activated source package, reuse unaffected hydrology, and recompute the detention and HGL chain affected by the intervention.
- Add task-owned verification for selection grounding, operation provenance, selective recomputation, downstream decision updates, and final readiness.
- Cap reward at `0.5` when the selected intervention remains physically ineffective, even when the model reports that failure honestly.
- Add a generic credential-free CLI smoke path that exercises the production lifecycle host, operation store, hydraulic engine, immutable submissions, and verifier.

## Why

PR17 and PR19 let the model request analyses that change which evidence becomes visible, but the host still selected the source revision. This successor lifecycle moves one step further: the model chooses a physical change, commits to it, and then has to reason through the consequences that choice creates.

The two public choices are deliberately different. Resizing the controlled orifice resolves the declared major-event criteria. Enlarging the emergency weir improves freeboard but leaves pipe capacity failed. The benchmark can therefore distinguish a well-grounded choice from an honestly documented but ineffective one.

## Review guide

1. `hydraulics/interventions.py` defines the two bounded source transformations.
2. `hydraulics/intervention_operations.py` activates the archived choice and records immutable source identity.
3. `lifecycles/ssc03_hydraulic_intervention.py` materializes the four-checkpoint task.
4. `lifecycles/ssc03_hydraulic_intervention_verifier.py` checks provenance, recomputation, effectiveness, and the reward cap.
5. `meta_harness/evidence_lifecycle.py` enforces prior-submission immutability before resolver planning.
6. The adversarial regressions cover post-release selection tampering, undeclared package hijacking, invalid submissions, and missing-major-evidence reward inflation.

## Claim boundary

This is a synthetic hydraulic screening task. It is not project design assurance, authority acceptance, SWMM validation, model-performance evidence, post-training evidence, or continual learning. No provider or model call was made while developing or validating this PR.

## Validation

- Real credential-free workflow: 4 checkpoints completed, all 11 verifier gates passed, reward `1.0`.
- Focused intervention, predecessor-verifier, product, and CLI slice: `53 passed`.
- Ruff check and format check over `src` and `tests`: clean.
- Strict mypy over the changed source modules: clean.
- `git diff --check`: clean.
- Independent final review: no remaining P0-P2 findings.

## Stack

This draft is based on PR #22 (`feat/ssc03-sealed-holdout-audit`) so reviewers see only the successor-task change.
