### PR TITLE
research: complete ASW-0B3 engine role spike

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,20 @@ research/asset-stewardship/*
 !research/asset-stewardship/temporal-evidence-frontier-prd.md
 !research/asset-stewardship/au-nsw-lh-syn-sps-v1-claim-and-profile.md
 !research/asset-stewardship/au-nsw-lh-syn-sps-v1-evidence-and-rights-pack.md
+!research/asset-stewardship/asw-0b3-swmm-engine-spike/
+research/asset-stewardship/asw-0b3-swmm-engine-spike/*
+!research/asset-stewardship/asw-0b3-swmm-engine-spike/README.md
+!research/asset-stewardship/asw-0b3-swmm-engine-spike/fixtures/
+!research/asset-stewardship/asw-0b3-swmm-engine-spike/fixtures/spike-probes.json
+!research/asset-stewardship/asw-0b3-swmm-engine-spike/patches/
+!research/asset-stewardship/asw-0b3-swmm-engine-spike/patches/swmm-5.2.4-cmake-portability.patch
+!research/asset-stewardship/asw-0b3-swmm-engine-spike/src/
+!research/asset-stewardship/asw-0b3-swmm-engine-spike/src/asw_b3_swmm/
+!research/asset-stewardship/asw-0b3-swmm-engine-spike/src/asw_b3_swmm/*.py
+!research/asset-stewardship/asw-0b3-swmm-engine-spike/tests/
+!research/asset-stewardship/asw-0b3-swmm-engine-spike/tests/*.py
+!research/asset-stewardship/au-nsw-lh-syn-sps-v1-engine-role-decision.md
+!research/asset-stewardship/au-nsw-lh-syn-sps-v1-engine-verification-record.json
 
 # Local run outputs from aec-bench run-local
 _local_runs/

--- a/research/asset-stewardship/asw-0b3-swmm-engine-spike/README.md
+++ b/research/asset-stewardship/asw-0b3-swmm-engine-spike/README.md
@@ -1,0 +1,106 @@
+# ABOUTME: Defines the isolated ASW-0B3 real-engine spike and its non-authoritative research boundary.
+# ABOUTME: Keeps disposable diagnostic inputs and vendor build outputs separate from later world and runtime contracts.
+
+# ASW-0B3 SWMM engine spike
+
+This directory is an isolated, non-authoritative research implementation for
+`ASW-0B3 — Engine roles and research spike`. It answers one question: can the
+exact pinned SWMM engine execute and export the hydraulic semantics needed to
+make an explicit software-role decision for `AU-NSW-LH-SYN-SPS-v1`?
+
+It is not a production package, generator family, certifier, runtime adapter,
+agent tool, scenario, or promoted asset definition. Nothing under this
+directory may be imported by `src/aec_bench`. Its paths, Python names, fixture
+shape, diagnostic constants, and result layout are research conveniences, not
+contracts.
+
+## Authority boundary
+
+The spike:
+
+- starts from the accepted B1 topology of Pump A and Pump B;
+- runs one Pump-A-duty probe and one separately rendered Pump-B-duty label
+  probe;
+- never runs the two pumps together;
+- contains no duty-transfer event, timing, trigger, or control policy;
+- contains no obstruction, degradation, failure, intervention, observation,
+  maintenance, obligation, authority, handover, or scoring semantics;
+- treats every numerical fixture value and numerical comparison as disposable
+  engine-diagnostic material that ASW-0B4 must neither inherit nor cite as a
+  selected world value;
+- uses real SWMM execution and the official output library only; and
+- performs separately implemented label-symmetry, finite-value, period-count,
+  standby-zero-flow, and cylindrical-storage identity checks.
+
+The research report with external SHA-256
+`861229eb4237c7c476fcd88d68f29d0c416446803897da3487bdf2fbda70f8e8`
+provided candidate discovery and risk prompts. No supplied prototype byte,
+configuration, schema, generated input, or result was copied or treated as
+authority. This implementation was independently specified against the
+accepted B1/B2 authorities and the official pinned SWMM source.
+
+## Pinned candidate
+
+| Item | Pin |
+| --- | --- |
+| Source | `https://github.com/USEPA/Stormwater-Management-Model.git` |
+| Version | `5.2.4` |
+| Commit | `7952ca837988b1c32f791812eccc9fd64547e093` |
+| Source rights | US EPA public-domain source; verify the official repository notices with the recorded commit |
+
+The pinned source needs three CMake portability repairs on the local
+single-config Apple toolchain: an OpenMP generator expression uses a literal
+variable name, the upstream output test is registered at a configuration
+subdirectory different from its actual target path, and current CMake needs an
+explicit guarded declaration that this pinned source uses the legacy
+`FindBoost` policy. The tracked patch changes build/test wiring only. It does
+not alter solver or output calculations. Its hash and application diff are
+recorded in each build receipt.
+
+## Tracked and excluded surfaces
+
+Tracked:
+
+- this boundary statement;
+- the independently authored research source;
+- focused tests;
+- the disposable spike-only fixture declaration; and
+- the exact build-wiring patch.
+
+Excluded from Git:
+
+- cloned vendor source and `.git` data;
+- build and install trees;
+- binaries and shared libraries;
+- generated SWMM `.inp`, `.out`, and `.rpt` files;
+- terminal logs, caches, and local receipts; and
+- discarded experiments.
+
+The stage-level engine-role decision and compact verification record live one
+directory above. They contain semantic identities and hashes, not raw solver
+exports or filesystem contracts.
+
+## Focused workflow
+
+All commands are run from the repository root with the spike source on
+`PYTHONPATH`. A new, absent temporary directory must be supplied for every
+build or reproduction; the implementation never deletes or reuses a build or
+run directory.
+
+```sh
+PYTHONPATH=research/asset-stewardship/asw-0b3-swmm-engine-spike/src \
+  uv run pytest \
+  research/asset-stewardship/asw-0b3-swmm-engine-spike/tests/test_specification.py \
+  research/asset-stewardship/asw-0b3-swmm-engine-spike/tests/test_rendering.py \
+  research/asset-stewardship/asw-0b3-swmm-engine-spike/tests/test_build_boundary.py \
+  research/asset-stewardship/asw-0b3-swmm-engine-spike/tests/test_output_contract.py \
+  research/asset-stewardship/asw-0b3-swmm-engine-spike/tests/test_verification.py -q
+```
+
+The real-engine build and replay commands are documented by the CLI help after
+the focused unit boundary is green:
+
+```sh
+PYTHONPATH=research/asset-stewardship/asw-0b3-swmm-engine-spike/src \
+  uv run python -m asw_b3_swmm --help
+```

--- a/research/asset-stewardship/asw-0b3-swmm-engine-spike/fixtures/spike-probes.json
+++ b/research/asset-stewardship/asw-0b3-swmm-engine-spike/fixtures/spike-probes.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": "asw-0b3.spike-probes.v1",
+  "authority": {
+    "stage": "ASW-0B3",
+    "scope": "spike_only",
+    "promotable": false,
+    "world_parameters_selected": false,
+    "purpose": "Disposable diagnostic values used only to exercise pinned-engine calculations and export semantics."
+  },
+  "simulation": {
+    "start": "2020-01-01T00:00:00",
+    "horizon_seconds": 7200,
+    "report_step_seconds": 60,
+    "routing_step_seconds": 1,
+    "flow_units": "LPS",
+    "routing_model": "DYNWAVE",
+    "force_main_equation": "D-W",
+    "threads": 1
+  },
+  "diagnostic_geometry": {
+    "wet_well_shape": "CYLINDRICAL",
+    "wet_well_invert_m": 0.0,
+    "wet_well_max_depth_m": 3.0,
+    "wet_well_initial_depth_m": 1.5,
+    "wet_well_major_axis_m": 2.0,
+    "wet_well_minor_axis_m": 2.0,
+    "wet_well_side_slope": 0.0,
+    "dry_weather_inflow_lps": 5.0,
+    "discharge_invert_m": 5.2,
+    "discharge_max_depth_m": 3.0,
+    "outfall_invert_m": 5.0,
+    "force_main_length_m": 100.0,
+    "force_main_conduit_roughness": 0.01,
+    "force_main_diameter_m": 0.15,
+    "force_main_absolute_roughness_mm": 0.1
+  },
+  "pump_curve": [
+    [0.0, 12.0],
+    [5.0, 10.0],
+    [10.0, 7.0],
+    [15.0, 0.0]
+  ],
+  "components": ["PUMP_A", "PUMP_B"],
+  "probes": [
+    {
+      "id": "a_duty",
+      "purpose": "Initial B1 topology probe with Pump A active and Pump B inactive.",
+      "active_pump": "PUMP_A",
+      "inactive_pump": "PUMP_B"
+    },
+    {
+      "id": "b_duty_label_probe",
+      "purpose": "Separate label-symmetry probe only; not a transfer event or scenario state.",
+      "active_pump": "PUMP_B",
+      "inactive_pump": "PUMP_A"
+    }
+  ]
+}

--- a/research/asset-stewardship/asw-0b3-swmm-engine-spike/patches/swmm-5.2.4-cmake-portability.patch
+++ b/research/asset-stewardship/asw-0b3-swmm-engine-spike/patches/swmm-5.2.4-cmake-portability.patch
@@ -1,0 +1,38 @@
+diff --git a/extern/boost.cmake b/extern/boost.cmake
+index c512fb5..1e96bac 100644
+--- a/extern/boost.cmake
++++ b/extern/boost.cmake
+@@ -12,2 +12,7 @@
++if(POLICY CMP0167)
++    cmake_policy(SET CMP0167 OLD)
++endif()
++
++
+ if(WIN32)
+     set(Boost_USE_STATIC_LIBS       ON)
+diff --git a/src/solver/CMakeLists.txt b/src/solver/CMakeLists.txt
+index 8fc8504..3b73f3a 100644
+--- a/src/solver/CMakeLists.txt
++++ b/src/solver/CMakeLists.txt
+@@ -62,5 +62,5 @@
+ target_link_libraries(swmm5
+     PUBLIC
+         $<$<NOT:$<BOOL:$<C_COMPILER_ID:MSVC>>>:m>
+-        $<$<BOOL:OpenMP_C_FOUND>:OpenMP::OpenMP_C>
++        $<$<BOOL:${OpenMP_C_FOUND}>:OpenMP::OpenMP_C>
+ )
+diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
+index 6849149..4ac6bd6 100644
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -19,9 +19,5 @@
+-# Setting up tests to run from build tree
+-set(TEST_BIN_DIRECTORY "${CMAKE_BINARY_DIR}/bin/$<CONFIGURATION>")
+-
+-
+ # ctest doesn't like tests added in subdirectories so adding them here
+ add_test(NAME test_output
+-    COMMAND "${TEST_BIN_DIRECTORY}/test_output"
++    COMMAND "$<TARGET_FILE:test_output>"
+     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/outfile/data
+     )

--- a/research/asset-stewardship/asw-0b3-swmm-engine-spike/src/asw_b3_swmm/__init__.py
+++ b/research/asset-stewardship/asw-0b3-swmm-engine-spike/src/asw_b3_swmm/__init__.py
@@ -1,0 +1,4 @@
+# ABOUTME: Marks the isolated ASW-0B3 SWMM research implementation.
+# ABOUTME: Exposes no production aec-bench contract or runtime integration.
+
+"""Isolated ASW-0B3 SWMM research spike."""

--- a/research/asset-stewardship/asw-0b3-swmm-engine-spike/src/asw_b3_swmm/__main__.py
+++ b/research/asset-stewardship/asw-0b3-swmm-engine-spike/src/asw_b3_swmm/__main__.py
@@ -1,0 +1,6 @@
+# ABOUTME: Runs the isolated ASW-0B3 research CLI as a Python module.
+# ABOUTME: Delegates all path and authority checks to the narrow CLI implementation.
+
+from asw_b3_swmm.cli import main
+
+raise SystemExit(main())

--- a/research/asset-stewardship/asw-0b3-swmm-engine-spike/src/asw_b3_swmm/build.py
+++ b/research/asset-stewardship/asw-0b3-swmm-engine-spike/src/asw_b3_swmm/build.py
@@ -1,0 +1,296 @@
+# ABOUTME: Builds the exact pinned SWMM source in a fresh research workspace and records provenance.
+# ABOUTME: Applies only the hashed CMake portability patch and never deletes or reuses build material.
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from asw_b3_swmm.constants import SWMM_COMMIT, SWMM_REPOSITORY, SWMM_VERSION
+
+
+class BuildBoundaryError(RuntimeError):
+    """Raised when the pinned build cannot be proven or crosses its safe workspace boundary."""
+
+
+def sha256_file(path: Path) -> str:
+    """Return the SHA-256 identity of one file."""
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def assert_absent_workspace(path: Path) -> None:
+    """Reject all existing workspace paths so no stale output can be reused."""
+    if path.exists() or path.is_symlink():
+        raise BuildBoundaryError(f"workspace already exists and will not be reused: {path}")
+
+
+def validate_version_output(output: str) -> None:
+    """Require the CLI version response to be exactly the selected candidate version."""
+    if re.fullmatch(r"\s*5\.2\.4\s*", output) is None:
+        raise BuildBoundaryError(f"engine version must be exactly {SWMM_VERSION!r}; got {output!r}")
+
+
+def build_commands(patch_path: Path, workspace: Path) -> tuple[tuple[str, ...], ...]:
+    """Describe the build commands in execution order for tests and provenance."""
+    source = workspace / "source"
+    build = workspace / "build"
+    install = workspace / "install"
+    return (
+        ("git", "clone", SWMM_REPOSITORY, str(source)),
+        ("git", "checkout", SWMM_COMMIT),
+        ("git", "apply", str(patch_path)),
+        (
+            "cmake",
+            "-S",
+            str(source),
+            "-B",
+            str(build),
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DBUILD_TESTS=ON",
+            f"-DCMAKE_INSTALL_PREFIX={install}",
+        ),
+        ("cmake", "--build", str(build), "--parallel", "1"),
+        ("ctest", "--test-dir", str(build), "--output-on-failure"),
+        ("cmake", "--install", str(build)),
+    )
+
+
+def _run(
+    command: tuple[str, ...],
+    *,
+    cwd: Path | None = None,
+    environment: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    completed = subprocess.run(
+        command,
+        cwd=cwd,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=900,
+    )
+    if completed.returncode != 0:
+        output = "\n".join(part for part in (completed.stdout, completed.stderr) if part)
+        raise BuildBoundaryError(f"command failed ({completed.returncode}): {command!r}\n{output}")
+    return completed
+
+
+def _dynamic_library_environment(bin_directory: Path) -> dict[str, str]:
+    environment = dict(os.environ)
+    variable = "DYLD_LIBRARY_PATH" if sys.platform == "darwin" else "LD_LIBRARY_PATH"
+    existing = environment.get(variable)
+    environment[variable] = str(bin_directory) if not existing else f"{bin_directory}{os.pathsep}{existing}"
+    return environment
+
+
+def _find_one(directory: Path, names: tuple[str, ...]) -> Path:
+    matches = [directory / name for name in names if (directory / name).is_file()]
+    if len(matches) != 1:
+        raise BuildBoundaryError(f"expected exactly one of {names!r} under {directory}; found {matches!r}")
+    return matches[0]
+
+
+def _tool_output(command: tuple[str, ...]) -> str:
+    return _run(command).stdout.strip()
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def build_engine(workspace: Path, patch_path: Path) -> Path:
+    """Clone, patch, test, and install SWMM in a new workspace, returning its receipt."""
+    workspace = workspace.resolve()
+    patch_path = patch_path.resolve()
+    assert_absent_workspace(workspace)
+    if not patch_path.is_file():
+        raise BuildBoundaryError(f"portability patch does not exist: {patch_path}")
+    workspace.mkdir(parents=True)
+    source = workspace / "source"
+    install = workspace / "install"
+    commands = build_commands(patch_path, workspace)
+
+    clone = _run(commands[0])
+    checkout = _run(commands[1], cwd=source)
+    resolved_commit = _run(("git", "rev-parse", "HEAD"), cwd=source).stdout.strip()
+    if resolved_commit != SWMM_COMMIT:
+        raise BuildBoundaryError(f"checkout resolved to {resolved_commit}, not {SWMM_COMMIT}")
+    if _run(("git", "diff"), cwd=source).stdout:
+        raise BuildBoundaryError("fresh checkout unexpectedly contains tracked changes")
+
+    patch = _run(commands[2], cwd=source)
+    status_after_patch = _run(("git", "status", "--short"), cwd=source).stdout.splitlines()
+    expected_patch_status = {
+        " M extern/boost.cmake",
+        " M src/solver/CMakeLists.txt",
+        " M tests/CMakeLists.txt",
+    }
+    if set(status_after_patch) != expected_patch_status:
+        raise BuildBoundaryError(f"patch changed unexpected source paths: {status_after_patch!r}")
+
+    configure = _run(commands[3])
+    compile_result = _run(commands[4])
+    upstream_test = _run(commands[5])
+    install_result = _run(commands[6])
+
+    status_after_build = _run(("git", "status", "--short"), cwd=source).stdout.splitlines()
+    expected_build_status = expected_patch_status
+    if set(status_after_build) != expected_build_status:
+        raise BuildBoundaryError(f"build changed unexpected source paths: {status_after_build!r}")
+    generated_header = source / "src" / "outfile" / "include" / "swmm_output_export.h"
+    if not generated_header.is_file():
+        raise BuildBoundaryError("build did not create the expected output-API export header")
+    ignored_header = _run(
+        ("git", "check-ignore", "src/outfile/include/swmm_output_export.h"),
+        cwd=source,
+    ).stdout.strip()
+    if ignored_header != "src/outfile/include/swmm_output_export.h":
+        raise BuildBoundaryError("generated output-API header is not covered by the upstream ignore boundary")
+
+    bin_directory = install / "bin"
+    executable = _find_one(bin_directory, ("runswmm", "runswmm.exe"))
+    output_library = _find_one(
+        bin_directory,
+        ("libswmm-output.dylib", "libswmm-output.so", "swmm-output.dll"),
+    )
+    solver_library = _find_one(bin_directory, ("libswmm5.dylib", "libswmm5.so", "swmm5.dll"))
+    version = _run(
+        (str(executable), "--version"),
+        environment=_dynamic_library_environment(bin_directory),
+    )
+    validate_version_output(version.stdout)
+
+    readme = source / "README.md"
+    readme_text = readme.read_text(encoding="utf-8")
+    if "released in the Public Domain" not in readme_text:
+        raise BuildBoundaryError("pinned official README no longer contains the expected public-domain notice")
+
+    artifacts = {
+        "runswmm": {"path": str(executable), "sha256": sha256_file(executable)},
+        "swmm_output_library": {
+            "path": str(output_library),
+            "sha256": sha256_file(output_library),
+        },
+        "swmm_solver_library": {
+            "path": str(solver_library),
+            "sha256": sha256_file(solver_library),
+        },
+    }
+    receipt: dict[str, Any] = {
+        "receipt_version": "asw-0b3.engine-build-receipt.v1",
+        "authority": {
+            "stage": "ASW-0B3",
+            "scope": "research_only",
+            "promotable": False,
+            "path_is_contract": False,
+        },
+        "source": {
+            "repository": SWMM_REPOSITORY,
+            "version": SWMM_VERSION,
+            "commit": resolved_commit,
+            "readme_sha256": sha256_file(readme),
+            "rights_notice": "Official pinned README states that the C source is released in the Public Domain.",
+        },
+        "patch": {
+            "path": str(patch_path),
+            "sha256": sha256_file(patch_path),
+            "tracked_paths": sorted(expected_patch_status),
+            "changes_solver_or_output_calculations": False,
+        },
+        "build": {
+            "workspace": str(workspace),
+            "commands": [list(command) for command in commands],
+            "source_status_after_build": status_after_build,
+            "ignored_generated_header_sha256": sha256_file(generated_header),
+            "compiler": _tool_output(("cc", "--version")),
+            "cmake": _tool_output(("cmake", "--version")),
+            "git": _tool_output(("git", "--version")),
+            "python": platform.python_version(),
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+            "upstream_test_output": upstream_test.stdout.strip(),
+            "logs": {
+                "clone": clone.stdout + clone.stderr,
+                "checkout": checkout.stdout + checkout.stderr,
+                "patch": patch.stdout + patch.stderr,
+                "configure": configure.stdout + configure.stderr,
+                "compile": compile_result.stdout + compile_result.stderr,
+                "install": install_result.stdout + install_result.stderr,
+            },
+        },
+        "artifacts": artifacts,
+        "version_output": version.stdout.strip(),
+    }
+    receipt_path = workspace / "engine-build-receipt.json"
+    _write_json(receipt_path, receipt)
+    return receipt_path
+
+
+def verify_build_receipt(path: Path) -> dict[str, Any]:
+    """Reload a receipt and prove its pin and artifact hashes before execution."""
+    try:
+        receipt = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise BuildBoundaryError(f"cannot read build receipt: {exc}") from exc
+    if receipt.get("receipt_version") != "asw-0b3.engine-build-receipt.v1":
+        raise BuildBoundaryError("unsupported build receipt version")
+    source = receipt.get("source", {})
+    if (
+        source.get("repository"),
+        source.get("version"),
+        source.get("commit"),
+    ) != (SWMM_REPOSITORY, SWMM_VERSION, SWMM_COMMIT):
+        raise BuildBoundaryError("build receipt does not identify the exact candidate")
+    authority = receipt.get("authority", {})
+    if (
+        authority.get("stage") != "ASW-0B3"
+        or authority.get("promotable") is not False
+        or authority.get("scope") != "research_only"
+        or authority.get("path_is_contract") is not False
+    ):
+        raise BuildBoundaryError("build receipt lacks the research-only authority boundary")
+    if receipt.get("version_output") != SWMM_VERSION:
+        raise BuildBoundaryError("build receipt lacks the exact version response")
+    patch = receipt.get("patch", {})
+    patch_path = Path(str(patch.get("path", "")))
+    if (
+        not patch_path.is_absolute()
+        or not patch_path.is_file()
+        or patch.get("changes_solver_or_output_calculations") is not False
+        or sha256_file(patch_path) != patch.get("sha256")
+    ):
+        raise BuildBoundaryError("portability patch identity changed after build")
+    artifacts = receipt.get("artifacts")
+    if not isinstance(artifacts, dict) or set(artifacts) != {
+        "runswmm",
+        "swmm_output_library",
+        "swmm_solver_library",
+    }:
+        raise BuildBoundaryError("build receipt has an incomplete artifact inventory")
+    for name, item in artifacts.items():
+        if not isinstance(item, dict):
+            raise BuildBoundaryError(f"invalid artifact receipt for {name}")
+        artifact_path = Path(str(item.get("path", "")))
+        expected_hash = item.get("sha256")
+        if (
+            not artifact_path.is_absolute()
+            or not artifact_path.is_file()
+            or sha256_file(artifact_path) != expected_hash
+        ):
+            raise BuildBoundaryError(f"artifact identity changed after build: {name}")
+    return receipt

--- a/research/asset-stewardship/asw-0b3-swmm-engine-spike/src/asw_b3_swmm/cli.py
+++ b/research/asset-stewardship/asw-0b3-swmm-engine-spike/src/asw_b3_swmm/cli.py
@@ -1,0 +1,64 @@
+# ABOUTME: Provides a narrow command-line surface for the isolated B3 build and replay workflow.
+# ABOUTME: Requires fresh paths and exposes no aec-bench production command, registry, or adapter.
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+from pathlib import Path
+
+from asw_b3_swmm.build import assert_absent_workspace, build_engine
+from asw_b3_swmm.execution import reproduce, spike_root
+from asw_b3_swmm.rendering import render_probe
+from asw_b3_swmm.specification import load_specification
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m asw_b3_swmm",
+        description="Isolated, non-authoritative ASW-0B3 SWMM research spike.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    build_parser = subparsers.add_parser("build", help="build the exact pinned real engine")
+    build_parser.add_argument("--workspace", type=Path, required=True)
+    build_parser.add_argument(
+        "--patch",
+        type=Path,
+        default=spike_root() / "patches" / "swmm-5.2.4-cmake-portability.patch",
+    )
+
+    reproduce_parser = subparsers.add_parser("reproduce", help="run both probes twice")
+    reproduce_parser.add_argument("--engine-receipt", type=Path, required=True)
+    reproduce_parser.add_argument("--workspace", type=Path, required=True)
+
+    render_parser = subparsers.add_parser("render", help="render one disposable probe")
+    render_parser.add_argument(
+        "--probe",
+        choices=("a_duty", "b_duty_label_probe"),
+        required=True,
+    )
+    render_parser.add_argument("--output", type=Path, required=True)
+    return parser
+
+
+def main(arguments: Sequence[str] | None = None) -> int:
+    """Execute one bounded B3 research operation."""
+    parsed = _parser().parse_args(arguments)
+    if parsed.command == "build":
+        receipt_path = build_engine(parsed.workspace, parsed.patch)
+        print(receipt_path)
+        return 0
+    if parsed.command == "reproduce":
+        evidence = reproduce(parsed.engine_receipt, parsed.workspace)
+        print(json.dumps(evidence, indent=2, sort_keys=True, allow_nan=False))
+        return 0
+    if parsed.command == "render":
+        output = parsed.output.resolve()
+        assert_absent_workspace(output)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        specification = load_specification(spike_root() / "fixtures" / "spike-probes.json")
+        output.write_text(render_probe(specification, parsed.probe), encoding="utf-8")
+        print(output)
+        return 0
+    raise AssertionError(f"unhandled command: {parsed.command}")

--- a/research/asset-stewardship/asw-0b3-swmm-engine-spike/src/asw_b3_swmm/constants.py
+++ b/research/asset-stewardship/asw-0b3-swmm-engine-spike/src/asw_b3_swmm/constants.py
@@ -1,0 +1,8 @@
+# ABOUTME: Pins the sole SWMM candidate evaluated by the ASW-0B3 spike.
+# ABOUTME: Centralizes exact source and version identities used by build and replay checks.
+
+SWMM_REPOSITORY = "https://github.com/USEPA/Stormwater-Management-Model.git"
+SWMM_VERSION = "5.2.4"
+SWMM_COMMIT = "7952ca837988b1c32f791812eccc9fd64547e093"
+SWMM_OUTPUT_VERSION = 52004
+SWMM_FLOW_UNIT_LPS = 4

--- a/research/asset-stewardship/asw-0b3-swmm-engine-spike/src/asw_b3_swmm/execution.py
+++ b/research/asset-stewardship/asw-0b3-swmm-engine-spike/src/asw_b3_swmm/execution.py
@@ -1,0 +1,255 @@
+# ABOUTME: Runs fresh pinned-engine probes twice and assembles B3 replay evidence.
+# ABOUTME: Fails on stale paths, identity drift, warnings, convergence failures, or independent-check failures.
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from asw_b3_swmm.build import (
+    BuildBoundaryError,
+    assert_absent_workspace,
+    sha256_file,
+    validate_version_output,
+    verify_build_receipt,
+)
+from asw_b3_swmm.constants import SWMM_COMMIT, SWMM_VERSION
+from asw_b3_swmm.output import OutputApi, canonical_semantic_hash
+from asw_b3_swmm.rendering import render_probe
+from asw_b3_swmm.specification import load_specification
+from asw_b3_swmm.verification import verify_mirrored_probes, verify_probe
+
+
+class ExecutionError(RuntimeError):
+    """Raised when a real SWMM probe cannot produce valid B3 evidence."""
+
+
+def spike_root() -> Path:
+    """Return the research source root without making it a runtime contract."""
+    return Path(__file__).resolve().parents[2]
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _dynamic_library_environment(bin_directory: Path) -> dict[str, str]:
+    environment = dict(os.environ)
+    variable = "DYLD_LIBRARY_PATH" if sys.platform == "darwin" else "LD_LIBRARY_PATH"
+    existing = environment.get(variable)
+    environment[variable] = str(bin_directory) if not existing else f"{bin_directory}{os.pathsep}{existing}"
+    return environment
+
+
+def _run_engine(executable: Path, input_path: Path, report_path: Path, output_path: Path) -> str:
+    if report_path.exists() or output_path.exists():
+        raise ExecutionError("refusing to run with stale report or output paths")
+    completed = subprocess.run(
+        (str(executable), str(input_path), str(report_path), str(output_path)),
+        env=_dynamic_library_environment(executable.parent),
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if completed.returncode != 0:
+        raise ExecutionError(
+            f"runswmm exited {completed.returncode}\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+        )
+    if not report_path.is_file() or not output_path.is_file():
+        raise ExecutionError("runswmm returned without producing both report and binary output")
+    return completed.stdout + completed.stderr
+
+
+def _report_summary(report_path: Path, console_output: str) -> dict[str, object]:
+    report = report_path.read_text(encoding="latin-1", errors="strict")
+    combined = f"{console_output}\n{report}"
+    errors = sorted(set(re.findall(r"\bERROR\s+\d+\b[^\n]*", combined)))
+    warnings = sorted(set(re.findall(r"\bWARNING\s+\d+\b[^\n]*", combined)))
+    if errors:
+        raise ExecutionError(f"SWMM report contains errors: {errors!r}")
+    if warnings:
+        raise ExecutionError(f"SWMM report contains unapproved warnings: {warnings!r}")
+    if "Simulation complete" not in console_output or "Analysis ended on:" not in report:
+        raise ExecutionError("SWMM completion markers are absent")
+
+    continuity_match = re.search(r"Continuity Error \(%\)\s+\.+\s+(-?\d+(?:\.\d+)?)", report)
+    nonconverging_match = re.search(
+        r"% of Steps Not Converging\s+:\s+(\d+(?:\.\d+)?)",
+        report,
+    )
+    if continuity_match is None or nonconverging_match is None:
+        raise ExecutionError("SWMM report omits required convergence or continuity metadata")
+    not_converging_percent = float(nonconverging_match.group(1))
+    if not_converging_percent != 0.0 or "Convergence obtained at all time steps." not in report:
+        raise ExecutionError(f"SWMM did not converge at all steps; percent not converging={not_converging_percent}")
+    return {
+        "errors": [],
+        "warnings": [],
+        "flow_routing_continuity_error_percent": float(continuity_match.group(1)),
+        "steps_not_converging_percent": not_converging_percent,
+        "convergence_obtained_at_all_steps": True,
+    }
+
+
+def _artifact(receipt: dict[str, Any], name: str) -> tuple[Path, str]:
+    raw = receipt["artifacts"][name]
+    if not isinstance(raw, dict):
+        raise BuildBoundaryError(f"invalid artifact receipt for {name}")
+    return Path(raw["path"]), str(raw["sha256"])
+
+
+def _execute_probe(
+    *,
+    executable: Path,
+    output_library: Path,
+    run_directory: Path,
+    probe_id: str,
+    specification_path: Path,
+) -> tuple[dict[str, object], dict[str, object]]:
+    run_directory.mkdir()
+    specification = load_specification(specification_path)
+    probe = specification.probe(probe_id)
+    input_path = run_directory / f"{probe_id}.inp"
+    report_path = run_directory / f"{probe_id}.rpt"
+    output_path = run_directory / f"{probe_id}.out"
+    input_path.write_text(render_probe(specification, probe_id), encoding="utf-8")
+
+    console_output = _run_engine(executable, input_path, report_path, output_path)
+    report_summary = _report_summary(report_path, console_output)
+    semantic_result = OutputApi(output_library).extract(output_path, specification, probe)
+    findings = verify_probe(
+        semantic_result,
+        wet_well_plan_area_m2=specification.diagnostic_geometry.wet_well_plan_area_m2,
+    )
+    semantic_hash = canonical_semantic_hash(semantic_result)
+    result_path = run_directory / f"{probe_id}.semantic.json"
+    _write_json(result_path, semantic_result)
+    run_record: dict[str, object] = {
+        "probe_id": probe_id,
+        "input_sha256": sha256_file(input_path),
+        "report_sha256": sha256_file(report_path),
+        "binary_output_sha256": sha256_file(output_path),
+        "semantic_output_sha256": semantic_hash,
+        "semantic_result_sha256": sha256_file(result_path),
+        "report": report_summary,
+        "independent_diagnostic_checks": findings,
+    }
+    return semantic_result, run_record
+
+
+def reproduce(build_receipt_path: Path, run_root: Path) -> dict[str, Any]:
+    """Run both probes twice and issue a fail-closed local verification receipt."""
+    run_root = run_root.resolve()
+    assert_absent_workspace(run_root)
+    run_root.mkdir(parents=True)
+    receipt = verify_build_receipt(build_receipt_path.resolve())
+    executable, executable_hash = _artifact(receipt, "runswmm")
+    output_library, output_library_hash = _artifact(receipt, "swmm_output_library")
+    solver_library, solver_library_hash = _artifact(receipt, "swmm_solver_library")
+    version = subprocess.run(
+        (str(executable), "--version"),
+        env=_dynamic_library_environment(executable.parent),
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if version.returncode != 0:
+        raise ExecutionError(f"version check failed with exit code {version.returncode}")
+    validate_version_output(version.stdout)
+
+    specification_path = spike_root() / "fixtures" / "spike-probes.json"
+    replay_records: dict[str, object] = {}
+    semantic_results: dict[str, dict[str, dict[str, object]]] = {}
+    for replay_index in (1, 2):
+        replay_id = f"replay_{replay_index}"
+        replay_directory = run_root / replay_id
+        replay_directory.mkdir()
+        probe_results: dict[str, dict[str, object]] = {}
+        probe_records: dict[str, object] = {}
+        for probe_id in ("a_duty", "b_duty_label_probe"):
+            result, record = _execute_probe(
+                executable=executable,
+                output_library=output_library,
+                run_directory=replay_directory / probe_id,
+                probe_id=probe_id,
+                specification_path=specification_path,
+            )
+            probe_results[probe_id] = result
+            probe_records[probe_id] = record
+        mirror_findings = verify_mirrored_probes(
+            probe_results["a_duty"],
+            probe_results["b_duty_label_probe"],
+        )
+        semantic_results[replay_id] = probe_results
+        replay_records[replay_id] = {
+            "probes": probe_records,
+            "independent_label_symmetry_checks": mirror_findings,
+        }
+
+    replay_hashes_match = all(
+        canonical_semantic_hash(semantic_results["replay_1"][probe_id])
+        == canonical_semantic_hash(semantic_results["replay_2"][probe_id])
+        for probe_id in ("a_duty", "b_duty_label_probe")
+    )
+    if not replay_hashes_match:
+        raise ExecutionError("second run produced a different semantic output hash")
+    input_hashes_match = all(
+        replay_records["replay_1"]["probes"][probe_id]["input_sha256"]
+        == replay_records["replay_2"]["probes"][probe_id]["input_sha256"]
+        for probe_id in ("a_duty", "b_duty_label_probe")
+    )
+    if not input_hashes_match:
+        raise ExecutionError("replay inputs differ")
+
+    evidence: dict[str, Any] = {
+        "record_version": "asw-0b3.engine-verification.v1",
+        "status": "pass",
+        "authority": {
+            "stage": "ASW-0B3",
+            "scope": "research_only",
+            "promotable": False,
+            "world_parameters_selected": False,
+            "raw_outputs_promoted": False,
+        },
+        "engine": {
+            "version": SWMM_VERSION,
+            "commit": SWMM_COMMIT,
+            "runswmm_sha256": executable_hash,
+            "output_library_sha256": output_library_hash,
+            "solver_library_sha256": solver_library_hash,
+            "build_receipt_sha256": sha256_file(build_receipt_path),
+        },
+        "fixture": {
+            "sha256": sha256_file(specification_path),
+            "scope": "spike_only",
+            "promotable": False,
+        },
+        "runs": replay_records,
+        "replay": {
+            "semantic_hashes_match": True,
+            "input_hashes_match": True,
+            "semantic_hashes": {
+                probe_id: canonical_semantic_hash(semantic_results["replay_1"][probe_id])
+                for probe_id in ("a_duty", "b_duty_label_probe")
+            },
+        },
+        "verification": {
+            "all_checks_passed": True,
+            "claims_physical_world_certification": False,
+            "claims_benchmark_validity": False,
+        },
+    }
+    evidence_path = run_root / "engine-verification-receipt.json"
+    _write_json(evidence_path, evidence)
+    evidence["local_receipt_path"] = str(evidence_path)
+    return evidence

--- a/research/asset-stewardship/asw-0b3-swmm-engine-spike/src/asw_b3_swmm/output.py
+++ b/research/asset-stewardship/asw-0b3-swmm-engine-spike/src/asw_b3_swmm/output.py
@@ -1,0 +1,290 @@
+# ABOUTME: Extracts an allowlisted semantic result through the official SWMM output API.
+# ABOUTME: Computes expected periods and replay hashes independently from engine-reported metadata.
+
+from __future__ import annotations
+
+import ctypes
+import hashlib
+import json
+import os
+from pathlib import Path
+
+from asw_b3_swmm.constants import SWMM_FLOW_UNIT_LPS, SWMM_OUTPUT_VERSION
+from asw_b3_swmm.specification import Probe, Specification
+
+
+class OutputContractError(RuntimeError):
+    """Raised when SWMM output violates the B3 semantic extraction boundary."""
+
+
+def expected_period_count(horizon_seconds: int, report_step_seconds: int) -> int:
+    """Calculate period count without consulting the engine output file."""
+    if horizon_seconds <= 0 or report_step_seconds <= 0:
+        raise OutputContractError("horizon and report step must be positive")
+    periods, remainder = divmod(horizon_seconds, report_step_seconds)
+    if remainder:
+        raise OutputContractError("report step must divide the horizon exactly")
+    return periods
+
+
+def canonical_semantic_hash(payload: dict[str, object]) -> str:
+    """Hash canonical JSON while rejecting NaN and path-dependent formatting."""
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+class OutputApi:
+    """Minimal ctypes boundary around the pinned official SWMM output library."""
+
+    _ELEMENT_NODE = 1
+    _ELEMENT_LINK = 2
+    _TIME_REPORT_STEP = 0
+    _TIME_NUM_PERIODS = 1
+    _NODE_DEPTH = 0
+    _NODE_VOLUME = 2
+    _NODE_FLOODING = 5
+    _LINK_FLOW = 0
+
+    def __init__(self, library_path: Path) -> None:
+        try:
+            self._library = ctypes.CDLL(str(library_path))
+        except OSError as exc:
+            raise OutputContractError(f"cannot load pinned output library: {exc}") from exc
+        self._configure_signatures()
+
+    def _configure_signatures(self) -> None:
+        library = self._library
+        handle = ctypes.c_void_p
+        void_pointer = ctypes.c_void_p
+        library.SMO_init.argtypes = [ctypes.POINTER(handle)]
+        library.SMO_init.restype = ctypes.c_int
+        library.SMO_open.argtypes = [handle, ctypes.c_char_p]
+        library.SMO_open.restype = ctypes.c_int
+        library.SMO_close.argtypes = [ctypes.POINTER(handle)]
+        library.SMO_close.restype = ctypes.c_int
+        library.SMO_getVersion.argtypes = [handle, ctypes.POINTER(ctypes.c_int)]
+        library.SMO_getVersion.restype = ctypes.c_int
+        library.SMO_getProjectSize.argtypes = [
+            handle,
+            ctypes.POINTER(void_pointer),
+            ctypes.POINTER(ctypes.c_int),
+        ]
+        library.SMO_getProjectSize.restype = ctypes.c_int
+        library.SMO_getFlowUnits.argtypes = [handle, ctypes.POINTER(ctypes.c_int)]
+        library.SMO_getFlowUnits.restype = ctypes.c_int
+        library.SMO_getTimes.argtypes = [handle, ctypes.c_int, ctypes.POINTER(ctypes.c_int)]
+        library.SMO_getTimes.restype = ctypes.c_int
+        library.SMO_getElementName.argtypes = [
+            handle,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.POINTER(void_pointer),
+            ctypes.POINTER(ctypes.c_int),
+        ]
+        library.SMO_getElementName.restype = ctypes.c_int
+        series_arguments = [
+            handle,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.POINTER(void_pointer),
+            ctypes.POINTER(ctypes.c_int),
+        ]
+        library.SMO_getNodeSeries.argtypes = series_arguments
+        library.SMO_getNodeSeries.restype = ctypes.c_int
+        library.SMO_getLinkSeries.argtypes = series_arguments
+        library.SMO_getLinkSeries.restype = ctypes.c_int
+        library.SMO_free.argtypes = [ctypes.POINTER(void_pointer)]
+        library.SMO_free.restype = None
+
+    @staticmethod
+    def _check(code: int, operation: str) -> None:
+        if code != 0:
+            raise OutputContractError(f"{operation} failed with SWMM output API code {code}")
+
+    def _integer(self, function_name: str, handle: ctypes.c_void_p, code: int | None = None) -> int:
+        output = ctypes.c_int()
+        function = getattr(self._library, function_name)
+        if code is None:
+            result = function(handle, ctypes.byref(output))
+        else:
+            result = function(handle, code, ctypes.byref(output))
+        self._check(result, function_name)
+        return output.value
+
+    def _project_size(self, handle: ctypes.c_void_p) -> tuple[int, ...]:
+        pointer = ctypes.c_void_p()
+        length = ctypes.c_int()
+        self._check(
+            self._library.SMO_getProjectSize(handle, ctypes.byref(pointer), ctypes.byref(length)),
+            "SMO_getProjectSize",
+        )
+        try:
+            values = ctypes.cast(pointer, ctypes.POINTER(ctypes.c_int))
+            return tuple(values[index] for index in range(length.value))
+        finally:
+            self._library.SMO_free(ctypes.byref(pointer))
+
+    def _element_names(self, handle: ctypes.c_void_p, element_type: int, count: int) -> tuple[str, ...]:
+        names: list[str] = []
+        for index in range(count):
+            pointer = ctypes.c_void_p()
+            length = ctypes.c_int()
+            self._check(
+                self._library.SMO_getElementName(
+                    handle,
+                    element_type,
+                    index,
+                    ctypes.byref(pointer),
+                    ctypes.byref(length),
+                ),
+                "SMO_getElementName",
+            )
+            try:
+                names.append(ctypes.string_at(pointer, length.value).decode("utf-8"))
+            finally:
+                self._library.SMO_free(ctypes.byref(pointer))
+        return tuple(names)
+
+    def _series(
+        self,
+        function_name: str,
+        handle: ctypes.c_void_p,
+        element_index: int,
+        attribute: int,
+        periods: int,
+    ) -> list[float]:
+        pointer = ctypes.c_void_p()
+        length = ctypes.c_int()
+        function = getattr(self._library, function_name)
+        self._check(
+            function(
+                handle,
+                element_index,
+                attribute,
+                0,
+                periods,
+                ctypes.byref(pointer),
+                ctypes.byref(length),
+            ),
+            function_name,
+        )
+        try:
+            if length.value != periods:
+                raise OutputContractError(f"{function_name} returned {length.value} values for {periods} periods")
+            values = ctypes.cast(pointer, ctypes.POINTER(ctypes.c_float))
+            return [float(values[index]) for index in range(length.value)]
+        finally:
+            self._library.SMO_free(ctypes.byref(pointer))
+
+    def extract(self, output_path: Path, specification: Specification, probe: Probe) -> dict[str, object]:
+        """Extract only semantic series required for the B3 role decision."""
+        if not output_path.is_file():
+            raise OutputContractError(f"SWMM output does not exist: {output_path}")
+        handle = ctypes.c_void_p()
+        self._check(self._library.SMO_init(ctypes.byref(handle)), "SMO_init")
+        opened = False
+        try:
+            open_code = self._library.SMO_open(handle, os.fsencode(output_path))
+            if open_code != 0:
+                raise OutputContractError(f"SMO_open failed with SWMM output API code {open_code}")
+            opened = True
+            engine_version = self._integer("SMO_getVersion", handle)
+            flow_units = self._integer("SMO_getFlowUnits", handle)
+            report_step = self._integer("SMO_getTimes", handle, self._TIME_REPORT_STEP)
+            period_count = self._integer("SMO_getTimes", handle, self._TIME_NUM_PERIODS)
+            expected = expected_period_count(
+                specification.simulation.horizon_seconds,
+                specification.simulation.report_step_seconds,
+            )
+            if engine_version != SWMM_OUTPUT_VERSION:
+                raise OutputContractError(f"output version is {engine_version}, expected {SWMM_OUTPUT_VERSION}")
+            if flow_units != SWMM_FLOW_UNIT_LPS:
+                raise OutputContractError(f"output flow-unit code is {flow_units}, expected LPS")
+            if report_step != specification.simulation.report_step_seconds:
+                raise OutputContractError(
+                    f"output report step is {report_step}, expected {specification.simulation.report_step_seconds}"
+                )
+            if period_count != expected:
+                raise OutputContractError(f"output contains {period_count} periods, independently expected {expected}")
+
+            project_size = self._project_size(handle)
+            if len(project_size) < 3:
+                raise OutputContractError(f"unexpected project-size vector: {project_size!r}")
+            node_names = self._element_names(handle, self._ELEMENT_NODE, project_size[1])
+            link_names = self._element_names(handle, self._ELEMENT_LINK, project_size[2])
+            expected_nodes = {"DISCHARGE", "OUTFALL", "WET_WELL"}
+            expected_links = {"FORCE_MAIN", "PUMP_A", "PUMP_B"}
+            if set(node_names) != expected_nodes or set(link_names) != expected_links:
+                raise OutputContractError(f"unexpected model elements: nodes={node_names!r}, links={link_names!r}")
+            node_index = {name: index for index, name in enumerate(node_names)}
+            link_index = {name: index for index, name in enumerate(link_names)}
+            series = {
+                "wet_well_depth_m": self._series(
+                    "SMO_getNodeSeries",
+                    handle,
+                    node_index["WET_WELL"],
+                    self._NODE_DEPTH,
+                    period_count,
+                ),
+                "wet_well_volume_m3": self._series(
+                    "SMO_getNodeSeries",
+                    handle,
+                    node_index["WET_WELL"],
+                    self._NODE_VOLUME,
+                    period_count,
+                ),
+                "wet_well_flooding_lps": self._series(
+                    "SMO_getNodeSeries",
+                    handle,
+                    node_index["WET_WELL"],
+                    self._NODE_FLOODING,
+                    period_count,
+                ),
+                "pump_a_flow_lps": self._series(
+                    "SMO_getLinkSeries",
+                    handle,
+                    link_index["PUMP_A"],
+                    self._LINK_FLOW,
+                    period_count,
+                ),
+                "pump_b_flow_lps": self._series(
+                    "SMO_getLinkSeries",
+                    handle,
+                    link_index["PUMP_B"],
+                    self._LINK_FLOW,
+                    period_count,
+                ),
+                "force_main_flow_lps": self._series(
+                    "SMO_getLinkSeries",
+                    handle,
+                    link_index["FORCE_MAIN"],
+                    self._LINK_FLOW,
+                    period_count,
+                ),
+            }
+            return {
+                "probe_id": probe.probe_id,
+                "active_pump": probe.active_pump,
+                "inactive_pump": probe.inactive_pump,
+                "engine_version": engine_version,
+                "flow_units": "LPS",
+                "report_step_seconds": report_step,
+                "period_count": period_count,
+                "expected_period_count": expected,
+                "elements": {
+                    "nodes": list(node_names),
+                    "links": list(link_names),
+                },
+                "series": series,
+            }
+        finally:
+            if opened:
+                self._check(self._library.SMO_close(ctypes.byref(handle)), "SMO_close")

--- a/research/asset-stewardship/asw-0b3-swmm-engine-spike/src/asw_b3_swmm/rendering.py
+++ b/research/asset-stewardship/asw-0b3-swmm-engine-spike/src/asw_b3_swmm/rendering.py
@@ -1,0 +1,117 @@
+# ABOUTME: Renders deterministic SWMM inputs for isolated Pump A and Pump B diagnostic probes.
+# ABOUTME: Encodes no transfer, degradation, maintenance, scenario, or production-world semantics.
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from asw_b3_swmm.specification import Specification
+
+
+def _time(value: int) -> str:
+    hours, remainder = divmod(value, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
+
+
+def _curve_lines(specification: Specification) -> str:
+    lines: list[str] = []
+    for index, (head_m, flow_lps) in enumerate(specification.pump_curve):
+        curve_type = "PUMP3" if index == 0 else ""
+        lines.append(f"PUMP_CURVE      {curve_type:<5}  {head_m:<8} {flow_lps}")
+    return "\n".join(lines)
+
+
+def render_probe(specification: Specification, probe_id: str) -> str:
+    """Render one disposable, single-active-pump SWMM probe."""
+    probe = specification.probe(probe_id)
+    simulation = specification.simulation
+    geometry = specification.diagnostic_geometry
+    end = simulation.start + timedelta(seconds=simulation.horizon_seconds)
+    statuses = {
+        probe.active_pump: "ON",
+        probe.inactive_pump: "OFF",
+    }
+    storage_line = (
+        f"WET_WELL        {geometry.wet_well_invert_m}        "
+        f"{geometry.wet_well_max_depth_m}       {geometry.wet_well_initial_depth_m}        "
+        f"{geometry.wet_well_shape}  {geometry.wet_well_major_axis_m}   "
+        f"{geometry.wet_well_minor_axis_m}   {geometry.wet_well_side_slope}  0.0       0.0"
+    )
+    conduit_line = (
+        f"FORCE_MAIN      DISCHARGE   OUTFALL   {geometry.force_main_length_m}   "
+        f"{geometry.force_main_conduit_roughness}       0.0       0.0        0.0       0.0"
+    )
+    xsection_line = (
+        f"FORCE_MAIN      FORCE_MAIN  {geometry.force_main_diameter_m}   "
+        f"{geometry.force_main_absolute_roughness_mm}    0      0      1"
+    )
+    return f"""[TITLE]
+;; ASW-0B3 disposable engine diagnostic
+;; Probe: {probe.probe_id}
+
+[OPTIONS]
+FLOW_UNITS              {simulation.flow_units}
+INFILTRATION            HORTON
+FLOW_ROUTING            {simulation.routing_model}
+LINK_OFFSETS            DEPTH
+FORCE_MAIN_EQUATION     {simulation.force_main_equation}
+IGNORE_RAINFALL         YES
+SKIP_STEADY_STATE       NO
+START_DATE              {simulation.start:%m/%d/%Y}
+START_TIME              {simulation.start:%H:%M:%S}
+REPORT_START_DATE       {simulation.start:%m/%d/%Y}
+REPORT_START_TIME       {simulation.start:%H:%M:%S}
+END_DATE                {end:%m/%d/%Y}
+END_TIME                {end:%H:%M:%S}
+REPORT_STEP             {_time(simulation.report_step_seconds)}
+WET_STEP                {_time(simulation.report_step_seconds)}
+DRY_STEP                {_time(simulation.report_step_seconds)}
+ROUTING_STEP            {_time(simulation.routing_step_seconds)}
+RULE_STEP               {_time(simulation.routing_step_seconds)}
+ALLOW_PONDING           NO
+VARIABLE_STEP           0.00
+MINIMUM_STEP            0.50
+THREADS                 {simulation.threads}
+
+[JUNCTIONS]
+;;Name          Elevation  MaxDepth  InitDepth  SurDepth  Aponded
+DISCHARGE       {geometry.discharge_invert_m}        {geometry.discharge_max_depth_m}       0.0        0.0       0.0
+
+[OUTFALLS]
+;;Name          Elevation  Type  Stage Data  Gated  Route To
+OUTFALL         {geometry.outfall_invert_m}        FREE              NO
+
+[STORAGE]
+;;Name          Elevation  MaxDepth  InitDepth  Shape        L     W     Z  SurDepth  Fevap
+{storage_line}
+
+[DWF]
+;;Node          Constituent  Baseline
+WET_WELL        FLOW         {geometry.dry_weather_inflow_lps}
+
+[CONDUITS]
+;;Name          From Node   To Node   Length  Roughness  InOffset  OutOffset  InitFlow  MaxFlow
+{conduit_line}
+
+[PUMPS]
+;;Name          From Node   To Node    Pump Curve  Status  Startup  Shutoff
+PUMP_A          WET_WELL    DISCHARGE  PUMP_CURVE  {statuses["PUMP_A"]}     0.0      0.0
+PUMP_B          WET_WELL    DISCHARGE  PUMP_CURVE  {statuses["PUMP_B"]}     0.0      0.0
+
+[XSECTIONS]
+;;Link          Shape       Geom1  Geom2  Geom3  Geom4  Barrels
+{xsection_line}
+
+[CURVES]
+;;Name          Type   Head-m   Flow-LPS
+{_curve_lines(specification)}
+
+[REPORT]
+INPUT           NO
+CONTROLS        NO
+AVERAGES        NO
+SUBCATCHMENTS   NONE
+NODES           ALL
+LINKS           ALL
+"""

--- a/research/asset-stewardship/asw-0b3-swmm-engine-spike/src/asw_b3_swmm/specification.py
+++ b/research/asset-stewardship/asw-0b3-swmm-engine-spike/src/asw_b3_swmm/specification.py
@@ -1,0 +1,311 @@
+# ABOUTME: Loads and validates the disposable ASW-0B3 engine-probe declaration.
+# ABOUTME: Enforces the B1 two-pump topology and B2 non-promotion boundary before rendering.
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+class SpecificationError(ValueError):
+    """Raised when a research probe declaration crosses the ASW-0B3 boundary."""
+
+
+@dataclass(frozen=True)
+class Authority:
+    stage: str
+    scope: str
+    promotable: bool
+    world_parameters_selected: bool
+    purpose: str
+
+
+@dataclass(frozen=True)
+class Simulation:
+    start: datetime
+    horizon_seconds: int
+    report_step_seconds: int
+    routing_step_seconds: int
+    flow_units: str
+    routing_model: str
+    force_main_equation: str
+    threads: int
+
+
+@dataclass(frozen=True)
+class DiagnosticGeometry:
+    wet_well_shape: str
+    wet_well_invert_m: float
+    wet_well_max_depth_m: float
+    wet_well_initial_depth_m: float
+    wet_well_major_axis_m: float
+    wet_well_minor_axis_m: float
+    wet_well_side_slope: float
+    dry_weather_inflow_lps: float
+    discharge_invert_m: float
+    discharge_max_depth_m: float
+    outfall_invert_m: float
+    force_main_length_m: float
+    force_main_conduit_roughness: float
+    force_main_diameter_m: float
+    force_main_absolute_roughness_mm: float
+
+    @property
+    def wet_well_plan_area_m2(self) -> float:
+        from math import pi
+
+        return pi * self.wet_well_major_axis_m * self.wet_well_minor_axis_m / 4.0
+
+
+@dataclass(frozen=True)
+class Probe:
+    probe_id: str
+    purpose: str
+    active_pump: str
+    inactive_pump: str
+
+
+@dataclass(frozen=True)
+class Specification:
+    schema_version: str
+    authority: Authority
+    simulation: Simulation
+    diagnostic_geometry: DiagnosticGeometry
+    pump_curve: tuple[tuple[float, float], ...]
+    components: tuple[str, ...]
+    probes: tuple[Probe, ...]
+
+    def probe(self, probe_id: str) -> Probe:
+        for probe in self.probes:
+            if probe.probe_id == probe_id:
+                return probe
+        raise SpecificationError(f"unknown probe: {probe_id}")
+
+
+def _mapping(value: object, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise SpecificationError(f"{field} must be an object")
+    return value
+
+
+def _exact_keys(mapping: dict[str, Any], expected: set[str], field: str) -> None:
+    actual = set(mapping)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        unknown = sorted(actual - expected)
+        raise SpecificationError(f"{field} keys differ; missing={missing}, unknown={unknown}")
+
+
+def _string(mapping: dict[str, Any], key: str) -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise SpecificationError(f"{key} must be a non-empty string")
+    return value
+
+
+def _bool(mapping: dict[str, Any], key: str) -> bool:
+    value = mapping.get(key)
+    if not isinstance(value, bool):
+        raise SpecificationError(f"{key} must be a boolean")
+    return value
+
+
+def _number(mapping: dict[str, Any], key: str, *, minimum: float | None = None) -> float:
+    value = mapping.get(key)
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise SpecificationError(f"{key} must be numeric")
+    result = float(value)
+    if minimum is not None and result < minimum:
+        raise SpecificationError(f"{key} must be at least {minimum}")
+    return result
+
+
+def _integer(mapping: dict[str, Any], key: str, *, minimum: int = 1) -> int:
+    value = mapping.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise SpecificationError(f"{key} must be an integer of at least {minimum}")
+    return value
+
+
+def _load_authority(raw: object) -> Authority:
+    mapping = _mapping(raw, "authority")
+    _exact_keys(
+        mapping,
+        {"stage", "scope", "promotable", "world_parameters_selected", "purpose"},
+        "authority",
+    )
+    authority = Authority(
+        stage=_string(mapping, "stage"),
+        scope=_string(mapping, "scope"),
+        promotable=_bool(mapping, "promotable"),
+        world_parameters_selected=_bool(mapping, "world_parameters_selected"),
+        purpose=_string(mapping, "purpose"),
+    )
+    if authority.stage != "ASW-0B3" or authority.scope != "spike_only":
+        raise SpecificationError("fixture authority must remain ASW-0B3 spike_only")
+    if authority.promotable or authority.world_parameters_selected:
+        raise SpecificationError("fixture must remain non-promotable and select no world parameters")
+    return authority
+
+
+def _load_simulation(raw: object) -> Simulation:
+    mapping = _mapping(raw, "simulation")
+    _exact_keys(
+        mapping,
+        {
+            "start",
+            "horizon_seconds",
+            "report_step_seconds",
+            "routing_step_seconds",
+            "flow_units",
+            "routing_model",
+            "force_main_equation",
+            "threads",
+        },
+        "simulation",
+    )
+    try:
+        start = datetime.fromisoformat(_string(mapping, "start"))
+    except ValueError as exc:
+        raise SpecificationError("simulation start must be ISO-8601") from exc
+    simulation = Simulation(
+        start=start,
+        horizon_seconds=_integer(mapping, "horizon_seconds"),
+        report_step_seconds=_integer(mapping, "report_step_seconds"),
+        routing_step_seconds=_integer(mapping, "routing_step_seconds"),
+        flow_units=_string(mapping, "flow_units"),
+        routing_model=_string(mapping, "routing_model"),
+        force_main_equation=_string(mapping, "force_main_equation"),
+        threads=_integer(mapping, "threads"),
+    )
+    if simulation.horizon_seconds % simulation.report_step_seconds:
+        raise SpecificationError("report step must divide the diagnostic horizon exactly")
+    if (
+        simulation.flow_units,
+        simulation.routing_model,
+        simulation.force_main_equation,
+        simulation.threads,
+    ) != ("LPS", "DYNWAVE", "D-W", 1):
+        raise SpecificationError("simulation must use the frozen B3 deterministic engine settings")
+    return simulation
+
+
+def _load_geometry(raw: object) -> DiagnosticGeometry:
+    mapping = _mapping(raw, "diagnostic_geometry")
+    expected = set(DiagnosticGeometry.__dataclass_fields__)
+    _exact_keys(mapping, expected, "diagnostic_geometry")
+    geometry = DiagnosticGeometry(
+        wet_well_shape=_string(mapping, "wet_well_shape"),
+        wet_well_invert_m=_number(mapping, "wet_well_invert_m"),
+        wet_well_max_depth_m=_number(mapping, "wet_well_max_depth_m", minimum=0.0),
+        wet_well_initial_depth_m=_number(mapping, "wet_well_initial_depth_m", minimum=0.0),
+        wet_well_major_axis_m=_number(mapping, "wet_well_major_axis_m", minimum=0.000001),
+        wet_well_minor_axis_m=_number(mapping, "wet_well_minor_axis_m", minimum=0.000001),
+        wet_well_side_slope=_number(mapping, "wet_well_side_slope", minimum=0.0),
+        dry_weather_inflow_lps=_number(mapping, "dry_weather_inflow_lps", minimum=0.0),
+        discharge_invert_m=_number(mapping, "discharge_invert_m"),
+        discharge_max_depth_m=_number(mapping, "discharge_max_depth_m", minimum=0.0),
+        outfall_invert_m=_number(mapping, "outfall_invert_m"),
+        force_main_length_m=_number(mapping, "force_main_length_m", minimum=0.000001),
+        force_main_conduit_roughness=_number(mapping, "force_main_conduit_roughness", minimum=0.000001),
+        force_main_diameter_m=_number(mapping, "force_main_diameter_m", minimum=0.000001),
+        force_main_absolute_roughness_mm=_number(
+            mapping,
+            "force_main_absolute_roughness_mm",
+            minimum=0.000001,
+        ),
+    )
+    if geometry.wet_well_shape != "CYLINDRICAL" or geometry.wet_well_side_slope != 0.0:
+        raise SpecificationError("B3 uses only a constant-area CYLINDRICAL diagnostic storage")
+    if geometry.wet_well_initial_depth_m > geometry.wet_well_max_depth_m:
+        raise SpecificationError("wet-well initial depth exceeds maximum depth")
+    return geometry
+
+
+def _load_curve(raw: object) -> tuple[tuple[float, float], ...]:
+    if not isinstance(raw, list) or len(raw) < 2:
+        raise SpecificationError("pump_curve must contain at least two points")
+    points: list[tuple[float, float]] = []
+    for index, item in enumerate(raw):
+        if (
+            not isinstance(item, list)
+            or len(item) != 2
+            or any(isinstance(value, bool) or not isinstance(value, int | float) for value in item)
+        ):
+            raise SpecificationError(f"pump_curve point {index} must contain two numbers")
+        points.append((float(item[0]), float(item[1])))
+    if any(left[0] >= right[0] for left, right in zip(points, points[1:], strict=False)):
+        raise SpecificationError("pump_curve head coordinates must increase")
+    if any(left[1] < right[1] for left, right in zip(points, points[1:], strict=False)):
+        raise SpecificationError("pump_curve flow coordinates must not increase")
+    return tuple(points)
+
+
+def _load_components(raw: object) -> tuple[str, ...]:
+    if raw != ["PUMP_A", "PUMP_B"]:
+        raise SpecificationError("components must preserve the exact B1 Pump A/Pump B boundary")
+    return ("PUMP_A", "PUMP_B")
+
+
+def _load_probes(raw: object, components: tuple[str, ...]) -> tuple[Probe, ...]:
+    if not isinstance(raw, list) or len(raw) != 2:
+        raise SpecificationError("B3 requires exactly one mirrored probe for each pump")
+    probes: list[Probe] = []
+    for index, item in enumerate(raw):
+        mapping = _mapping(item, f"probes[{index}]")
+        _exact_keys(mapping, {"id", "purpose", "active_pump", "inactive_pump"}, f"probes[{index}]")
+        probe = Probe(
+            probe_id=_string(mapping, "id"),
+            purpose=_string(mapping, "purpose"),
+            active_pump=_string(mapping, "active_pump"),
+            inactive_pump=_string(mapping, "inactive_pump"),
+        )
+        if {probe.active_pump, probe.inactive_pump} != set(components):
+            raise SpecificationError("each probe must activate one B1 pump and inactivate the other")
+        probes.append(probe)
+    expected = {
+        ("a_duty", "PUMP_A", "PUMP_B"),
+        ("b_duty_label_probe", "PUMP_B", "PUMP_A"),
+    }
+    actual = {(probe.probe_id, probe.active_pump, probe.inactive_pump) for probe in probes}
+    if actual != expected:
+        raise SpecificationError("B3 requires exactly one mirrored probe for each B1 pump")
+    return tuple(probes)
+
+
+def load_specification(path: Path) -> Specification:
+    """Load the exact research fixture and enforce its non-authoritative boundary."""
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SpecificationError(f"cannot load probe declaration: {exc}") from exc
+    mapping = _mapping(raw, "root")
+    _exact_keys(
+        mapping,
+        {
+            "schema_version",
+            "authority",
+            "simulation",
+            "diagnostic_geometry",
+            "pump_curve",
+            "components",
+            "probes",
+        },
+        "root",
+    )
+    schema_version = _string(mapping, "schema_version")
+    if schema_version != "asw-0b3.spike-probes.v1":
+        raise SpecificationError("unsupported research fixture schema")
+    components = _load_components(mapping["components"])
+    return Specification(
+        schema_version=schema_version,
+        authority=_load_authority(mapping["authority"]),
+        simulation=_load_simulation(mapping["simulation"]),
+        diagnostic_geometry=_load_geometry(mapping["diagnostic_geometry"]),
+        pump_curve=_load_curve(mapping["pump_curve"]),
+        components=components,
+        probes=_load_probes(mapping["probes"], components),
+    )

--- a/research/asset-stewardship/asw-0b3-swmm-engine-spike/src/asw_b3_swmm/verification.py
+++ b/research/asset-stewardship/asw-0b3-swmm-engine-spike/src/asw_b3_swmm/verification.py
@@ -1,0 +1,150 @@
+# ABOUTME: Independently checks extracted B3 probe series without calling SWMM hydraulic helpers.
+# ABOUTME: Limits conclusions to diagnostic period, finiteness, standby, storage, flooding, and mirror identities.
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+
+class VerificationError(RuntimeError):
+    """Raised when extracted probe semantics violate a B3 diagnostic identity."""
+
+
+_FLOAT_OUTPUT_ABSOLUTE_TOLERANCE = 1.0e-5
+
+
+def _series_mapping(result: dict[str, object]) -> dict[str, list[float]]:
+    raw = result.get("series")
+    if not isinstance(raw, dict):
+        raise VerificationError("result has no semantic series mapping")
+    expected_names = {
+        "wet_well_depth_m",
+        "wet_well_volume_m3",
+        "wet_well_flooding_lps",
+        "pump_a_flow_lps",
+        "pump_b_flow_lps",
+        "force_main_flow_lps",
+    }
+    if set(raw) != expected_names:
+        raise VerificationError(f"semantic series allowlist differs: {sorted(raw)!r}")
+    series: dict[str, list[float]] = {}
+    for name, values in raw.items():
+        if not isinstance(values, list) or any(
+            isinstance(value, bool) or not isinstance(value, int | float) for value in values
+        ):
+            raise VerificationError(f"{name} is not a numeric series")
+        series[str(name)] = [float(value) for value in values]
+    return series
+
+
+def _require_metadata(result: dict[str, object], key: str, expected_type: type[Any]) -> Any:
+    value = result.get(key)
+    if not isinstance(value, expected_type):
+        raise VerificationError(f"{key} is missing or has the wrong type")
+    return value
+
+
+def _all_close(left: list[float], right: list[float]) -> bool:
+    return len(left) == len(right) and all(
+        math.isclose(
+            left_value,
+            right_value,
+            rel_tol=0.0,
+            abs_tol=_FLOAT_OUTPUT_ABSOLUTE_TOLERANCE,
+        )
+        for left_value, right_value in zip(left, right, strict=True)
+    )
+
+
+def verify_probe(result: dict[str, object], wet_well_plan_area_m2: float) -> dict[str, bool]:
+    """Check one real-engine probe using only extracted series and physical identities."""
+    period_count = _require_metadata(result, "period_count", int)
+    expected_periods = _require_metadata(result, "expected_period_count", int)
+    active_pump = _require_metadata(result, "active_pump", str)
+    inactive_pump = _require_metadata(result, "inactive_pump", str)
+    if {active_pump, inactive_pump} != {"PUMP_A", "PUMP_B"}:
+        raise VerificationError("probe does not contain one active and one inactive B1 pump")
+    if period_count != expected_periods:
+        raise VerificationError(f"period count is {period_count}, expected {expected_periods}")
+
+    series = _series_mapping(result)
+    if any(len(values) != period_count for values in series.values()):
+        raise VerificationError("one or more series lengths differ from the period count")
+    if any(not math.isfinite(value) for values in series.values() for value in values):
+        raise VerificationError("one or more semantic series contain a non-finite value")
+
+    active_name = "pump_a_flow_lps" if active_pump == "PUMP_A" else "pump_b_flow_lps"
+    inactive_name = "pump_a_flow_lps" if inactive_pump == "PUMP_A" else "pump_b_flow_lps"
+    inactive_zero = all(abs(value) <= _FLOAT_OUTPUT_ABSOLUTE_TOLERANCE for value in series[inactive_name])
+    if not inactive_zero:
+        raise VerificationError("inactive pump has nonzero exported flow")
+    active_positive = any(value > _FLOAT_OUTPUT_ABSOLUTE_TOLERANCE for value in series[active_name])
+    if not active_positive:
+        raise VerificationError("active pump never has positive exported flow")
+
+    flooding_zero = all(abs(value) <= _FLOAT_OUTPUT_ABSOLUTE_TOLERANCE for value in series["wet_well_flooding_lps"])
+    if not flooding_zero:
+        raise VerificationError("diagnostic wet well has exported flooding")
+
+    volume_identity = all(
+        math.isclose(
+            volume,
+            wet_well_plan_area_m2 * depth,
+            rel_tol=_FLOAT_OUTPUT_ABSOLUTE_TOLERANCE,
+            abs_tol=_FLOAT_OUTPUT_ABSOLUTE_TOLERANCE,
+        )
+        for depth, volume in zip(
+            series["wet_well_depth_m"],
+            series["wet_well_volume_m3"],
+            strict=True,
+        )
+    )
+    if not volume_identity:
+        raise VerificationError("cylindrical depth/volume identity does not hold in exported series")
+
+    return {
+        "period_count_exact": True,
+        "all_series_finite": True,
+        "inactive_pump_zero_flow": True,
+        "active_pump_positive_flow": True,
+        "cylindrical_volume_identity": True,
+        "no_flooding": True,
+    }
+
+
+def verify_mirrored_probes(
+    a_duty: dict[str, object],
+    b_duty: dict[str, object],
+) -> dict[str, bool]:
+    """Compare separate probes after swapping only the active pump label."""
+    a_series = _series_mapping(a_duty)
+    b_series = _series_mapping(b_duty)
+    active_match = _all_close(a_series["pump_a_flow_lps"], b_series["pump_b_flow_lps"])
+    if not active_match:
+        raise VerificationError("active-pump series differ after the label swap")
+    inactive_match = _all_close(a_series["pump_b_flow_lps"], b_series["pump_a_flow_lps"])
+    if not inactive_match:
+        raise VerificationError("inactive-pump series differ after the label swap")
+    wet_well_match = all(
+        _all_close(a_series[name], b_series[name])
+        for name in (
+            "wet_well_depth_m",
+            "wet_well_volume_m3",
+            "wet_well_flooding_lps",
+        )
+    )
+    if not wet_well_match:
+        raise VerificationError("wet-well series differ after the label swap")
+    force_main_match = _all_close(
+        a_series["force_main_flow_lps"],
+        b_series["force_main_flow_lps"],
+    )
+    if not force_main_match:
+        raise VerificationError("force-main series differ after the label swap")
+    return {
+        "active_pump_series_match": True,
+        "inactive_pump_series_match": True,
+        "wet_well_series_match": True,
+        "force_main_series_match": True,
+    }

--- a/research/asset-stewardship/asw-0b3-swmm-engine-spike/tests/test_build_boundary.py
+++ b/research/asset-stewardship/asw-0b3-swmm-engine-spike/tests/test_build_boundary.py
@@ -1,0 +1,98 @@
+# ABOUTME: Tests exact engine pins and fail-closed build-workspace rules for the B3 spike.
+# ABOUTME: Guards against loose version checks, reused workspaces, and unrecorded portability changes.
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from asw_b3_swmm.build import (
+    BuildBoundaryError,
+    assert_absent_workspace,
+    build_commands,
+    sha256_file,
+    validate_version_output,
+    verify_build_receipt,
+)
+from asw_b3_swmm.constants import SWMM_COMMIT, SWMM_REPOSITORY, SWMM_VERSION
+
+
+def test_candidate_identity_is_exact() -> None:
+    assert SWMM_REPOSITORY == "https://github.com/USEPA/Stormwater-Management-Model.git"
+    assert SWMM_VERSION == "5.2.4"
+    assert SWMM_COMMIT == "7952ca837988b1c32f791812eccc9fd64547e093"
+
+
+def test_version_output_requires_an_exact_full_match() -> None:
+    validate_version_output("\n5.2.4\n")
+
+    for invalid in ("5.2.40", "EPA SWMM 5.2.4", "5.2.4-dev", "5.2"):
+        with pytest.raises(BuildBoundaryError, match="exactly"):
+            validate_version_output(invalid)
+
+
+def test_build_workspace_must_not_exist(tmp_path: Path) -> None:
+    target = tmp_path / "build-root"
+    assert_absent_workspace(target)
+    target.mkdir()
+
+    with pytest.raises(BuildBoundaryError, match="already exists"):
+        assert_absent_workspace(target)
+
+
+def test_build_commands_enable_the_single_relevant_upstream_test() -> None:
+    commands = build_commands(Path("/research/patch.patch"), Path("/tmp/work"))
+
+    assert commands[0] == ("git", "clone", SWMM_REPOSITORY, "/tmp/work/source")
+    assert ("git", "checkout", SWMM_COMMIT) in commands
+    assert ("git", "apply", "/research/patch.patch") in commands
+    configure = next(command for command in commands if command[:2] == ("cmake", "-S"))
+    assert "-DBUILD_TESTS=ON" in configure
+    assert "-DCMAKE_BUILD_TYPE=Release" in configure
+    assert ("ctest", "--test-dir", "/tmp/work/build", "--output-on-failure") in commands
+
+
+def test_receipt_rechecks_the_portability_patch_before_execution(tmp_path: Path) -> None:
+    patch = tmp_path / "portability.patch"
+    patch.write_text("build wiring only\n", encoding="utf-8")
+    artifacts: dict[str, dict[str, str]] = {}
+    for name in ("runswmm", "swmm_output_library", "swmm_solver_library"):
+        artifact = tmp_path / name
+        artifact.write_bytes(name.encode("ascii"))
+        artifacts[name] = {
+            "path": str(artifact),
+            "sha256": sha256_file(artifact),
+        }
+    receipt_path = tmp_path / "receipt.json"
+    receipt_path.write_text(
+        json.dumps(
+            {
+                "receipt_version": "asw-0b3.engine-build-receipt.v1",
+                "authority": {
+                    "stage": "ASW-0B3",
+                    "scope": "research_only",
+                    "promotable": False,
+                    "path_is_contract": False,
+                },
+                "source": {
+                    "repository": SWMM_REPOSITORY,
+                    "version": SWMM_VERSION,
+                    "commit": SWMM_COMMIT,
+                },
+                "patch": {
+                    "path": str(patch),
+                    "sha256": sha256_file(patch),
+                    "changes_solver_or_output_calculations": False,
+                },
+                "artifacts": artifacts,
+                "version_output": SWMM_VERSION,
+            }
+        ),
+        encoding="utf-8",
+    )
+    verify_build_receipt(receipt_path)
+    patch.write_text("changed after build\n", encoding="utf-8")
+
+    with pytest.raises(BuildBoundaryError, match="portability patch identity changed"):
+        verify_build_receipt(receipt_path)

--- a/research/asset-stewardship/asw-0b3-swmm-engine-spike/tests/test_output_contract.py
+++ b/research/asset-stewardship/asw-0b3-swmm-engine-spike/tests/test_output_contract.py
@@ -1,0 +1,25 @@
+# ABOUTME: Tests the research-only semantic output contract and replay hash.
+# ABOUTME: Keeps expected periods, units, and canonical hashing independent from SWMM-reported counts.
+
+from __future__ import annotations
+
+import pytest
+from asw_b3_swmm.output import OutputContractError, canonical_semantic_hash, expected_period_count
+
+
+def test_expected_period_count_is_computed_independently() -> None:
+    assert expected_period_count(horizon_seconds=7200, report_step_seconds=60) == 120
+
+
+def test_expected_period_count_rejects_partial_periods() -> None:
+    with pytest.raises(OutputContractError, match="divide the horizon"):
+        expected_period_count(horizon_seconds=7201, report_step_seconds=60)
+
+
+def test_semantic_hash_is_key_order_independent_and_value_sensitive() -> None:
+    left = {"periods": 2, "series": {"flow": [1.0, 2.0], "depth": [0.1, 0.2]}}
+    reordered = {"series": {"depth": [0.1, 0.2], "flow": [1.0, 2.0]}, "periods": 2}
+    changed = {"periods": 2, "series": {"flow": [1.0, 2.1], "depth": [0.1, 0.2]}}
+
+    assert canonical_semantic_hash(left) == canonical_semantic_hash(reordered)
+    assert canonical_semantic_hash(left) != canonical_semantic_hash(changed)

--- a/research/asset-stewardship/asw-0b3-swmm-engine-spike/tests/test_real_engine.py
+++ b/research/asset-stewardship/asw-0b3-swmm-engine-spike/tests/test_real_engine.py
@@ -1,0 +1,22 @@
+# ABOUTME: Executes the pinned real SWMM build twice and validates semantic replay evidence.
+# ABOUTME: Deliberately fails without a real build receipt instead of skipping or substituting an engine.
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from asw_b3_swmm.execution import reproduce
+
+
+def test_pinned_real_engine_replays_with_independent_checks(tmp_path: Path) -> None:
+    receipt_value = os.environ.get("ASW_B3_ENGINE_RECEIPT")
+    assert receipt_value, "ASW_B3_ENGINE_RECEIPT must name a receipt from a real pinned SWMM build"
+
+    evidence = reproduce(Path(receipt_value), tmp_path / "real-engine-replay")
+
+    assert evidence["status"] == "pass"
+    assert evidence["engine"]["version"] == "5.2.4"
+    assert evidence["engine"]["commit"] == "7952ca837988b1c32f791812eccc9fd64547e093"
+    assert evidence["replay"]["semantic_hashes_match"] is True
+    assert evidence["verification"]["all_checks_passed"] is True

--- a/research/asset-stewardship/asw-0b3-swmm-engine-spike/tests/test_rendering.py
+++ b/research/asset-stewardship/asw-0b3-swmm-engine-spike/tests/test_rendering.py
@@ -1,0 +1,48 @@
+# ABOUTME: Tests deterministic SWMM input rendering for the two isolated duty probes.
+# ABOUTME: Ensures the renderer exercises engine semantics without encoding a duty transfer or shared operation.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from asw_b3_swmm.rendering import render_probe
+from asw_b3_swmm.specification import load_specification
+
+SPIKE_ROOT = Path(__file__).resolve().parents[1]
+SPECIFICATION = load_specification(SPIKE_ROOT / "fixtures" / "spike-probes.json")
+
+
+def test_a_duty_render_has_one_active_pump_and_no_controls() -> None:
+    rendered = render_probe(SPECIFICATION, "a_duty")
+
+    assert "PUMP_A          WET_WELL    DISCHARGE  PUMP_CURVE  ON" in rendered
+    assert "PUMP_B          WET_WELL    DISCHARGE  PUMP_CURVE  OFF" in rendered
+    assert "[CONTROLS]" not in rendered
+    assert "TRANSFER" not in rendered.upper()
+
+
+def test_b_label_probe_mirrors_status_without_changing_hydraulic_fixture() -> None:
+    a_duty = render_probe(SPECIFICATION, "a_duty")
+    b_duty = render_probe(SPECIFICATION, "b_duty_label_probe")
+
+    assert "PUMP_A          WET_WELL    DISCHARGE  PUMP_CURVE  OFF" in b_duty
+    assert "PUMP_B          WET_WELL    DISCHARGE  PUMP_CURVE  ON" in b_duty
+    assert a_duty.replace(";; Probe: a_duty", ";; Probe: MIRROR").replace(
+        "PUMP_A          WET_WELL    DISCHARGE  PUMP_CURVE  ON",
+        "PUMP_A          WET_WELL    DISCHARGE  PUMP_CURVE  OFF",
+    ).replace(
+        "PUMP_B          WET_WELL    DISCHARGE  PUMP_CURVE  OFF",
+        "PUMP_B          WET_WELL    DISCHARGE  PUMP_CURVE  ON",
+    ) == b_duty.replace(";; Probe: b_duty_label_probe", ";; Probe: MIRROR")
+
+
+def test_render_exercises_required_swmm_semantics() -> None:
+    rendered = render_probe(SPECIFICATION, "a_duty")
+
+    assert "FLOW_ROUTING            DYNWAVE" in rendered
+    assert "FORCE_MAIN_EQUATION     D-W" in rendered
+    assert "THREADS                 1" in rendered
+    assert "WET_WELL        0.0        3.0       1.5        CYLINDRICAL" in rendered
+    assert "FORCE_MAIN      FORCE_MAIN" in rendered
+    assert "PUMP_CURVE      PUMP3" in rendered
+    assert rendered.endswith("\n")

--- a/research/asset-stewardship/asw-0b3-swmm-engine-spike/tests/test_specification.py
+++ b/research/asset-stewardship/asw-0b3-swmm-engine-spike/tests/test_specification.py
@@ -1,0 +1,70 @@
+# ABOUTME: Tests the disposable ASW-0B3 probe declaration and its B1/B2 boundary.
+# ABOUTME: Prevents research fixtures from acquiring transfer, degradation, or promotion semantics.
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from asw_b3_swmm.specification import SpecificationError, load_specification
+
+SPIKE_ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_PATH = SPIKE_ROOT / "fixtures" / "spike-probes.json"
+
+
+def test_fixture_is_non_promotable_and_preserves_b1_topology() -> None:
+    specification = load_specification(FIXTURE_PATH)
+
+    assert specification.authority.stage == "ASW-0B3"
+    assert specification.authority.scope == "spike_only"
+    assert specification.authority.promotable is False
+    assert specification.authority.world_parameters_selected is False
+    assert specification.components == ("PUMP_A", "PUMP_B")
+    assert tuple(probe.probe_id for probe in specification.probes) == (
+        "a_duty",
+        "b_duty_label_probe",
+    )
+    assert {(probe.active_pump, probe.inactive_pump) for probe in specification.probes} == {
+        ("PUMP_A", "PUMP_B"),
+        ("PUMP_B", "PUMP_A"),
+    }
+
+
+def test_fixture_uses_only_b3_engine_diagnostics() -> None:
+    raw_text = FIXTURE_PATH.read_text(encoding="utf-8").lower()
+
+    forbidden_semantics = (
+        "obstruction",
+        "degradation",
+        "failure_rate",
+        "maintenance",
+        "intervention",
+        "handover",
+        "obligation",
+        "transfer_time",
+        "transfer_trigger",
+        "load_sharing",
+    )
+    assert all(term not in raw_text for term in forbidden_semantics)
+
+
+def test_loader_rejects_authority_expansion(tmp_path: Path) -> None:
+    raw = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    raw["authority"]["promotable"] = True
+    invalid_path = tmp_path / "invalid.json"
+    invalid_path.write_text(json.dumps(raw), encoding="utf-8")
+
+    with pytest.raises(SpecificationError, match="must remain non-promotable"):
+        load_specification(invalid_path)
+
+
+def test_loader_rejects_non_mirror_probe_pair(tmp_path: Path) -> None:
+    raw = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    raw["probes"][1]["active_pump"] = "PUMP_A"
+    raw["probes"][1]["inactive_pump"] = "PUMP_B"
+    invalid_path = tmp_path / "invalid.json"
+    invalid_path.write_text(json.dumps(raw), encoding="utf-8")
+
+    with pytest.raises(SpecificationError, match="exactly one mirrored probe"):
+        load_specification(invalid_path)

--- a/research/asset-stewardship/asw-0b3-swmm-engine-spike/tests/test_stage_artifacts.py
+++ b/research/asset-stewardship/asw-0b3-swmm-engine-spike/tests/test_stage_artifacts.py
@@ -1,0 +1,50 @@
+# ABOUTME: Tests the durable B3 decision and compact verification summary as bounded research evidence.
+# ABOUTME: Ensures the handoff authorises only B4 and contains no local-path or production-contract leakage.
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+ASSET_RESEARCH_ROOT = Path(__file__).resolve().parents[2]
+DECISION_PATH = ASSET_RESEARCH_ROOT / "au-nsw-lh-syn-sps-v1-engine-role-decision.md"
+RECORD_PATH = ASSET_RESEARCH_ROOT / "au-nsw-lh-syn-sps-v1-engine-verification-record.json"
+
+
+def test_compact_record_preserves_research_only_authority() -> None:
+    record = json.loads(RECORD_PATH.read_text(encoding="utf-8"))
+
+    assert record["status"] == "pass"
+    assert record["authority"] == {
+        "stage": "ASW-0B3",
+        "scope": "research_only",
+        "promotable": False,
+        "path_is_contract": False,
+        "world_parameters_selected": False,
+        "raw_engine_artifacts_promoted": False,
+    }
+    assert record["execution"]["real_engine_runs"] == 4
+    assert record["execution"]["engine_errors"] == 0
+    assert record["execution"]["engine_warnings"] == 0
+    assert record["limitations"]["physical_world_certified"] is False
+    assert record["limitations"]["runtime_dependency_authorized"] is False
+
+
+def test_decision_binds_the_compact_record_and_only_opens_b4() -> None:
+    decision = DECISION_PATH.read_text(encoding="utf-8")
+    record_sha = hashlib.sha256(RECORD_PATH.read_bytes()).hexdigest()
+
+    assert f"Compact verification record SHA-256 | `{record_sha}`" in decision
+    assert "**ASW-0B3 is accepted. ASW-0B4 is authorised as the only next stage.**" in decision
+    assert "Offline generator/oracle | **Selected for B4 protocol design**" in decision
+    assert "Independent certifier | **Not selected**" in decision
+    assert "Asset-world runtime | **Rejected for the first implementation**" in decision
+
+
+def test_durable_artifacts_contain_no_ephemeral_local_paths() -> None:
+    combined = DECISION_PATH.read_text(encoding="utf-8") + RECORD_PATH.read_text(encoding="utf-8")
+
+    assert "/private/tmp" not in combined
+    assert "/Users/" not in combined
+    assert ".worktrees/" not in combined

--- a/research/asset-stewardship/asw-0b3-swmm-engine-spike/tests/test_verification.py
+++ b/research/asset-stewardship/asw-0b3-swmm-engine-spike/tests/test_verification.py
@@ -1,0 +1,78 @@
+# ABOUTME: Tests independent diagnostic checks over extracted SWMM semantic series.
+# ABOUTME: Verifies label symmetry and physical identities without certifying a B4 world family.
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from asw_b3_swmm.verification import VerificationError, verify_mirrored_probes, verify_probe
+
+
+def _result(active: str) -> dict[str, object]:
+    inactive = "PUMP_B" if active == "PUMP_A" else "PUMP_A"
+    area = math.pi
+    return {
+        "probe_id": "a_duty" if active == "PUMP_A" else "b_duty_label_probe",
+        "active_pump": active,
+        "inactive_pump": inactive,
+        "engine_version": 52004,
+        "flow_units": "LPS",
+        "report_step_seconds": 60,
+        "period_count": 3,
+        "expected_period_count": 3,
+        "series": {
+            "wet_well_depth_m": [1.0, 0.9, 0.8],
+            "wet_well_volume_m3": [area, 0.9 * area, 0.8 * area],
+            "wet_well_flooding_lps": [0.0, 0.0, 0.0],
+            "pump_a_flow_lps": [5.0, 5.0, 5.0] if active == "PUMP_A" else [0.0, 0.0, 0.0],
+            "pump_b_flow_lps": [0.0, 0.0, 0.0] if active == "PUMP_A" else [5.0, 5.0, 5.0],
+            "force_main_flow_lps": [5.0, 5.0, 5.0],
+        },
+    }
+
+
+def test_probe_checks_finite_periods_standby_and_cylindrical_identity() -> None:
+    findings = verify_probe(_result("PUMP_A"), wet_well_plan_area_m2=math.pi)
+
+    assert findings["period_count_exact"] is True
+    assert findings["all_series_finite"] is True
+    assert findings["inactive_pump_zero_flow"] is True
+    assert findings["active_pump_positive_flow"] is True
+    assert findings["cylindrical_volume_identity"] is True
+    assert findings["no_flooding"] is True
+
+
+def test_probe_rejects_nonzero_standby_flow() -> None:
+    result = _result("PUMP_A")
+    result["series"]["pump_b_flow_lps"][1] = 0.1  # type: ignore[index]
+
+    with pytest.raises(VerificationError, match="inactive pump"):
+        verify_probe(result, wet_well_plan_area_m2=math.pi)
+
+
+def test_probe_rejects_nonfinite_values() -> None:
+    result = _result("PUMP_A")
+    result["series"]["wet_well_depth_m"][1] = math.nan  # type: ignore[index]
+
+    with pytest.raises(VerificationError, match="non-finite"):
+        verify_probe(result, wet_well_plan_area_m2=math.pi)
+
+
+def test_mirror_check_compares_hydraulics_after_label_swap() -> None:
+    findings = verify_mirrored_probes(_result("PUMP_A"), _result("PUMP_B"))
+
+    assert findings == {
+        "active_pump_series_match": True,
+        "inactive_pump_series_match": True,
+        "wet_well_series_match": True,
+        "force_main_series_match": True,
+    }
+
+
+def test_mirror_check_rejects_changed_hydraulics() -> None:
+    b_result = _result("PUMP_B")
+    b_result["series"]["force_main_flow_lps"][1] = 4.9  # type: ignore[index]
+
+    with pytest.raises(VerificationError, match="force-main"):
+        verify_mirrored_probes(_result("PUMP_A"), b_result)

--- a/research/asset-stewardship/au-nsw-lh-syn-sps-v1-engine-role-decision.md
+++ b/research/asset-stewardship/au-nsw-lh-syn-sps-v1-engine-role-decision.md
@@ -1,0 +1,235 @@
+# ABOUTME: Records the ASW-0B3 engineering-engine role decision for the synthetic duty/standby profile.
+# ABOUTME: Authorises only a bounded B4 generator/certification protocol and creates no runtime or production contract.
+
+# AU-NSW-LH-SYN-SPS-v1 — ASW-0B3 engine-role decision
+
+| Field | Decision identity |
+| --- | --- |
+| Stage | `ASW-0B3 — Engine roles and research spike` |
+| Status | **Accepted** |
+| Repository baseline | `2725bf522b3b4d3c557649d452faec06b8cf349a` |
+| Parent PRD SHA-256 | `56d6fe6a9c69796d819a1995ae63a85392ba85a4240df8baa87df99a76678335` |
+| B1 profile SHA-256 | `1956883951dd70ce52ec89f4c24ed69e5aaa4617796b803668e44002eafed954` |
+| B2 pack SHA-256 | `8d8e057792763531ebd3c8709f039c0aa7150a22ce734857221cef3339378e96` |
+| Compact verification record SHA-256 | `db93443b31a197864709e7011af8a6aa15932cbec3260cf1a2afed735ffa3f11` |
+| Next permitted stage | `ASW-0B4 — Generator and certification protocol` only |
+
+## 1. Decision
+
+Select **EPA SWMM 5.2.4 at commit
+`7952ca837988b1c32f791812eccc9fd64547e093`** as the hydraulic software
+for which ASW-0B4 may specify an offline synthetic generator/oracle.
+
+This is a bounded research-role decision:
+
+- SWMM may produce candidate hydraulic consequences for later, separately
+  specified synthetic-family generation;
+- SWMM and its output wrapper may not certify their own claim-critical
+  results;
+- SWMM is not an asset-world runtime dependency;
+- raw SWMM is not an agent-visible tool;
+- no live-solver integration is authorised; and
+- no diagnostic value, curve, comparison tolerance, generated input, output,
+  path, Python name, or file layout from B3 is a B4 or production contract.
+
+The decision establishes that the pinned engine can perform and export the
+narrow hydraulic operations needed to design B4. It does not establish a
+physically coherent world, a certified generator family, benchmark validity,
+regional representativeness, operational suitability, or any real-asset claim.
+
+## 2. Candidate assessment
+
+The accepted B2 pack retained SWMM, EPANET, and OpenModelica as candidate
+metadata. B3 evaluated them against the frozen profile and executed only the
+candidate with the strongest direct fit.
+
+| Candidate | B3 assessment | Role outcome |
+| --- | --- | --- |
+| EPA SWMM 5.2.4 | Direct support for storage, externally imposed inflow, pumps, dynamic-wave routing, force-main calculation, report output, and an official binary output API; exact pinned source built and executed | **Selected for B4 offline generator/oracle protocol design** |
+| EPANET 2.2 | Strong pressurised-network solver, but a weaker primary fit for the profile's wet-well filling, flooding boundary, and wastewater/sewer context | Not selected as the first generator; may be reconsidered only as a separately justified pressure-network comparison |
+| OpenModelica | Expressive enough to construct a station, but would make the first world depend on more self-authored component equations and a broader toolchain before those equations are independently certified | Not selected for the first generator or certifier |
+
+EPANET and OpenModelica were not executed in B3. This is a profile-fit
+selection, not a general quality judgement and not evidence that those tools
+cannot model related systems.
+
+## 3. Exact executed candidate
+
+| Item | Executed identity |
+| --- | --- |
+| Official source | `https://github.com/USEPA/Stormwater-Management-Model.git` |
+| Version response | Exact full match `5.2.4` |
+| Commit | `7952ca837988b1c32f791812eccc9fd64547e093` |
+| Official README SHA-256 | `11b8645890d1befb9dded9aea32c17611f1595a252edca6eea8400a2576a04a8` |
+| Rights basis | The official pinned README states that the C source is released in the Public Domain |
+| Portability patch SHA-256 | `522fa1f285b27bfdd614eae79a841e5b9a7892573521d032f78fdbd281dba894` |
+| Build receipt SHA-256 | `36dffda0813faf3f3e6581046e6d1c3ce100927ac06a096511ae23a3fdc67e93` |
+| `runswmm` SHA-256 | `a944ecff7ebb0d01b3c4aba934046feb578c9373418914a78e0c9150bc235188` |
+| Output library SHA-256 | `11be24989820a3fc21d48f07182b8641ed621da498acb4edcf84c486fc5b9e22` |
+| Solver library SHA-256 | `adc467fc3db029617b4b9280bcec72fde0a7a0e7e236a7f8cf9e7218a43ff796` |
+| Build environment | macOS 15.7.5 arm64; Apple clang 17.0.0; CMake 3.31.5; Boost 1.87.0; no OpenMP |
+| Upstream validation | The single relevant official output-API test passed; one executed, zero failed |
+
+The portability patch:
+
+1. corrects an OpenMP generator expression that otherwise links a nonexistent
+   target when OpenMP is unavailable;
+2. registers the upstream output test at its actual target path on a
+   single-config generator; and
+3. declares the pinned source's intended legacy `FindBoost` policy on current
+   CMake.
+
+It changes no solver or output calculation. Build and upstream-test output was
+clean after the patch. Exact source, patch, toolchain, commands, and executed
+artifact identities are recorded. Cross-workspace byte-identical rebuilds were
+not demonstrated or made an acceptance claim.
+
+## 4. B1-compatible spike
+
+The disposable fixture SHA-256 is
+`17aaefb61745ab99332e0ebdde9bb7108bcc85b2005d4926d7da9eac9dbd66fe`.
+It has exactly two component labels, `PUMP_A` and `PUMP_B`, and two separate
+probes:
+
+- `a_duty`: Pump A active and Pump B inactive; and
+- `b_duty_label_probe`: Pump B active and Pump A inactive solely to test
+  label-symmetric calculation and export.
+
+The second probe is not a transfer event or scenario state. The fixture has no
+controls section, simultaneous pumping, duty-transfer timing or trigger,
+obstruction, degradation, failure, maintenance, intervention, observation,
+obligation, handover, authority, or scoring semantics.
+
+Every numerical fixture value is disposable diagnostic material. ASW-0B4 must
+select, derive, document, and independently challenge its own family; it may
+not inherit B3 values or tolerances by path, name, or convenience.
+
+## 5. Real-engine result
+
+The final verification executed four real simulations: both probes twice.
+
+| Gate | Result |
+| --- | --- |
+| Expected reporting periods | `120` per run, computed without the output API |
+| Extracted reporting periods | `120` per run |
+| Engine errors | `0` |
+| Engine warnings | `0` |
+| Steps not converging | `0.0%` |
+| Input hashes across replay | Exact match |
+| Binary output hashes across replay | Exact match |
+| Semantic output hashes across replay | Exact match |
+| Pump A duty semantic SHA-256 | `aaa0281b0c10c06e4e6b361d85c727d4fdc22f6a2946d871d05f2efb4ae54252` |
+| Pump B label-probe semantic SHA-256 | `fb1faf4d897abd0cfd276bd0d40014fc7b2604ab524e34283b78f812a12b61ad` |
+
+The independently implemented diagnostic checks passed:
+
+- period count exactly matched the independently calculated value;
+- every allowlisted series was finite;
+- the inactive pump exported zero flow;
+- the active pump exported positive flow;
+- exported depth and volume satisfied the constant-area cylindrical-storage
+  identity within float-output representation tolerance;
+- the wet well did not flood; and
+- active-pump, inactive-pump, wet-well, and force-main series matched after the
+  A/B label swap.
+
+The reports disclosed a flow-routing continuity error of `-0.943%`. B3 records
+that value but does not turn it into a physical-coherence pass or tolerance.
+ASW-0B4 owns numerical acceptance criteria and ASW-0B5 owns family
+certification. A B4 protocol must reject or revise candidates that fail its
+preregistered continuity, sensitivity, or independent-check thresholds.
+
+Human-readable report bytes are not replay contracts because they contain
+wall-clock analysis timestamps. The generated input, binary output, and
+allowlisted semantic outputs were stable across the two runs.
+
+## 6. Role matrix
+
+| Engineering role | B3 decision | Authority boundary |
+| --- | --- | --- |
+| Offline generator/oracle | **Selected for B4 protocol design** | SWMM may generate candidate hydraulic consequences from B4-owned inputs; it cannot promote or certify them |
+| Independent certifier | **Not selected** | B4 must specify a separately executable path for claim-critical equations, units, invariants, sensitivities, and tolerances |
+| Asset-world runtime | **Rejected for the first implementation** | A later runtime may consume only a B5-promoted deterministic package and must succeed without SWMM, research code, or raw solver artifacts |
+| Agent-visible engineering tool | **Not authorised** | Raw SWMM would expose an unbounded surface; any later calculator needs a separate capability and visibility review |
+| Live solver integration | **Deferred** | Remains out of scope through ASW-4 unless separately authorised for replay, availability, licensing, failure, cost, and version controls |
+
+The selected initial architecture is therefore asymmetric:
+
+```text
+B4/B5 research generation: pinned SWMM
+Claim-critical certification: separately implemented independent path
+First asset runtime: promoted deterministic package, not live SWMM
+Agent tool: none
+```
+
+## 7. Contract, boundary, and invariant review
+
+The B3 change preserves the parent PRD guardrails:
+
+- no file under `src/aec_bench` changes;
+- no contract, registry identifier, `TrialRecord` field, CLI command, Harbor
+  key, runtime schema, example, or production import is created;
+- the research package is excluded from the distributable wheel and source
+  archive;
+- exact `.gitignore` allowlisting tracks only research source, tests, fixture,
+  patch, decision, and compact record;
+- vendor source, `.git` data, build/install trees, binaries, shared libraries,
+  generated `.inp/.out/.rpt` files, logs, caches, local receipts, and discarded
+  experiments remain ignored or outside the worktree;
+- every build and run requires an absent target path and never deletes or
+  silently reuses a workspace;
+- the exact executable and library hashes are rechecked before every run;
+- stale report and output paths fail closed;
+- output version, units, report step, period count, element names, warnings,
+  errors, and convergence status fail closed;
+- generator output cannot self-certify; and
+- the research Python package, fixture structure, and paths are expressly
+  non-authoritative.
+
+Later production work must re-express only fields named by a B5 promotion
+manifest in the owning asset-local package. It must not import, copy, or read
+this research package at runtime.
+
+## 8. B3 acceptance gate
+
+| Requirement | Assessment |
+| --- | --- |
+| Predecessor binding | Pass: exact PRD, B1, B2, and repository identities recorded |
+| Candidate pin and rights | Pass: exact official source, version, commit, README hash, and public-domain notice recorded |
+| Reproducible build evidence | Pass: fresh path, declared patch, toolchain, commands, hashes, and relevant upstream test recorded |
+| B1 topology | Pass: exactly Pump A/Pump B, one active per independent probe, no load sharing |
+| B4 separation | Pass: no family value, mechanism, transfer, tolerance, observation model, or intervention selected |
+| Real engine | Pass: four actual simulations; no mock, fallback, skipped integration gate, or fabricated output |
+| Export semantics | Pass: exact version, LPS units, report step, independently expected period count, element allowlist, and series extracted through the official API |
+| Replay | Pass: inputs, binary outputs, and semantic hashes stable across repeated runs |
+| Independent checks | Pass for B3 diagnostics only; no generator self-certification or physical-world claim |
+| Warning and convergence handling | Pass: zero engine warnings/errors and zero non-converging steps |
+| Production boundary | Pass: no vendor, spike, raw output, research receipt, or dependency becomes a runtime contract |
+| Explicit role decision | Pass: generator selected; certifier separate; runtime rejected; agent tool not authorised; live solver deferred |
+
+**ASW-0B3 is accepted. ASW-0B4 is authorised as the only next stage.**
+
+## 9. B4 handoff
+
+ASW-0B4 must begin in a new focused worktree and PR after this stage is
+accepted. Its first task is not to copy the spike. It is to freeze the
+generator and independent-certification protocol:
+
+1. define an original bounded synthetic parameter family and derivation chain;
+2. select the primary and secondary mechanisms without importing the report's
+   old obstruction transform;
+3. specify SWMM inputs and the semantic output allowlist owned by the
+   generator;
+4. specify a separately executable certifier with disclosed common
+   dependencies;
+5. preregister units, invariants, sensitivities, tolerances, rejection rules,
+   and stop conditions;
+6. define lineage and content-addressed receipts without making research paths
+   authoritative; and
+7. define the B5 promotion-manifest schema without producing or promoting a
+   world family yet.
+
+ASW-0B4 may revisit the SWMM generator decision if the constructed family,
+certification requirements, solver limitations, or portability evidence make
+the selected role unsuitable. That stop would be a successful stage result,
+not pressure to weaken a verifier.

--- a/research/asset-stewardship/au-nsw-lh-syn-sps-v1-engine-verification-record.json
+++ b/research/asset-stewardship/au-nsw-lh-syn-sps-v1-engine-verification-record.json
@@ -1,0 +1,112 @@
+{
+  "record_version": "asw-0b3.engine-verification-summary.v1",
+  "authority": {
+    "stage": "ASW-0B3",
+    "scope": "research_only",
+    "promotable": false,
+    "path_is_contract": false,
+    "world_parameters_selected": false,
+    "raw_engine_artifacts_promoted": false
+  },
+  "baseline": {
+    "repository_commit": "2725bf522b3b4d3c557649d452faec06b8cf349a",
+    "parent_prd_sha256": "56d6fe6a9c69796d819a1995ae63a85392ba85a4240df8baa87df99a76678335",
+    "claim_profile_sha256": "1956883951dd70ce52ec89f4c24ed69e5aaa4617796b803668e44002eafed954",
+    "evidence_pack_sha256": "8d8e057792763531ebd3c8709f039c0aa7150a22ce734857221cef3339378e96"
+  },
+  "engine": {
+    "repository": "https://github.com/USEPA/Stormwater-Management-Model.git",
+    "version": "5.2.4",
+    "commit": "7952ca837988b1c32f791812eccc9fd64547e093",
+    "official_readme_sha256": "11b8645890d1befb9dded9aea32c17611f1595a252edca6eea8400a2576a04a8",
+    "source_rights": "Official pinned README states that the C source is released in the Public Domain.",
+    "build_receipt_sha256": "36dffda0813faf3f3e6581046e6d1c3ce100927ac06a096511ae23a3fdc67e93",
+    "executable_sha256": "a944ecff7ebb0d01b3c4aba934046feb578c9373418914a78e0c9150bc235188",
+    "output_library_sha256": "11be24989820a3fc21d48f07182b8641ed621da498acb4edcf84c486fc5b9e22",
+    "solver_library_sha256": "adc467fc3db029617b4b9280bcec72fde0a7a0e7e236a7f8cf9e7218a43ff796",
+    "portability_patch_sha256": "522fa1f285b27bfdd614eae79a841e5b9a7892573521d032f78fdbd281dba894",
+    "patch_changes_calculations": false
+  },
+  "build_environment": {
+    "operating_system": "macOS 15.7.5",
+    "machine": "arm64",
+    "compiler": "Apple clang 17.0.0",
+    "cmake": "3.31.5",
+    "git": "2.39.5 Apple Git-154",
+    "boost": "1.87.0",
+    "openmp": "not found; not linked",
+    "build_type": "Release",
+    "build_parallelism": 1,
+    "upstream_output_api_test": {
+      "executed": 1,
+      "passed": 1,
+      "failed": 0
+    },
+    "build_warnings": []
+  },
+  "spike_fixture": {
+    "sha256": "17aaefb61745ab99332e0ebdde9bb7108bcc85b2005d4926d7da9eac9dbd66fe",
+    "scope": "spike_only",
+    "promotable": false,
+    "world_parameters_selected": false,
+    "components": [
+      "PUMP_A",
+      "PUMP_B"
+    ],
+    "probes": [
+      "a_duty",
+      "b_duty_label_probe"
+    ],
+    "contains_transfer": false,
+    "contains_simultaneous_pumping": false,
+    "contains_degradation_or_maintenance_semantics": false
+  },
+  "execution": {
+    "verification_receipt_sha256": "4587873503209ac5fbf7184c2c237fbc67ad7b733844249ae32b091d7c564b14",
+    "real_engine_runs": 4,
+    "replays_per_probe": 2,
+    "expected_periods_per_run": 120,
+    "actual_periods_per_run": 120,
+    "engine_errors": 0,
+    "engine_warnings": 0,
+    "steps_not_converging_percent": 0.0,
+    "flow_routing_continuity_error_percent": -0.943,
+    "continuity_value_is_b4_acceptance_threshold": false,
+    "input_hashes_match_across_replay": true,
+    "binary_output_hashes_match_across_replay": true,
+    "semantic_output_hashes_match_across_replay": true,
+    "semantic_output_sha256": {
+      "a_duty": "aaa0281b0c10c06e4e6b361d85c727d4fdc22f6a2946d871d05f2efb4ae54252",
+      "b_duty_label_probe": "fb1faf4d897abd0cfd276bd0d40014fc7b2604ab524e34283b78f812a12b61ad"
+    },
+    "binary_output_sha256": {
+      "a_duty": "56c476ba2c1cde87aec77cdbacf7bfd252958f74c01acf2af1c4c1de992b0a15",
+      "b_duty_label_probe": "da8c9fa54e844aae03ca9d4a040787954a616a8569844a8c0829fc67d437d1b8"
+    }
+  },
+  "independent_diagnostic_checks": {
+    "period_count_exact": true,
+    "all_series_finite": true,
+    "inactive_pump_zero_flow": true,
+    "active_pump_positive_flow": true,
+    "cylindrical_volume_identity": true,
+    "no_flooding": true,
+    "active_pump_series_match_after_label_swap": true,
+    "inactive_pump_series_match_after_label_swap": true,
+    "wet_well_series_match_after_label_swap": true,
+    "force_main_series_match_after_label_swap": true
+  },
+  "limitations": {
+    "physical_world_certified": false,
+    "benchmark_validity_claimed": false,
+    "independent_certifier_selected": false,
+    "runtime_dependency_authorized": false,
+    "agent_tool_authorized": false,
+    "live_solver_authorized": false,
+    "bit_reproducible_cross_workspace_build_demonstrated": false,
+    "build_reproducibility_claim": "Exact source, patch, toolchain, commands, and executed artifact identities are recorded; cross-workspace byte-identical rebuilds were not a B3 acceptance claim.",
+    "report_bytes_are_replay_contract": false,
+    "reason_report_bytes_are_not_contract": "Human-readable reports contain wall-clock analysis timestamps; semantic and binary outputs are the replay evidence."
+  },
+  "status": "pass"
+}


### PR DESCRIPTION
## Summary

- adds an isolated, research-only SWMM 5.2.4 build and replay spike
- executes B1-compatible Pump A duty and mirrored Pump B label probes
- records the explicit role decision: SWMM is a B4 offline-generator candidate; certification stays independent; runtime, agent-tool, and live-solver roles remain unauthorised
- stores only compact verification evidence while excluding vendor source, binaries, raw solver outputs, logs, and local receipts

## Focused verification

- Ruff format: 17 files already formatted
- Ruff lint: all checks passed
- focused non-engine tests: 23 passed
- real-engine integration: 1 passed
- official upstream output API test: 1/1 passed
- four real SWMM runs: 120 periods each, zero errors, zero warnings, zero non-converging steps
- input, binary-output, and semantic-output replay hashes stable
- stored portability patch applies cleanly to the pinned source and passes the staged whitespace gate

No full repository suite was run because this change is confined to the ignored research surface and does not alter production code.

## Boundaries

- no changes under `src/aec_bench`
- no B4 world parameters, production schema, CLI, registry entry, runtime dependency, agent tool, vendor source, binary, or raw engine output
- after merge, this opens only `ASW-0B4 — Generator and certification protocol`