### PR TITLE
Add ASW-0B2 evidence and rights pack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ research/asset-stewardship/*
 !research/asset-stewardship/asset-stewardship-worlds-prd.md
 !research/asset-stewardship/temporal-evidence-frontier-prd.md
 !research/asset-stewardship/au-nsw-lh-syn-sps-v1-claim-and-profile.md
+!research/asset-stewardship/au-nsw-lh-syn-sps-v1-evidence-and-rights-pack.md
 
 # Local run outputs from aec-bench run-local
 _local_runs/

--- a/research/asset-stewardship/au-nsw-lh-syn-sps-v1-evidence-and-rights-pack.md
+++ b/research/asset-stewardship/au-nsw-lh-syn-sps-v1-evidence-and-rights-pack.md
@@ -1,0 +1,448 @@
+# ABOUTME: Freezes the ASW-0B2 evidence, rights, claim mapping, unit authority, and research-to-runtime exclusions for the first reference profile.
+# ABOUTME: Accepts no engine role, numerical mechanism, generated world, runtime schema, or validity claim ahead of its later gated stage.
+
+# `AU-NSW-LH-SYN-SPS-v1` evidence and rights pack
+
+| Field | Value |
+| --- | --- |
+| Stage | `ASW-0B2 — evidence and rights pack` |
+| Status | ASW-0B2 accepted; ASW-0B3 is the next permitted stage |
+| Recorded | 2026-07-27 |
+| Reference profile | `AU-NSW-LH-SYN-SPS-v1` |
+| Parent authority | [Asset Stewardship Worlds PRD](asset-stewardship-worlds-prd.md), revision `ASW-PRD-F-2026-07-27` |
+| Required parent SHA-256 | `56d6fe6a9c69796d819a1995ae63a85392ba85a4240df8baa87df99a76678335` |
+| Accepted predecessor | [ASW-0B1 claim and profile freeze](au-nsw-lh-syn-sps-v1-claim-and-profile.md) |
+| Required predecessor SHA-256 | `1956883951dd70ce52ec89f4c24ed69e5aaa4617796b803668e44002eafed954` |
+| Claim maturity | Evidence and rights authority only; V0, V1, V2, V3, and V4 have not been earned |
+| Contract status | Design and provenance authority only; not a runtime schema, package manifest, persisted payload, public API, compliance statement, or compatibility promise |
+
+## 1. Stage decision
+
+ASW-0B2 accepts a bounded evidence basis and conservative rights treatment for
+the fictional reference profile. The accepted basis is sufficient to:
+
+- preserve the original synthetic profile assumptions as `S` evidence;
+- treat a duplex submersible wastewater pumping station as a coherent fictional
+  Lower Hunter engineering context without claiming utility compliance,
+  representativeness, or approval;
+- retain system-head, operating-point, conservation, and hydraulic-power
+  principles as candidate physical foundations;
+- retain wastewater-pump obstruction and hydraulic-clearance loss as credible
+  candidate phenomena without accepting a universal deterioration law;
+- use SI as the dimensional authority for later synthetic construction;
+- distinguish redistributable original material from source material that may
+  only be cited, and from external prototype material that is excluded; and
+- open a focused ASW-0B3 engine-role and real-engine research spike.
+
+This stage does **not** accept:
+
+- a hydraulic engine, generator, certifier, runtime, or agent-tool role;
+- a pump curve, system curve, inflow, control level, obstruction transform,
+  deterioration law, event timing, intervention effect, operating range,
+  physical constant, tolerance, sensitivity range, or numerical parameter;
+- a prototype schema, file layout, generated input, solver output, checker
+  implementation, package manifest, or build script;
+- an executable-evidence (`E`) result or field/calibration (`C`) result;
+- a generated reference-world member or research-to-runtime promotion manifest;
+  or
+- any V0, V1, V2, V3, V4, compliance, operational, real-asset, digital-twin, or
+  benchmark-effectiveness claim.
+
+ASW-0B2 therefore accepts the **authority to construct and test** a narrowly
+claimed original synthetic family. It does not accept any constructed member of
+that family.
+
+## 2. Classification rules
+
+### 2.1 Evidence classes
+
+Every claim-critical input accepted by this pack has exactly one evidence class:
+
+| Class | Meaning in this programme |
+| --- | --- |
+| `N` | Normative legislation, regulator, standards, metrology, or utility requirements, applied only within the source's stated authority and context |
+| `P` | Physical or mechanistic primary literature, equations, or engineering principles |
+| `E` | Executable, validated, independently reproducible behaviour or a published verification case |
+| `S` | An original synthetic assumption, parameter, history, event, or scenario declared by the benchmark |
+| `C` | Calibration evidence from field, manufacturer, or SME material tied to a defined population or equipment configuration |
+
+Authority documents and research-intake artifacts are recorded for provenance,
+but are not relabelled as engineering evidence when they do not support a
+claim-critical physical, normative, executable, synthetic, or calibration
+input.
+
+### 2.2 Rights classes
+
+Every accepted source or external input has exactly one rights class:
+
+| Class | Permitted treatment |
+| --- | --- |
+| `Redistributable` | Bytes or original material may be redistributed subject to the recorded licence and attribution conditions |
+| `Derived-only` | Only a permitted transformation or derived result may be distributed; source bytes remain outside the package |
+| `Cite-only` | Store citation identity and a concise original paraphrase; do not copy source bytes, tables, figures, drawings, logos, or substantial text |
+| `Excluded` | Do not package, copy, import, derive implementation bytes from, or make a runtime dependency of the item |
+
+Public accessibility is not redistribution permission. A citation proves neither
+derivation nor applicability. A hash proves byte identity, not ownership,
+authority, licence, or correctness.
+
+### 2.3 Claim-critical input rule
+
+An input becomes claim-critical when a proposed world, generator, certifier, or
+report relies on it to establish profile meaning, a mechanism, a numerical
+result, a unit, an invariant, a tolerance, or a validity claim. Before such an
+input may be used, its record must name:
+
+1. exactly one evidence class;
+2. exactly one rights class;
+3. source authority and applicable scope;
+4. citation or content identity;
+5. the claim it supports;
+6. original and canonical units where applicable;
+7. assumptions and transformations; and
+8. the later verification that may accept or reject it.
+
+If B3 or B4 proposes an input not covered by this pack, ASW-0B2 must be amended
+and separately accepted before that input is relied upon. Later stages may
+narrow this pack; they may not silently broaden it.
+
+## 3. Authority and provenance inventory
+
+These items control programme meaning or preserve research provenance. They are
+not physical evidence merely because they are authoritative within the
+repository.
+
+| ID | Item and identity | Authority | Rights class | B2 disposition |
+| --- | --- | --- | --- | --- |
+| `AUTH-001` | [Asset Stewardship Worlds PRD](asset-stewardship-worlds-prd.md), SHA-256 `56d6fe6a9c69796d819a1995ae63a85392ba85a4240df8baa87df99a76678335` | Parent programme authority | `Redistributable` under repository licence | Controls classes, gates, role separation, promotion doctrine, and stage ownership |
+| `AUTH-002` | [ASW-0A baseline and authority record](asw-0a-baseline-and-authority.md), SHA-256 `14a7f13a461efbeb33676362ceb429e02496c24d4bd603c8a756c86f9c88a439` | Accepted repository-baseline authority | `Redistributable` under repository licence | Controls baseline, ownership, dependency, and durability boundaries |
+| `AUTH-003` | [ASW-0B1 claim and profile freeze](au-nsw-lh-syn-sps-v1-claim-and-profile.md), SHA-256 `1956883951dd70ce52ec89f4c24ed69e5aaa4617796b803668e44002eafed954` | Accepted profile authority | `Redistributable` under repository licence | Supplies the original `S` profile assumptions and prohibited claims |
+| `AUTH-004` | Repository `LICENSE`, SHA-256 `a5e57c0e89c4ca0b40ae583b3ac895847abc28515323cbe6bc8f639d20af76c4` | Licence authority for original repository material | `Redistributable` | Governs original repository-authored material; does not relicense third-party sources |
+| `INTAKE-001` | Earlier pump research dossier, external SHA-256 `092dc798206bdefa13b1138c955be33399bf24bf66340b4503f928854cb93b39` | Discovery and gap-analysis input | `Cite-only` | Preserves useful source discovery and real-asset warnings; superseded as B2 decision authority by this pack |
+| `INTAKE-002` | Synthetic hydraulic-world research report, external SHA-256 `861229eb4237c7c476fcd88d68f29d0c416446803897da3487bdf2fbda70f8e8` | External research recommendation | `Cite-only` | Source discovery and B3/B4 candidate design only; its classifications and decisions are not adopted verbatim |
+| `INTAKE-003` | Supplied prototype inventory `SHA256SUMS.txt`, external SHA-256 `ffc53b1884743a133e2730120caa6aa2c71bb39d04c89e3c52f36ec23707c041` | Byte-identity evidence for the supplied prototype directory | `Excluded` | No prototype source, generated input, output, schema, configuration, script, or package layout enters this repository |
+
+The external paths used during intake are workstation locations, not canonical
+repository identifiers. Only the citations and hashes above are durable
+provenance. The external files are not runtime inputs and need not exist for any
+later runtime, verifier, or packaged task.
+
+## 4. Accepted synthetic inputs
+
+The profile itself introduces the following original assumptions. Each is
+classified once as `S` and is redistributable as original repository material.
+
+| ID | Accepted synthetic input | Evidence class | Rights class | Source authority | Limits |
+| --- | --- | --- | --- | --- | --- |
+| `S-001` | The reference profile is original and fictional | `S` | `Redistributable` | `AUTH-003` | It is not a reconstruction, anonymisation, approximation, or model of a real station |
+| `S-002` | The fictional operating context is Lower Hunter, New South Wales | `S` | `Redistributable` | `AUTH-003` | It names no utility, council, catchment, network, site, or representative population |
+| `S-003` | The benchmark asset is one pump set with exactly Pump A and Pump B as components | `S` | `Redistributable` | `AUTH-003` | Wet well, rising main, access, power, people, and spares remain context or constraint surfaces |
+| `S-004` | Pump A is initially duty and Pump B is initially standby, with one canonical A-to-B duty transfer available to the first slice | `S` | `Redistributable` | `AUTH-003` | No periodic alternation, simultaneous load sharing, adaptive selection, or control recommendation |
+| `S-005` | Future world generations will use deterministic, replayable synthetic histories | `S` | `Redistributable` | `AUTH-003` | Mechanisms, numerical values, histories, observations, and intervention effects remain unselected |
+| `S-006` | The intended construct is bounded asset stewardship across simulated time and handover | `S` | `Redistributable` | `AUTH-003` | No benchmark-suitability or treatment-effect claim exists before its later gates |
+
+The Lower Hunter label is therefore an original profile choice. Regional sources
+may show that this choice is coherent or constrain later synthetic assumptions;
+they do not convert it into an observed regional fact.
+
+## 5. Normative and unit-authority register
+
+External web sources in this pack were accessed on 27 July 2026. A source with a
+mutable current-document URL must be rechecked before a later stage extracts a
+claim-critical value or requirement from it.
+
+### 5.1 Claim-critical normative sources
+
+| ID | Source identity and inspected scope | Evidence class | Rights class | Accepted use | Prohibited inference |
+| --- | --- | --- | --- | --- | --- |
+| `N-001` | Hunter Water, [*Design Manual Section 4 — Wastewater Pump Stations and Rising Mains*](https://www.hunterwater.com.au/documents/assets/src/uploads/documents/Drawings_Plans_Specs/Water-and-sewer-design-manuals/Guideline-Design-Manual-Section-4-Wastewater-Pump-Stations-and-Rising-Mains-Current.PDF), version 13, approved 9 April 2026; inspected sections on capacity, emergency storage, pump selection, wet-well levels, access, controls, and maintenance | `N` | `Cite-only` | Establishes that the fictional profile's station context, duty/standby topology, wet-well/rising-main boundary conditions, starts, storage, access, and maintainability concerns are coherent topics in the selected regional utility context | Hunter Water compliance, approval, endorsement, a required profile value, a typical Lower Hunter station, or applicability outside the source's own project authority |
+| `N-002` | Hunter Water, [*STS 402 — Construction of Submersible Sewage Pump Stations and Rising Mains*](https://www.hunterwater.com.au/documents/assets/src/uploads/documents/Drawings_Plans_Specs/Standard-Technical-Specifications/Civil/STS402-Construction-of-Submersible-Sewage-Pump-Stations-and-Rising-Mains.pdf), version 1.3, approved 9 April 2026; inspected purpose, construction, testing, and commissioning scope | `N` | `Cite-only` | Corroborates the regional coherence of a submersible sewage-pump-station and rising-main context and the importance of inspectable construction/commissioning boundaries | A design input, copied technical requirement, real station, utility acceptance, or operational instruction |
+| `N-003` | BIPM, [*The International System of Units (SI Brochure)*](https://www.bipm.org/en/publications/si-brochure), ninth edition, updated 2026, DOI [10.59161/AUEZ1291](https://doi.org/10.59161/AUEZ1291) | `N` | `Redistributable` under CC BY 4.0 with attribution | Authoritative quantity and SI-unit vocabulary for later manifests, calculations, transformations, and reports | Numerical parameter authority, engineering applicability, or proof that a calculation is dimensionally or physically correct |
+| `N-004` | U.S. Army Corps of Engineers, [*Sanitary and Industrial Wastewater Pumping*](https://www.publications.usace.army.mil/Portals/76/Publications/EngineerManuals/EM_1110-3-173.pdf), `EM 1110-3-173`, 9 April 1984 | `N` | `Cite-only` | Historical government engineering context supporting the qualitative relevance of wastewater solids, rags, clogging, and abrasive grit to pump selection and maintenance | Old military guidance; not a Lower Hunter requirement, current design rule, deterministic blockage transition, selected-pump model, or numerical authority |
+
+Hunter Water's [copyright and disclaimer](https://www.hunterwater.com.au/copyright-and-disclaimer)
+is the controlling rights pointer for `N-001` and `N-002`. Although that page
+permits some copying with notice, it reserves conditions for modification and
+commercial-product use and excludes third-party material. This programme
+therefore applies the narrower `Cite-only` treatment: link and paraphrase; do
+not bundle, modify, or reproduce source pages, tables, drawings, logos, or
+substantial text.
+
+### 5.2 Supplementary normative context
+
+The earlier dossier identified the following owner-specific sources. They remain
+useful corroboration but are not claim-critical to the Lower Hunter profile and
+do not supply profile values:
+
+| ID | Source | Evidence class | Rights class | B2 treatment |
+| --- | --- | --- | --- | --- |
+| `N-S01` | Water Corporation, [*DS 32 — Pump Stations: Conventional Water and Sewage — Mechanical*](https://pw-cdn.watercorporation.com.au/-/media/WaterCorp/Documents/About-us/Suppliers-and-contractors/Resources/Design-standards/DS32-Pump-Stations-Mechanical.pdf), version 1 revision 5, September 2024 | `N` | `Cite-only` | Secondary context for redundancy, maintenance, testing, spares, and repair; not transferable as a Lower Hunter rule |
+| `N-S02` | Water Corporation, [*DS 51 — Design and Construction of Wastewater Pumping Stations and Pressure Mains*](https://www.watercorporation.com.au/-/media/WaterCorp/Documents/About-us/Suppliers-and-contractors/Resources/Design-standards/DS51-DesignConstructionofWastewaterPumpingStationsPressureMains4to90LitresperSecondCapacity.pdf), version 2 revision 17, September 2025 | `N` | `Cite-only` | Secondary context for pump duty, cycling, storage, and response constraints; no numerical value is adopted |
+| `N-S03` | SA Water, [*TS 0220 — Requirements for Pump Specification, Procurement and Testing*](https://www.sawater.com.au/__data/assets/pdf_file/0009/776070/SAWS-ENG-0220.pdf), revision 1.0, 8 December 2023 | `N` | `Cite-only` | Secondary procurement and test context; confidential/copyright markings prevent packaging |
+| `N-S04` | SA Water, [*WWPS Interim Design Requirements*](https://www.sawater.com.au/__data/assets/pdf_file/0005/688136/Technical-Bulletin-WWPS-Interim-Design-Requirements.pdf), version 1.0, 12 January 2023 | `N` | `Cite-only` | Secondary access and maintainability context only |
+| `N-S05` | Uisce Éireann / Irish Water, [*PUMPS*](https://www.water.ie/docs/standards-portal/IW-TEC-1000-03-02.pdf), document `IW-TEC-1000-03-02`, revision 1.0 | `N` | `Cite-only` | Secondary duty/standby and works-test context only; date and applicability limitations remain |
+
+These sources cannot outvote or extend the selected regional source. If later
+work relies on one of them for a claim-critical input, its exact current
+identity, applicability, rights, and claim mapping must be promoted from
+supplementary to claim-critical through a B2 amendment.
+
+## 6. Physical and mechanistic evidence register
+
+| ID | Source identity and inspected scope | Evidence class | Rights class | Accepted use | Limitation |
+| --- | --- | --- | --- | --- | --- |
+| `P-001` | Hydraulic Institute, [*Pump System Curves*](https://datatool.pumps.org/pump-fundamentals/sys-curves), public Data Tool, last-updated date recorded by the prior dossier as 19 July 2024 | `P` | `Cite-only` | Candidate physical basis for static head, friction and minor losses, system curves, and the pump/system operating-point concept | Educational guidance; supplies no profile geometry, pump curve, parameter, operating range, or verification tolerance |
+| `P-002` | U.S. Department of Energy and Hydraulic Institute, [*Improving Pumping System Performance: A Sourcebook for Industry*](https://www.energy.gov/sites/prod/files/2014/05/f16/pump.pdf), second edition, May 2006, `DOE/GO-102006-2079` | `P` | `Cite-only` | Corroborates general pump/system behaviour, multiple-pump arrangements, hydraulic power/efficiency concepts, and maintenance context | General industrial guidance; credited third-party content and no wastewater-profile calibration |
+| `P-003` | F. Brokhausen, E. Herfurth, D. Beck, and P. U. Thamsen, [“Exploring Characteristics of Time-Resolved Signals in the Operation of Wastewater Pumps”](https://www.euroturbo.eu/paper/ETC2023-237.pdf), `ETC2023-237`, 2023 | `P` | `Cite-only` | Supports obstruction/ragging as a credible wastewater-pump phenomenon whose measured response depends on pump design, contamination, and operating point and may alter head, flow, power, efficiency, and time-resolved signals in non-universal ways | Individual pump identities and raw mappings are not disclosed; results are not a transition law, failure rate, synthetic multiplier, or transferable pump curve |
+| `P-004` | X. Wu, X. Du, M. Tan, and H. Liu, [“Experiment and simulation about the effect of wear-ring abrasion on the performance of a marine centrifugal pump”](https://doi.org/10.1177/1687814021998115), *Advances in Mechanical Engineering* 13(2), 2021 | `P` | `Redistributable` under CC BY 4.0 with attribution | Supports hydraulic-clearance loss as a physically credible secondary candidate capable of affecting pump performance | One marine-pump configuration; not evidence that the eventual synthetic wastewater pump has wear rings, not a wear-rate law, and not authority for parameter transfer |
+| `P-S01` | Robert Connolly, [*An experimental and numerical investigation into flow phenomena leading to wastewater centrifugal pump blockage*](https://doras.dcu.ie/21969/), Dublin City University, 2017 | `P` | `Cite-only`; repository licence is CC BY-NC-ND 3.0 | Supplementary corroboration of design- and operating-point-dependent blockage behaviour | Thesis evidence only; no derivative content, raw-data transfer, transition law, or claim-critical parameter is accepted |
+
+The physical register accepts candidate mechanism **forms and principles only**.
+It does not select the primary or secondary mechanism, prescribe how a latent
+state evolves, or authorize a numerical transformation. ASW-0B4 must either
+construct a bounded original synthetic mechanism supported by this evidence and
+falsification tests, or return to B2 with a new source.
+
+## 7. Claim register and direct source mapping
+
+| Claim ID | B2 claim | Claim-critical inputs | Evidence basis | B2 status and ceiling |
+| --- | --- | --- | --- | --- |
+| `CL-001` | `AU-NSW-LH-SYN-SPS-v1` is an original fictional profile, not a real station | `S-001`, `S-002` | `S` | Accepted; no representativeness, reconstruction, or calibration inference |
+| `CL-002` | One fictional duplex submersible wastewater pump set is coherent within the selected Lower Hunter engineering context | `S-002`, `S-003`, `N-001`, `N-002` | Each input retains its own `S` or `N` class | Accepted as contextual coherence only; V2 and compliance remain unearned |
+| `CL-003` | An A-duty/B-standby arrangement is a legitimate bounded synthetic topology | `S-004`, `N-001` | Each input retains its own `S` or `N` class | Accepted as a benchmark topology; not a controller design or operational recommendation |
+| `CL-004` | Wet-well, incoming wastewater, discharge, storage, access, outage, people, and spares may be represented as explicit context or constraint surfaces | `S-003`, `N-001`, `N-002` | Each input retains its own `S` or `N` class | Accepted subject to the B1 rule that they do not become additional managed assets |
+| `CL-005` | System head, pump/system intersection, conservation, and hydraulic power are credible candidate physical foundations | `P-001`, `P-002` | `P` | Accepted as principles; equations, constants, numerical methods, and tolerances remain B4 decisions |
+| `CL-006` | Ragging or obstruction is a credible primary-mechanism candidate for a wastewater pump, but its response is design- and operating-point-dependent | `N-004`, `P-003` | Each input retains its own `N` or `P` class | Accepted as a candidate phenomenon; no universal curve, progression law, multiplier, or failure rate |
+| `CL-007` | Hydraulic-clearance loss is a credible secondary-mechanism candidate in a pump configuration that actually contains the relevant clearance surface | `P-004` | `P` | Accepted only as a candidate; B4 must establish applicability or reject it |
+| `CL-008` | Calendar time, operating runtime, and start count are meaningfully distinct quantities for later synthetic construction | `S-005`, `N-001`, `P-002` | Each input retains its own `S`, `N`, or `P` class | Accepted semantically; clocks, counting rules, limits, and histories remain later decisions |
+| `CL-009` | Storage, access, outage, spare, and repair constraints can make stewardship decisions consequential | `S-003`, `N-001`, `N-002` | Each input retains its own `S` or `N` class | Accepted as available design support; no exact constraint or schedule is selected |
+| `CL-010` | SI provides the dimensional authority for later values and derivations | `N-003` | `N` | Accepted; dimensional authority is not evidence for a numerical value or physical model |
+| `CL-011` | No executable hydraulic behaviour has been accepted | None | No `E` input accepted | Closed as a B2 exclusion; B3 owns the first possible executable evidence |
+| `CL-012` | No field, manufacturer, or population-linked calibration evidence has been accepted | None | No `C` input accepted | Closed as a claim limit; V4 remains optional and unclaimed |
+
+No claim in this register is a V-level pass. The accepted source base may later
+contribute to V1 or V2 only when one exact generated world passes the required
+B4/B5 derivation, sensitivity, reproduction, and certification gates.
+
+## 8. Assumption, derivation, and transformation register
+
+### 8.1 Current assumptions
+
+| Assumption ID | Assumption | Evidence class | Source | Rights class | Later owner |
+| --- | --- | --- | --- | --- | --- |
+| `A-001` | The regional setting is fictional Lower Hunter rather than a named utility asset | `S` | `S-001`, `S-002` | `Redistributable` | Frozen by B1; all later stages preserve the nonclaim |
+| `A-002` | The asset has exactly two pump components | `S` | `S-003` | `Redistributable` | Frozen by B1 |
+| `A-003` | A is initially duty, B is initially standby, and the first slice permits one A-to-B transfer | `S` | `S-004` | `Redistributable` | Frozen topology; B4 owns trigger/consequence and 0C owns scenario timing |
+| `A-004` | Future physical histories are deterministic and original rather than inferred from a real station | `S` | `S-005` | `Redistributable` | B4 must construct and justify the family; B5 must certify or reject members |
+| `A-005` | V4 calibration is unnecessary for the explicitly synthetic claim | `S` | `AUTH-001`, `AUTH-003` | `Redistributable` | Original programme decision; V4 remains optional and any later empirical claim requires new `C` evidence |
+
+### 8.2 No accepted numerical derivations
+
+ASW-0B2 contains **no accepted numerical derivation**. In particular:
+
+- no source value has been copied or converted into a profile value;
+- no source table, curve, figure, sample, or equation output has been digitised;
+- no report or prototype parameter has been adopted;
+- no synthetic parameter has been sampled;
+- no engine output has been accepted; and
+- no `Derived-only` input is needed by the present claim set.
+
+The current transformation chain is limited to:
+
+```text
+source identity
+  -> applicability and rights review
+  -> concise original paraphrase
+  -> bounded qualitative claim
+  -> later-stage question
+```
+
+This chain does not produce a runtime value. Any B4 value must instead carry a
+complete record:
+
+```text
+source or declared synthetic assumption
+  -> exact transformation and equation
+  -> original unit and canonical unit
+  -> generated value and precision
+  -> independent dimensional and physical check
+  -> sensitivity and boundary tests
+  -> accepted or rejected generation
+```
+
+Citation alone cannot occupy the transformation step, and a shared implementation
+cannot be its own independent check.
+
+## 9. Unit and dimensional policy
+
+`N-003` is the unit authority. Later generator, certifier, and promotion records
+must use unambiguous quantity types rather than bare numbers.
+
+| Quantity | Symbol where used | Canonical internal unit | Permitted source or presentation unit | Required treatment |
+| --- | --- | --- | --- | --- |
+| Volumetric flow rate | `Q` | cubic metre per second (`m³/s`) | litre per second (`L/s`) | Retain original unit and exact conversion |
+| Head, level, length, diameter, roughness | `H`, `L`, `D` where applicable | metre (`m`) | millimetre (`mm`) | Name the quantity; do not treat head as pressure without an explicit relation |
+| Volume | `V` | cubic metre (`m³`) | litre (`L`) | Retain original unit and exact conversion |
+| Duration, runtime, interval | `t` | second (`s`) | minute (`min`), hour (`h`), day (`d`) | Record the clock domain and conversion |
+| Pressure | `p` | pascal (`Pa`) | kilopascal (`kPa`) | Keep distinct from head |
+| Power | `P` | watt (`W`) | kilowatt (`kW`) | Distinguish hydraulic, shaft, and electrical power |
+| Energy | `E` | joule (`J`) | kilowatt-hour (`kWh`) | State the integration basis |
+| Density | `ρ` | kilogram per cubic metre (`kg/m³`) | None by default | Source or declare the value in B4 |
+| Dynamic viscosity | `μ` | pascal second (`Pa·s`) | None by default | Source or declare the value and temperature basis in B4 |
+| Efficiency or fraction | context-specific | dimensionless fraction | percent (`%`) | Preserve whether the source uses fraction or percentage |
+| Start count | none | integer count | starts per declared interval | Define event edge and clock window before use |
+| Role, status, restriction, evidence quality | none | typed non-numeric value | None | Never encode as a dimensionless physical quantity |
+
+This table freezes quantity and unit policy, not numerical constants, acceptable
+ranges, rounding, solver precision, or tolerances. Every later numerical record
+must state original value/unit, canonical value/unit, exact conversion,
+significant-digit or precision treatment, evidence class, rights class,
+assumptions, transform, output, and independent check.
+
+## 10. Redistribution and runtime disposition
+
+| Material | Rights class | May enter this research pack? | May enter a future distributable runtime package? | Rule |
+| --- | --- | --- | --- | --- |
+| Original profile statements and repository-authored paraphrases | `Redistributable` | Yes | Only if explicitly named by a later promotion manifest | Repository licence applies |
+| BIPM and Wu material covered by CC BY 4.0 | `Redistributable` with attribution | Citation metadata and original paraphrase only in B2 | Only exact later-approved material with attribution and a demonstrated runtime need | Permissive rights do not establish applicability |
+| Hunter Water, Water Corporation, SA Water, Uisce Éireann, Hydraulic Institute, DOE, USACE, Brokhausen, and Connolly source bytes | `Cite-only` | Links, identity, applicability, limits, and concise original paraphrase only | No source bytes | Runtime may retain only permitted citation metadata if the later manifest names it |
+| Earlier dossier and hydraulic research report | `Cite-only` | Hash, role, and conclusions may be recorded | No source bytes and no dependency | They are research inputs, not world truth |
+| Supplied prototype directory and inventory-covered files | `Excluded` | Hash and exclusion decision only | No | No code, schema, input, output, script, configuration, or path is promoted |
+| Raw future engine inputs/outputs, build trees, reports, and discarded candidates | Not yet classified; default `Excluded` from runtime | Research-stage evidence only after B3 classification | No, unless a later manifest names a separately rights-cleared semantic artifact | Raw research material never enters by path coincidence |
+| Future original synthetic values and promoted semantic artifacts | Not yet created | Later B4/B5 records only | Only after classification, independent certification, and exact manifest allowlisting | Originality does not waive provenance or certification |
+
+The runtime package must load, execute, replay, and verify with research
+directories, source documents, external workstation paths, raw engine outputs,
+and generator installations physically absent. Nothing in this B2 document is a
+runtime package shape or a promise that a citation field will exist in code.
+
+## 11. Prior-dossier reconciliation and supersession
+
+The earlier pump dossier correctly blocked claims that required a selected real
+pump, licensed pump-specific curves, empirical deterioration data, utility
+approval, or SME validation. Those warnings remain valid for any future
+real-equipment, population, operational, safety, compliance, reliability,
+remaining-useful-life, or V4 calibration claim.
+
+They do not block the narrower programme now frozen in B1: an original,
+deterministic synthetic family whose assumptions are explicit and whose
+robustness is independently tested. The following reconciliation prevents the
+change in claim boundary from being mistaken for evidence that the old gaps were
+filled:
+
+| Earlier hold | B2 ruling | Later requirement |
+| --- | --- | --- |
+| No selected commercial pump or real station | Not required for the fictional profile; no real analogue will be implied | B4 must define an original bounded synthetic configuration |
+| No licensed pump-specific clean/fouled curves | The profile will not claim equipment-specific performance | B4 may construct original curves only with complete assumptions, physical support, units, sensitivities, and stop rules |
+| No empirical blockage progression law | Still absent; no universal law is inferred from qualitative literature | B4 must construct and preregister a synthetic mechanism, or select another supported mechanism |
+| No source-derived tolerances | Still absent | B4 owns tolerance derivation; B5 must reject fragile members |
+| No complete raw-data redistribution permission | Resolved for B2 by adopting no external raw data and treating source bytes conservatively | B5 promotion must contain no `Cite-only` or `Excluded` bytes |
+| No SME approval | Not required for the explicitly synthetic V3 target | Required only for a later claim whose authority actually depends on SME or field evidence |
+| No pump-specific alarm, maintenance, or return-to-service rules | Still absent and not invented here | ASW-0B4, ASW-0C, and ASW-1 must construct bounded benchmark semantics without presenting operational prescriptions |
+
+This pack supersedes the earlier dossier **only as the ASW-0B2 decision
+authority**. It does not erase the dossier, turn an old `insufficient data`
+finding into empirical evidence, or relax the prohibited claims.
+
+## 12. Hydraulic report and prototype disposition
+
+The supplied research report is accepted as a strong research contribution but
+is deliberately split by programme stage:
+
+| Supplied result | Stage owner | B2 disposition |
+| --- | --- | --- |
+| Source discovery, rights observations, regional-source pointers, and synthetic-claim reconciliation | ASW-0B2 | Rechecked, normalized, and narrowed in this pack |
+| SWMM/EPANET/OpenModelica comparison and exact software pins | ASW-0B3 | Candidate metadata only; no role accepted |
+| Portable SWMM spike, build boundary, and real-engine reproduction proposal | ASW-0B3 | External excluded prototype; must be safely re-expressed and independently executed before any decision |
+| Clean/obstructed curves, fixed obstruction treatment, station parameters, solver settings, checker tolerances, and case definitions | ASW-0B4 | Not accepted; no value or model is imported by this pack |
+| Generated trajectories, repeated real-engine runs, sensitivity results, and V0–V3 claims | ASW-0B5 | Not produced and not claimed |
+
+SWMM 5.2.4 at the report's pinned commit remains the leading B3 candidate, but
+that is a research priority rather than an engine-role decision. The portable
+test result was not a real-engine trajectory, the integration gates were
+skipped, and the supplied reproduction boundary still requires fail-closed and
+provenance repair. B3 must begin from the B1 topology and this B2 pack, not from
+an assumption that the prototype is authoritative.
+
+No supplied prototype bytes are copied or derived into this repository. An idea
+described by the report is not a reusable implementation: if B3 investigates
+one, it must cite the report, independently specify and re-express the semantics
+in an isolated non-authoritative research workspace, record provenance, and
+pass a new review. A successful B3 spike can decide software roles; it cannot
+freeze the B4 family, certify a B5 generation, define an ASW-2 contract, or
+award task success.
+
+## 13. Open questions and later owners
+
+| Open question | Current B2 answer | Owning stage and required evidence |
+| --- | --- | --- |
+| Which software, if any, should generate hydraulic consequences? | Unselected; SWMM is the leading research candidate | ASW-0B3: pinned, licensed, real execution with safe build receipt, exact inputs/outputs, warnings, repeatability, and independent checks |
+| Can one software path serve as generator and certifier? | No unchecked self-certification | ASW-0B3: explicit role decision; ASW-0B4: separately executable certifier and common-mode controls |
+| Should a live solver be used at runtime? | Deferred; no live-solver dependency exists | ASW-0B3 may defer the role; any later authorization needs deterministic replay, availability, failure, cost, and version controls |
+| Which primary and secondary mechanisms are selected? | Obstruction and clearance loss are candidates only | ASW-0B4: mechanism selection, applicability, constructed family, equations, sensitivities, and stop rules |
+| What are the pump, system, inflow, storage, and control values? | None selected | ASW-0B4: original synthetic parameter family with complete derivation and units |
+| What triggers and physically follows the A-to-B duty transfer? | Unselected | ASW-0B4: physical trigger and consequence |
+| When does transfer occur in the first scenario? | Unselected | ASW-0C after B5: scenario timing and fixed histories |
+| What observations differ from latent truth? | Unselected | ASW-0B4: observation model; B5: paired and sensitivity certification |
+| What maintenance, restriction, intervention, and verification actions exist? | Semantically required but unspecified | ASW-0C/ASW-1: bounded scenario and authority semantics; no operational prescription |
+| Which world members reach V0–V3? | None exist | ASW-0B5: generation, replay, independent certification, rejection log, and promotion decision |
+| Is V4 calibration required? | No | Optional future stage only if a narrower empirical claim and admissible `C` evidence justify it |
+
+No open item in this table is a hidden B2 defect. Each is deliberately outside
+the accepted B2 authority and blocks its dependent later claim until its named
+stage resolves it.
+
+## 14. Contract, boundary, and staging guardrails
+
+This document is a dossier authority, not a data model. The following rules
+apply to all continuation work:
+
+1. Do not create an importable model, source package, engine adapter, registry
+   identifier, CLI surface, persisted layout, example, or `TrialRecord` field
+   during ASW-0B2 or by interpreting this Markdown structure as a schema.
+2. Keep B3 engines, build trees, scripts, generated inputs, raw outputs,
+   receipts, and experiments in an isolated non-authoritative research
+   workspace. Their filesystem paths are not contracts.
+3. Do not place `Cite-only` or `Excluded` bytes in a distributable or
+   agent-visible package.
+4. Do not let one solver or wrapper generate a claim and certify its own
+   correctness. Shared equations, parameters, units, or libraries must be
+   disclosed and independently checked.
+5. Do not freeze B4 values while repairing B3 execution, and do not change B1
+   topology to fit a convenient engine fixture.
+6. Do not create a production package before B5 issues an exact promotion
+   manifest for an independently certified generation.
+7. When promotion is eventually authorized, re-express only the approved
+   semantics in the owning asset-local package. Do not import from research,
+   temporary, download, build, or run directories.
+8. Treat every stage as a separate reviewable change with its own allowlist,
+   focused validation, acceptance decision, and rollback surface.
+
+The sole durable B2 artifact is this authority document. Supporting intake
+material remains ignored, non-contractual research evidence and does not become
+a second source of runtime truth.
+
+## 15. ASW-0B2 acceptance gate
+
+| Gate | Assessment |
+| --- | --- |
+| Parent and predecessor binding | Pass: exact parent, B1, baseline, licence, and intake identities are recorded |
+| Evidence classification | Pass: every accepted claim-critical input has exactly one `N`, `P`, or `S` class; no `E` or `C` result is implied |
+| Rights classification | Pass: every accepted source/input is `Redistributable`, `Cite-only`, or `Excluded`; no unrecorded or ambiguous `Derived-only` content is used |
+| Claim mapping | Pass: accepted synthetic, regional-context, physical-principle, candidate-mechanism, constraint, clock, and unit claims map directly to bounded sources |
+| Applicability | Pass: utility, industry, government, and research sources retain explicit authority limits and cannot imply compliance or transferability |
+| Derivation | Pass for B2: no numerical derivation or source value is accepted; the mandatory later derivation chain is explicit |
+| Units | Pass: BIPM SI is the authority and every anticipated quantity has an unambiguous canonical type/unit policy without freezing a value |
+| Assumptions | Pass: original profile assumptions are separate from normative and physical evidence |
+| Redistribution | Pass: source bytes, external dossiers, prototype material, raw engine artifacts, and future research outputs are separable from any distributable runtime |
+| Prior-dossier reconciliation | Pass: real-asset and empirical holds remain valid while the narrower original-synthetic claim is allowed |
+| Prototype boundary | Pass: no prototype byte, path, schema, configuration, numerical result, or role becomes repository or runtime authority |
+| Contract boundary | Pass: this Markdown authority introduces no importable, persisted, CLI, registry, example, or compatibility-bearing surface |
+| Deferred ownership | Pass: engine roles, numerical family, certification, scenario, runtime, and optional calibration each have a named later owner |
+| Claim maturity | Pass: V0 through V4 remain unearned and no compliance, operational, representative, real-asset, or digital-twin claim is made |
+| Exit gate | Pass: every B2 claim-critical input is lawful, attributable, dimensioned where applicable, and separable from distributable runtime material |
+
+ASW-0B2 acceptance authorises **ASW-0B3 — engine roles and research spike** as
+the only next programme stage. It does not authorise ASW-0B4, ASW-0B5, ASW-0C,
+ASW-1, ASW-2, a runtime package, or any Temporal Evidence Frontier work by
+implication.


### PR DESCRIPTION
## Summary

- Freeze the ASW-0B2 evidence, rights, claim mapping, assumption, and unit authority for `AU-NSW-LH-SYN-SPS-v1`.
- Reconcile the earlier real-asset evidence holds with the narrower original-synthetic claim boundary.
- Record direct source applicability, conservative redistribution treatment, prototype exclusion, and later-stage ownership.

## Boundary

- Track only the self-contained ASW-0B2 authority and its exact `.gitignore` exception.
- Keep the supporting SWMM intake-review bundle ignored and non-contractual.
- Accept no engine role, prototype code, numerical parameter, generated world, runtime schema, or V0-V4 claim.
- Authorize only the separately reviewed ASW-0B3 stage.

## Validation

- Reverified all recorded local and external authority hashes.
- Validated Markdown table widths, declared claim-input references, and local links.
- Confirmed the intake bundle remains ignored and only the two durable files enter Git scope.
- Passed whitespace, allowlist, forbidden-prototype-value, and staged-diff checks.
- No full code suite was run for this documentation-only change; validation remained focused on the affected authority boundary.