### PR TITLE
ASW-0B4: repair forced hydraulic case horizons

### DIFF
--- a/research/asset-stewardship/au-nsw-lh-syn-sps-v1-generator-protocol.md
+++ b/research/asset-stewardship/au-nsw-lh-syn-sps-v1-generator-protocol.md
@@ -9,8 +9,9 @@
 | --- | --- |
 | Programme stage | `ASW-0B4 — Generator and certification protocol` |
 | Internal work package | `B4-W2 — Generator protocol` |
-| Status | **Accepted for B4 protocol design only** |
+| Status | **Accepted for B4 protocol design only; amended by the pre-W4 horizon repair** |
 | Repository baseline | `54c31cb4a3550fd1ae33efa2eb5ce7e4253b6468` |
+| Horizon-repair baseline | `eed52934b3fba5b17b9901df0d23a8120febcc0f` |
 | Parent PRD SHA-256 | `56d6fe6a9c69796d819a1995ae63a85392ba85a4240df8baa87df99a76678335` |
 | B1 claim/profile SHA-256 | `1956883951dd70ce52ec89f4c24ed69e5aaa4617796b803668e44002eafed954` |
 | B2 evidence/rights SHA-256 | `8d8e057792763531ebd3c8709f039c0aa7150a22ce734857221cef3339378e96` |
@@ -19,13 +20,37 @@
 | B4 execution-plan SHA-256 | `fad8cb04fad9729a81466e4527e38bcf42cffcc11c940423f610b6ffb8d8118e` |
 | B4-W1 family authority SHA-256 | `337aeab9465a8a1801b67c2ab0b408a2a2f07becddffc4a02161b64e6a8630de` |
 | Reference profile | `AU-NSW-LH-SYN-SPS-v1` |
-| Generator protocol identity | `asw-0b4.generator-protocol.v1` |
+| Generator protocol identity | `asw-0b4.generator-protocol.v2` |
 | Next permitted internal package | `B4-W3 — Independent certification protocol` only |
 
 This record resolves only `B4-D12`. Decisions `B4-D13` through `B4-D17`
 remain open under W3 through W5. This record does not implement the generator,
 run SWMM, certify or promote a family member, create a world, open B5, or earn
 a V-level.
+
+### 1.1 Pre-W4 forced-horizon repair
+
+W4 preflight review found that the original `1,200 s` forced-on snapshots
+could leave the positive-storage operating envelope before their terminal
+period. The W1 anchor clean assessment reaches zero depth at approximately
+second `1,146`, and the original G70 clean Pump B segment reaches zero depth
+at approximately local second `639`. W1 defines no dry-pump, starvation,
+cavitation, or below-storage-boundary physics. W4 therefore cannot hide that
+undefined regime inside a numerical tolerance.
+
+This amendment:
+
+- advances the generator protocol identity from `v1` to `v2`;
+- derives a bounded forced-snapshot duration from the complete W1 envelope;
+- changes individual forced hydraulic snapshots to `120 s`;
+- changes each G70 segment to `60 s`, for a `120 s` complete sequence;
+- makes each G80 checkpoint an explicit `120 s` forced snapshot; and
+- leaves every W1 parameter, equation, case purpose, engine setting, semantic
+  output, serialization rule, and claim boundary unchanged.
+
+No generator or candidate output was run to select these durations. Generator
+protocol `v1` remains historical review evidence but is not an allowed B5
+request identity.
 
 ## 2. Authority, maturity, and placement
 
@@ -658,6 +683,49 @@ three. Any later W4 sensitivity members inside one case/checkpoint are ordered
 by canonical case-content ID. A different execution order is a protocol
 failure even if outputs later happen to match.
 
