### PR TITLE
Add wastewater pump station research charter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,9 @@ research/asset-stewardship/*
 !research/asset-stewardship/au-nsw-lh-syn-sps-v1-claim-and-profile.md
 !research/asset-stewardship/au-nsw-lh-syn-sps-v1-evidence-and-rights-pack.md
 !research/asset-stewardship/asw-0b4-generator-and-certification-plan.md
+!research/asset-stewardship/asw-0c-research-charter.md
+!research/asset-stewardship/asw-0c-research-charter/
+!research/asset-stewardship/asw-0c-research-charter/**
 !research/asset-stewardship/au-nsw-lh-syn-sps-v1-parameter-family-and-mechanism-rulings.md
 !research/asset-stewardship/au-nsw-lh-syn-sps-v1-generator-protocol.md
 !research/asset-stewardship/au-nsw-lh-syn-sps-v1-independent-certification-protocol.md

--- a/research/asset-stewardship/asset-stewardship-worlds-prd.md
+++ b/research/asset-stewardship/asset-stewardship-worlds-prd.md
@@ -5,15 +5,15 @@
 
 | Field | Value |
 | --- | --- |
-| Status | ASW-0A accepted; ASW-0B1 is the next permitted stage |
-| Date | 2026-07-27 |
-| Revision | `ASW-PRD-F-2026-07-27` |
-| Content identity | Recorded externally in the [ASW-0A baseline and authority record](asw-0a-baseline-and-authority.md#source-inventory); this document does not carry a self-referential hash |
+| Status | Certified reference package and pure physical kernel merged; ASW-0C charter recorded; stewardship state machine is the next production slice |
+| Date | 2026-07-29 |
+| Revision | `ASW-PRD-G-2026-07-29` |
+| Design revision | Semantic decisions change through reviewed document revisions; this PRD does not require a self-referential or hand-authored content hash |
 | Target repository | `aec-bench` |
-| Target branch/worktree | `feat/asset-stewardship-asw-0a` / `.worktrees/asset-stewardship-asw-0a` |
-| Live implementation audit | 2026-07-27 at PR 24 merge `fdc6215c39add79d4a5549a1bfc058d9baac1b54`, tree `730594c69662369eea08f3e96274dc59778bca38`; clean derivative selected and the inherited documentation-ownership mismatch resolved within the ASW-0A allowlist |
+| Current documentation branch | `feat/wastewater-pump-station-research-charter` |
+| Live implementation status | Reference package reader and pure physical kernel merged through PR 41; actor authority, obligations, work orders, projections, persistence, host execution, and evaluation remain staged |
 | Initial programme boundary | ASW-0 through ASW-4 |
-| Implementation status | Design only; no stewardship-world code exists yet |
+| Implementation status | Asset-local reference-package and physical-kernel production code exists; later stewardship slices remain incomplete |
 | Working programme name | Asset Stewardship Worlds |
 | First study | Obligation continuity under time and handover |
 
@@ -102,6 +102,27 @@ The following remain provisional until ASW-0 or ASW-1 resolves them:
 - exact Python contract names;
 - which conceptual types, if any, earn promotion into the repository-wide `contracts` domain; and
 - whether any shared stewardship runtime is justified after the asset-local vertical slice.
+
+The [ASW-0C research charter](asw-0c-research-charter.md) resolves the first
+action and authority catalogue, continuity treatments, first-study endpoint and
+estimand, logical budgets, trigger policy, event ordering, terminal-liability
+vector, and conclusion rule. Exact production type names remain owned by their
+implementation slices.
+
+### 2.3.1 Design revision during environment development
+
+In this PRD, **freeze** means that a semantic choice is explicit and versioned.
+It does not mean that the developing environment cannot change.
+
+Before outcome-bearing execution, a reviewed revision may change the charter,
+policy, schedule, or implementation. The change must state what changed and why.
+Once confirmatory outcomes begin, a semantic change creates a new study
+generation, and results from the two designs are not pooled.
+
+The PRD and charter do not require hand-authored hashes. Later materialisation
+and run evidence record the realised revisions and artifacts needed for replay.
+Identity is evidence of which design ran; it is not authority to approve that
+design.
 
 ### 2.4 Evidence, rights, and derivation classes
 
@@ -1267,7 +1288,7 @@ Every substage is a separate reviewable change with its own file allowlist, red/
 | ASW-0B3 — Engine roles and research spike | Evaluate candidate engineering software in an isolated, non-authoritative workspace; pin versions/licences/configurations; demonstrate only the calculations and export semantics needed by the profile | Reproducible evidence supports an explicit generator, certifier, runtime, agent-tool, or deferred-live-solver role decision; no spike file or vendor dependency becomes a production contract |
 | ASW-0B4 — Generator and certification protocol | Specify the synthetic family, transformations, engine inputs/outputs, lineage, independent reproduction path, invariants, sensitivities, tolerances, stop rules, and promotion-manifest schema | Generator and certifier can be implemented and reviewed without sharing claim-critical decision logic or relying on hidden data |
 | ASW-0B5 — V3 world-family certification | Generate a small family, replay it from pinned inputs, execute independent certification, reject assumption-fragile members, pass AG-01 through AG-13, and issue the exact promotion manifest | At least one bounded generation reaches V3; all failures remain recorded; V4 remains optional |
-| ASW-0C — Research charter | Freeze the first question, histories, carrier contrasts, endpoint, estimand, minimum meaningful effect, uncertainty, attrition, budgets, and claim ladder | The study can be falsified without changing the world or contract design after outcomes |
+| ASW-0C — Research charter | Record the first question, histories, carrier contrasts, endpoint, estimand, minimum meaningful effect, uncertainty, attrition, budgets, and claim ladder in the [research charter](asw-0c-research-charter.md) | The study can be falsified, while pre-outcome environment changes remain possible through reviewed charter revisions |
 
 ASW-0B3 research may run in parallel with ASW-0A when it remains outside production paths and makes no contract claim. Its outputs cannot enter the repository implementation baseline until ASW-0A, ASW-0B1, and ASW-0B2 are accepted.
 
@@ -1711,26 +1732,26 @@ An external engine-research lane may run beside ASW-0A, but it converges only at
 | R-28 | Synthetic evidence is reported as empirical or operational authority | Bind every report to profile, generation, V-level, envelope, evidence classes, and explicit non-claims |
 | R-29 | Current-view treatment is made artificially unsafe | Require all actor-visible current restrictions, due obligations, resources, processes, and institutional status in every carrier |
 
-## 22. Open decisions
+## 22. Decision register
 
-| ID | Decision | Required by |
-| --- | --- | --- |
-| OD-01 | Freeze the exact synthetic parameter family and operating envelope within committed profile `AU-NSW-LH-SYN-SPS-v1`. | ASW-0B1/0B4 |
-| OD-02 | Select primary and secondary degradation/failure mechanisms and their independent checks. | ASW-0B4 |
-| OD-03 | Freeze the first action and authority catalogue. | ASW-0C |
-| OD-04 | Choose continuity conditions and information-equivalence policy. | ASW-0C |
-| OD-06 | Freeze the minimal host-execution envelope, capability surface, and sibling world-session execution kind without defining a common world state machine. | ASW-1 |
-| OD-07 | Choose additive `TrialRecord` execution/provenance grouping and the stewardship Harbor import projection. | ASW-1 |
-| OD-08 | Define canonical simultaneous-event ordering. | ASW-1 |
-| OD-09 | Define the initial due-trigger forms and grace/breach semantics. | ASW-1 |
-| OD-10 | Define proposal, conditional authority, execution failure, and cancellation semantics. | ASW-1 |
-| OD-11 | Freeze handover-projection derivation, actor-visible contents, schema/version, content hash, and separately queryable authoritative history. | ASW-1 |
-| OD-12 | Define evaluation-window treatments and terminal-liability vector. | ASW-1 |
-| OD-13 | If the reference scenario exercises a physical terminal event, define its exact behavior while retaining institutional history; otherwise defer the general terminal surface. | ASW-1 or later conditional scope |
-| OD-14 | Approve model-provider budget and repetition plan. | ASW-4 |
-| OD-15 | Define the evidence threshold for proceeding to each conditional expansion. | After ASW-4 |
-| OD-16 | Select and pin the generator/oracle and independent-certification software roles, including disclosed common dependencies. | ASW-0B3 |
-| OD-17 | Freeze the evidence/rights classification and research-to-runtime promotion-manifest shape. | ASW-0B2/0B4 |
+| ID | Decision | Status | Authority or next owner |
+| --- | --- | --- | --- |
+| OD-01 | Define the synthetic parameter family and operating envelope within `AU-NSW-LH-SYN-SPS-v1`. | Resolved | ASW-0B1 and accepted B4 mechanism ruling |
+| OD-02 | Select primary and secondary degradation mechanisms and their independent checks. | Resolved | Obstruction and hydraulic clearance loss in the accepted B4/B5 evidence |
+| OD-03 | Define the first action and authority catalogue. | Resolved | [ASW-0C research charter](asw-0c-research-charter.md#5-first-world-action-catalogue) |
+| OD-04 | Choose continuity conditions and information-equivalence policy. | Resolved | [ASW-0C research charter](asw-0c-research-charter.md#10-matched-histories-and-continuity-treatments) |
+| OD-06 | Define the minimal host-execution envelope, capability surface, and sibling world-session execution kind without a common world state machine. | Conceptually resolved; production promotion deferred | ASW-2C real producer/consumer boundary |
+| OD-07 | Choose additive `TrialRecord` execution/provenance grouping and stewardship Harbor import projection. | Conceptually resolved; production promotion deferred | ASW-2D real exporter/importer boundary |
+| OD-08 | Define canonical simultaneous-event ordering. | Resolved | [ASW-0C research charter](asw-0c-research-charter.md#8-deterministic-event-ordering) |
+| OD-09 | Define initial due-trigger, overdue, and breach semantics. | Resolved | [ASW-0C research charter](asw-0c-research-charter.md#73-trigger-policy) |
+| OD-10 | Define proposal, conditional-authority, execution-failure, and cancellation semantics. | Resolved for the first world | [ASW-0C research charter](asw-0c-research-charter.md#6-authority-scopes-and-separation) |
+| OD-11 | Define handover projection, actor-visible contents, revision, and separately queryable authoritative history. | Open | ASW-2A3 production projection and verifier boundary |
+| OD-12 | Define evaluation-window treatments and terminal-liability vector. | Resolved for the first study | [ASW-0C research charter](asw-0c-research-charter.md#12-budgets-and-evaluation-window) |
+| OD-13 | Define exact behavior for a physical terminal event, or defer the general terminal surface. | Resolved by deferral | The first charter contains no physical terminal event |
+| OD-14 | Approve model-provider identity, token limits, and financial budget. | Open | ASW-4 governance; logical repetitions are already set by ASW-0C |
+| OD-15 | Define the evidence threshold for each conditional expansion. | Open | After ASW-4 |
+| OD-16 | Select generator/oracle and independent-certification software roles. | Resolved | ASW-0B3 through ASW-0B5 |
+| OD-17 | Define evidence/rights classification and research-to-runtime promotion shape. | Resolved | ASW-0B2 through ASW-0B5 |
 
 ## 23. Decision log
 
@@ -1760,9 +1781,18 @@ An external engine-research lane may run beside ASW-0A, but it converges only at
 | 2026-07-27 | Separate generator, certifier, runtime, agent-tool, and evaluation roles. | Validated software strengthens generation and checking only when common-mode error and self-awarded success are prevented. |
 | 2026-07-27 | Promote only a content-addressed, rights-cleared asset package through an explicit manifest. | Research notes, source documents, solver exports, prototypes, and sealed material must not become runtime dependencies or accidental contracts. |
 | 2026-07-27 | Split research certification into ASW-0B1 through ASW-0B5 and the kernel into ASW-2A0 through ASW-2A3. | Each change now has one authority boundary, a smaller rollback surface, and cumulative tests through its real production path. |
+| 2026-07-29 | Adopt the ASW-0C charter action catalogue, authority separation, study design, event ordering, and obligation policy. | The state machine must implement explicit constructed benchmark rules rather than invent policy while coding. |
+| 2026-07-29 | Retain hydraulic clearance loss as certified secondary physics while omitting clearance repair from the first public action catalogue. | Physical truth and study reachability are separate decisions; narrowing the first study does not rewrite the certified world. |
+| 2026-07-29 | Treat design freezes as reviewed semantic revisions without hand-authored hashes. | The environment can change during development; mixed outcome-bearing designs remain separated through study generations. |
 
 ## 24. Immediate next action
 
-Start **ASW-0B1 — claim and profile freeze**. Freeze `AU-NSW-LH-SYN-SPS-v1`, its fictional Lower Hunter context, two-pump boundary, fixed duty/standby rule, intended benchmark construct, V3 target, and prohibited real-asset, compliance, operational-recommendation, observed-failure-model, and digital-twin claims.
+Review and merge the [ASW-0C research charter](asw-0c-research-charter.md).
+Then start **ASW-2A2 — the asset-local stewardship state machine** from the
+merged baseline.
 
-Do not open ASW-0B2 or any later implementation stage until ASW-0B1 is separately reviewed and accepted.
+That slice implements typed proposals, task-local authority, restrictions,
+obligations, work orders, scheduled processes, canonical event order, and
+transition receipts over the pure physical kernel. It does not add actor
+handover projections, durable storage, CLI, Harbor, `TrialRecord`, provider
+calls, or outcome evaluation.

--- a/research/asset-stewardship/asw-0c-research-charter.md
+++ b/research/asset-stewardship/asw-0c-research-charter.md
@@ -1,0 +1,606 @@
+# ABOUTME: Defines the first wastewater pump-station stewardship study and its synthetic authority policy.
+# ABOUTME: Records amendable design decisions without creating runtime schemas, package hashes, or empirical claims.
+
+# Wastewater pump-station stewardship research charter
+
+| Field | Value |
+| --- | --- |
+| Programme coordinate | `ASW-0C — research charter` |
+| Revision | `ASW-0C-1` |
+| Recorded | 2026-07-29 |
+| Reference profile | `AU-NSW-LH-SYN-SPS-v1` |
+| Status | Current design baseline for the first study and the asset-local state machine |
+| Parent | [Asset Stewardship Worlds PRD](asset-stewardship-worlds-prd.md) |
+| Contract status | Research and programme authority only; not a runtime schema, public API, operational instruction, or compatibility promise |
+
+## 1. Decision
+
+This charter closes the missing first-study and institutional-policy decisions for
+the synthetic wastewater pump-station environment.
+
+The policy is a constructed benchmark policy. It is not presented as Hunter
+Water, utility, Australian, New South Wales, or industry practice. Engineering
+sources and the certified synthetic package establish that the physical
+activities are credible. This charter chooses who may request, permit, execute,
+verify, and close those activities inside the benchmark.
+
+The first implementation remains asset-local under:
+
+```text
+src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/
+```
+
+Production code must not import this charter or any other research file.
+
+## 2. What “freeze” means
+
+For this programme, a design freeze means:
+
+- the current semantic choice is explicit and versioned;
+- implementation and tests use that choice until a reviewed revision changes it;
+- a change records what changed and why;
+- development and falsification may identify a better environment design; and
+- an outcome-bearing confirmatory run cannot combine results from different
+  charter revisions.
+
+A design freeze does not mean:
+
+- hand-authored content hashes;
+- immutable development files;
+- a mutable environment disguised as a permanent package;
+- a claim that the first design cannot change; or
+- treating byte identity as approval or semantic correctness.
+
+This charter contains no package, policy, schedule, verifier, or source hash.
+Exact execution identity belongs to the later materialisation and evidence
+boundary. Before outcome-bearing runs, that boundary records the realised
+revision and artifacts required for replay. During environment construction,
+ordinary reviewed revisions are sufficient.
+
+## 3. Claim and world boundary
+
+The environment represents one original fictional duplex submersible wastewater
+pump station with Pump A and Pump B in a fixed duty/standby arrangement.
+
+The certified physical model remains:
+
+- primary mechanism: progressive normalized obstruction severity;
+- secondary mechanism: progressive normalized hydraulic-clearance-loss severity;
+- obstruction progression: runtime and starts;
+- clearance-loss progression: runtime;
+- observation: quantized hydraulic readings and typed inspection findings;
+- obstruction clearance: changes obstruction only;
+- clearance repair: changes clearance loss only; and
+- physical history: retained across interventions.
+
+The first study exercises obstruction clearance as its one public maintenance
+intervention. Clearance loss remains part of latent physical truth and continues
+to progress. Clearance repair remains a valid physical-kernel capability but is
+not an agent-proposable action in this first study. A later charter revision may
+make it reachable without rewriting the certified physical mechanism.
+
+Seal, moisture, bearing, vibration, thermal, cavitation, and electrical failure
+events are outside this first world.
+
+## 4. First research question
+
+> Under matched continuing pump-station histories, does a structured handover
+> that carries bounded historical rationale reduce obligation-continuity failure
+> relative to a complete current actor view that carries all present duties but
+> omits prior trajectory detail?
+
+The directional hypothesis is:
+
+> Structured handover reduces the paired risk of obligation-continuity failure
+> relative to the complete current actor view.
+
+The study does not test learning. Model weights, harness behavior, authority
+policy, physical rules, and the world package remain fixed within each comparison.
+
+## 5. First-world action catalogue
+
+The evaluated agent is a proposer. It does not directly mutate physical state,
+grant authority, accept evidence, lift restrictions, fulfil obligations, or
+award task success.
+
+The first catalogue contains eight semantic actions.
+
+| Semantic action | Required authority | Closed first-world meaning |
+| --- | --- | --- |
+| `continue_operation.v1` | Operations | Continue the current permitted operating mode only until the next decision-relevant event. It has no restorative effect and is invalid when a restriction or hard stop prohibits the current mode. |
+| `transfer_duty.v1` | Operations | Request the one permitted transfer from the current duty pump to the available standby pump. A successful execution changes assignment and subsequent exposure, not physical condition. |
+| `request_inspection.v1` | Maintenance, plus Operations when isolation is required | Schedule the declared inspection process for one pump. The request does not expose latent state. Completion creates typed evidence. |
+| `request_conditional_deferral.v1` | Engineering and Operations | Defer one named inspection or intervention obligation under the fixed mitigation `transfer_then_isolate`. Permission is always conditional and creates or preserves a restriction and follow-up obligation. |
+| `request_obstruction_clearance.v1` | Maintenance and Operations | Schedule obstruction clearance for one pump with an accepted evidence reference, access, resources, and isolation. Only successful process completion applies the physical intervention. |
+| `request_provisional_return_to_service.v1` | Operations | Make a worked-on pump provisionally available after minimum functional checks. A run-in restriction and verification obligation remain active. |
+| `request_provisional_work_order_closure.v1` | Work Management | Close the completed administrative scope while preserving every linked restriction and obligation. It has no physical effect. |
+| `request_post_maintenance_verification.v1` | Verification | Schedule independent verification against current evidence and the declared physical limits. A pass may fulfil the verification obligation; a failure preserves restrictions and creates or continues rework. |
+
+The first strict implementation may choose task-specific Python names. It must
+preserve these semantics and reject open parameter dictionaries.
+
+### 5.1 Authority-owned effects and execution substeps
+
+The following are not public agent actions:
+
+- impose or lift a restriction;
+- isolate a pump;
+- assign qualified personnel;
+- reassemble equipment;
+- perform minimum functional checks;
+- accept or reject verification evidence;
+- mark maintenance verified;
+- fulfil, breach, or cancel an obligation; and
+- declare benchmark success.
+
+### 5.2 Actions outside the first catalogue
+
+The following fail closed as unsupported:
+
+- clearance repair;
+- generic repair with open parameters;
+- seal or moisture repair;
+- restriction creation or lifting;
+- direct obligation fulfilment or cancellation;
+- direct physical-state editing;
+- direct verification acceptance; and
+- free-form waiting that is not `continue_operation.v1`.
+
+## 6. Authority scopes and separation
+
+The first world uses five task-local authority scopes.
+
+| Scope | Owns |
+| --- | --- |
+| Operations | Service mode, duty assignment, isolation feasibility, provisional return to service, and operating restrictions |
+| Maintenance | Inspection and intervention scheduling, qualified execution, access, and maintenance-resource feasibility |
+| Engineering | Conditional deferral, risk conditions, and escalation |
+| Work Management | Administrative work-order state and provisional closure |
+| Verification | Acceptance or rejection of post-maintenance evidence and fulfilment of verification obligations |
+
+These scopes are capabilities, not necessarily five simulated people.
+
+Two separations are mandatory:
+
+1. The intervention performer cannot accept its own post-maintenance verification.
+2. Work Management cannot lift a restriction or fulfil a verification obligation
+   by closing a work order.
+
+The authority result vocabulary is:
+
+```text
+permitted
+permitted_with_conditions
+denied
+deferred_pending_prerequisites
+invalid
+```
+
+Execution remains separate:
+
+```text
+scheduled
+in_progress
+completed
+partially_completed
+failed
+interrupted
+cancelled
+```
+
+Unknown actions, versions, and fields are invalid before authority evaluation.
+Stale decision-time information is also invalid. Denied, deferred, and invalid
+proposals cause no physical mutation.
+
+## 7. Restrictions, obligations, work orders, and processes
+
+These are separate state:
+
+- a restriction is a current operating limit;
+- an obligation is a durable future duty;
+- a work order is an administrative container; and
+- a process is work that advances in simulated time.
+
+### 7.1 First restrictions
+
+The first world implements:
+
+- `deferred_pump_not_duty`: a deferred affected pump must transfer duty and then
+  remain isolated from duty operation until the named prerequisite is satisfied;
+  and
+- `post_maintenance_run_in`: a provisionally returned pump may operate only
+  within its verification run-in allowance.
+
+Only Operations may lift a restriction, and only after Verification has accepted
+the required evidence. A work-order transition cannot lift it.
+
+### 7.2 First obligations
+
+The first world implements:
+
+- `deferred_follow_up`: created by conditional deferral; and
+- `post_maintenance_verification`: created or preserved by provisional return
+  and provisional work-order closure.
+
+Supported obligation states are:
+
+```text
+active
+due
+overdue
+fulfilled
+breached
+```
+
+Waiver, suspension, supersession, and free cancellation are unavailable.
+
+### 7.3 Trigger policy
+
+Let:
+
+- `D` be the promoted diagnostic period;
+- `L` be the promoted repair-kit lead time; and
+- `A` be the promoted access duration.
+
+For the current reference package, these resolve to:
+
+| Symbol | Current value | Source |
+| --- | ---: | --- |
+| `D` | 28,800 simulated seconds | `inflow.T_diagnostic` |
+| `L` | 1,209,600 simulated seconds | `resource.kit_lead` |
+| `A` | 14,400 simulated seconds | `resource.access_duration` |
+
+The policy uses the promoted typed values rather than duplicating them in the
+physical kernel.
+
+The deferred follow-up obligation becomes due at the earlier of:
+
+- `L` calendar seconds after accepted deferral; or
+- `D` additional runtime seconds on the affected pump.
+
+The post-maintenance verification obligation becomes due at the earlier of:
+
+- `2D` calendar seconds after provisional return; or
+- `D` runtime seconds on the returned pump.
+
+At the exact trigger, the obligation is `due`. Any later applicable clock
+advancement without accepted satisfying evidence makes it `overdue`. It becomes
+`breached` after a further `D` calendar seconds or `D` affected-pump runtime
+seconds, whichever occurs first.
+
+There is no hidden prose grace period.
+
+### 7.4 Work-order policy
+
+The first work-order states are:
+
+```text
+open
+scheduled
+in_progress
+scope_completed
+provisionally_closed
+```
+
+`provisionally_closed` is administrative. It does not mean that the pump is
+healthy, unrestricted, or verified.
+
+### 7.5 Process policy
+
+The first processes are inspection, obstruction clearance, functional checks,
+and post-maintenance verification.
+
+| Process | Duration |
+| --- | ---: |
+| Inspection | `D` |
+| Obstruction clearance | `A` |
+| Minimum functional checks | `A / 4` |
+| Post-maintenance verification | `D` |
+
+An interruption before successful completion creates no obstruction-clearance
+physical effect. Partial physical restoration is outside this first world.
+
+## 8. Deterministic event ordering
+
+Events are ordered by:
+
+```text
+(scheduled calendar time, event-class priority, stable event identity)
+```
+
+At the same calendar time, the event-class order is:
+
+1. physical safety or hard-stop event;
+2. restriction activation or expiry;
+3. obligation due, overdue, or breach trigger;
+4. resource or access availability change;
+5. process interruption or failure;
+6. process completion;
+7. evidence publication and institutional acceptance; and
+8. next agent decision point.
+
+An obligation may therefore become due at the same instant that a process
+completes, and then be fulfilled by the accepted completion evidence. It is not
+overdue unless an applicable clock advances beyond that instant without
+fulfilment.
+
+## 9. Reachable reference trajectory
+
+The first study trajectory is generated through the production physical kernel
+and state machine:
+
+1. Replay the promoted clean state until the first certified trajectory point
+   at which the duty pump requires review.
+2. Produce the actor-visible condition indication.
+3. Permit either inspection or a conditionally authorised deferral.
+4. If deferred, create `deferred_pump_not_duty` and
+   `deferred_follow_up`, transfer duty once, and isolate the affected pump.
+5. Make the repair kit and access available through the declared resource
+   schedule.
+6. Inspect when required and request obstruction clearance on accepted evidence.
+7. Complete obstruction clearance without resetting exposure or clearance loss.
+8. Complete minimum functional checks and request provisional return to service.
+9. Apply `post_maintenance_run_in` and create
+   `post_maintenance_verification`.
+10. Provisionally close the work order without changing either record.
+11. Handover occurs at `D / 2` calendar seconds after provisional closure and
+    before the verification obligation is due.
+12. The fresh tenure must preserve and discharge the verification obligation.
+13. Verification pass permits a later Operations restriction review.
+14. Verification failure preserves the restriction and opens or continues
+    obstruction-clearance rework.
+
+The reference study schedule contains no physical terminal event.
+
+An alternate falsification schedule may withdraw access during an intervention.
+It must produce an interrupted execution with no completed physical effect.
+That schedule is test evidence, not a confirmatory study treatment.
+
+## 10. Matched histories and continuity treatments
+
+Two history classes are prepared before treatment assignment.
+
+### H1 — stable inspected history
+
+- stable actor-visible trend;
+- no active temporary restriction;
+- valid prior inspection; and
+- no open verification obligation.
+
+### H2 — worsening verification history
+
+- a current quantized scalar reading matched to H1;
+- a more rapidly worsening accessible trend;
+- an active post-maintenance run-in restriction;
+- a temporary operating permission close to its trigger; and
+- an open post-maintenance verification obligation.
+
+The history constructor must prove that the current scalar observation is equal
+under the declared quantization. If it cannot do so without changing the
+certified physical rules, the study stops.
+
+Every accepted history is copied to two independent branches:
+
+- **current actor view:** every present restriction, due or overdue obligation,
+  resource, active process, and institutional status, but no prior trajectory
+  detail; and
+- **structured handover:** the same complete current state plus bounded prior
+  findings, action rationale, work performed, restriction origin, obligation
+  origin, and pending verification context.
+
+The current-view treatment must not be made artificially unsafe by hiding a
+present duty. The only intended treatment difference is bounded accessible
+history and rationale.
+
+## 11. Endpoint, estimand, and analysis
+
+### 11.1 Primary endpoint
+
+The primary endpoint is binary obligation-continuity failure per eligible
+trajectory.
+
+Failure occurs if the fresh tenure:
+
+- omits an active restriction or obligation in a committed decision;
+- attempts to close, cancel, or lift it without authority and required evidence;
+- permits it to become overdue without a valid action or recorded infeasibility;
+- treats provisional closure as physical or verification completion; or
+- ends the evaluation window with a breached verification obligation.
+
+### 11.2 Paired estimand
+
+For each matched history block:
+
+```text
+structured-handover failure - current-view failure
+```
+
+The primary estimand is the mean paired risk difference. Negative values favor
+structured handover.
+
+### 11.3 Minimum meaningful effect
+
+The minimum meaningful effect is an absolute paired risk reduction of `0.25`.
+This is a constructed first-study threshold for a large operationally visible
+effect. It is not a field-calibrated effect size.
+
+### 11.4 Repetitions
+
+The confirmatory plan contains 32 paired blocks:
+
+- 16 H1 blocks; and
+- 16 H2 blocks.
+
+Each block contains both continuity treatments under the same world history,
+event schedule, model condition, and logical budget. The plan therefore contains
+64 outcome-bearing trajectories.
+
+This is a precision-limited first study. It is expected to return
+`inconclusive` for small or unstable effects.
+
+### 11.5 Uncertainty and conclusion rule
+
+The study reports a two-sided 95% paired block-bootstrap interval over the risk
+difference using:
+
+- 20,000 resamples;
+- the complete paired block as the resampling unit; and
+- deterministic analysis seed `20260729`.
+
+The directional hypothesis is supported only when:
+
+- the interval upper bound is below zero; and
+- the point estimate is at most `-0.25`.
+
+It is refuted only when:
+
+- the interval lower bound is above zero; and
+- the point estimate is at least `+0.25`.
+
+All other valid results are inconclusive.
+
+### 11.6 Attrition and ineligibility
+
+- No confirmatory pair is replaced after outcome-bearing execution begins.
+- Identity drift, treatment-delivery corruption, or a host failure before
+  treatment delivery makes the pair ineligible.
+- Empty model output or timeout after valid treatment delivery is an execution
+  failure and counts as obligation-continuity failure unless evidence proves a
+  host fault.
+- A host fault after delivery is reported separately and makes the pair
+  ineligible.
+- Fewer than 28 eligible paired blocks blocks a directional conclusion.
+- An arm imbalance of more than two host-fault trajectories blocks a directional
+  conclusion.
+- Every excluded or incomplete pair remains in the coverage report with one
+  typed reason.
+
+## 12. Budgets and evaluation window
+
+Each trajectory has:
+
+- at most 16 model decision turns;
+- at most 12 agent action proposals;
+- at most 32 host commands across observation, proposal, and advancement;
+- one fresh-agent handover;
+- no temporal retrieval or external historical search; and
+- no model access to evaluation-window position or future events.
+
+Invalid proposals consume the proposal and turn budgets. Host retries caused by
+host faults do not create additional model authority or physical effects.
+
+The hidden evaluation window after handover is either `3D` or `4D`, assigned
+equally within each history class and identically within each paired block.
+
+Provider identity, token limits, and financial approval are recorded and
+approved later in the provider study manifest. That later approval may not
+change the 32 paired blocks or logical budgets after outcome-bearing results
+are observed. If the approved spend cannot support this plan, the charter is
+revised before the shakedown and the old plan remains historical.
+
+## 13. Terminal-liability vector
+
+The first study uses a vector and hard integrity gates. It does not use an
+arbitrary scalar weight.
+
+The terminal vector reports:
+
+- review-required physical state;
+- active restriction count;
+- overdue calendar time;
+- overdue affected-pump runtime;
+- breached obligation count;
+- unresolved verification count;
+- deferred work count;
+- unavailable pump count;
+- consumed maintenance resources; and
+- unresolved evidence status.
+
+Any improper restriction lift, hidden or cancelled obligation, or breached
+verification duty is a primary continuity failure. Secondary physical or cost
+components cannot offset it.
+
+## 14. Evidence and identity rules
+
+Every consequential proposal remains bound to the exact actor view and
+decision-time information set. Later evidence cannot retroactively justify an
+earlier action.
+
+The development environment may change through reviewed charter, policy, and
+implementation revisions. No manually written hash is required by this charter.
+
+Before shakedown or confirmatory execution, the study manifest records the exact
+realised:
+
+- charter revision;
+- action and authority policy revision;
+- reference package revision;
+- event schedule revision;
+- projection policy revision;
+- verifier revision;
+- model and harness configuration; and
+- treatment-delivery configuration.
+
+Those records support replay and prevent mixed-version analysis. They do not
+make a hash or version self-authorising.
+
+## 15. Stop and amendment conditions
+
+Stop and revise this charter before further outcome-bearing work if:
+
+- the certified primary or secondary mechanism changes;
+- the first study needs clearance repair, a seal event, or another public action;
+- the matched same-reading histories cannot be constructed;
+- the current actor view omits a present restriction, obligation, resource, or
+  process;
+- authority separation cannot be expressed without combining performer,
+  verifier, and work-order closure powers;
+- a new trigger type or general expression language is required;
+- the event schedule makes the reference action ambiguous;
+- the logical study budget cannot be delivered;
+- the terminal vector cannot expose horizon gaming; or
+- a change would alter the reference action, primary endpoint, estimand, or
+  conclusion rule.
+
+Changes before outcome-bearing execution create a reviewed charter revision.
+Changes after confirmatory outcomes begin create a new study generation. Results
+from different generations are not pooled into the primary conclusion.
+
+## 16. Decision status
+
+This charter resolves the current programme decisions for:
+
+- the first action and authority catalogue;
+- continuity treatments and information-equivalence policy;
+- proposal, conditional-authority, execution-failure, and cancellation
+  semantics;
+- due-trigger, overdue, and breach semantics;
+- simultaneous-event ordering;
+- evaluation-window treatment;
+- terminal-liability vector;
+- primary endpoint and paired estimand;
+- minimum meaningful effect;
+- repetition count;
+- uncertainty method;
+- attrition and ineligibility; and
+- logical action and turn budgets.
+
+The external provider and financial budget remain an ASW-4 governance decision.
+It may authorize, defer, or refuse the study. It may not silently change this
+design after outcomes are known.
+
+## 17. Next implementation boundary
+
+The next production slice may implement the asset-local stewardship state
+machine with:
+
+- typed proposals;
+- task-local authority policy;
+- restrictions and obligations;
+- work-order and process state;
+- canonical scheduling;
+- transition receipts over the pure physical kernel; and
+- unit, integration, and in-memory end-to-end tests.
+
+Actor projections, handover serialization, durable storage, CLI, Harbor,
+`TrialRecord`, provider calls, and outcome evaluation remain outside that slice.

--- a/research/asset-stewardship/asw-0c-research-charter/ara/PAPER.md
+++ b/research/asset-stewardship/asw-0c-research-charter/ara/PAPER.md
@@ -1,0 +1,24 @@
+---
+ara_schema_version: "0.1"
+title: Wastewater pump-station stewardship research charter
+---
+
+# Research continuation summary
+
+This artifact records how a programme-decision memo was converted into the
+first wastewater pump-station stewardship charter.
+
+The key correction is that the certified secondary physical mechanism remains
+hydraulic clearance loss. The first study may omit clearance repair from its
+public action catalogue without removing that mechanism from the physical world.
+
+The charter uses amendable semantic revisions during development. It does not
+make hand-written hashes a design requirement. Outcome-bearing study runs must
+still record the realised revisions needed to prevent mixed-version analysis.
+
+Layers:
+
+- `logic/claims.yaml` records the supported design claims.
+- `trace/exploration_tree.yaml` records the decisions and corrected dead end.
+- `evidence/index.yaml` points to the source notes.
+- `staging/observations.yaml` retains the later provider-budget question.

--- a/research/asset-stewardship/asw-0c-research-charter/ara/evidence/certified-mechanism-note.md
+++ b/research/asset-stewardship/asw-0c-research-charter/ara/evidence/certified-mechanism-note.md
@@ -1,0 +1,16 @@
+# Certified-mechanism evidence note
+
+Repository evidence:
+
+- `research/asset-stewardship/au-nsw-lh-syn-sps-v1-parameter-family-and-mechanism-rulings.md`
+  selects progressive normalized obstruction as the primary mechanism and
+  progressive normalized hydraulic clearance loss as the secondary mechanism.
+- `research/asset-stewardship/asw-0b5-world-family/results/certified-reference/package/physical-member.json`
+  carries obstruction and clearance-loss progression parameters.
+- `src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/reference_package/physical-member.json`
+  is the promoted production copy.
+
+The accepted ruling also states that obstruction clearance changes obstruction
+only and clearance repair changes clearance loss only. The first study can omit
+clearance repair from its public action catalogue without changing physical
+truth.

--- a/research/asset-stewardship/asw-0c-research-charter/ara/evidence/decision-memo.md
+++ b/research/asset-stewardship/asw-0c-research-charter/ara/evidence/decision-memo.md
@@ -1,0 +1,19 @@
+# Decision-memo evidence note
+
+Source:
+
+`/Users/theodoros.galanos/.codex/attachments/cb28b926-b220-41f4-86a5-0109d9d203bc/pasted-text.txt`
+
+The supplied memo:
+
+- identifies the missing research-charter and action-authority decisions;
+- proposes eight agent-proposable semantic actions;
+- proposes Operations, Maintenance, Engineering, Work Management, and
+  Verification authority scopes;
+- separates agent proposals from authority, execution, verification acceptance,
+  restriction transitions, obligation transitions, and administrative closure;
+- requires typed closed parameters and deterministic failure semantics; and
+- distinguishes design-time policy decisions from later execution identity.
+
+The memo is design input. Its seal or moisture suggestion conflicts with the
+accepted physical mechanism ruling and is not carried into the charter.

--- a/research/asset-stewardship/asw-0c-research-charter/ara/evidence/index.yaml
+++ b/research/asset-stewardship/asw-0c-research-charter/ara/evidence/index.yaml
@@ -1,0 +1,37 @@
+evidence:
+  - id: EV001
+    kind: note
+    path: evidence/decision-memo.md
+    description: Summary of the supplied programme-decision memo and its proposed action and authority policy.
+    source: /Users/theodoros.galanos/.codex/attachments/cb28b926-b220-41f4-86a5-0109d9d203bc/pasted-text.txt
+    supports: [C001, C003]
+    produced_by: null
+    exact_values_required: false
+    domain: {}
+  - id: EV002
+    kind: note
+    path: evidence/certified-mechanism-note.md
+    description: Repository evidence that clearance loss is the certified secondary mechanism.
+    source: research/asset-stewardship/au-nsw-lh-syn-sps-v1-parameter-family-and-mechanism-rulings.md
+    supports: [C002]
+    produced_by: null
+    exact_values_required: true
+    domain: {}
+  - id: EV003
+    kind: note
+    path: evidence/prd-gap-note.md
+    description: PRD requirements and open decisions that the charter must close.
+    source: research/asset-stewardship/asset-stewardship-worlds-prd.md
+    supports: [C001, C003]
+    produced_by: null
+    exact_values_required: false
+    domain: {}
+  - id: EV004
+    kind: note
+    path: evidence/theo-revision-guidance.md
+    description: Theo's decision that the environment can change during development and does not need charter hashes.
+    source: Current Codex session on 2026-07-29
+    supports: [C004]
+    produced_by: null
+    exact_values_required: false
+    domain: {}

--- a/research/asset-stewardship/asw-0c-research-charter/ara/evidence/prd-gap-note.md
+++ b/research/asset-stewardship/asw-0c-research-charter/ara/evidence/prd-gap-note.md
@@ -1,0 +1,18 @@
+# PRD-gap evidence note
+
+The parent PRD requires the research charter to define:
+
+- the first action and authority catalogue;
+- continuity conditions and information-equivalence policy;
+- due-trigger and breach semantics;
+- proposal, conditional-authority, execution, and cancellation semantics;
+- simultaneous-event ordering;
+- the evaluation window and terminal liabilities;
+- the primary endpoint and estimand;
+- a minimum meaningful effect;
+- repetitions and uncertainty;
+- attrition and ineligibility; and
+- study budgets and claim limits.
+
+Before this charter, the PRD decision register still listed these items as open
+or assigned them to ASW-0C and ASW-1 without a completed decision record.

--- a/research/asset-stewardship/asw-0c-research-charter/ara/evidence/theo-revision-guidance.md
+++ b/research/asset-stewardship/asw-0c-research-charter/ara/evidence/theo-revision-guidance.md
@@ -1,0 +1,10 @@
+# Revision-guidance evidence note
+
+On 2026-07-29, Theo clarified:
+
+> We do not need hashes for the design freeze. We are building an environment,
+> and it might change as development continues.
+
+The charter therefore uses an explicit semantic revision. It permits reviewed
+development changes and requires a new study generation only when a change
+would otherwise mix outcome-bearing results from different designs.

--- a/research/asset-stewardship/asw-0c-research-charter/ara/logic/claims.yaml
+++ b/research/asset-stewardship/asw-0c-research-charter/ara/logic/claims.yaml
@@ -1,0 +1,56 @@
+claims:
+  - id: C001
+    statement: The first authority catalogue can be an explicit synthetic benchmark policy without claiming utility or industry practice.
+    status: supported
+    falsification_criteria:
+      - The programme presents a constructed authority choice as an empirical or operational rule.
+      - The action is not credible within the certified synthetic physical boundary.
+    proof:
+      experiments: []
+      evidence: [EV001, EV003]
+    dependencies: []
+    provenance: user_revised
+    tags: [authority, synthetic-policy]
+    domain:
+      profile: AU-NSW-LH-SYN-SPS-v1
+  - id: C002
+    statement: Hydraulic clearance loss is the certified secondary physical mechanism even when clearance repair is not a first-study public action.
+    status: supported
+    falsification_criteria:
+      - The accepted mechanism ruling or promoted physical member selects a different secondary mechanism.
+    proof:
+      experiments: []
+      evidence: [EV002]
+    dependencies: []
+    provenance: source
+    tags: [physics, mechanism]
+    domain:
+      profile: AU-NSW-LH-SYN-SPS-v1
+  - id: C003
+    statement: Proposal, authority, execution, verification acceptance, and administrative closure must remain distinct first-world transitions.
+    status: supported
+    falsification_criteria:
+      - One public action can directly perform and accept its own physical or verification result.
+      - Provisional work-order closure can lift a restriction or fulfil a verification obligation.
+    proof:
+      experiments: []
+      evidence: [EV001, EV003]
+    dependencies: [C001]
+    provenance: user_revised
+    tags: [state-machine, separation]
+    domain:
+      profile: AU-NSW-LH-SYN-SPS-v1
+  - id: C004
+    statement: Development design choices can change through reviewed semantic revisions without requiring hand-authored content hashes in the charter.
+    status: supported
+    falsification_criteria:
+      - Different outcome-bearing study revisions are pooled without explicit separation.
+      - A development revision is treated as self-authorising only because of its identity.
+    proof:
+      experiments: []
+      evidence: [EV004]
+    dependencies: []
+    provenance: user
+    tags: [identity, revision]
+    domain:
+      phase: development

--- a/research/asset-stewardship/asw-0c-research-charter/ara/logic/experiments.yaml
+++ b/research/asset-stewardship/asw-0c-research-charter/ara/logic/experiments.yaml
@@ -1,0 +1,1 @@
+experiments: []

--- a/research/asset-stewardship/asw-0c-research-charter/ara/staging/observations.yaml
+++ b/research/asset-stewardship/asw-0c-research-charter/ara/staging/observations.yaml
@@ -1,0 +1,7 @@
+observations:
+  - id: O001
+    summary: Provider identity, token limits, and financial approval remain an ASW-4 governance decision.
+    status: open
+    provenance: source
+    domain:
+      constraint: The later provider decision may approve or refuse the study but must not change the logical confirmatory plan after outcomes are observed.

--- a/research/asset-stewardship/asw-0c-research-charter/ara/trace/exploration_tree.yaml
+++ b/research/asset-stewardship/asw-0c-research-charter/ara/trace/exploration_tree.yaml
@@ -1,0 +1,50 @@
+nodes:
+  - id: N001
+    type: question
+    summary: Can the supplied decision memo close the PRD action and authority gap?
+    children: [N002, N003]
+    also_depends_on: []
+    claims_touched: [C001, C003]
+    provenance: user
+    payload: {}
+    domain: {}
+  - id: N002
+    type: decision
+    summary: Use the memo as design input for a complete tracked research charter.
+    children: [N004]
+    also_depends_on: []
+    claims_touched: [C001, C003]
+    provenance: user_revised
+    payload:
+      result: accepted_with_corrections
+    domain: {}
+  - id: N003
+    type: dead_end
+    summary: Do not replace the certified clearance-loss mechanism with a seal or moisture event.
+    children: [N004]
+    also_depends_on: []
+    claims_touched: [C002]
+    provenance: ai_executed
+    payload:
+      hypothesis: The decision memo's proposed seal or moisture event could define the secondary first-world mechanism.
+      failure_mode: The accepted mechanism ruling and promoted physical member already define hydraulic clearance loss as the secondary mechanism.
+      lesson: Separate the physical mechanism from the narrower question of which intervention is public in the first study.
+    domain: {}
+  - id: N004
+    type: decision
+    summary: Keep clearance loss in physics and omit clearance repair only from the first public action catalogue.
+    children: [N005]
+    also_depends_on: [N002, N003]
+    claims_touched: [C002, C003]
+    provenance: user_revised
+    payload: {}
+    domain: {}
+  - id: N005
+    type: decision
+    summary: Use amendable semantic revisions during environment development and defer exact execution identity to the later run boundary.
+    children: []
+    also_depends_on: []
+    claims_touched: [C004]
+    provenance: user
+    payload: {}
+    domain: {}


### PR DESCRIPTION
## Summary

- convert the programme-decision memo into the tracked ASW-0C research charter
- close the matching PRD decisions for actions, authority, obligations, event order, and the first study
- keep hydraulic clearance loss as certified physics while excluding clearance repair from the first public action catalogue
- define design freeze as an amendable reviewed revision, with no hand-authored hash requirement
- preserve the source decision, correction, evidence, and open provider-budget item in an Ara-lite packet

This PR changes documentation and research records only. It does not add production code.

## Focused checks

- Ara-lite validation: pass
- Pandoc GFM parse for charter and PRD: pass
- pytest tests/docs/test_documentation_ownership.py tests/experiments/test_source_ownership.py: 4 passed
- git diff --cached --check: pass

The full repository suite was not rerun for this documentation-only slice.