### PR TITLE
Add wastewater pump station physical kernel

### DIFF
--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/__init__.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/__init__.py
@@ -1,6 +1,36 @@
-# ABOUTME: Exposes the certified wastewater pump-station reference-package boundary.
-# ABOUTME: Keeps package validation and models local to the pump-station environment.
+# ABOUTME: Exposes the certified package and physical wastewater pump-station boundary.
+# ABOUTME: Keeps package validation, state, and deterministic physics local to the task.
 
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.physical_kernel import (
+    advance_pump_station,
+    apply_pump_intervention,
+    assess_pump_station,
+    initial_pump_station_state,
+    inspect_pump,
+    pump_station_model_from_package,
+    transfer_duty_to_standby,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.physical_models import (
+    ClearanceFinding,
+    ObstructionFinding,
+    OperatingInterval,
+    PumpCapability,
+    PumpCondition,
+    PumpExposure,
+    PumpInspectionObservation,
+    PumpIntervention,
+    PumpInterventionKind,
+    PumpState,
+    PumpStationChangeKind,
+    PumpStationEnvironment,
+    PumpStationHydraulicBalance,
+    PumpStationInputError,
+    PumpStationModel,
+    PumpStationObservation,
+    PumpStationResources,
+    PumpStationResult,
+    PumpStationState,
+)
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.reference_package_models import (
     ReferencePackage,
 )
@@ -16,9 +46,35 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.referenc
 __all__ = [
     "EXPECTED_MANIFEST_CONTENT_ID",
     "EXPECTED_PACKAGE_CONTENT_ID",
+    "ClearanceFinding",
+    "ObstructionFinding",
+    "OperatingInterval",
+    "PumpCapability",
+    "PumpCondition",
+    "PumpExposure",
+    "PumpIntervention",
+    "PumpInterventionKind",
+    "PumpInspectionObservation",
+    "PumpState",
+    "PumpStationEnvironment",
+    "PumpStationChangeKind",
+    "PumpStationHydraulicBalance",
+    "PumpStationInputError",
+    "PumpStationModel",
+    "PumpStationObservation",
+    "PumpStationResources",
+    "PumpStationResult",
+    "PumpStationState",
     "REFERENCE_PACKAGE_FILE_NAMES",
     "ReferencePackage",
     "ReferencePackageError",
+    "advance_pump_station",
+    "apply_pump_intervention",
+    "assess_pump_station",
     "bundled_reference_package_root",
+    "initial_pump_station_state",
+    "inspect_pump",
     "load_reference_package",
+    "pump_station_model_from_package",
+    "transfer_duty_to_standby",
 ]

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/physical_kernel.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/physical_kernel.py
@@ -1,0 +1,689 @@
+# ABOUTME: Applies deterministic wastewater pump-station physics to immutable state.
+# ABOUTME: Consumes validated package data without file access, persistence, or authority logic.
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import replace
+from decimal import ROUND_HALF_UP, Decimal
+from typing import NoReturn, cast
+
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.physical_models import (
+    ClearanceFinding,
+    DegradationParameters,
+    ExposureLimits,
+    FluidProperties,
+    ForceMainParameters,
+    InflowParameters,
+    InterventionParameters,
+    ObservationParameters,
+    ObstructionFinding,
+    OperatingInterval,
+    PumpCapability,
+    PumpCondition,
+    PumpCurveParameters,
+    PumpExposure,
+    PumpInspectionObservation,
+    PumpIntervention,
+    PumpInterventionKind,
+    PumpState,
+    PumpStationChangeKind,
+    PumpStationEnvironment,
+    PumpStationHydraulicBalance,
+    PumpStationInputError,
+    PumpStationModel,
+    PumpStationObservation,
+    PumpStationResourceRequirements,
+    PumpStationResources,
+    PumpStationResult,
+    PumpStationState,
+    WetWellGeometry,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.reference_package_models import (
+    FrozenJsonValue,
+    ReferencePackage,
+)
+
+
+def _fail(code: str, detail: str) -> NoReturn:
+    raise PumpStationInputError(code, detail)
+
+
+def _mapping(value: object, label: str) -> Mapping[str, FrozenJsonValue]:
+    if not isinstance(value, Mapping):
+        _fail("reference-package-data", f"{label} is not an object")
+    return cast(Mapping[str, FrozenJsonValue], value)
+
+
+def _sequence(value: object, label: str) -> Sequence[FrozenJsonValue]:
+    if not isinstance(value, Sequence) or isinstance(value, str | bytes):
+        _fail("reference-package-data", f"{label} is not a sequence")
+    return cast(Sequence[FrozenJsonValue], value)
+
+
+def _text(value: object, label: str) -> str:
+    if not isinstance(value, str):
+        _fail("reference-package-data", f"{label} is not text")
+    return value
+
+
+def _decimal(value: object, label: str) -> Decimal:
+    if isinstance(value, bool) or not isinstance(value, str | int):
+        _fail("reference-package-data", f"{label} is not numeric")
+    try:
+        return Decimal(value)
+    except ArithmeticError:
+        _fail("reference-package-data", f"{label} is not a decimal")
+
+
+def _integer(value: object, label: str) -> int:
+    number = _decimal(value, label)
+    if number != number.to_integral_value():
+        _fail("reference-package-data", f"{label} is not an integer")
+    return int(number)
+
+
+def _boolean(value: object, label: str) -> bool:
+    if not isinstance(value, bool):
+        _fail("reference-package-data", f"{label} is not boolean")
+    return value
+
+
+def _parameter_values(member: Mapping[str, FrozenJsonValue]) -> dict[str, FrozenJsonValue]:
+    values: dict[str, FrozenJsonValue] = {}
+    for index, item in enumerate(_sequence(member.get("parameters"), "parameters")):
+        parameter = _mapping(item, f"parameters[{index}]")
+        identity = _text(parameter.get("identity"), f"parameters[{index}].identity")
+        values[identity] = parameter["value"]
+    return values
+
+
+def _inspection_band_edges(
+    member: Mapping[str, FrozenJsonValue],
+) -> tuple[Decimal, Decimal]:
+    for index, item in enumerate(_sequence(member.get("composites"), "composites")):
+        composite = _mapping(item, f"composites[{index}]")
+        if composite.get("identity") != "observation.inspection_band_edges":
+            continue
+        members = _sequence(
+            composite.get("members"),
+            "observation.inspection_band_edges.members",
+        )
+        if len(members) != 2:
+            _fail(
+                "reference-package-data",
+                "inspection band edges must contain two values",
+            )
+        return (
+            _decimal(members[0], "inspection lower threshold"),
+            _decimal(members[1], "inspection upper threshold"),
+        )
+    _fail("reference-package-data", "inspection band edges are missing")
+
+
+def pump_station_model_from_package(package: ReferencePackage) -> PumpStationModel:
+    """Compile typed pump-station physics from validated package data."""
+    member = package.physical_member
+    asset = _mapping(member.get("asset"), "asset")
+    pump_ids_value = _sequence(asset.get("component_ids"), "asset.component_ids")
+    if len(pump_ids_value) != 2:
+        _fail("reference-package-data", "asset must contain two pumps")
+    pump_ids = (
+        _text(pump_ids_value[0], "asset.component_ids[0]"),
+        _text(pump_ids_value[1], "asset.component_ids[1]"),
+    )
+    values = _parameter_values(member)
+    inspection_lower_threshold, inspection_upper_threshold = _inspection_band_edges(member)
+
+    def decimal_parameter(identity: str) -> Decimal:
+        try:
+            value = values[identity]
+        except KeyError:
+            _fail("reference-package-data", f"missing parameter {identity}")
+        return _decimal(value, identity)
+
+    def integer_parameter(identity: str) -> int:
+        try:
+            value = values[identity]
+        except KeyError:
+            _fail("reference-package-data", f"missing parameter {identity}")
+        return _integer(value, identity)
+
+    def boolean_parameter(identity: str) -> bool:
+        try:
+            value = values[identity]
+        except KeyError:
+            _fail("reference-package-data", f"missing parameter {identity}")
+        return _boolean(value, identity)
+
+    asset_transfer_limit = _integer(
+        asset.get("maximum_duty_transfers"),
+        "asset.maximum_duty_transfers",
+    )
+    parameter_transfer_limit = integer_parameter("topology.transfer_limit")
+    if asset_transfer_limit != parameter_transfer_limit:
+        _fail(
+            "reference-package-data",
+            "asset and topology transfer limits differ",
+        )
+
+    return PumpStationModel(
+        asset_id=_text(asset.get("asset_id"), "asset.asset_id"),
+        pump_ids=pump_ids,
+        initial_duty_pump_id=_text(
+            asset.get("initial_duty_component_id"),
+            "asset.initial_duty_component_id",
+        ),
+        initial_standby_pump_id=_text(
+            asset.get("initial_standby_component_id"),
+            "asset.initial_standby_component_id",
+        ),
+        maximum_running_pumps=integer_parameter("topology.max_running_pumps"),
+        maximum_duty_transfers=asset_transfer_limit,
+        fluid=FluidProperties(
+            density_kg_m3=decimal_parameter("fluid.rho"),
+            dynamic_viscosity_pa_s=decimal_parameter("fluid.mu"),
+            gravity_m_s2=decimal_parameter("fluid.g"),
+        ),
+        wet_well=WetWellGeometry(
+            diameter_m=decimal_parameter("well.D_w"),
+            stop_level_m=decimal_parameter("well.h_stop"),
+            start_level_m=decimal_parameter("well.h_start"),
+            high_level_m=decimal_parameter("well.h_high"),
+            overflow_level_m=decimal_parameter("well.h_overflow"),
+        ),
+        force_main=ForceMainParameters(
+            discharge_level_m=decimal_parameter("system.z_d"),
+            length_m=decimal_parameter("system.L"),
+            diameter_m=decimal_parameter("system.D"),
+            roughness_m=decimal_parameter("system.epsilon"),
+            minor_loss_coefficient=decimal_parameter("system.K_minor"),
+            minimum_reynolds_number=decimal_parameter("system.Re_min"),
+        ),
+        pump_curve=PumpCurveParameters(
+            shutoff_head_m=decimal_parameter("pump.H_0"),
+            zero_head_flow_m3_s=decimal_parameter("pump.Q_0"),
+            obstruction_head_loss_factor=decimal_parameter("mechanism.a_o"),
+            obstruction_curve_factor=decimal_parameter("mechanism.b_o"),
+            clearance_head_loss_factor=decimal_parameter("mechanism.a_c"),
+            clearance_curve_factor=decimal_parameter("mechanism.b_c"),
+        ),
+        inflow=InflowParameters(
+            low_m3_s=decimal_parameter("inflow.Q_low"),
+            nominal_m3_s=decimal_parameter("inflow.Q_nominal"),
+            assessment_m3_s=decimal_parameter("inflow.Q_assess"),
+            diagnostic_period_seconds=integer_parameter("inflow.T_diagnostic"),
+        ),
+        degradation=DegradationParameters(
+            obstruction_runtime_rate=decimal_parameter("mechanism.r_o_runtime"),
+            obstruction_start_rate=decimal_parameter("mechanism.r_o_start"),
+            clearance_runtime_rate=decimal_parameter("mechanism.r_c_runtime"),
+        ),
+        exposure_limits=ExposureLimits(
+            calendar_seconds=integer_parameter("exposure.calendar_max"),
+            pump_runtime_seconds=integer_parameter("exposure.runtime_max"),
+            pump_completed_starts=integer_parameter("exposure.starts_max"),
+        ),
+        capability_drawdown_limit_seconds=decimal_parameter("capability.t_draw_limit"),
+        observations=ObservationParameters(
+            level_resolution_m=decimal_parameter("observation.level_resolution"),
+            level_bias_m=decimal_parameter("observation.level_bias"),
+            flow_resolution_m3_s=decimal_parameter("observation.flow_resolution"),
+            flow_bias_fraction=decimal_parameter("observation.flow_bias"),
+            runtime_resolution_seconds=integer_parameter("observation.runtime_resolution"),
+            inspection_lower_threshold=inspection_lower_threshold,
+            inspection_upper_threshold=inspection_upper_threshold,
+        ),
+        interventions=InterventionParameters(
+            obstruction_clearance_effectiveness=decimal_parameter("intervention.e_clear"),
+            obstruction_residual=decimal_parameter("intervention.o_residual"),
+            clearance_repair_effectiveness=decimal_parameter("intervention.e_repair"),
+            clearance_residual=decimal_parameter("intervention.c_residual"),
+        ),
+        resources=PumpStationResourceRequirements(
+            repair_kit_initially_available=boolean_parameter("resource.kit_initial"),
+            repair_kit_lead_seconds=integer_parameter("resource.kit_lead"),
+            access_duration_seconds=integer_parameter("resource.access_duration"),
+            concurrent_intervention_limit=integer_parameter("resource.concurrent_limit"),
+        ),
+    )
+
+
+def initial_pump_station_state(model: PumpStationModel) -> PumpStationState:
+    """Create the clean initial physical state for a pump-station model."""
+    pumps = tuple(
+        PumpState(
+            pump_id=pump_id,
+            condition=PumpCondition.clean(),
+            exposure=PumpExposure.zero(),
+        )
+        for pump_id in model.pump_ids
+    )
+    return PumpStationState(
+        calendar_seconds=0,
+        duty_pump_id=model.initial_duty_pump_id,
+        standby_pump_id=model.initial_standby_pump_id,
+        duty_transfer_count=0,
+        pumps=cast(tuple[PumpState, PumpState], pumps),
+    )
+
+
+def _validate_state(model: PumpStationModel, state: PumpStationState) -> None:
+    if tuple(pump.pump_id for pump in state.pumps) != model.pump_ids:
+        _fail("pump-station-state", "pump identities or order differ from model")
+    if state.calendar_seconds > model.exposure_limits.calendar_seconds:
+        _fail("exposure-limit", "calendar time exceeds the certified envelope")
+    if state.duty_transfer_count > model.maximum_duty_transfers:
+        _fail("duty-transfer-limit", "state exceeds the permitted transfer count")
+    for pump in state.pumps:
+        if pump.exposure.runtime_seconds > model.exposure_limits.pump_runtime_seconds:
+            _fail("exposure-limit", f"{pump.pump_id} runtime exceeds the certified envelope")
+        if pump.exposure.completed_starts > model.exposure_limits.pump_completed_starts:
+            _fail("exposure-limit", f"{pump.pump_id} starts exceed the certified envelope")
+
+
+def _validate_environment(
+    model: PumpStationModel,
+    environment: PumpStationEnvironment,
+) -> None:
+    if environment.wet_well_level_m > model.wet_well.overflow_level_m:
+        _fail(
+            "pump-station-environment",
+            "wet-well level exceeds the certified overflow level",
+        )
+
+
+def _pump_support_factors(
+    model: PumpStationModel,
+    condition: PumpCondition,
+) -> tuple[float, float]:
+    curve = model.pump_curve
+    obstruction = float(condition.obstruction)
+    clearance = float(condition.clearance_loss)
+    head_factor = (
+        1.0
+        - float(curve.obstruction_head_loss_factor) * obstruction
+        - float(curve.clearance_head_loss_factor) * clearance
+    )
+    curve_factor = (
+        1.0 + float(curve.obstruction_curve_factor) * obstruction + float(curve.clearance_curve_factor) * clearance
+    )
+    if head_factor <= 0.0 or curve_factor <= 0.0:
+        _fail("operating-point", "pump support factors must be positive")
+    return head_factor, curve_factor
+
+
+def _pump_head_m(
+    model: PumpStationModel,
+    flow_m3_s: float,
+    condition: PumpCondition,
+) -> float:
+    head_factor, curve_factor = _pump_support_factors(model, condition)
+    flow_ratio = flow_m3_s / float(model.pump_curve.zero_head_flow_m3_s)
+    return max(
+        0.0,
+        float(model.pump_curve.shutoff_head_m) * (head_factor - curve_factor * flow_ratio * flow_ratio),
+    )
+
+
+def _support_flow_m3_s(
+    model: PumpStationModel,
+    condition: PumpCondition,
+) -> float:
+    head_factor, curve_factor = _pump_support_factors(model, condition)
+    support = float(model.pump_curve.zero_head_flow_m3_s) * math.sqrt(head_factor / curve_factor)
+    if not 0.0 < support <= float(model.pump_curve.zero_head_flow_m3_s):
+        _fail("operating-point", "pump support flow leaves the physical envelope")
+    return support
+
+
+def _system_loss_head_m(model: PumpStationModel, flow_m3_s: float) -> float:
+    if flow_m3_s == 0.0:
+        return 0.0
+    force_main = model.force_main
+    diameter = float(force_main.diameter_m)
+    velocity = 4.0 * flow_m3_s / (math.pi * diameter * diameter)
+    reynolds = float(model.fluid.density_kg_m3) * velocity * diameter / float(model.fluid.dynamic_viscosity_pa_s)
+    if reynolds < float(force_main.minimum_reynolds_number):
+        _fail("operating-point", "positive flow leaves the turbulent envelope")
+    friction = 0.25 / (math.log10(float(force_main.roughness_m) / (3.7 * diameter) + 5.74 / reynolds**0.9) ** 2)
+    velocity_head = velocity * velocity / (2.0 * float(model.fluid.gravity_m_s2))
+    return (friction * float(force_main.length_m) / diameter + float(force_main.minor_loss_coefficient)) * velocity_head
+
+
+def _system_head_m(
+    model: PumpStationModel,
+    flow_m3_s: float,
+    wet_well_level_m: Decimal,
+) -> float:
+    return float(model.force_main.discharge_level_m) - float(wet_well_level_m) + _system_loss_head_m(model, flow_m3_s)
+
+
+def _operating_flow_m3_s(
+    model: PumpStationModel,
+    condition: PumpCondition,
+    wet_well_level_m: Decimal,
+) -> float:
+    lower = 0.0
+    upper = _support_flow_m3_s(model, condition)
+
+    def residual(flow_m3_s: float) -> float:
+        return _pump_head_m(model, flow_m3_s, condition) - _system_head_m(
+            model,
+            flow_m3_s,
+            wet_well_level_m,
+        )
+
+    if residual(lower) <= 0.0 or residual(upper) >= 0.0:
+        _fail("operating-point", "operating-flow root is not strictly internal")
+    for _ in range(128):
+        midpoint = (lower + upper) / 2.0
+        if residual(midpoint) > 0.0:
+            lower = midpoint
+        else:
+            upper = midpoint
+    return (lower + upper) / 2.0
+
+
+def _capability(
+    model: PumpStationModel,
+    condition: PumpCondition,
+) -> PumpCapability:
+    operating_flow = _operating_flow_m3_s(
+        model,
+        condition,
+        model.wet_well.start_level_m,
+    )
+    net_flow = operating_flow - float(model.inflow.assessment_m3_s)
+    wet_well_area = math.pi * float(model.wet_well.diameter_m) ** 2 / 4.0
+    working_volume = wet_well_area * float(model.wet_well.start_level_m - model.wet_well.stop_level_m)
+    drawdown_seconds = math.inf if net_flow <= 0.0 else working_volume / net_flow
+    return PumpCapability(
+        operating_flow_m3_s=operating_flow,
+        drawdown_seconds=drawdown_seconds,
+        review_required=(net_flow <= 0.0 or drawdown_seconds > float(model.capability_drawdown_limit_seconds)),
+    )
+
+
+def _quantize_half_up(value: Decimal, resolution: Decimal) -> Decimal:
+    return resolution * (value / resolution).quantize(
+        Decimal(1),
+        rounding=ROUND_HALF_UP,
+    )
+
+
+def _observation(
+    model: PumpStationModel,
+    state: PumpStationState,
+    environment: PumpStationEnvironment,
+    hydraulic_balance: PumpStationHydraulicBalance,
+) -> PumpStationObservation:
+    duty_pump = state.pump(state.duty_pump_id)
+    flow = Decimal(str(hydraulic_balance.pump_flow_m3_s)) * (Decimal(1) + model.observations.flow_bias_fraction)
+    level = environment.wet_well_level_m + model.observations.level_bias_m
+    runtime_resolution = Decimal(model.observations.runtime_resolution_seconds)
+    runtime_meter = _quantize_half_up(
+        Decimal(duty_pump.exposure.runtime_seconds),
+        runtime_resolution,
+    )
+    return PumpStationObservation(
+        sample_time_seconds=state.calendar_seconds,
+        duty_pump_id=state.duty_pump_id,
+        standby_pump_id=state.standby_pump_id,
+        wet_well_level_m=_quantize_half_up(
+            level,
+            model.observations.level_resolution_m,
+        ),
+        active_pump_flow_m3_s=_quantize_half_up(
+            flow,
+            model.observations.flow_resolution_m3_s,
+        ),
+        runtime_meter_seconds=int(runtime_meter),
+        completed_starts=duty_pump.exposure.completed_starts,
+        isolated=environment.isolated,
+    )
+
+
+def _hydraulic_balance(
+    model: PumpStationModel,
+    state: PumpStationState,
+    environment: PumpStationEnvironment,
+) -> PumpStationHydraulicBalance:
+    duty_pump = state.pump(state.duty_pump_id)
+    pump_flow = (
+        0.0
+        if environment.isolated
+        else _operating_flow_m3_s(
+            model,
+            duty_pump.condition,
+            environment.wet_well_level_m,
+        )
+    )
+    inflow = float(environment.inflow_m3_s)
+    return PumpStationHydraulicBalance(
+        inflow_m3_s=inflow,
+        pump_flow_m3_s=pump_flow,
+        net_wet_well_inflow_m3_s=inflow - pump_flow,
+    )
+
+
+def _pump_station_result(
+    model: PumpStationModel,
+    previous_state: PumpStationState,
+    state: PumpStationState,
+    environment: PumpStationEnvironment,
+    change_kind: PumpStationChangeKind,
+) -> PumpStationResult:
+    _validate_state(model, state)
+    _validate_environment(model, environment)
+    duty_pump = state.pump(state.duty_pump_id)
+    hydraulic_balance = _hydraulic_balance(model, state, environment)
+    return PumpStationResult(
+        previous_state=previous_state,
+        state=state,
+        change_kind=change_kind,
+        capability=_capability(model, duty_pump.condition),
+        hydraulic_balance=hydraulic_balance,
+        observation=_observation(
+            model,
+            state,
+            environment,
+            hydraulic_balance,
+        ),
+    )
+
+
+def assess_pump_station(
+    model: PumpStationModel,
+    state: PumpStationState,
+    environment: PumpStationEnvironment,
+) -> PumpStationResult:
+    """Return current physical capability and quantized readings without mutation."""
+    return _pump_station_result(
+        model,
+        state,
+        state,
+        environment,
+        PumpStationChangeKind.ASSESSMENT,
+    )
+
+
+def inspect_pump(
+    model: PumpStationModel,
+    state: PumpStationState,
+    pump_id: str,
+) -> PumpInspectionObservation:
+    """Generate deterministic inspection bands without changing physical state."""
+    _validate_state(model, state)
+    condition = state.pump(pump_id).condition
+    lower = model.observations.inspection_lower_threshold
+    upper = model.observations.inspection_upper_threshold
+    if condition.obstruction < lower:
+        obstruction_finding = ObstructionFinding.NO_MATERIAL_CONFIRMED
+    elif condition.obstruction < upper:
+        obstruction_finding = ObstructionFinding.MATERIAL_PRESENT
+    else:
+        obstruction_finding = ObstructionFinding.SUBSTANTIAL_MATERIAL_PRESENT
+    if condition.clearance_loss < lower:
+        clearance_finding = ClearanceFinding.CLEARANCE_LOSS_LOW
+    elif condition.clearance_loss < upper:
+        clearance_finding = ClearanceFinding.CLEARANCE_LOSS_MODERATE
+    else:
+        clearance_finding = ClearanceFinding.CLEARANCE_LOSS_HIGH
+    return PumpInspectionObservation(
+        sample_time_seconds=state.calendar_seconds,
+        pump_id=pump_id,
+        obstruction_finding=obstruction_finding,
+        clearance_finding=clearance_finding,
+    )
+
+
+def _progress_condition(
+    model: PumpStationModel,
+    condition: PumpCondition,
+    runtime_seconds: int,
+    completed_starts: int,
+) -> PumpCondition:
+    degradation = model.degradation
+    obstruction = min(
+        Decimal(1),
+        condition.obstruction
+        + degradation.obstruction_runtime_rate * runtime_seconds
+        + degradation.obstruction_start_rate * completed_starts,
+    )
+    clearance_loss = min(
+        Decimal(1),
+        condition.clearance_loss + degradation.clearance_runtime_rate * runtime_seconds,
+    )
+    return PumpCondition(
+        obstruction=obstruction,
+        clearance_loss=clearance_loss,
+    )
+
+
+def advance_pump_station(
+    model: PumpStationModel,
+    state: PumpStationState,
+    interval: OperatingInterval,
+) -> PumpStationResult:
+    """Advance calendar, duty exposure, latent condition, and end observations."""
+    _validate_state(model, state)
+    _validate_environment(model, interval.environment)
+    duty_pump = state.pump(state.duty_pump_id)
+    updated_pump = replace(
+        duty_pump,
+        condition=_progress_condition(
+            model,
+            duty_pump.condition,
+            interval.duty_runtime_seconds,
+            interval.duty_completed_starts,
+        ),
+        exposure=PumpExposure(
+            runtime_seconds=(duty_pump.exposure.runtime_seconds + interval.duty_runtime_seconds),
+            completed_starts=(duty_pump.exposure.completed_starts + interval.duty_completed_starts),
+        ),
+    )
+    updated_state = replace(
+        state.with_pump(updated_pump),
+        calendar_seconds=state.calendar_seconds + interval.elapsed_seconds,
+    )
+    _validate_state(model, updated_state)
+    return _pump_station_result(
+        model,
+        state,
+        updated_state,
+        interval.environment,
+        PumpStationChangeKind.OPERATING_INTERVAL,
+    )
+
+
+def transfer_duty_to_standby(
+    model: PumpStationModel,
+    state: PumpStationState,
+    environment: PumpStationEnvironment,
+) -> PumpStationResult:
+    """Apply the one permitted physical duty-to-standby transfer."""
+    _validate_state(model, state)
+    if state.duty_transfer_count >= model.maximum_duty_transfers:
+        _fail("duty-transfer-limit", "no further duty transfer is permitted")
+    updated_state = replace(
+        state,
+        duty_pump_id=state.standby_pump_id,
+        standby_pump_id=state.duty_pump_id,
+        duty_transfer_count=state.duty_transfer_count + 1,
+    )
+    return _pump_station_result(
+        model,
+        state,
+        updated_state,
+        environment,
+        PumpStationChangeKind.DUTY_TRANSFER,
+    )
+
+
+def _validate_intervention_resources(
+    model: PumpStationModel,
+    intervention: PumpIntervention,
+    resources: PumpStationResources,
+) -> None:
+    requirements = model.resources
+    if (
+        resources.access_window_seconds < requirements.access_duration_seconds
+        or resources.available_intervention_slots < 1
+        or (intervention.kind is PumpInterventionKind.REPAIR_CLEARANCE and not resources.repair_kit_available)
+    ):
+        _fail(
+            "intervention-resources",
+            "access, repair kit, or intervention capacity is insufficient",
+        )
+
+
+def apply_pump_intervention(
+    model: PumpStationModel,
+    state: PumpStationState,
+    intervention: PumpIntervention,
+    resources: PumpStationResources,
+    environment: PumpStationEnvironment,
+) -> PumpStationResult:
+    """Apply one completed physical intervention without authority semantics."""
+    _validate_state(model, state)
+    _validate_environment(model, environment)
+    _validate_intervention_resources(model, intervention, resources)
+    pump = state.pump(intervention.pump_id)
+    condition = pump.condition
+    parameters = model.interventions
+    if intervention.kind is PumpInterventionKind.CLEAR_OBSTRUCTION:
+        updated_condition = PumpCondition(
+            obstruction=max(
+                parameters.obstruction_residual,
+                (Decimal(1) - parameters.obstruction_clearance_effectiveness) * condition.obstruction,
+            ),
+            clearance_loss=condition.clearance_loss,
+        )
+    else:
+        updated_condition = PumpCondition(
+            obstruction=condition.obstruction,
+            clearance_loss=max(
+                parameters.clearance_residual,
+                (Decimal(1) - parameters.clearance_repair_effectiveness) * condition.clearance_loss,
+            ),
+        )
+    updated_state = state.with_pump(
+        replace(
+            pump,
+            condition=updated_condition,
+        )
+    )
+    change_kind = (
+        PumpStationChangeKind.CLEAR_OBSTRUCTION
+        if intervention.kind is PumpInterventionKind.CLEAR_OBSTRUCTION
+        else PumpStationChangeKind.REPAIR_CLEARANCE
+    )
+    return _pump_station_result(
+        model,
+        state,
+        updated_state,
+        environment,
+        change_kind,
+    )

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/physical_models.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/physical_models.py
@@ -1,0 +1,444 @@
+# ABOUTME: Defines immutable physical models for the synthetic wastewater pump station.
+# ABOUTME: Keeps clocks, latent condition, environment, resources, and observations task-local.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from decimal import Decimal
+from enum import StrEnum
+from typing import NoReturn, Self
+
+
+class PumpStationInputError(ValueError):
+    """Raised when a physical input leaves the pump-station contract."""
+
+    def __init__(self, code: str, detail: str) -> None:
+        self.code = code
+        super().__init__(f"{code}: {detail}")
+
+
+def _fail(code: str, detail: str) -> NoReturn:
+    raise PumpStationInputError(code, detail)
+
+
+def _require_non_negative(value: int | Decimal, code: str, field_name: str) -> None:
+    if value < 0:
+        _fail(code, f"{field_name} must be non-negative")
+
+
+@dataclass(frozen=True, slots=True)
+class FluidProperties:
+    """Fluid values used by the station hydraulic equations."""
+
+    density_kg_m3: Decimal
+    dynamic_viscosity_pa_s: Decimal
+    gravity_m_s2: Decimal
+
+
+@dataclass(frozen=True, slots=True)
+class WetWellGeometry:
+    """Wet-well geometry and ordered operating levels."""
+
+    diameter_m: Decimal
+    stop_level_m: Decimal
+    start_level_m: Decimal
+    high_level_m: Decimal
+    overflow_level_m: Decimal
+
+
+@dataclass(frozen=True, slots=True)
+class ForceMainParameters:
+    """Force-main values used to calculate the system head."""
+
+    discharge_level_m: Decimal
+    length_m: Decimal
+    diameter_m: Decimal
+    roughness_m: Decimal
+    minor_loss_coefficient: Decimal
+    minimum_reynolds_number: Decimal
+
+
+@dataclass(frozen=True, slots=True)
+class PumpCurveParameters:
+    """Pump-curve values and deterministic condition response coefficients."""
+
+    shutoff_head_m: Decimal
+    zero_head_flow_m3_s: Decimal
+    obstruction_head_loss_factor: Decimal
+    obstruction_curve_factor: Decimal
+    clearance_head_loss_factor: Decimal
+    clearance_curve_factor: Decimal
+
+
+@dataclass(frozen=True, slots=True)
+class InflowParameters:
+    """Declared inflow values used by the reference station."""
+
+    low_m3_s: Decimal
+    nominal_m3_s: Decimal
+    assessment_m3_s: Decimal
+    diagnostic_period_seconds: int
+
+
+@dataclass(frozen=True, slots=True)
+class DegradationParameters:
+    """Exposure rates for obstruction and clearance loss."""
+
+    obstruction_runtime_rate: Decimal
+    obstruction_start_rate: Decimal
+    clearance_runtime_rate: Decimal
+
+
+@dataclass(frozen=True, slots=True)
+class ExposureLimits:
+    """Certified clock limits for one physical world run."""
+
+    calendar_seconds: int
+    pump_runtime_seconds: int
+    pump_completed_starts: int
+
+
+@dataclass(frozen=True, slots=True)
+class ObservationParameters:
+    """Resolution and fixed bias values for physical readings."""
+
+    level_resolution_m: Decimal
+    level_bias_m: Decimal
+    flow_resolution_m3_s: Decimal
+    flow_bias_fraction: Decimal
+    runtime_resolution_seconds: int
+    inspection_lower_threshold: Decimal
+    inspection_upper_threshold: Decimal
+
+
+@dataclass(frozen=True, slots=True)
+class InterventionParameters:
+    """Physical effectiveness and residual floors for pump interventions."""
+
+    obstruction_clearance_effectiveness: Decimal
+    obstruction_residual: Decimal
+    clearance_repair_effectiveness: Decimal
+    clearance_residual: Decimal
+
+
+@dataclass(frozen=True, slots=True)
+class PumpStationResourceRequirements:
+    """Physical resource requirements supplied to intervention effects."""
+
+    repair_kit_initially_available: bool
+    repair_kit_lead_seconds: int
+    access_duration_seconds: int
+    concurrent_intervention_limit: int
+
+
+@dataclass(frozen=True, slots=True)
+class PumpStationModel:
+    """Typed physical definition compiled from a validated reference package."""
+
+    asset_id: str
+    pump_ids: tuple[str, str]
+    initial_duty_pump_id: str
+    initial_standby_pump_id: str
+    maximum_running_pumps: int
+    maximum_duty_transfers: int
+    fluid: FluidProperties
+    wet_well: WetWellGeometry
+    force_main: ForceMainParameters
+    pump_curve: PumpCurveParameters
+    inflow: InflowParameters
+    degradation: DegradationParameters
+    exposure_limits: ExposureLimits
+    capability_drawdown_limit_seconds: Decimal
+    observations: ObservationParameters
+    interventions: InterventionParameters
+    resources: PumpStationResourceRequirements
+
+    def __post_init__(self) -> None:
+        if len(set(self.pump_ids)) != 2:
+            _fail("physical-model", "pump identities must be distinct")
+        if (
+            self.initial_duty_pump_id not in self.pump_ids
+            or self.initial_standby_pump_id not in self.pump_ids
+            or self.initial_duty_pump_id == self.initial_standby_pump_id
+        ):
+            _fail("physical-model", "initial duty and standby assignments differ")
+        if self.maximum_duty_transfers < 0:
+            _fail("physical-model", "maximum duty transfers must be non-negative")
+        if self.maximum_running_pumps != 1:
+            _fail("physical-model", "the reference station permits one running pump")
+
+
+@dataclass(frozen=True, slots=True)
+class PumpCondition:
+    """Latent obstruction and clearance-loss severity for one pump."""
+
+    obstruction: Decimal
+    clearance_loss: Decimal
+
+    def __post_init__(self) -> None:
+        if not Decimal(0) <= self.obstruction <= Decimal(1):
+            _fail("pump-condition", "obstruction must remain inside [0, 1]")
+        if not Decimal(0) <= self.clearance_loss <= Decimal(1):
+            _fail("pump-condition", "clearance loss must remain inside [0, 1]")
+
+    @classmethod
+    def clean(cls) -> Self:
+        """Return the clean latent condition."""
+        return cls(obstruction=Decimal(0), clearance_loss=Decimal(0))
+
+
+@dataclass(frozen=True, slots=True)
+class PumpExposure:
+    """Runtime and completed-start clocks for one pump."""
+
+    runtime_seconds: int
+    completed_starts: int
+
+    def __post_init__(self) -> None:
+        _require_non_negative(
+            self.runtime_seconds,
+            "pump-exposure",
+            "runtime_seconds",
+        )
+        _require_non_negative(
+            self.completed_starts,
+            "pump-exposure",
+            "completed_starts",
+        )
+
+    @classmethod
+    def zero(cls) -> Self:
+        """Return clocks with no operating exposure."""
+        return cls(runtime_seconds=0, completed_starts=0)
+
+
+@dataclass(frozen=True, slots=True)
+class PumpState:
+    """Latent condition and exposure for one physical pump."""
+
+    pump_id: str
+    condition: PumpCondition
+    exposure: PumpExposure
+
+
+@dataclass(frozen=True, slots=True)
+class PumpStationState:
+    """Immutable physical state for the two-pump station."""
+
+    calendar_seconds: int
+    duty_pump_id: str
+    standby_pump_id: str
+    duty_transfer_count: int
+    pumps: tuple[PumpState, PumpState]
+
+    def __post_init__(self) -> None:
+        _require_non_negative(
+            self.calendar_seconds,
+            "pump-station-state",
+            "calendar_seconds",
+        )
+        _require_non_negative(
+            self.duty_transfer_count,
+            "pump-station-state",
+            "duty_transfer_count",
+        )
+        pump_ids = tuple(pump.pump_id for pump in self.pumps)
+        if len(set(pump_ids)) != 2:
+            _fail("pump-station-state", "state must contain two distinct pumps")
+        if (
+            self.duty_pump_id not in pump_ids
+            or self.standby_pump_id not in pump_ids
+            or self.duty_pump_id == self.standby_pump_id
+        ):
+            _fail("pump-station-state", "duty and standby assignments differ")
+
+    def pump(self, pump_id: str) -> PumpState:
+        """Return one pump by its stable component identity."""
+        for pump in self.pumps:
+            if pump.pump_id == pump_id:
+                return pump
+        _fail("unknown-pump", pump_id)
+
+    def with_pump(self, updated_pump: PumpState) -> Self:
+        """Return state with one pump replaced by matching identity."""
+        if updated_pump.pump_id not in {pump.pump_id for pump in self.pumps}:
+            _fail("unknown-pump", updated_pump.pump_id)
+        first, second = self.pumps
+        return replace(
+            self,
+            pumps=(
+                updated_pump if first.pump_id == updated_pump.pump_id else first,
+                updated_pump if second.pump_id == updated_pump.pump_id else second,
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PumpStationEnvironment:
+    """Current physical conditions supplied by the world controller."""
+
+    inflow_m3_s: Decimal
+    wet_well_level_m: Decimal
+    isolated: bool
+
+    def __post_init__(self) -> None:
+        _require_non_negative(
+            self.inflow_m3_s,
+            "pump-station-environment",
+            "inflow_m3_s",
+        )
+        _require_non_negative(
+            self.wet_well_level_m,
+            "pump-station-environment",
+            "wet_well_level_m",
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class OperatingInterval:
+    """One explicit interval of calendar and duty-pump exposure."""
+
+    elapsed_seconds: int
+    duty_runtime_seconds: int
+    duty_completed_starts: int
+    environment: PumpStationEnvironment
+
+    def __post_init__(self) -> None:
+        if self.elapsed_seconds <= 0:
+            _fail("operating-interval", "elapsed_seconds must be positive")
+        if not 0 <= self.duty_runtime_seconds <= self.elapsed_seconds:
+            _fail(
+                "operating-interval",
+                "duty runtime must be inside the elapsed interval",
+            )
+        _require_non_negative(
+            self.duty_completed_starts,
+            "operating-interval",
+            "duty_completed_starts",
+        )
+        if self.duty_completed_starts and self.duty_runtime_seconds == 0:
+            _fail(
+                "operating-interval",
+                "completed starts require positive duty runtime",
+            )
+        if self.environment.isolated and (self.duty_runtime_seconds or self.duty_completed_starts):
+            _fail(
+                "operating-interval",
+                "isolated intervals cannot add runtime or starts",
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class PumpStationResources:
+    """Available physical resources for a completed intervention."""
+
+    access_window_seconds: int
+    repair_kit_available: bool
+    available_intervention_slots: int
+
+    def __post_init__(self) -> None:
+        _require_non_negative(
+            self.access_window_seconds,
+            "pump-station-resources",
+            "access_window_seconds",
+        )
+        _require_non_negative(
+            self.available_intervention_slots,
+            "pump-station-resources",
+            "available_intervention_slots",
+        )
+
+
+class PumpInterventionKind(StrEnum):
+    """Physical effect supported by the reference pump station."""
+
+    CLEAR_OBSTRUCTION = "clear-obstruction"
+    REPAIR_CLEARANCE = "repair-clearance"
+
+
+class ObstructionFinding(StrEnum):
+    """Deterministic obstruction inspection band."""
+
+    NO_MATERIAL_CONFIRMED = "no_material_confirmed"
+    MATERIAL_PRESENT = "material_present"
+    SUBSTANTIAL_MATERIAL_PRESENT = "substantial_material_present"
+
+
+class ClearanceFinding(StrEnum):
+    """Deterministic clearance-loss inspection band."""
+
+    CLEARANCE_LOSS_LOW = "clearance_loss_low"
+    CLEARANCE_LOSS_MODERATE = "clearance_loss_moderate"
+    CLEARANCE_LOSS_HIGH = "clearance_loss_high"
+
+
+@dataclass(frozen=True, slots=True)
+class PumpIntervention:
+    """One completed physical intervention effect."""
+
+    kind: PumpInterventionKind
+    pump_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class PumpCapability:
+    """Physical duty capability at the declared assessment condition."""
+
+    operating_flow_m3_s: float
+    drawdown_seconds: float
+    review_required: bool
+
+
+@dataclass(frozen=True, slots=True)
+class PumpStationHydraulicBalance:
+    """Current inflow, pump flow, and net wet-well inflow."""
+
+    inflow_m3_s: float
+    pump_flow_m3_s: float
+    net_wet_well_inflow_m3_s: float
+
+
+@dataclass(frozen=True, slots=True)
+class PumpStationObservation:
+    """Quantized physical readings that exclude latent pump condition."""
+
+    sample_time_seconds: int
+    duty_pump_id: str
+    standby_pump_id: str
+    wet_well_level_m: Decimal
+    active_pump_flow_m3_s: Decimal
+    runtime_meter_seconds: int
+    completed_starts: int
+    isolated: bool
+
+
+class PumpStationChangeKind(StrEnum):
+    """Physical operation represented by one pump-station result."""
+
+    ASSESSMENT = "assessment"
+    OPERATING_INTERVAL = "operating-interval"
+    DUTY_TRANSFER = "duty-transfer"
+    CLEAR_OBSTRUCTION = "clear-obstruction"
+    REPAIR_CLEARANCE = "repair-clearance"
+
+
+@dataclass(frozen=True, slots=True)
+class PumpInspectionObservation:
+    """Inspection bands derived from latent condition without changing it."""
+
+    sample_time_seconds: int
+    pump_id: str
+    obstruction_finding: ObstructionFinding
+    clearance_finding: ClearanceFinding
+
+
+@dataclass(frozen=True, slots=True)
+class PumpStationResult:
+    """Resulting state, physical capability, and end observation."""
+
+    previous_state: PumpStationState
+    state: PumpStationState
+    change_kind: PumpStationChangeKind
+    capability: PumpCapability
+    hydraulic_balance: PumpStationHydraulicBalance
+    observation: PumpStationObservation

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_physical_kernel.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_physical_kernel.py
@@ -1,0 +1,384 @@
+# ABOUTME: Unit-tests deterministic wastewater pump-station state changes and observations.
+# ABOUTME: Covers independent clocks, degradation, duty transfer, resources, and interventions.
+
+from __future__ import annotations
+
+from dataclasses import replace
+from decimal import Decimal
+
+import pytest
+
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station import (
+    ClearanceFinding,
+    ObstructionFinding,
+    OperatingInterval,
+    PumpCondition,
+    PumpIntervention,
+    PumpInterventionKind,
+    PumpStationChangeKind,
+    PumpStationEnvironment,
+    PumpStationInputError,
+    PumpStationModel,
+    PumpStationResources,
+    PumpStationState,
+    advance_pump_station,
+    apply_pump_intervention,
+    assess_pump_station,
+    initial_pump_station_state,
+    inspect_pump,
+    load_reference_package,
+    pump_station_model_from_package,
+    transfer_duty_to_standby,
+)
+
+
+def _model_and_state() -> tuple[PumpStationModel, PumpStationState]:
+    model = pump_station_model_from_package(load_reference_package())
+    return model, initial_pump_station_state(model)
+
+
+def _assessment_environment(*, isolated: bool = False) -> PumpStationEnvironment:
+    return PumpStationEnvironment(
+        inflow_m3_s=Decimal("0.0155"),
+        wet_well_level_m=Decimal("1.65"),
+        isolated=isolated,
+    )
+
+
+def test_operating_interval_advances_distinct_clocks_and_latent_condition() -> None:
+    model, state = _model_and_state()
+
+    result = advance_pump_station(
+        model,
+        state,
+        OperatingInterval(
+            elapsed_seconds=3_600_000,
+            duty_runtime_seconds=3_600_000,
+            duty_completed_starts=500,
+            environment=_assessment_environment(),
+        ),
+    )
+
+    pump_a = result.state.pump("pump-a")
+    pump_b = result.state.pump("pump-b")
+    assert result.state.calendar_seconds == 3_600_000
+    assert result.previous_state == state
+    assert result.change_kind is PumpStationChangeKind.OPERATING_INTERVAL
+    assert pump_a.exposure.runtime_seconds == 3_600_000
+    assert pump_a.exposure.completed_starts == 500
+    assert pump_a.condition == PumpCondition(
+        obstruction=Decimal("0.32499999998400000"),
+        clearance_loss=Decimal("0.11999999998800000"),
+    )
+    assert pump_b.exposure.runtime_seconds == 0
+    assert pump_b.exposure.completed_starts == 0
+    assert pump_b.condition == PumpCondition.clean()
+    assert result.capability.review_required is False
+    assert result.capability.operating_flow_m3_s == pytest.approx(
+        0.02339426856122102,
+        abs=1e-15,
+    )
+
+
+def test_isolation_advances_calendar_without_pump_exposure() -> None:
+    model, state = _model_and_state()
+
+    result = advance_pump_station(
+        model,
+        state,
+        OperatingInterval(
+            elapsed_seconds=86_400,
+            duty_runtime_seconds=0,
+            duty_completed_starts=0,
+            environment=_assessment_environment(isolated=True),
+        ),
+    )
+
+    assert result.state.calendar_seconds == 86_400
+    assert result.state.pumps == state.pumps
+    assert result.observation.active_pump_flow_m3_s == Decimal("0.0000")
+    assert result.observation.runtime_meter_seconds == 0
+    assert result.hydraulic_balance.inflow_m3_s == pytest.approx(0.0155)
+    assert result.hydraulic_balance.pump_flow_m3_s == 0.0
+    assert result.hydraulic_balance.net_wet_well_inflow_m3_s == pytest.approx(0.0155)
+
+
+def test_duty_transfer_preserves_prior_exposure_and_moves_future_exposure() -> None:
+    model, state = _model_and_state()
+    pump_a_result = advance_pump_station(
+        model,
+        state,
+        OperatingInterval(
+            elapsed_seconds=60,
+            duty_runtime_seconds=60,
+            duty_completed_starts=1,
+            environment=_assessment_environment(),
+        ),
+    )
+
+    transferred = transfer_duty_to_standby(
+        model,
+        pump_a_result.state,
+        _assessment_environment(),
+    )
+    pump_b_result = advance_pump_station(
+        model,
+        transferred.state,
+        OperatingInterval(
+            elapsed_seconds=120,
+            duty_runtime_seconds=120,
+            duty_completed_starts=1,
+            environment=_assessment_environment(),
+        ),
+    )
+
+    assert pump_b_result.state.duty_pump_id == "pump-b"
+    assert transferred.previous_state == pump_a_result.state
+    assert transferred.change_kind is PumpStationChangeKind.DUTY_TRANSFER
+    assert pump_b_result.state.standby_pump_id == "pump-a"
+    assert pump_b_result.state.duty_transfer_count == 1
+    assert pump_b_result.state.pump("pump-a") == pump_a_result.state.pump("pump-a")
+    assert pump_b_result.state.pump("pump-b").exposure.runtime_seconds == 120
+    assert pump_b_result.state.pump("pump-b").exposure.completed_starts == 1
+    with pytest.raises(PumpStationInputError, match="duty-transfer-limit"):
+        transfer_duty_to_standby(
+            model,
+            pump_b_result.state,
+            _assessment_environment(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("kind", "before", "after"),
+    [
+        (
+            PumpInterventionKind.CLEAR_OBSTRUCTION,
+            PumpCondition(
+                obstruction=Decimal("0.65"),
+                clearance_loss=Decimal("0.10"),
+            ),
+            PumpCondition(
+                obstruction=Decimal("0.0975"),
+                clearance_loss=Decimal("0.10"),
+            ),
+        ),
+        (
+            PumpInterventionKind.REPAIR_CLEARANCE,
+            PumpCondition(
+                obstruction=Decimal("0.50"),
+                clearance_loss=Decimal("0.50"),
+            ),
+            PumpCondition(
+                obstruction=Decimal("0.50"),
+                clearance_loss=Decimal("0.0500"),
+            ),
+        ),
+    ],
+)
+def test_intervention_changes_only_its_target_mechanism(
+    kind: PumpInterventionKind,
+    before: PumpCondition,
+    after: PumpCondition,
+) -> None:
+    model, state = _model_and_state()
+    pump_a = replace(
+        state.pump("pump-a"),
+        condition=before,
+    )
+    state = state.with_pump(pump_a)
+    resources = PumpStationResources(
+        access_window_seconds=14_400,
+        repair_kit_available=True,
+        available_intervention_slots=1,
+    )
+
+    result = apply_pump_intervention(
+        model,
+        state,
+        PumpIntervention(kind=kind, pump_id="pump-a"),
+        resources,
+        _assessment_environment(),
+    )
+
+    assert result.state.pump("pump-a").condition == after
+    assert result.previous_state == state
+    assert result.change_kind is (
+        PumpStationChangeKind.CLEAR_OBSTRUCTION
+        if kind is PumpInterventionKind.CLEAR_OBSTRUCTION
+        else PumpStationChangeKind.REPAIR_CLEARANCE
+    )
+    assert result.state.pump("pump-a").exposure == state.pump("pump-a").exposure
+    assert result.state.calendar_seconds == state.calendar_seconds
+    assert result.state.pump("pump-b") == state.pump("pump-b")
+
+
+def test_clearance_repair_requires_access_kit_and_one_available_slot() -> None:
+    model, state = _model_and_state()
+    intervention = PumpIntervention(
+        kind=PumpInterventionKind.REPAIR_CLEARANCE,
+        pump_id="pump-a",
+    )
+    insufficient_resources = (
+        PumpStationResources(
+            access_window_seconds=0,
+            repair_kit_available=True,
+            available_intervention_slots=1,
+        ),
+        PumpStationResources(
+            access_window_seconds=14_400,
+            repair_kit_available=False,
+            available_intervention_slots=1,
+        ),
+        PumpStationResources(
+            access_window_seconds=14_400,
+            repair_kit_available=True,
+            available_intervention_slots=0,
+        ),
+    )
+
+    for resources in insufficient_resources:
+        with pytest.raises(PumpStationInputError, match="intervention-resources"):
+            apply_pump_intervention(
+                model,
+                state,
+                intervention,
+                resources,
+                _assessment_environment(),
+            )
+
+    assert state == initial_pump_station_state(model)
+
+
+def test_interval_rejects_exposure_that_cannot_occur() -> None:
+    environment = _assessment_environment(isolated=True)
+
+    with pytest.raises(PumpStationInputError, match="operating-interval"):
+        OperatingInterval(
+            elapsed_seconds=60,
+            duty_runtime_seconds=60,
+            duty_completed_starts=1,
+            environment=environment,
+        )
+
+
+def test_environment_inflow_changes_the_physical_hydraulic_balance() -> None:
+    model, state = _model_and_state()
+    lower_inflow = advance_pump_station(
+        model,
+        state,
+        OperatingInterval(
+            elapsed_seconds=60,
+            duty_runtime_seconds=60,
+            duty_completed_starts=1,
+            environment=PumpStationEnvironment(
+                inflow_m3_s=Decimal("0.0050"),
+                wet_well_level_m=Decimal("1.65"),
+                isolated=False,
+            ),
+        ),
+    )
+    higher_inflow = advance_pump_station(
+        model,
+        state,
+        OperatingInterval(
+            elapsed_seconds=60,
+            duty_runtime_seconds=60,
+            duty_completed_starts=1,
+            environment=PumpStationEnvironment(
+                inflow_m3_s=Decimal("0.0090"),
+                wet_well_level_m=Decimal("1.65"),
+                isolated=False,
+            ),
+        ),
+    )
+
+    assert lower_inflow.hydraulic_balance.pump_flow_m3_s == (higher_inflow.hydraulic_balance.pump_flow_m3_s)
+    assert (
+        higher_inflow.hydraulic_balance.net_wet_well_inflow_m3_s
+        - lower_inflow.hydraulic_balance.net_wet_well_inflow_m3_s
+    ) == pytest.approx(0.004)
+
+
+@pytest.mark.parametrize(
+    ("condition", "obstruction_finding", "clearance_finding"),
+    [
+        (
+            PumpCondition(
+                obstruction=Decimal("0.249"),
+                clearance_loss=Decimal("0.249"),
+            ),
+            ObstructionFinding.NO_MATERIAL_CONFIRMED,
+            ClearanceFinding.CLEARANCE_LOSS_LOW,
+        ),
+        (
+            PumpCondition(
+                obstruction=Decimal("0.25"),
+                clearance_loss=Decimal("0.25"),
+            ),
+            ObstructionFinding.MATERIAL_PRESENT,
+            ClearanceFinding.CLEARANCE_LOSS_MODERATE,
+        ),
+        (
+            PumpCondition(
+                obstruction=Decimal("0.60"),
+                clearance_loss=Decimal("0.60"),
+            ),
+            ObstructionFinding.SUBSTANTIAL_MATERIAL_PRESENT,
+            ClearanceFinding.CLEARANCE_LOSS_HIGH,
+        ),
+    ],
+)
+def test_inspection_maps_latent_condition_without_changing_state(
+    condition: PumpCondition,
+    obstruction_finding: ObstructionFinding,
+    clearance_finding: ClearanceFinding,
+) -> None:
+    model, state = _model_and_state()
+    state = state.with_pump(
+        replace(
+            state.pump("pump-a"),
+            condition=condition,
+        )
+    )
+
+    observation = inspect_pump(model, state, "pump-a")
+
+    assert observation.obstruction_finding is obstruction_finding
+    assert observation.clearance_finding is clearance_finding
+    assert state.pump("pump-a").condition == condition
+
+
+def test_quantized_flow_does_not_disclose_latent_mechanism_mix() -> None:
+    model, clean_state = _model_and_state()
+    obstruction_state = clean_state.with_pump(
+        replace(
+            clean_state.pump("pump-a"),
+            condition=PumpCondition(
+                obstruction=Decimal("0.65"),
+                clearance_loss=Decimal("0.10"),
+            ),
+        )
+    )
+    clearance_state = clean_state.with_pump(
+        replace(
+            clean_state.pump("pump-a"),
+            condition=PumpCondition(
+                obstruction=Decimal("0.25"),
+                clearance_loss=Decimal("0.742300"),
+            ),
+        )
+    )
+
+    obstruction_result = assess_pump_station(
+        model,
+        obstruction_state,
+        _assessment_environment(),
+    )
+    clearance_result = assess_pump_station(
+        model,
+        clearance_state,
+        _assessment_environment(),
+    )
+
+    assert obstruction_result.state.pump("pump-a").condition != (clearance_result.state.pump("pump-a").condition)
+    assert obstruction_result.observation.active_pump_flow_m3_s == (clearance_result.observation.active_pump_flow_m3_s)

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_physical_package_integration.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_physical_package_integration.py
@@ -1,0 +1,87 @@
+# ABOUTME: Integration-tests the certified package as input to pump-station physics.
+# ABOUTME: Proves physical behavior comes from package data rather than fixed package identities.
+
+from __future__ import annotations
+
+from dataclasses import replace
+from decimal import Decimal
+from typing import Any, cast
+
+import pytest
+
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station import (
+    PumpStationEnvironment,
+    ReferencePackage,
+    assess_pump_station,
+    initial_pump_station_state,
+    load_reference_package,
+    pump_station_model_from_package,
+)
+
+
+def _reference_expected(
+    package: ReferencePackage,
+    role: str,
+) -> dict[str, Any]:
+    checks = cast(tuple[object, ...], package.physical_reference_checks["checks"])
+    for value in checks:
+        row = cast(dict[str, Any], value)
+        if row["role"] == role:
+            return cast(dict[str, Any], row["expected"])
+    raise AssertionError(f"missing reference role {role}")
+
+
+def test_reference_package_builds_task_specific_physical_model() -> None:
+    package = load_reference_package()
+
+    model = pump_station_model_from_package(package)
+
+    assert model.asset_id == "synthetic-wastewater-pump-station"
+    assert model.pump_ids == ("pump-a", "pump-b")
+    assert model.initial_duty_pump_id == "pump-a"
+    assert model.initial_standby_pump_id == "pump-b"
+    assert model.maximum_running_pumps == 1
+    assert model.maximum_duty_transfers == 1
+    assert model.degradation.obstruction_runtime_rate == Decimal("0.00000006944444444")
+    assert model.degradation.obstruction_start_rate == Decimal("0.00015")
+    assert model.degradation.clearance_runtime_rate == Decimal("0.00000003333333333")
+    assert model.resources.repair_kit_initially_available is False
+    assert model.resources.repair_kit_lead_seconds == 1_209_600
+    assert model.resources.access_duration_seconds == 14_400
+    assert model.resources.concurrent_intervention_limit == 1
+
+
+def test_model_creation_does_not_depend_on_package_hashes_or_generation_names() -> None:
+    package = load_reference_package()
+    different_outer_identity = replace(
+        package,
+        profile_id="another-profile",
+        generation_id="another-generation",
+        package_content_id="another-package",
+        manifest_content_id="another-manifest",
+    )
+
+    assert pump_station_model_from_package(different_outer_identity) == (pump_station_model_from_package(package))
+
+
+def test_clean_capability_matches_promoted_compact_reference() -> None:
+    package = load_reference_package()
+    model = pump_station_model_from_package(package)
+    state = initial_pump_station_state(model)
+    expected = _reference_expected(package, "clean")
+
+    result = assess_pump_station(
+        model,
+        state,
+        PumpStationEnvironment(
+            inflow_m3_s=Decimal("0.0155"),
+            wet_well_level_m=Decimal("1.65"),
+            isolated=False,
+        ),
+    )
+
+    assert result.capability.review_required is False
+    assert result.capability.operating_flow_m3_s == pytest.approx(
+        float(expected["finite_scalar"]),
+        abs=1e-15,
+    )

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_physical_world_e2e.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_physical_world_e2e.py
@@ -1,0 +1,210 @@
+# ABOUTME: Exercises complete in-memory wastewater pump-station physical journeys.
+# ABOUTME: Covers certified no-action progression and an intervention without research files.
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station import (
+    OperatingInterval,
+    PumpIntervention,
+    PumpInterventionKind,
+    PumpStationEnvironment,
+    PumpStationResources,
+    ReferencePackage,
+    advance_pump_station,
+    apply_pump_intervention,
+    assess_pump_station,
+    initial_pump_station_state,
+    load_reference_package,
+    pump_station_model_from_package,
+)
+
+
+def _reference_expected(
+    package: ReferencePackage,
+    role: str,
+) -> dict[str, Any]:
+    checks = cast(tuple[object, ...], package.physical_reference_checks["checks"])
+    for value in checks:
+        row = cast(dict[str, Any], value)
+        if row["role"] == role:
+            return cast(dict[str, Any], row["expected"])
+    raise AssertionError(f"missing reference role {role}")
+
+
+def _environment() -> PumpStationEnvironment:
+    return PumpStationEnvironment(
+        inflow_m3_s=Decimal("0.0155"),
+        wet_well_level_m=Decimal("1.65"),
+        isolated=False,
+    )
+
+
+def test_no_action_progression_matches_certified_capability_sequence() -> None:
+    package = load_reference_package()
+    model = pump_station_model_from_package(package)
+    state = initial_pump_station_state(model)
+    capabilities = [assess_pump_station(model, state, _environment()).capability]
+    intervals = (
+        (3_600_000, 500),
+        (3_600_000, 500),
+        (3_600_000, 1_000),
+    )
+
+    for runtime_seconds, completed_starts in intervals:
+        result = advance_pump_station(
+            model,
+            state,
+            OperatingInterval(
+                elapsed_seconds=runtime_seconds,
+                duty_runtime_seconds=runtime_seconds,
+                duty_completed_starts=completed_starts,
+                environment=_environment(),
+            ),
+        )
+        state = result.state
+        capabilities.append(result.capability)
+
+    assert [item.review_required for item in capabilities] == [
+        False,
+        False,
+        True,
+        True,
+    ]
+    assert [item.operating_flow_m3_s for item in capabilities] == pytest.approx(
+        [
+            0.02739942396643039,
+            0.02339426856122102,
+            0.02037250978021602,
+            0.01781623171840774,
+        ],
+        abs=1e-15,
+    )
+    expected_drop = Decimal(
+        cast(
+            str,
+            _reference_expected(package, "no-maintenance")["finite_scalar"],
+        )
+    )
+    actual_drop = Decimal(str(capabilities[0].operating_flow_m3_s)) - Decimal(str(capabilities[-1].operating_flow_m3_s))
+    assert actual_drop == pytest.approx(expected_drop, abs=Decimal("1e-15"))
+    assert state.calendar_seconds == 10_800_000
+    assert state.pump("pump-a").exposure.runtime_seconds == 10_800_000
+    assert state.pump("pump-a").exposure.completed_starts == 2_000
+
+
+def test_obstruction_clearing_restores_capability_without_resetting_history() -> None:
+    package = load_reference_package()
+    model = pump_station_model_from_package(package)
+    state = initial_pump_station_state(model)
+    degraded = advance_pump_station(
+        model,
+        state,
+        OperatingInterval(
+            elapsed_seconds=7_200_000,
+            duty_runtime_seconds=7_200_000,
+            duty_completed_starts=1_000,
+            environment=_environment(),
+        ),
+    )
+
+    cleared = apply_pump_intervention(
+        model,
+        degraded.state,
+        PumpIntervention(
+            kind=PumpInterventionKind.CLEAR_OBSTRUCTION,
+            pump_id="pump-a",
+        ),
+        PumpStationResources(
+            access_window_seconds=14_400,
+            repair_kit_available=False,
+            available_intervention_slots=1,
+        ),
+        _environment(),
+    )
+
+    before = degraded.state.pump("pump-a")
+    after = cleared.state.pump("pump-a")
+    assert after.condition.obstruction < before.condition.obstruction
+    assert after.condition.clearance_loss == before.condition.clearance_loss
+    assert after.exposure == before.exposure
+    assert cleared.state.calendar_seconds == degraded.state.calendar_seconds
+    assert cleared.capability.operating_flow_m3_s > degraded.capability.operating_flow_m3_s
+    assert not hasattr(cleared.observation, "obstruction")
+    assert not hasattr(cleared.observation, "clearance_loss")
+
+
+def test_physical_journey_runs_with_research_tree_absent(
+    tmp_path: Path,
+) -> None:
+    repository_root = Path(__file__).resolve().parents[4]
+    isolated_root = tmp_path / "isolated"
+    isolated_source = isolated_root / "src"
+    shutil.copytree(
+        repository_root / "src" / "aec_bench",
+        isolated_source / "aec_bench",
+    )
+    environment = os.environ.copy()
+    environment["PYTHONPATH"] = str(isolated_source)
+    environment["PYTHONNOUSERSITE"] = "1"
+    script = """
+import json
+from decimal import Decimal
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station import (
+    OperatingInterval,
+    PumpStationEnvironment,
+    advance_pump_station,
+    initial_pump_station_state,
+    load_reference_package,
+    pump_station_model_from_package,
+)
+
+model = pump_station_model_from_package(load_reference_package())
+state = initial_pump_station_state(model)
+result = advance_pump_station(
+    model,
+    state,
+    OperatingInterval(
+        elapsed_seconds=3600000,
+        duty_runtime_seconds=3600000,
+        duty_completed_starts=500,
+        environment=PumpStationEnvironment(
+            inflow_m3_s=Decimal("0.0155"),
+            wet_well_level_m=Decimal("1.65"),
+            isolated=False,
+        ),
+    ),
+)
+print(json.dumps({
+    "calendar_seconds": result.state.calendar_seconds,
+    "review_required": result.capability.review_required,
+    "runtime_seconds": result.state.pump("pump-a").exposure.runtime_seconds,
+}, sort_keys=True))
+"""
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=isolated_root,
+        env=environment,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert not (isolated_root / "research").exists()
+    assert completed.returncode == 0, completed.stderr
+    assert json.loads(completed.stdout) == {
+        "calendar_seconds": 3_600_000,
+        "review_required": False,
+        "runtime_seconds": 3_600_000,
+    }


### PR DESCRIPTION
## Summary

- add task-local immutable pump-station physical models
- add deterministic progression, duty transfer, inspection, and intervention behavior
- compile the physical model from the validated reference package without depending on package identity hashes
- keep authority, work orders, persistence, CLI, Harbor, and provider behavior outside this slice

## Verification

- 30 pump-station tests passed
- Ruff format check passed for source and tests
- Ruff lint passed for source and tests
- strict Mypy passed for the changed Python files
- staged whitespace check passed

The full repository suite reported seven unrelated failures after 7,406 passes. Six reproduce on clean origin/main. The remaining Azure reviewer failure passes alone and is order-dependent. No failing test imports or changes this pump-station slice.