+Forced-case duration is a diagnostic-observation horizon, not the W1
+`capability.t_draw_limit`. Capability remains an independent calculation at
+`h_start`; a snapshot is not extended to the capability limit.
+
+The forced horizons are bounded before execution from the most conservative
+W1 combination:
+
+```text
+A_w,min
+    = pi (2.80 m)^2 / 4
+    = 6.157521601... m²
+
+Q_net,draw,max
+    = Q_0,max - Q_in_assess,min
+    = 0.046 - 0.014
+    = 0.032 m³/s
+
+t_to_h_stop,min
+    = A_w,min (h_start,min - h_stop,max) / Q_net,draw,max
+    = 125.074657521... s
+
+h_after_120,min
+    = h_start,min - Q_net,draw,max (120 s) / A_w,min
+    = 0.876372467... m
+
+minimum margin above h_stop,max
+    = 0.876372467... - 0.85
+    = 0.026372467... m
+```
+
+The bound deliberately assumes continuous maximum support flow rather than a
+smaller solved operating flow. It is therefore conservative without using a
+generator result. Every individual forced-on snapshot in G12 through G61 and
+each G80 checkpoint lasts `120 s`. G70 divides the same total duration into
+two `60 s` segments, so the complete transfer sequence retains the same
+positive margin even if both pumps sustain the conservative maximum net draw.
+
+A request for one of those cases with another duration rejects. G00 remains
+the separately declared `3,600 s` pumps-off static-storage boundary. If B5 or
+W4 later shows that a claim-critical hydraulic transient cannot be assessed
+inside this bounded window, the case returns for protocol repair; it does not
+extend into an undefined dry-well regime.
+
 ### 12.2 Exact cases
 
 | Case ID | Purpose | Hydraulic stimulus and state |
@@ -665,32 +733,32 @@ failure even if outputs later happen to match.
 | `G00_ZERO_STATIC` | Static-storage limiting boundary | `3,600 s`; zero inflow; both pumps forced off; initial depth `h_start`; explicitly outside family and non-promotable |
 | `G10_CLEAN_A_BASE` | Clean automatic-duty base pattern | `28,800 s`; initial depth `h_stop`; W1 base inflow pattern; automatic Pump A thresholds; `(o_A,c_A)=(0,0)` |
 | `G11_CLEAN_B_BASE` | Label mirror | Exact G10 inputs with Pump B automatic and Pump A off |
-| `G12_CLEAN_ASSESS` | Clean capability snapshot | `1,200 s`; constant `Q_in_assess`; clean Pump A forced on |
-| `G20_OBSTRUCTION_HALF` | Primary mechanism interior | `1,200 s`; constant `Q_in_assess`; Pump A `(0.50,0)` forced on |
-| `G21_OBSTRUCTION_TRIGGER` | W1 primary trigger witness | `1,200 s`; constant `Q_in_assess`; Pump A `(0.75,0)` forced on |
-| `G22_OBSTRUCTION_UPPER` | Primary upper state | `1,200 s`; constant `Q_in_assess`; Pump A `(1,0)` forced on |
-| `G30_CLEARANCE_HALF` | Secondary mechanism interior | `1,200 s`; constant `Q_in_assess`; Pump A `(0,0.50)` forced on |
-| `G31_CLEARANCE_UPPER` | Secondary upper state | `1,200 s`; constant `Q_in_assess`; Pump A `(0,1)` forced on |
-| `G40_COMBINED_HALF` | Combined interior | `1,200 s`; constant `Q_in_assess`; Pump A `(0.50,0.50)` forced on |
-| `G41_COMBINED_UPPER` | Combined upper state | `1,200 s`; constant `Q_in_assess`; Pump A `(1,1)` forced on |
-| `G50_CLEAR_A_PRE` | Ambiguous-history A before clearing | `1,200 s`; constant `Q_in_assess`; Pump A `(0.65,0.10)` forced on |
+| `G12_CLEAN_ASSESS` | Clean capability snapshot | `120 s`; constant `Q_in_assess`; clean Pump A forced on |
+| `G20_OBSTRUCTION_HALF` | Primary mechanism interior | `120 s`; constant `Q_in_assess`; Pump A `(0.50,0)` forced on |
+| `G21_OBSTRUCTION_TRIGGER` | W1 primary trigger witness | `120 s`; constant `Q_in_assess`; Pump A `(0.75,0)` forced on |
+| `G22_OBSTRUCTION_UPPER` | Primary upper state | `120 s`; constant `Q_in_assess`; Pump A `(1,0)` forced on |
+| `G30_CLEARANCE_HALF` | Secondary mechanism interior | `120 s`; constant `Q_in_assess`; Pump A `(0,0.50)` forced on |
+| `G31_CLEARANCE_UPPER` | Secondary upper state | `120 s`; constant `Q_in_assess`; Pump A `(0,1)` forced on |
+| `G40_COMBINED_HALF` | Combined interior | `120 s`; constant `Q_in_assess`; Pump A `(0.50,0.50)` forced on |
+| `G41_COMBINED_UPPER` | Combined upper state | `120 s`; constant `Q_in_assess`; Pump A `(1,1)` forced on |
+| `G50_CLEAR_A_PRE` | Ambiguous-history A before clearing | `120 s`; constant `Q_in_assess`; Pump A `(0.65,0.10)` forced on |
 | `G51_CLEAR_A_POST` | Ambiguous-history A after anchor clearing | Same as G50 with `o_A=0.0975`, `c_A=0.10`; histories retained |
-| `G52_CLEAR_B_PRE` | Ambiguous-history B before clearing | `1,200 s`; constant `Q_in_assess`; Pump A `(0.25,0.742300)` forced on |
+| `G52_CLEAR_B_PRE` | Ambiguous-history B before clearing | `120 s`; constant `Q_in_assess`; Pump A `(0.25,0.742300)` forced on |
 | `G53_CLEAR_B_POST` | Ambiguous-history B after anchor clearing | Same as G52 with `o_A=0.0375`, `c_A=0.742300`; histories retained |
-| `G60_REPAIR_PRE` | Clearance repair before state | `1,200 s`; constant `Q_in_assess`; Pump A `(0.50,0.50)` forced on |
+| `G60_REPAIR_PRE` | Clearance repair before state | `120 s`; constant `Q_in_assess`; Pump A `(0.50,0.50)` forced on |
 | `G61_REPAIR_POST` | Anchor repair effect | Same as G60 with `o_A=0.50`, `c_A=0.05`; histories retained |
-| `G70_TRANSFER` | One physical A-to-B transfer sequence | Segment A: `1,200 s`, Pump A `(0.75,0)` forced on; Segment B: carry final well depth, Pump A off, clean Pump B forced on for `1,200 s`; constant `Q_in_assess` |
-| `G80_NO_MAINTENANCE` | Progression checkpoint family | Four independent capability snapshots at exposure `(0 s,0 starts)`, `(3,600,000 s,500)`, `(7,200,000 s,1,000)`, and `(10,800,000 s,2,000)`; severities recomputed from exact W1 anchor rates and clipping, never copied as rounded constants |
+| `G70_TRANSFER` | One physical A-to-B transfer sequence | Segment A: `60 s`, Pump A `(0.75,0)` forced on; Segment B: carry final well depth, Pump A off, clean Pump B forced on for `60 s`; constant `Q_in_assess` |
+| `G80_NO_MAINTENANCE` | Progression checkpoint family | Four independent `120 s` forced-on capability snapshots at exposure `(0 s,0 starts)`, `(3,600,000 s,500)`, `(7,200,000 s,1,000)`, and `(10,800,000 s,2,000)`; each begins at `h_start` with constant `Q_in_assess`; severities are recomputed from exact W1 anchor rates and clipping, never copied as rounded constants |
 
 ### 12.3 Sequence assembly
 
 G70 produces two segment results and one sequence result:
 
-- segment A semantic time is seconds `1 ... 1,200`;
+- segment A semantic time is seconds `1 ... 60`;
 - segment B receives segment A's exact final binary32 wet-well depth as its
   initial-depth source, records that carry hash, and has local seconds
-  `1 ... 1,200`;
-- the sequence time grid is seconds `1 ... 2,400`;
+  `1 ... 60`;
+- the sequence time grid is seconds `1 ... 120`;
 - sequence series concatenate A then B without duplicating the boundary;
 - segment diagnostics and hashes remain separate;
 - the sequence semantic hash binds both ordered segment hashes and the carry
@@ -1006,7 +1074,7 @@ labels and are intentionally invalid as executable schemas.
 ```json
 {
   "authority": {
-    "protocol": "asw-0b4.generator-protocol.v1",
+    "protocol": "asw-0b4.generator-protocol.v2",
     "profile": "AU-NSW-LH-SYN-SPS-v1",
     "w1_sha256": "337aeab9465a8a1801b67c2ab0b408a2a2f07becddffc4a02161b64e6a8630de",
     "scope": "research-only",
@@ -1028,7 +1096,7 @@ labels and are intentionally invalid as executable schemas.
       "pump-b": {"obstruction": "0", "clearance-loss": "0"}
     },
     "inflow_stimulus": "constant-assessment",
-    "horizon_s": 1200
+    "horizon_s": 120
   },
   "engine": {
     "version": "5.2.4",
@@ -1045,7 +1113,7 @@ labels and are intentionally invalid as executable schemas.
 {
   "status": "candidate-only",
   "case_content_id": "<sha256>",
-  "period_count": 1200,
+  "period_count": 120,
   "series": {
     "wet_well_depth_m": {
       "unit": "m",

--- a/research/asset-stewardship/au-nsw-lh-syn-sps-v1-independent-certification-protocol.md
+++ b/research/asset-stewardship/au-nsw-lh-syn-sps-v1-independent-certification-protocol.md
@@ -9,9 +9,10 @@
 | --- | --- |
 | Programme stage | `ASW-0B4 — Generator and certification protocol` |
 | Internal work package | `B4-W3 — Independent certification protocol` |
-| Protocol identity | `asw-0b4.independent-certification-protocol.v1` |
-| Protocol status | Accepted W3 research authority; not implemented, executed, or certified |
+| Protocol identity | `asw-0b4.independent-certification-protocol.v2` |
+| Protocol status | Accepted W3 research authority; amended by the pre-W4 horizon repair; not implemented, executed, or certified |
 | Repository baseline | `5c23c8cf2567dd08cded35207bfb2dd937c1b989` |
+| Horizon-repair baseline | `eed52934b3fba5b17b9901df0d23a8120febcc0f` |
 | Parent PRD SHA-256 | `56d6fe6a9c69796d819a1995ae63a85392ba85a4240df8baa87df99a76678335` |
 | B1 claim/profile SHA-256 | `1956883951dd70ce52ec89f4c24ed69e5aaa4617796b803668e44002eafed954` |
 | B2 evidence/rights SHA-256 | `8d8e057792763531ebd3c8709f039c0aa7150a22ce734857221cef3339378e96` |
@@ -19,7 +20,7 @@
 | B3 compact verification SHA-256 | `db93443b31a197864709e7011af8a6aa15932cbec3260cf1a2afed735ffa3f11` |
 | B4 plan SHA-256 | `fad8cb04fad9729a81466e4527e38bcf42cffcc11c940423f610b6ffb8d8118e` |
 | W1 parameter/mechanism SHA-256 | `337aeab9465a8a1801b67c2ab0b408a2a2f07becddffc4a02161b64e6a8630de` |
-| W2 generator-protocol SHA-256 | `5527d94034499d80f75f1815d932d235bd1c8654229fa19947edcba10e42ab56` |
+| W2 generator-protocol SHA-256 | `66e96610b19920f93ddfa613a1f42e5d9bec6a4eb704905f82ce7b301961d130` |
 | Reference profile | `AU-NSW-LH-SYN-SPS-v1` |
 | Decision resolved here | `B4-D13 — Independent calculation path` |
 | Next permitted internal package | `B4-W4 — Sensitivity, tolerance, and rejection protocol` only |
@@ -29,6 +30,35 @@ is a protocol-identity failure. A later correction to a predecessor requires
 an explicit impact review and a new certification-protocol identity; an
 implementation must not silently accept the nearest available file or a
 path-local substitute.
+
+### 1.1 Pre-W4 compatibility repair
+
+W4 preflight review found that generator protocol `v1` could force a pump
+beyond the positive-storage operating envelope: the clean anchor G12
+assessment reaches zero depth at approximately second `1,146`, G70's clean
+Pump B segment reaches zero at approximately local second `639`, and bounded
+W1 combinations can reach zero sooner. W1 defines no dry-pump or starvation
+physics, so the certifier cannot calculate an expected value there without
+inventing a mechanism.
+
+Generator protocol `v2` now bounds individual forced snapshots to `120 s`,
+G70 to two `60 s` segments, and G80 to explicit `120 s` snapshots. Its
+conservative derivation proves that the complete forced interval retains at
+least `0.026372467... m` above `h_stop,max` across the full W1 envelope.
+
+This amendment:
+
+- advances the independent-certification protocol identity from `v1` to
+  `v2`, as required for a corrected predecessor binding;
+- binds the exact generator protocol `v2` bytes above;
+- updates only duration, period, G70 sequence, and positive-storage
+  precondition checks; and
+- leaves the independent equations, numerical methods, residual definitions,
+  dependency boundary, result states, and W4 ownership unchanged.
+
+No SWMM or candidate output is used as the expected result. Certification
+protocol `v1` remains historical review evidence but is not an allowed B5
+certifier identity.
 
 ## 2. Ruling
 
@@ -516,6 +546,20 @@ The reference uses:
 - fixed pump state within an interval; and
 - no adaptive time step or external numerical library.
 
+Before integration, the certifier independently recomputes W2's conservative
+forced-horizon bound from the canonical W1 member and complete family limits.
+Each forced-on snapshot in G12 through G61 and each G80 checkpoint must have
+exact horizon `120 s`. G70 must have two exact `60 s` segments and a `120 s`
+complete sequence. G00 remains the declared pumps-off `3,600 s` boundary.
+The independently bounded trajectory must remain above `h_stop` for the
+complete forced-on interval. Failure is a case-construction rejection before
+any candidate comparison or W4 tolerance is applied.
+
+The rule prevents an engine-specific empty-storage behavior from becoming
+hidden benchmark physics. If a later hydraulic assessment requires more time
+than the bounded window, W2/W3 return for explicit repair rather than adding a
+dry-well branch inside the certifier.
+
 ### 11.2 Hydraulic derivative
 
 Below overflow:
@@ -708,6 +752,8 @@ These invariants do not wait for numerical tolerances:
 22. No institutional action, authority, obligation, score, handover, closure,
     or actor-visibility decision appears in the hydraulic candidate.
 23. The candidate remains explicitly non-promotable at W3.
+24. Every forced-case duration satisfies the preregistered conservative
+    positive-storage bound before execution.
 
 An invariant involving the magnitude of a floating value is exact only when
 the invariant is representational or sign-based. Near-zero, equality of
@@ -866,13 +912,13 @@ G70 is certified as one ordered physical sequence, not two unrelated runs.
 The certifier independently verifies:
 
 1. segment A has Pump A forced on at `(o_A,c_A)=(0.75,0)` and Pump B off;
-2. segment A has exactly `1,200` intervals;
+2. segment A has exactly `60` intervals;
 3. segment B initial depth is the exact binary32 terminal depth from segment A
    and its carry hash matches those bytes;
 4. the boundary appears once in the concatenated sequence;
 5. segment B has Pump A off and clean Pump B forced on;
-6. segment B has exactly `1,200` intervals;
-7. sequence time is exact `1...2,400`;
+6. segment B has exactly `60` intervals;
+7. sequence time is exact `1...120`;
 8. there is no simultaneous operation or second transfer;
 9. Pump A stops gaining runtime and starts after transfer;
 10. Pump B retains standby history and gains only future exposure;


### PR DESCRIPTION
## Summary

- repairs a pre-W4 contradiction where the accepted 1,200-second forced-on cases could leave the W1 positive-storage operating envelope
- advances the generator and independent-certifier identities from v1 to v2
- changes G12-G61 and each G80 checkpoint to 120-second forced-on snapshots
- changes G70 to two 60-second segments and a 120-second complete sequence
- binds W3 v2 to the exact amended W2 bytes and adds an exact positive-storage precondition

## Why this is required

The original clean anchor G12 reference reaches zero depth at approximately second 1,146, and G70's clean Pump B segment reaches zero at approximately local second 639. Across the full W1 bounds, the conservative minimum time from h_start,min to h_stop,max is 125.074657521 seconds.

The repaired total forced exposure is 120 seconds. Under the deliberately conservative assumption of maximum pump support flow and minimum assessment inflow, terminal depth remains 0.876372468 m, which is 0.026372468 m above h_stop,max.

W1 defines no dry-pump, starvation, or cavitation physics. W4 therefore cannot hide the old undefined regime inside a numerical tolerance.

## Boundary

This PR changes only the accepted W2 and W3 planning authorities. It changes no W1 physical parameter or equation, engine setting, residual definition, production contract, runtime code, generated case, or promoted artifact.

Protocol v1 remains historical review evidence but is not an allowed B5 request or certifier identity.

## Focused validation

- conservative 120-second positive-storage inequality passed across the complete W1 bounds
- no live 1,200-period request, result, or G70 sequence form remains
- W3's recorded W2 SHA-256 matches the amended W2 bytes
- all higher-authority hashes remain unchanged
- staged whitespace validation passed
- no full suite run: this PR changes planning Markdown only