### PR TITLE
ASW-2B: add durable pump-station world runs

### DIFF
--- a/research/asset-stewardship/asset-stewardship-worlds-prd.md
+++ b/research/asset-stewardship/asset-stewardship-worlds-prd.md
@@ -5,15 +5,15 @@
 
 | Field | Value |
 | --- | --- |
-| Status | Reference package, physical kernel, and stewardship state machine merged; ASW-2A3 projections and task verifier are in focused implementation |
+| Status | ASW-2A0 through ASW-2A3 merged; ASW-2B durable world run is in focused implementation |
 | Date | 2026-07-29 |
-| Revision | `ASW-PRD-I-2026-07-29` |
+| Revision | `ASW-PRD-J-2026-07-29` |
 | Design revision | Semantic decisions change through reviewed document revisions; this PRD does not require a self-referential or hand-authored content hash |
 | Target repository | `aec-bench` |
-| Current production branch | `feat/wastewater-pump-station-projections-verifier` |
-| Live implementation status | ASW-2A0 through ASW-2A2 are merged; ASW-2A3 adds actor views, timed episode and tenure context, handover, information binding, and verifier replay |
+| Current production branch | `feat/wastewater-pump-station-durable-world-run` |
+| Live implementation status | ASW-2A0 through ASW-2A3 are merged; ASW-2B adds immutable run artifacts, atomic transition publication, dynamic snapshots, strict resume, and selected crash recovery |
 | Initial programme boundary | ASW-0 through ASW-4 |
-| Implementation status | Asset-local package, physics, and stewardship state machine exist; projection and verifier code is under review; durable runtime and host integration remain incomplete |
+| Implementation status | Asset-local package, physics, state machine, projections, handover, verifier, and durable filesystem run exist; direct host, CLI, Harbor, records, and evaluation remain incomplete |
 | Working programme name | Asset Stewardship Worlds |
 | First study | Obligation continuity under time and handover |
 
@@ -23,7 +23,7 @@ Introduce an asset-specific persistent stewardship-world engine behind a small s
 
 Reuse the adaptive meta-harness and common execution infrastructure for agent/model execution, content addressing, experiment identity, Harbor dispatch, immutable evidence, and `TrialRecord` persistence. Reuse lifecycle transaction, recovery, and evaluation patterns without extending their checkpoint-specific models into stewardship state. Do not reinterpret SSC-03's `COMPLETE` status as continuing physical-world state.
 
-The live implementation audit confirms an asymmetric starting point. The repository is close to being able to execute, retain, verify, and compare bounded world sessions, but it has no executable stewardship kernel. The core engineering work is therefore a sibling world-semantic vertical slice, not another adapter stack, Harbor stack, artifact store, or meta-harness.
+The initial implementation audit confirmed an asymmetric starting point. The repository was close to being able to execute, retain, verify, and compare bounded world sessions, but it had no executable stewardship kernel. The core engineering work is therefore a sibling world-semantic vertical slice, not another adapter stack, Harbor stack, artifact store, or meta-harness.
 
 Adaptive repair, motif learning, promotion, and the existing four-cell harness/program candidate search are outside the ASW-0 through ASW-4 critical path. The first stewardship study freezes the model, adapter, and harness and varies only the declared continuity treatment.
 
@@ -779,6 +779,47 @@ A complete state snapshot preserves:
 - transition sequence;
 - view/projection lineage; and
 - rule identities.
+
+#### 9.10.1 ASW-2B durable run layout
+
+ASW-2B gives each pump-station world run one host-supplied repository root. The
+root belongs to one run only. The asset-local state machine still owns world
+semantics. `PumpStationWorldRunRepository` owns filesystem publication and
+strict reload.
+
+The serializer identity is `pump-station-world-run.v1`. It writes sorted,
+newline-terminated canonical JSON. Dataclass types use a closed `$type`
+discriminator, decimals use text, enums use their declared values, and tuples
+use ordered arrays. Unknown types, unknown fields, duplicate fields, unsupported
+numbers, non-canonical bytes, and invalid task records fail closed. There are no
+excluded transport fields in this version. The FR-15 transport exclusion
+allowlist is therefore the empty tuple.
+
+| Layout | Mutation | Writer | Reader/reloader | Visibility and authority | ASW-2B maturity |
+| --- | --- | --- | --- | --- | --- |
+| `manifest.json` | Immutable | `PumpStationWorldRun.create` through the repository | `PumpStationWorldRun.resume` through the repository | Host-private run, episode, branch, package, model, asset, and initial-state authority | Asset-local production |
+| `states/<state-id>.json` | Immutable | Repository state publisher | Repository state loader | Host-private complete physical and stewardship truth | Asset-local production |
+| `proposals/<content-id>.json` | Immutable | Repository transition stager | Repository step loader | Host-retained actor-origin decision evidence; not a public file | Asset-local production |
+| `information-sets/<content-id>.json` | Immutable | Repository transition stager | Repository step loader | Host-retained exact actor-visible commitment context; the containing file is not public | Asset-local production |
+| `receipts/<content-id>.json` | Immutable | Repository transition stager | Repository step loader and task verifier input | Host-private authoritative transition result | Asset-local production |
+| `events/<content-id>.json` | Immutable | Repository transition stager | Repository step loader | Host-private applied event IDs and types, including an empty proposal-only batch | Asset-local production |
+| `commits/<content-id>.json` | Immutable | Repository transition stager | Repository chain loader | Host-private link across parent commit, state, proposal, information set, receipt, and event batch | Asset-local production |
+| `current.json` | Atomic replacement only | Repository transition publisher | Snapshot, resume, and step reload | Host-private selector for the one committed state | Asset-local production |
+| `.world-run.lock` | Local coordination file | Repository | Repository | Host-private process coordination; not semantic evidence | Asset-local production |
+
+All immutable transition artifacts are flushed before `current.json` is
+replaced. The replacement and repository directory are then flushed. A local
+file lock serializes current-state selection. A crash before replacement can
+leave an unselected immutable commit, but it cannot change the selected world.
+A retry with the same proposal ID and content can reuse that evidence. Different
+content under the same proposal ID fails closed. A crash after replacement can
+lose only the caller response; the next identical request reloads the committed
+transition and does not apply physical or resource effects again.
+
+`PumpStationStateSnapshotRef` is the dynamic state reference. It contains run,
+episode, branch, sequence, state, and commit identity. It does not overload the
+compiled-package `WorldSnapshotRef`. Resume accepts only the exact state selected
+by `current.json` in ASW-2B. Historical branching remains later scope.
 
 Reset terminology is dimension-specific:
 
@@ -1759,7 +1800,7 @@ An external engine-research lane may run beside ASW-0A, but it converges only at
 | OD-08 | Define canonical simultaneous-event ordering. | Resolved | [ASW-0C research charter](asw-0c-research-charter.md#8-deterministic-event-ordering) |
 | OD-09 | Define initial due-trigger, overdue, and breach semantics. | Resolved | [ASW-0C research charter](asw-0c-research-charter.md#73-trigger-policy) |
 | OD-10 | Define proposal, conditional-authority, execution-failure, and cancellation semantics. | Resolved for the first world | [ASW-0C research charter](asw-0c-research-charter.md#6-authority-scopes-and-separation) |
-| OD-11 | Define handover projection, actor-visible contents, revision, and separately queryable authoritative history. | Resolved for the in-memory projection; durable history query deferred | ASW-2A3 projection and verifier boundary; ASW-2B artifact repository |
+| OD-11 | Define handover projection, actor-visible contents, revision, and separately queryable authoritative history. | Resolved for the selected durable commit chain; cross-branch history remains later scope | ASW-2A3 projection and verifier boundary; ASW-2B artifact repository |
 | OD-12 | Define evaluation-window treatments and terminal-liability vector. | Resolved for the first study | [ASW-0C research charter](asw-0c-research-charter.md#12-budgets-and-evaluation-window) |
 | OD-13 | Define exact behavior for a physical terminal event, or defer the general terminal surface. | Resolved by deferral | The first charter contains no physical terminal event |
 | OD-14 | Approve model-provider identity, token limits, and financial budget. | Open | ASW-4 governance; logical repetitions are already set by ASW-0C |
@@ -1801,15 +1842,16 @@ An external engine-research lane may run beside ASW-0A, but it converges only at
 | 2026-07-29 | Amend ASW-0C to complete inspection before the repair access window. | Starting the `D`-long inspection at `L` would make its completion simultaneous with breach, and canonical order would apply breach first. |
 | 2026-07-29 | Model episode time and actor-tenure time separately and keep handover inside the continuing episode. | The environment needs real simulated duration without treating a new actor or conversation as a physical reset. |
 | 2026-07-29 | Compute actor-facing identities from visible projection content only. | A full-state fingerprint in an actor view could reveal that hidden latent or future state differs even when permitted observations are equal. |
+| 2026-07-29 | Publish ASW-2B transitions as immutable task artifacts followed by one lock-serialised atomic current-state pointer. | This gives snapshot, resume, strict replay, and exactly-once physical and resource effects without a database, shared stewardship runtime, or hand-authored hashes. |
 
 ## 24. Immediate next action
 
-Complete and review **ASW-2A3 — actor views, handover, information binding,
-and the task-owned verifier** against
-[ASW-0C-3](asw-0c-research-charter.md).
+Complete and review **ASW-2B — durable world run** against
+[ASW-0C-3](asw-0c-research-charter.md), then start **ASW-2C — direct host
+session**.
 
-That slice projects complete permitted present state, carries bounded history
-across fresh actor tenures, binds every proposal to its exact visible
-information, and replays recorded transitions through a pure verifier. It does
-not add durable storage, CLI, Harbor, `TrialRecord`, provider calls, or outcome
-evaluation. After ASW-2A3 merges, start ASW-2B durable world-run persistence.
+ASW-2C may add only the minimum promoted host-execution types, provider-neutral
+world-session bridge, native typed tools, installed CLI start/resume/verify, and
+capability-disabled lifecycle regression. It must use the accepted ASW-2B
+repository and task semantics. It does not add Harbor import, `TrialRecord`
+changes, study contracts, or model-provider calls.

--- a/research/asset-stewardship/asw-0c-research-charter.md
+++ b/research/asset-stewardship/asw-0c-research-charter.md
@@ -9,7 +9,7 @@
 | Revision | `ASW-0C-3` |
 | Recorded | 2026-07-29 |
 | Reference profile | `AU-NSW-LH-SYN-SPS-v1` |
-| Status | Current design baseline for the first study, state machine, projections, and task verifier |
+| Status | Current design baseline for the first study and implemented asset-local world through ASW-2B |
 | Parent | [Asset Stewardship Worlds PRD](asset-stewardship-worlds-prd.md) |
 | Contract status | Research and programme authority only; not a runtime schema, public API, operational instruction, or compatibility promise |
 
@@ -637,16 +637,22 @@ design after outcomes are known.
 
 ## 17. Next implementation boundary
 
-The next production slice may implement the asset-local stewardship state
-machine with:
+ASW-2A2, ASW-2A3, and ASW-2B now implement the asset-local state machine,
+projections, handover, information binding, task verifier, immutable filesystem
+evidence, atomic transition publication, snapshot, resume, and selected crash
+recovery.
 
-- typed proposals;
-- task-local authority policy;
-- restrictions and obligations;
-- work-order and process state;
-- canonical scheduling;
-- transition receipts over the pure physical kernel; and
-- unit, integration, and in-memory end-to-end tests.
+This implementation record does not change the study policy in revision
+`ASW-0C-3`. Run identities and artifact content identities are computed from
+realised content. The charter does not gain hand-authored hashes.
 
-Actor projections, handover serialization, durable storage, CLI, Harbor,
-`TrialRecord`, provider calls, and outcome evaluation remain outside that slice.
+The next production slice is ASW-2C. It may add:
+
+- the minimum promoted host-execution types;
+- a provider-neutral direct world session;
+- native typed stewardship tools;
+- installed CLI start, resume, and verify commands; and
+- capability-disabled lifecycle regression evidence.
+
+Harbor import, `TrialRecord` changes, study contracts, provider calls, and
+outcome evaluation remain outside ASW-2C.

--- a/research/asset-stewardship/asw-0c-research-charter/ara/PAPER.md
+++ b/research/asset-stewardship/asw-0c-research-charter/ara/PAPER.md
@@ -28,6 +28,17 @@ resetting the continuing station. Actor-visible identities use only permitted
 projection content, so a hidden future-schedule change cannot become an
 identity side channel.
 
+ASW-2B adds a task-local durable world run under a host-supplied filesystem
+root. Complete state, proposals, information sets, receipts, applied event
+batches, and commit links are immutable. One lock-serialised atomic pointer
+selects the current state. Snapshot and resume retain simulated duration and
+all current stewardship duties. Retrying the same proposal across the selected
+crash windows cannot duplicate a resource record or physical duty transfer.
+
+This implementation computes content identities from realised artifacts. It
+does not add hashes to the task policy or make the development environment
+immutable.
+
 Layers:
 
 - `logic/claims.yaml` records the supported design claims.

--- a/research/asset-stewardship/asw-0c-research-charter/ara/evidence/asw-2b-durable-world-run-note.md
+++ b/research/asset-stewardship/asw-0c-research-charter/ara/evidence/asw-2b-durable-world-run-note.md
@@ -1,0 +1,47 @@
+# ABOUTME: Records the ASW-2B durable pump-station world-run evidence.
+# ABOUTME: Links immutable storage, snapshot, replay, duration, and crash-recovery checks.
+
+# ASW-2B durable world-run evidence
+
+Production paths:
+
+- `src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run.py`
+- `src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_models.py`
+- `src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_repository.py`
+- `src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_serialization.py`
+
+The host supplies one filesystem root for one pump-station run. The repository
+writes immutable state, proposal, information-set, receipt, event-batch, and
+commit artifacts. It then uses one atomic `current.json` replacement as the
+transition commit point. A local file lock serializes writers.
+
+The crash end-to-end test stages real immutable artifacts and stops before
+pointer publication. Resume still selects the earlier state. Retrying the same
+proposal publishes the transition once. A second resume models a lost caller
+response after publication. Repeating the proposal returns the stored
+transition. It does not create a second obligation, work order, restriction, or
+duty transfer.
+
+The filesystem integration test also advances through a real inspection event.
+The resumed state retains the simulated calendar duration and the exact applied
+event identity.
+
+Focused commands:
+
+```text
+uv run pytest -q tests/task_world_templates/stewardship/wastewater_pump_station
+uv run ruff check src/aec_bench/task_world_templates/stewardship/wastewater_pump_station tests/task_world_templates/stewardship/wastewater_pump_station
+uv run ruff format --check src/aec_bench/task_world_templates/stewardship/wastewater_pump_station tests/task_world_templates/stewardship/wastewater_pump_station
+uv run mypy <six changed pump-station production modules>
+```
+
+Observed results:
+
+- pump-station tests: 55 passed;
+- new ASW-2B tests: 6 passed;
+- Ruff lint: passed;
+- Ruff format: passed; and
+- focused Mypy: passed for six changed production modules.
+
+No CLI, Harbor, `TrialRecord`, study runner, provider call, database, or shared
+stewardship runtime is part of this evidence.

--- a/research/asset-stewardship/asw-0c-research-charter/ara/evidence/index.yaml
+++ b/research/asset-stewardship/asw-0c-research-charter/ara/evidence/index.yaml
@@ -54,3 +54,13 @@ evidence:
     exact_values_required: true
     domain:
       profile: AU-NSW-LH-SYN-SPS-v1
+  - id: EV007
+    kind: command_output
+    path: evidence/asw-2b-durable-world-run-note.md
+    description: ASW-2B production paths and strict serialization, filesystem reload, timed snapshot, replay, lock, and crash-recovery results.
+    source: feat/wastewater-pump-station-durable-world-run on 2026-07-29
+    supports: [C007]
+    produced_by: E002
+    exact_values_required: true
+    domain:
+      profile: AU-NSW-LH-SYN-SPS-v1

--- a/research/asset-stewardship/asw-0c-research-charter/ara/logic/claims.yaml
+++ b/research/asset-stewardship/asw-0c-research-charter/ara/logic/claims.yaml
@@ -85,3 +85,20 @@ claims:
     domain:
       profile: AU-NSW-LH-SYN-SPS-v1
       implementation_stage: ASW-2A3
+  - id: C007
+    statement: One task-local immutable commit chain and atomic current-state pointer can preserve a timed pump-station episode across resume without duplicating physical or resource effects on retry.
+    status: supported
+    falsification_criteria:
+      - Resume loses or changes a clock, scheduled event, restriction, obligation, work order, process, evidence record, or transition sequence.
+      - A crash before current-state publication changes the selected world.
+      - Repeating one committed proposal ID creates another physical duty transfer or another restriction, obligation, or work order.
+      - Stored unknown, malformed, non-canonical, or identity-inconsistent content reloads successfully.
+    proof:
+      experiments: [E002]
+      evidence: [EV007]
+    dependencies: [C003, C006]
+    provenance: ai_executed
+    tags: [persistence, snapshot, recovery, exactly-once]
+    domain:
+      profile: AU-NSW-LH-SYN-SPS-v1
+      implementation_stage: ASW-2B

--- a/research/asset-stewardship/asw-0c-research-charter/ara/logic/experiments.yaml
+++ b/research/asset-stewardship/asw-0c-research-charter/ara/logic/experiments.yaml
@@ -19,3 +19,26 @@ experiments:
     domain:
       profile: AU-NSW-LH-SYN-SPS-v1
       test_count: 49
+  - id: E002
+    verifies: [C007]
+    purpose: Check canonical task-artifact reload, atomic filesystem publication, timed snapshot continuity, and exactly-once crash recovery.
+    setup: Use the bundled certified package, real task state machine, and a temporary host-supplied filesystem root without mocks.
+    procedure:
+      - Run the complete pump-station test folder through pytest.
+      - Stage a resource transition without publishing the current-state pointer and resume from the prior snapshot.
+      - Retry and republish the same proposal, then repeat it after a second resume.
+      - Repeat the crash sequence for a physical duty transfer.
+      - Advance through a scheduled inspection event and resume the timed state.
+      - Run focused Ruff lint, Ruff format, and Mypy checks.
+    metrics:
+      - All pump-station unit, integration, and end-to-end tests pass.
+      - Pre-publication recovery retains the prior selected state.
+      - Post-publication retry returns the stored transition.
+      - Exactly one restriction, obligation, work order, and duty transfer exist.
+      - Calendar duration and applied event identity survive snapshot and resume.
+      - Lint, format, and type checks report no diagnostics.
+    evidence: [EV007]
+    exploratory: false
+    domain:
+      profile: AU-NSW-LH-SYN-SPS-v1
+      test_count: 55

--- a/research/asset-stewardship/asw-0c-research-charter/ara/trace/exploration_tree.yaml
+++ b/research/asset-stewardship/asw-0c-research-charter/ara/trace/exploration_tree.yaml
@@ -61,7 +61,7 @@ nodes:
   - id: N007
     type: experiment
     summary: Prove timed episode views, fresh-tenure handover, fail-closed binding, redaction, and verifier replay through ASW-2A3.
-    children: []
+    children: [N008]
     also_depends_on: [N005, N006]
     claims_touched: [C006]
     provenance: ai_executed
@@ -69,5 +69,18 @@ nodes:
       experiment_id: E001
       result: passed
       charter_revision: ASW-0C-3
+    domain:
+      profile: AU-NSW-LH-SYN-SPS-v1
+  - id: N008
+    type: experiment
+    summary: Prove durable timed state, immutable replay, atomic publication, and exactly-once crash recovery through ASW-2B.
+    children: []
+    also_depends_on: [N007]
+    claims_touched: [C007]
+    provenance: ai_executed
+    payload:
+      experiment_id: E002
+      result: passed
+      serialization_version: pump-station-world-run.v1
     domain:
       profile: AU-NSW-LH-SYN-SPS-v1

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/__init__.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/__init__.py
@@ -105,6 +105,25 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewards
     create_structured_handover,
     project_actor_view,
 )
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run import (
+    PumpStationWorldRun,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_models import (
+    PumpStationAppliedEventBatch,
+    PumpStationStagedTransition,
+    PumpStationStateSnapshotRef,
+    PumpStationWorldRunError,
+    PumpStationWorldRunManifest,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_repository import (
+    PumpStationWorldRunRepository,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_serialization import (
+    PUMP_STATION_SERIALIZATION_VERSION,
+    PUMP_STATION_TRANSPORT_FIELD_EXCLUSIONS,
+    load_pump_station_artifact,
+    pump_station_artifact_bytes,
+)
 
 __all__ = [
     "EXPECTED_MANIFEST_CONTENT_ID",
@@ -116,6 +135,7 @@ __all__ = [
     "ProposalContext",
     "PumpStationActorHistoryEntry",
     "PumpStationActorView",
+    "PumpStationAppliedEventBatch",
     "PumpStationAssignment",
     "PumpStationAuthority",
     "PumpStationAuthorityDecision",
@@ -159,6 +179,8 @@ __all__ = [
     "PumpStationSchedule",
     "PumpStationScheduledEvent",
     "PumpStationState",
+    "PumpStationStateSnapshotRef",
+    "PumpStationStagedTransition",
     "PumpStationStewardshipState",
     "PumpStationStructuredHandover",
     "PumpStationTransition",
@@ -168,6 +190,12 @@ __all__ = [
     "PumpStationWorkOrder",
     "PumpStationWorkOrderStatus",
     "PumpStationWorkResources",
+    "PumpStationWorldRun",
+    "PumpStationWorldRunError",
+    "PumpStationWorldRunManifest",
+    "PumpStationWorldRunRepository",
+    "PUMP_STATION_SERIALIZATION_VERSION",
+    "PUMP_STATION_TRANSPORT_FIELD_EXCLUSIONS",
     "REFERENCE_PACKAGE_FILE_NAMES",
     "ReferencePackage",
     "ReferencePackageError",
@@ -191,7 +219,9 @@ __all__ = [
     "initial_pump_station_state",
     "inspect_pump",
     "load_reference_package",
+    "load_pump_station_artifact",
     "project_actor_view",
+    "pump_station_artifact_bytes",
     "pump_station_model_from_package",
     "transfer_duty_to_standby",
     "verify_stewardship_run",

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/stewardship_models.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/stewardship_models.py
@@ -477,6 +477,7 @@ class PumpStationTransitionReceipt:
     pre_state_id: str
     post_state_id: str
     clock_delta_seconds: int
+    applied_event_ids: tuple[str, ...]
     applied_event_types: tuple[PumpStationEventType, ...]
     processes_changed: tuple[str, ...]
     restrictions_changed: tuple[str, ...]

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/stewardship_state_machine.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/stewardship_state_machine.py
@@ -109,6 +109,7 @@ def _finish_transition(
     authority: PumpStationAuthorityDecision | None,
     execution: PumpStationExecutionOutcome,
     clock_delta_seconds: int = 0,
+    applied_event_ids: tuple[str, ...] = (),
     applied_event_types: tuple[PumpStationEventType, ...] = (),
     processes_changed: tuple[str, ...] = (),
     restrictions_changed: tuple[str, ...] = (),
@@ -131,6 +132,7 @@ def _finish_transition(
             pre_state_id=_state_id(previous),
             post_state_id=_state_id(state),
             clock_delta_seconds=clock_delta_seconds,
+            applied_event_ids=applied_event_ids,
             applied_event_types=applied_event_types,
             processes_changed=processes_changed,
             restrictions_changed=restrictions_changed,
@@ -689,6 +691,7 @@ def _advance_to_next_decision_point(
     obligation_changes: tuple[str, ...] = ()
     work_order_changes: tuple[str, ...] = ()
     evidence_created: tuple[str, ...] = ()
+    applied_event_ids: tuple[str, ...] = ()
     applied_event_types: tuple[PumpStationEventType, ...] = ()
     sequence = state.sequence + 1
     for event in sorted(events, key=_event_sort_key):
@@ -702,6 +705,7 @@ def _advance_to_next_decision_point(
             event_evidence,
             event_physical_change,
         ) = _apply_scheduled_event(model, candidate, event, sequence)
+        applied_event_ids = (*applied_event_ids, event.event_id)
         applied_event_types = (*applied_event_types, event.event_type)
         process_changes = (*process_changes, *event_processes)
         restriction_changes = (*restriction_changes, *event_restrictions)
@@ -723,6 +727,7 @@ def _advance_to_next_decision_point(
         authority=authority,
         execution=execution,
         clock_delta_seconds=elapsed,
+        applied_event_ids=applied_event_ids,
         applied_event_types=applied_event_types,
         processes_changed=_unique(process_changes),
         restrictions_changed=_unique(restriction_changes),

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run.py
@@ -1,0 +1,247 @@
+# ABOUTME: Coordinates deterministic pump-station transitions with durable publication.
+# ABOUTME: Provides create, apply, stage, snapshot, resume, and replay over one repository.
+
+from __future__ import annotations
+
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.physical_models import (
+    PumpStationModel,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.reference_package_models import (
+    ReferencePackage,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_identity import (
+    stewardship_content_id,
+    stewardship_state_id,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_models import (
+    PumpStationProposal,
+    PumpStationStewardshipState,
+    PumpStationTransition,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_state_machine import (
+    apply_stewardship_proposal,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_verifier import (
+    PumpStationRunStep,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_views import (
+    PumpStationInformationSet,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_models import (
+    PumpStationStagedTransition,
+    PumpStationStateSnapshotRef,
+    PumpStationWorldRunError,
+    PumpStationWorldRunManifest,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_repository import (
+    PumpStationWorldRunRepository,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_serialization import (
+    PUMP_STATION_SERIALIZATION_VERSION,
+)
+
+
+def _fail(code: str, detail: str) -> None:
+    raise PumpStationWorldRunError(code, detail)
+
+
+class PumpStationWorldRun:
+    """One continuing pump-station branch backed by immutable filesystem evidence."""
+
+    def __init__(
+        self,
+        *,
+        repository: PumpStationWorldRunRepository,
+        package: ReferencePackage,
+        model: PumpStationModel,
+        manifest: PumpStationWorldRunManifest,
+    ) -> None:
+        self._repository = repository
+        self._package = package
+        self._model = model
+        self._manifest = manifest
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        repository: PumpStationWorldRunRepository,
+        package: ReferencePackage,
+        model: PumpStationModel,
+        initial_state: PumpStationStewardshipState,
+        run_id: str,
+        episode_id: str,
+        world_branch_id: str,
+    ) -> PumpStationWorldRun:
+        """Create and atomically select one durable initial state."""
+        manifest = PumpStationWorldRunManifest(
+            serialization_version=PUMP_STATION_SERIALIZATION_VERSION,
+            run_id=run_id,
+            episode_id=episode_id,
+            world_branch_id=world_branch_id,
+            profile_id=package.profile_id,
+            generation_id=package.generation_id,
+            package_content_id=package.package_content_id,
+            manifest_content_id=package.manifest_content_id,
+            asset_id=model.asset_id,
+            model_id=stewardship_content_id(model),
+            initial_sequence=initial_state.sequence,
+            initial_state_id=stewardship_state_id(initial_state),
+        )
+        repository.initialize(manifest, initial_state)
+        return cls(
+            repository=repository,
+            package=package,
+            model=model,
+            manifest=manifest,
+        )
+
+    @classmethod
+    def resume(
+        cls,
+        *,
+        repository: PumpStationWorldRunRepository,
+        package: ReferencePackage,
+        model: PumpStationModel,
+        snapshot: PumpStationStateSnapshotRef,
+    ) -> PumpStationWorldRun:
+        """Resume only the exact state currently selected by the repository."""
+        manifest = repository.load_manifest()
+        cls._validate_identity(manifest, package=package, model=model)
+        current = repository.current_snapshot()
+        if current != snapshot:
+            _fail("snapshot-drift", "requested snapshot is not the selected world state")
+        return cls(
+            repository=repository,
+            package=package,
+            model=model,
+            manifest=manifest,
+        )
+
+    @property
+    def repository(self) -> PumpStationWorldRunRepository:
+        """Return the host-supplied repository."""
+        return self._repository
+
+    @property
+    def package(self) -> ReferencePackage:
+        """Return the validated reference package bound to this run."""
+        return self._package
+
+    @property
+    def model(self) -> PumpStationModel:
+        """Return the physical model bound to this run."""
+        return self._model
+
+    @property
+    def manifest(self) -> PumpStationWorldRunManifest:
+        """Return the immutable run identity."""
+        return self._manifest
+
+    @property
+    def state(self) -> PumpStationStewardshipState:
+        """Reload the current complete state through the repository."""
+        snapshot = self._repository.current_snapshot()
+        return self._repository.load_state(snapshot.state_id)
+
+    def snapshot(self) -> PumpStationStateSnapshotRef:
+        """Return the exact currently selected dynamic state."""
+        return self._repository.current_snapshot()
+
+    def stage(
+        self,
+        proposal: PumpStationProposal,
+        *,
+        information_set: PumpStationInformationSet,
+    ) -> PumpStationStagedTransition:
+        """Write immutable transition evidence without selecting its state."""
+        with self._repository.locked():
+            prior = self._repository.current_snapshot()
+            committed = self._repository.find_committed_proposal(
+                proposal.context.proposal_id,
+            )
+            if committed is not None:
+                _fail(
+                    "proposal-already-committed",
+                    proposal.context.proposal_id,
+                )
+            state = self._repository.load_state(prior.state_id)
+            transition = apply_stewardship_proposal(
+                self._model,
+                state,
+                proposal,
+                information_set=information_set,
+            )
+            return self._repository.stage_transition(
+                manifest=self._manifest,
+                prior_snapshot=prior,
+                proposal=proposal,
+                information_set=information_set,
+                transition=transition,
+            )
+
+    def apply(
+        self,
+        proposal: PumpStationProposal,
+        *,
+        information_set: PumpStationInformationSet,
+    ) -> PumpStationTransition:
+        """Apply or idempotently replay one exact bound proposal."""
+        with self._repository.locked():
+            prior = self._repository.current_snapshot()
+            committed = self._repository.find_committed_proposal(
+                proposal.context.proposal_id,
+            )
+            if committed is not None:
+                return self._repository.validate_repeated_proposal(
+                    committed,
+                    proposal,
+                    information_set,
+                )
+            state = self._repository.load_state(prior.state_id)
+            transition = apply_stewardship_proposal(
+                self._model,
+                state,
+                proposal,
+                information_set=information_set,
+            )
+            staged = self._repository.stage_transition(
+                manifest=self._manifest,
+                prior_snapshot=prior,
+                proposal=proposal,
+                information_set=information_set,
+                transition=transition,
+            )
+            return self._repository.publish_staged_transition(staged)
+
+    def steps(self) -> tuple[PumpStationRunStep, ...]:
+        """Reload all selected run steps for independent replay."""
+        return self._repository.steps()
+
+    @staticmethod
+    def _validate_identity(
+        manifest: PumpStationWorldRunManifest,
+        *,
+        package: ReferencePackage,
+        model: PumpStationModel,
+    ) -> None:
+        if manifest.serialization_version != PUMP_STATION_SERIALIZATION_VERSION:
+            _fail("serialization-version", manifest.serialization_version)
+        expected = (
+            package.profile_id,
+            package.generation_id,
+            package.package_content_id,
+            package.manifest_content_id,
+            model.asset_id,
+            stewardship_content_id(model),
+        )
+        observed = (
+            manifest.profile_id,
+            manifest.generation_id,
+            manifest.package_content_id,
+            manifest.manifest_content_id,
+            manifest.asset_id,
+            manifest.model_id,
+        )
+        if observed != expected:
+            _fail("world-run-identity", "package or physical model differs")

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_models.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_models.py
@@ -1,0 +1,147 @@
+# ABOUTME: Defines durable run, snapshot, commit, and event records for the pump station.
+# ABOUTME: Keeps evolving state references separate from compiled world-package identity.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_models import (
+    PumpStationEventType,
+    PumpStationProposal,
+    PumpStationTransition,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_views import (
+    PumpStationInformationSet,
+)
+
+
+class PumpStationWorldRunError(RuntimeError):
+    """Raised when durable pump-station run evidence is invalid or unsafe."""
+
+    def __init__(self, code: str, detail: str) -> None:
+        self.code = code
+        super().__init__(f"{code}: {detail}")
+
+
+def require_world_run_text(value: str, field_name: str) -> None:
+    """Require one non-empty durable identity."""
+    if not value.strip():
+        raise PumpStationWorldRunError(
+            "world-run-shape",
+            f"{field_name} must not be empty",
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PumpStationWorldRunManifest:
+    """Immutable identity and initial state for one continuing world branch."""
+
+    serialization_version: str
+    run_id: str
+    episode_id: str
+    world_branch_id: str
+    profile_id: str
+    generation_id: str
+    package_content_id: str
+    manifest_content_id: str
+    asset_id: str
+    model_id: str
+    initial_sequence: int
+    initial_state_id: str
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "serialization_version",
+            "run_id",
+            "episode_id",
+            "world_branch_id",
+            "profile_id",
+            "generation_id",
+            "package_content_id",
+            "manifest_content_id",
+            "asset_id",
+            "model_id",
+            "initial_state_id",
+        ):
+            require_world_run_text(getattr(self, field_name), field_name)
+        if self.initial_sequence < 0:
+            raise PumpStationWorldRunError(
+                "world-run-shape",
+                "initial sequence must be non-negative",
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class PumpStationStateSnapshotRef:
+    """Exact dynamic state selected for one durable pump-station run."""
+
+    run_id: str
+    episode_id: str
+    world_branch_id: str
+    sequence: int
+    state_id: str
+    commit_id: str
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "run_id",
+            "episode_id",
+            "world_branch_id",
+            "state_id",
+            "commit_id",
+        ):
+            require_world_run_text(getattr(self, field_name), field_name)
+        if self.sequence < 0:
+            raise PumpStationWorldRunError(
+                "world-run-shape",
+                "snapshot sequence must be non-negative",
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class PumpStationAppliedEventBatch:
+    """Events applied by one transition, including an empty proposal-only batch."""
+
+    transition_id: str
+    sequence: int
+    event_ids: tuple[str, ...]
+    event_types: tuple[PumpStationEventType, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class PumpStationWorldRunCommit:
+    """Immutable link from one committed state to its complete transition evidence."""
+
+    serialization_version: str
+    run_id: str
+    sequence: int
+    parent_commit_id: str | None
+    state_id: str
+    proposal_id: str | None
+    proposal_content_id: str | None
+    information_set_content_id: str | None
+    receipt_content_id: str | None
+    event_batch_content_id: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class PumpStationCurrentRunPointer:
+    """Single mutable selector for the last atomically published commit."""
+
+    serialization_version: str
+    run_id: str
+    sequence: int
+    state_id: str
+    commit_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class PumpStationStagedTransition:
+    """Immutable evidence prepared before the current-state commit point."""
+
+    prior_snapshot: PumpStationStateSnapshotRef
+    snapshot: PumpStationStateSnapshotRef
+    proposal: PumpStationProposal
+    information_set: PumpStationInformationSet
+    transition: PumpStationTransition
+    commit: PumpStationWorldRunCommit

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_repository.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_repository.py
@@ -1,0 +1,596 @@
+# ABOUTME: Publishes one pump-station run to a host-supplied filesystem root.
+# ABOUTME: Owns immutable evidence, file locking, atomic current-state selection, and strict reload.
+
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import os
+import stat
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import cast
+
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_identity import (
+    stewardship_state_id,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_models import (
+    ContinueOperation,
+    PumpStationProposal,
+    PumpStationStewardshipState,
+    PumpStationTransition,
+    PumpStationTransitionReceipt,
+    RequestConditionalDeferral,
+    RequestInspection,
+    RequestObstructionClearance,
+    RequestProvisionalClosure,
+    RequestProvisionalReturn,
+    RequestVerification,
+    TransferDuty,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_verifier import (
+    PumpStationRunStep,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_views import (
+    PumpStationInformationSet,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_models import (
+    PumpStationAppliedEventBatch,
+    PumpStationCurrentRunPointer,
+    PumpStationStagedTransition,
+    PumpStationStateSnapshotRef,
+    PumpStationWorldRunCommit,
+    PumpStationWorldRunError,
+    PumpStationWorldRunManifest,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_serialization import (
+    PUMP_STATION_SERIALIZATION_VERSION,
+    load_pump_station_artifact,
+    pump_station_artifact_bytes,
+    pump_station_artifact_id,
+)
+
+_PROPOSAL_TYPES: dict[str, type[object]] = {
+    proposal_type.__name__: proposal_type
+    for proposal_type in (
+        ContinueOperation,
+        TransferDuty,
+        RequestInspection,
+        RequestConditionalDeferral,
+        RequestObstructionClearance,
+        RequestProvisionalReturn,
+        RequestProvisionalClosure,
+        RequestVerification,
+    )
+}
+
+
+def _fail(code: str, detail: str) -> None:
+    raise PumpStationWorldRunError(code, detail)
+
+
+def _fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _mkdir_durable(path: Path) -> None:
+    missing: list[Path] = []
+    cursor = path
+    while not cursor.exists():
+        missing.append(cursor)
+        cursor = cursor.parent
+    path.mkdir(parents=True, exist_ok=True)
+    for directory in reversed(missing):
+        directory.chmod(0o700)
+        _fsync_directory(directory.parent)
+
+
+def _require_regular_file(path: Path, label: str) -> None:
+    if path.is_symlink():
+        _fail("artifact-confinement", f"{label} is a symbolic link")
+    try:
+        details = path.stat(follow_symlinks=False)
+    except OSError as error:
+        _fail("artifact-integrity", f"{label} is unavailable: {error}")
+    if not stat.S_ISREG(details.st_mode):
+        _fail("artifact-integrity", f"{label} is not a regular file")
+    if stat.S_IMODE(details.st_mode) & 0o077:
+        _fail("artifact-confinement", f"{label} must be host-private")
+
+
+class PumpStationWorldRunRepository:
+    """A confined durable repository for exactly one pump-station world run."""
+
+    def __init__(self, root: Path) -> None:
+        selected = Path(root)
+        if selected.exists() and (selected.is_symlink() or not selected.is_dir()):
+            _fail("artifact-confinement", "world-run root must be a plain directory")
+        _mkdir_durable(selected)
+        selected.chmod(0o700)
+        self._root = selected.resolve(strict=True)
+        self._lock_path = self._root / ".world-run.lock"
+
+    @property
+    def root(self) -> Path:
+        """Return the exact host-supplied run root."""
+        return self._root
+
+    @contextmanager
+    def locked(self) -> Iterator[None]:
+        """Serialize state selection across local processes."""
+        flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_CLOEXEC", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(self._lock_path, flags, 0o600)
+        try:
+            details = os.fstat(descriptor)
+            if not stat.S_ISREG(details.st_mode):
+                _fail("artifact-confinement", "world-run lock is not a regular file")
+            fcntl.flock(descriptor, fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+        finally:
+            os.close(descriptor)
+
+    def initialize(
+        self,
+        manifest: PumpStationWorldRunManifest,
+        initial_state: PumpStationStewardshipState,
+    ) -> PumpStationStateSnapshotRef:
+        """Publish an immutable initial state and select it atomically."""
+        with self.locked():
+            if (self._root / "current.json").exists():
+                _fail("world-run-exists", manifest.run_id)
+            self._publish_root_immutable("manifest.json", manifest)
+            self._publish_state(initial_state)
+            commit = PumpStationWorldRunCommit(
+                serialization_version=PUMP_STATION_SERIALIZATION_VERSION,
+                run_id=manifest.run_id,
+                sequence=manifest.initial_sequence,
+                parent_commit_id=None,
+                state_id=manifest.initial_state_id,
+                proposal_id=None,
+                proposal_content_id=None,
+                information_set_content_id=None,
+                receipt_content_id=None,
+                event_batch_content_id=None,
+            )
+            commit_id = pump_station_artifact_id(commit)
+            self._publish_content("commits", commit_id, commit)
+            pointer = PumpStationCurrentRunPointer(
+                serialization_version=PUMP_STATION_SERIALIZATION_VERSION,
+                run_id=manifest.run_id,
+                sequence=manifest.initial_sequence,
+                state_id=manifest.initial_state_id,
+                commit_id=commit_id,
+            )
+            self._replace_current(pointer)
+            return self._snapshot(manifest, pointer)
+
+    def load_manifest(self) -> PumpStationWorldRunManifest:
+        """Reload the immutable run identity."""
+        return load_pump_station_artifact(
+            self._read(self._root / "manifest.json", "world-run manifest"),
+            PumpStationWorldRunManifest,
+        )
+
+    def current_snapshot(self) -> PumpStationStateSnapshotRef:
+        """Reload and validate the atomically selected state reference."""
+        manifest = self.load_manifest()
+        pointer = self._load_current()
+        if pointer.run_id != manifest.run_id:
+            _fail("artifact-integrity", "current pointer belongs to another run")
+        commit = self.load_commit(pointer.commit_id)
+        if (
+            commit.run_id != manifest.run_id
+            or commit.sequence != pointer.sequence
+            or commit.state_id != pointer.state_id
+        ):
+            _fail("artifact-integrity", "current pointer and commit differ")
+        self.load_state(pointer.state_id)
+        return self._snapshot(manifest, pointer)
+
+    def load_state(self, state_id: str) -> PumpStationStewardshipState:
+        """Reload a complete state and verify its semantic identity."""
+        state = load_pump_station_artifact(
+            self._read_content("states", state_id),
+            PumpStationStewardshipState,
+        )
+        if stewardship_state_id(state) != state_id:
+            _fail("artifact-integrity", f"state identity differs for {state_id}")
+        return state
+
+    def load_commit(self, commit_id: str) -> PumpStationWorldRunCommit:
+        """Reload one immutable commit by content identity."""
+        commit = load_pump_station_artifact(
+            self._read_content("commits", commit_id),
+            PumpStationWorldRunCommit,
+        )
+        if pump_station_artifact_id(commit) != commit_id:
+            _fail("artifact-integrity", f"commit identity differs for {commit_id}")
+        return commit
+
+    def stage_transition(
+        self,
+        *,
+        manifest: PumpStationWorldRunManifest,
+        prior_snapshot: PumpStationStateSnapshotRef,
+        proposal: PumpStationProposal,
+        information_set: PumpStationInformationSet,
+        transition: PumpStationTransition,
+    ) -> PumpStationStagedTransition:
+        """Publish all immutable evidence without changing the current pointer."""
+        receipt = transition.receipt
+        if (
+            receipt.sequence != prior_snapshot.sequence + 1
+            or receipt.pre_state_id != prior_snapshot.state_id
+            or receipt.post_state_id != stewardship_state_id(transition.state)
+            or receipt.proposal_id != proposal.context.proposal_id
+        ):
+            _fail("transition-integrity", "transition does not extend the selected state")
+        self._reject_proposal_collision(
+            proposal,
+            information_set=information_set,
+            parent_commit_id=prior_snapshot.commit_id,
+        )
+        state_id = self._publish_state(transition.state)
+        proposal_content_id = pump_station_artifact_id(proposal)
+        information_set_content_id = pump_station_artifact_id(information_set)
+        receipt_content_id = pump_station_artifact_id(receipt)
+        event_batch = PumpStationAppliedEventBatch(
+            transition_id=receipt.transition_id,
+            sequence=receipt.sequence,
+            event_ids=receipt.applied_event_ids,
+            event_types=receipt.applied_event_types,
+        )
+        event_batch_content_id = pump_station_artifact_id(event_batch)
+        self._publish_content("proposals", proposal_content_id, proposal)
+        self._publish_content(
+            "information-sets",
+            information_set_content_id,
+            information_set,
+        )
+        self._publish_content("receipts", receipt_content_id, receipt)
+        self._publish_content("events", event_batch_content_id, event_batch)
+        commit = PumpStationWorldRunCommit(
+            serialization_version=PUMP_STATION_SERIALIZATION_VERSION,
+            run_id=manifest.run_id,
+            sequence=receipt.sequence,
+            parent_commit_id=prior_snapshot.commit_id,
+            state_id=state_id,
+            proposal_id=proposal.context.proposal_id,
+            proposal_content_id=proposal_content_id,
+            information_set_content_id=information_set_content_id,
+            receipt_content_id=receipt_content_id,
+            event_batch_content_id=event_batch_content_id,
+        )
+        commit_id = pump_station_artifact_id(commit)
+        self._publish_content("commits", commit_id, commit)
+        snapshot = PumpStationStateSnapshotRef(
+            run_id=manifest.run_id,
+            episode_id=manifest.episode_id,
+            world_branch_id=manifest.world_branch_id,
+            sequence=receipt.sequence,
+            state_id=state_id,
+            commit_id=commit_id,
+        )
+        return PumpStationStagedTransition(
+            prior_snapshot=prior_snapshot,
+            snapshot=snapshot,
+            proposal=proposal,
+            information_set=information_set,
+            transition=transition,
+            commit=commit,
+        )
+
+    def publish_staged_transition(
+        self,
+        staged: PumpStationStagedTransition,
+    ) -> PumpStationTransition:
+        """Select a fully staged transition with one atomic pointer replacement."""
+        current = self.current_snapshot()
+        if current == staged.snapshot:
+            return self.load_transition(staged.commit)
+        if current != staged.prior_snapshot:
+            _fail("stale-publication", "world run advanced after transition preparation")
+        if pump_station_artifact_id(staged.commit) != staged.snapshot.commit_id:
+            _fail("transition-integrity", "staged commit identity differs")
+        self.load_transition(staged.commit)
+        self._replace_current(
+            PumpStationCurrentRunPointer(
+                serialization_version=PUMP_STATION_SERIALIZATION_VERSION,
+                run_id=staged.snapshot.run_id,
+                sequence=staged.snapshot.sequence,
+                state_id=staged.snapshot.state_id,
+                commit_id=staged.snapshot.commit_id,
+            )
+        )
+        return staged.transition
+
+    def find_committed_proposal(
+        self,
+        proposal_id: str,
+    ) -> PumpStationWorldRunCommit | None:
+        """Return a proposal commit only when it is on the selected chain."""
+        for commit in reversed(self.commits()):
+            if commit.proposal_id == proposal_id:
+                return commit
+        return None
+
+    def commits(self) -> tuple[PumpStationWorldRunCommit, ...]:
+        """Reload the exact selected commit chain from initial state to current."""
+        pointer = self._load_current()
+        chain: list[PumpStationWorldRunCommit] = []
+        seen: set[str] = set()
+        commit_id: str | None = pointer.commit_id
+        while commit_id is not None:
+            if commit_id in seen:
+                _fail("artifact-integrity", "commit chain contains a cycle")
+            seen.add(commit_id)
+            commit = self.load_commit(commit_id)
+            chain.append(commit)
+            commit_id = commit.parent_commit_id
+        chain.reverse()
+        self._validate_chain(tuple(chain), pointer)
+        return tuple(chain)
+
+    def steps(self) -> tuple[PumpStationRunStep, ...]:
+        """Reload every committed proposal, information set, receipt, event batch, and state."""
+        return tuple(
+            PumpStationRunStep(
+                proposal=proposal,
+                information_set=information_set,
+                transition=transition,
+            )
+            for commit in self.commits()[1:]
+            for proposal, information_set, transition in (self._load_step(commit),)
+        )
+
+    def load_transition(
+        self,
+        commit: PumpStationWorldRunCommit,
+    ) -> PumpStationTransition:
+        """Reload the transition selected by one non-initial commit."""
+        _, _, transition = self._load_step(commit)
+        return transition
+
+    def validate_repeated_proposal(
+        self,
+        commit: PumpStationWorldRunCommit,
+        proposal: PumpStationProposal,
+        information_set: PumpStationInformationSet,
+    ) -> PumpStationTransition:
+        """Return a committed retry only when its complete input is identical."""
+        stored_proposal, stored_information_set, transition = self._load_step(commit)
+        if stored_proposal != proposal or stored_information_set != information_set:
+            _fail(
+                "proposal-id-conflict",
+                f"{proposal.context.proposal_id} was already bound to different content",
+            )
+        return transition
+
+    def _load_step(
+        self,
+        commit: PumpStationWorldRunCommit,
+    ) -> tuple[PumpStationProposal, PumpStationInformationSet, PumpStationTransition]:
+        if None in {
+            commit.proposal_id,
+            commit.proposal_content_id,
+            commit.information_set_content_id,
+            commit.receipt_content_id,
+            commit.event_batch_content_id,
+        }:
+            _fail("artifact-integrity", "transition commit lacks evidence references")
+        proposal = self._load_proposal(cast(str, commit.proposal_content_id))
+        information_set = load_pump_station_artifact(
+            self._read_content(
+                "information-sets",
+                cast(str, commit.information_set_content_id),
+            ),
+            PumpStationInformationSet,
+        )
+        receipt = load_pump_station_artifact(
+            self._read_content("receipts", cast(str, commit.receipt_content_id)),
+            PumpStationTransitionReceipt,
+        )
+        event_batch = load_pump_station_artifact(
+            self._read_content(
+                "events",
+                cast(str, commit.event_batch_content_id),
+            ),
+            PumpStationAppliedEventBatch,
+        )
+        state = self.load_state(commit.state_id)
+        if (
+            pump_station_artifact_id(proposal) != commit.proposal_content_id
+            or pump_station_artifact_id(information_set) != commit.information_set_content_id
+            or pump_station_artifact_id(receipt) != commit.receipt_content_id
+            or pump_station_artifact_id(event_batch) != commit.event_batch_content_id
+            or proposal.context.proposal_id != commit.proposal_id
+            or proposal.context.information_set_id != information_set.information_set_id
+            or receipt.proposal_id != commit.proposal_id
+            or receipt.sequence != commit.sequence
+            or receipt.post_state_id != commit.state_id
+            or event_batch.transition_id != receipt.transition_id
+            or event_batch.sequence != receipt.sequence
+            or event_batch.event_ids != receipt.applied_event_ids
+            or event_batch.event_types != receipt.applied_event_types
+        ):
+            _fail("artifact-integrity", "commit evidence does not reconcile")
+        return proposal, information_set, PumpStationTransition(state=state, receipt=receipt)
+
+    def _load_proposal(self, content_id: str) -> PumpStationProposal:
+        payload = self._read_content("proposals", content_id)
+        try:
+            document = json.loads(payload)
+            type_name = document["$type"]
+        except (json.JSONDecodeError, KeyError, TypeError) as error:
+            _fail("artifact-type", f"stored proposal has no valid type: {error}")
+        proposal_type = _PROPOSAL_TYPES.get(type_name)
+        if proposal_type is None:
+            _fail("artifact-type", f"unknown stored proposal type {type_name!r}")
+        return cast(
+            PumpStationProposal,
+            load_pump_station_artifact(payload, proposal_type),
+        )
+
+    def _reject_proposal_collision(
+        self,
+        proposal: PumpStationProposal,
+        *,
+        information_set: PumpStationInformationSet,
+        parent_commit_id: str,
+    ) -> None:
+        commits_root = self._root / "commits"
+        if not commits_root.exists():
+            return
+        for path in commits_root.glob("*.json"):
+            commit = self.load_commit(path.stem)
+            if commit.proposal_id != proposal.context.proposal_id:
+                continue
+            stored_proposal, stored_information_set, _ = self._load_step(commit)
+            if (
+                stored_proposal != proposal
+                or stored_information_set != information_set
+                or commit.parent_commit_id != parent_commit_id
+            ):
+                _fail(
+                    "proposal-id-conflict",
+                    f"{proposal.context.proposal_id} has different staged content",
+                )
+
+    def _validate_chain(
+        self,
+        chain: tuple[PumpStationWorldRunCommit, ...],
+        pointer: PumpStationCurrentRunPointer,
+    ) -> None:
+        if (
+            not chain
+            or chain[0].sequence != self.load_manifest().initial_sequence
+            or chain[0].parent_commit_id is not None
+        ):
+            _fail("artifact-integrity", "commit chain lacks one initial state")
+        manifest = self.load_manifest()
+        if chain[0].state_id != manifest.initial_state_id:
+            _fail("artifact-integrity", "initial commit differs from manifest")
+        previous = chain[0]
+        for commit in chain[1:]:
+            if commit.sequence != previous.sequence + 1:
+                _fail("artifact-integrity", "commit sequence is not contiguous")
+            proposal, information_set, transition = self._load_step(commit)
+            if (
+                commit.parent_commit_id != pump_station_artifact_id(previous)
+                or transition.receipt.pre_state_id != previous.state_id
+                or proposal.context.based_on_sequence != previous.sequence
+                or information_set.base_view.current_state.state_sequence != previous.sequence
+            ):
+                _fail("artifact-integrity", "commit does not extend its parent")
+            previous = commit
+        if (
+            previous.sequence != pointer.sequence
+            or previous.state_id != pointer.state_id
+            or pump_station_artifact_id(previous) != pointer.commit_id
+        ):
+            _fail("artifact-integrity", "commit chain does not reach current pointer")
+
+    def _publish_state(self, state: PumpStationStewardshipState) -> str:
+        state_id = stewardship_state_id(state)
+        self._publish_content("states", state_id, state)
+        return state_id
+
+    def _publish_content(self, collection: str, content_id: str, value: object) -> None:
+        payload = pump_station_artifact_bytes(value)
+        if collection != "states" and hashlib.sha256(payload).hexdigest() != content_id:
+            _fail("artifact-integrity", f"{collection} content identity differs")
+        path = self._root / collection / f"{content_id}.json"
+        self._publish_immutable(path, payload)
+
+    def _publish_root_immutable(self, name: str, value: object) -> None:
+        self._publish_immutable(self._root / name, pump_station_artifact_bytes(value))
+
+    def _publish_immutable(self, path: Path, payload: bytes) -> None:
+        if path.exists():
+            observed = self._read(path, str(path.relative_to(self._root)))
+            if observed != payload:
+                _fail("artifact-collision", str(path.relative_to(self._root)))
+            return
+        _mkdir_durable(path.parent)
+        temporary = path.parent / f".{path.name}.{uuid.uuid4().hex}.tmp"
+        descriptor = os.open(
+            temporary,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+        )
+        try:
+            with os.fdopen(descriptor, "wb") as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            try:
+                os.link(temporary, path)
+            except FileExistsError:
+                if self._read(path, str(path.relative_to(self._root))) != payload:
+                    _fail("artifact-collision", str(path.relative_to(self._root)))
+            _fsync_directory(path.parent)
+        finally:
+            temporary.unlink(missing_ok=True)
+
+    def _replace_current(self, pointer: PumpStationCurrentRunPointer) -> None:
+        payload = pump_station_artifact_bytes(pointer)
+        temporary = self._root / f".current.{uuid.uuid4().hex}.tmp"
+        descriptor = os.open(
+            temporary,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+        )
+        try:
+            with os.fdopen(descriptor, "wb") as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, self._root / "current.json")
+            _fsync_directory(self._root)
+        finally:
+            temporary.unlink(missing_ok=True)
+
+    def _load_current(self) -> PumpStationCurrentRunPointer:
+        return load_pump_station_artifact(
+            self._read(self._root / "current.json", "current pointer"),
+            PumpStationCurrentRunPointer,
+        )
+
+    def _read_content(self, collection: str, content_id: str) -> bytes:
+        return self._read(
+            self._root / collection / f"{content_id}.json",
+            f"{collection}/{content_id}.json",
+        )
+
+    def _read(self, path: Path, label: str) -> bytes:
+        _require_regular_file(path, label)
+        try:
+            return path.read_bytes()
+        except OSError as error:
+            _fail("artifact-integrity", f"{label} cannot be read: {error}")
+        raise AssertionError("unreachable")
+
+    @staticmethod
+    def _snapshot(
+        manifest: PumpStationWorldRunManifest,
+        pointer: PumpStationCurrentRunPointer,
+    ) -> PumpStationStateSnapshotRef:
+        return PumpStationStateSnapshotRef(
+            run_id=manifest.run_id,
+            episode_id=manifest.episode_id,
+            world_branch_id=manifest.world_branch_id,
+            sequence=pointer.sequence,
+            state_id=pointer.state_id,
+            commit_id=pointer.commit_id,
+        )

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_serialization.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_serialization.py
@@ -1,0 +1,201 @@
+# ABOUTME: Serializes durable pump-station artifacts as strict canonical JSON.
+# ABOUTME: Rebuilds only declared task-owned dataclasses, enums, decimals, and tuples.
+
+from __future__ import annotations
+
+import hashlib
+import json
+import types
+from dataclasses import fields, is_dataclass
+from decimal import Decimal, InvalidOperation
+from enum import Enum
+from typing import Any, NoReturn, TypeVar, cast, get_args, get_origin, get_type_hints, overload
+
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_models import (
+    PumpStationWorldRunError,
+)
+
+PUMP_STATION_SERIALIZATION_VERSION = "pump-station-world-run.v1"
+PUMP_STATION_TRANSPORT_FIELD_EXCLUSIONS: tuple[str, ...] = ()
+
+ArtifactT = TypeVar("ArtifactT")
+
+
+def _fail(code: str, detail: str) -> NoReturn:
+    raise PumpStationWorldRunError(code, detail)
+
+
+def _encoded(value: object) -> object:
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, Decimal):
+        return str(value)
+    if is_dataclass(value) and not isinstance(value, type):
+        return {
+            "$type": type(value).__name__,
+            **{field.name: _encoded(getattr(value, field.name)) for field in fields(value)},
+        }
+    if isinstance(value, tuple):
+        return [_encoded(item) for item in value]
+    if value is None or type(value) in {str, int, bool}:
+        return value
+    _fail("artifact-type", f"unsupported value {type(value).__name__}")
+    raise AssertionError("unreachable")
+
+
+def pump_station_artifact_bytes(value: object) -> bytes:
+    """Return one canonical, newline-terminated task artifact."""
+    return (
+        json.dumps(
+            _encoded(value),
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def pump_station_artifact_id(value: object) -> str:
+    """Return the content identity of one canonical task artifact."""
+    return hashlib.sha256(pump_station_artifact_bytes(value)).hexdigest()
+
+
+def _unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for key, child in pairs:
+        if key in value:
+            _fail("canonical-json", f"duplicate field {key}")
+        value[key] = child
+    return value
+
+
+def _reject_number(value: str) -> NoReturn:
+    _fail("canonical-json", f"unsupported JSON number {value}")
+
+
+def _expected_value(expected: object) -> object:
+    return getattr(expected, "__value__", expected)
+
+
+def _decode_union(value: object, expected: object) -> object:
+    options = get_args(expected)
+    if value is None and type(None) in options:
+        return None
+    if isinstance(value, dict) and isinstance(value.get("$type"), str):
+        type_name = value["$type"]
+        for option in options:
+            candidate = _expected_value(option)
+            if isinstance(candidate, type) and is_dataclass(candidate) and candidate.__name__ == type_name:
+                return _decode(value, candidate)
+        _fail("artifact-type", f"unknown stored type {type_name}")
+    failures: list[PumpStationWorldRunError] = []
+    for option in options:
+        if option is type(None):
+            continue
+        try:
+            return _decode(value, option)
+        except PumpStationWorldRunError as error:
+            failures.append(error)
+    detail = failures[0] if failures else "no matching union member"
+    _fail("artifact-type", str(detail))
+    raise AssertionError("unreachable")
+
+
+def _decode_dataclass(value: object, expected: type[Any]) -> object:
+    if not isinstance(value, dict):
+        _fail("artifact-shape", f"{expected.__name__} must be an object")
+    if value.get("$type") != expected.__name__:
+        _fail(
+            "artifact-type",
+            f"expected {expected.__name__}, received {value.get('$type')!r}",
+        )
+    declared_fields = fields(expected)
+    expected_keys = {"$type", *(field.name for field in declared_fields)}
+    if set(value) != expected_keys:
+        _fail("artifact-shape", f"{expected.__name__} fields differ")
+    type_hints = get_type_hints(expected)
+    decoded = {field.name: _decode(value[field.name], type_hints[field.name]) for field in declared_fields}
+    try:
+        return expected(**decoded)
+    except PumpStationWorldRunError:
+        raise
+    except (TypeError, ValueError) as error:
+        _fail("artifact-shape", f"{expected.__name__}: {error}")
+    raise AssertionError("unreachable")
+
+
+def _decode_tuple(value: object, expected: object) -> tuple[object, ...]:
+    if not isinstance(value, list):
+        _fail("artifact-shape", "tuple value must be a JSON array")
+    members = get_args(expected)
+    if len(members) == 2 and members[1] is Ellipsis:
+        return tuple(_decode(item, members[0]) for item in value)
+    if len(value) != len(members):
+        _fail("artifact-shape", "fixed tuple length differs")
+    return tuple(_decode(item, member) for item, member in zip(value, members, strict=True))
+
+
+def _decode(value: object, expected: object) -> object:
+    expected = _expected_value(expected)
+    origin = get_origin(expected)
+    if origin is types.UnionType or isinstance(expected, types.UnionType):
+        return _decode_union(value, expected)
+    if origin is tuple:
+        return _decode_tuple(value, expected)
+    if isinstance(expected, type) and is_dataclass(expected):
+        return _decode_dataclass(value, expected)
+    if isinstance(expected, type) and issubclass(expected, Enum):
+        try:
+            return expected(value)
+        except (TypeError, ValueError):
+            _fail("artifact-type", f"invalid {expected.__name__} value")
+    if expected is Decimal:
+        if not isinstance(value, str):
+            _fail("artifact-type", "decimal must be stored as text")
+        try:
+            decoded_decimal = Decimal(value)
+        except (InvalidOperation, ValueError):
+            _fail("artifact-type", "invalid decimal text")
+        if not decoded_decimal.is_finite():
+            _fail("artifact-type", "decimal must be finite")
+        return decoded_decimal
+    if expected in {str, int, bool}:
+        if type(value) is not expected:
+            _fail(
+                "artifact-type",
+                f"expected {cast(type[object], expected).__name__}",
+            )
+        return value
+    if expected is type(None) and value is None:
+        return None
+    _fail("artifact-type", f"unsupported declared type {expected!r}")
+    raise AssertionError("unreachable")
+
+
+@overload
+def load_pump_station_artifact(payload: bytes, expected_type: type[ArtifactT]) -> ArtifactT: ...
+
+
+@overload
+def load_pump_station_artifact(payload: bytes, expected_type: object) -> object: ...
+
+
+def load_pump_station_artifact(payload: bytes, expected_type: object) -> object:
+    """Strictly rebuild one declared task artifact from canonical bytes."""
+    try:
+        text = payload.decode("utf-8")
+        document = json.loads(
+            text,
+            object_pairs_hook=_unique_object,
+            parse_float=_reject_number,
+            parse_constant=_reject_number,
+        )
+    except PumpStationWorldRunError:
+        raise
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        _fail("canonical-json", str(error))
+    restored = _decode(document, expected_type)
+    if pump_station_artifact_bytes(restored) != payload:
+        _fail("canonical-json", "stored bytes are not canonical")
+    return restored

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_world_run_crash_e2e.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_world_run_crash_e2e.py
@@ -1,0 +1,82 @@
+# ABOUTME: Exercises pump-station recovery at the real filesystem commit boundary.
+# ABOUTME: Proves retries cannot duplicate durable resource or physical effects.
+
+from __future__ import annotations
+
+from world_run_support import bind_proposal, create_world_run
+
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station import (
+    PumpStationWorldRun,
+    RequestConditionalDeferral,
+    TransferDuty,
+)
+
+
+def test_crash_recovery_applies_resource_and_physical_effects_once(tmp_path) -> None:
+    run = create_world_run(tmp_path / "run")
+
+    deferral, deferral_information = bind_proposal(
+        run,
+        RequestConditionalDeferral,
+        "proposal-resource-effect",
+        pump_id="pump-a",
+    )
+    before_deferral = run.snapshot()
+    run.stage(deferral, information_set=deferral_information)
+
+    resumed = PumpStationWorldRun.resume(
+        repository=run.repository,
+        package=run.package,
+        model=run.model,
+        snapshot=before_deferral,
+    )
+    first_deferral = resumed.apply(
+        deferral,
+        information_set=deferral_information,
+    )
+    repeated_deferral = resumed.apply(
+        deferral,
+        information_set=deferral_information,
+    )
+
+    assert repeated_deferral == first_deferral
+    assert len(resumed.state.restrictions) == 1
+    assert len(resumed.state.obligations) == 1
+    assert len(resumed.state.work_orders) == 1
+
+    transfer, transfer_information = bind_proposal(
+        resumed,
+        TransferDuty,
+        "proposal-physical-effect",
+    )
+    before_transfer = resumed.snapshot()
+    resumed.stage(transfer, information_set=transfer_information)
+
+    recovered = PumpStationWorldRun.resume(
+        repository=resumed.repository,
+        package=resumed.package,
+        model=resumed.model,
+        snapshot=before_transfer,
+    )
+    first_transfer = recovered.apply(
+        transfer,
+        information_set=transfer_information,
+    )
+    committed_snapshot = recovered.snapshot()
+
+    response_lost = PumpStationWorldRun.resume(
+        repository=recovered.repository,
+        package=recovered.package,
+        model=recovered.model,
+        snapshot=committed_snapshot,
+    )
+    repeated_transfer = response_lost.apply(
+        transfer,
+        information_set=transfer_information,
+    )
+
+    assert repeated_transfer == first_transfer
+    assert response_lost.state.sequence == 2
+    assert response_lost.state.physical.duty_pump_id == "pump-b"
+    assert response_lost.state.physical.duty_transfer_count == 1
+    assert len(response_lost.steps()) == 2

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_world_run_repository.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_world_run_repository.py
@@ -1,0 +1,136 @@
+# ABOUTME: Tests the real filesystem repository for one durable pump-station run.
+# ABOUTME: Proves immutable artifacts, strict reload, snapshot continuity, and verifier replay.
+
+from __future__ import annotations
+
+import stat
+from dataclasses import replace
+
+import pytest
+from world_run_support import bind_proposal, create_world_run
+
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station import (
+    ContinueOperation,
+    PumpStationExecutionOutcome,
+    PumpStationObligationKind,
+    PumpStationWorldRun,
+    PumpStationWorldRunError,
+    RequestConditionalDeferral,
+    RequestInspection,
+    TransferDuty,
+    pump_station_artifact_bytes,
+    verify_stewardship_run,
+)
+
+
+def test_filesystem_run_reloads_complete_state_and_verifier_steps(tmp_path) -> None:
+    run = create_world_run(tmp_path / "run")
+    initial_state = run.state
+    proposal, information_set = bind_proposal(
+        run,
+        RequestConditionalDeferral,
+        "proposal-resource-effect",
+        pump_id="pump-a",
+    )
+
+    transition = run.apply(
+        proposal,
+        information_set=information_set,
+    )
+    snapshot = run.snapshot()
+    resumed = PumpStationWorldRun.resume(
+        repository=run.repository,
+        package=run.package,
+        model=run.model,
+        snapshot=snapshot,
+    )
+    verification = verify_stewardship_run(
+        run.model,
+        initial_state,
+        resumed.steps(),
+    )
+
+    assert resumed.state == transition.state
+    assert resumed.snapshot() == snapshot
+    assert resumed.state.obligation(
+        PumpStationObligationKind.DEFERRED_FOLLOW_UP,
+        "pump-a",
+    ) == transition.state.obligation(
+        PumpStationObligationKind.DEFERRED_FOLLOW_UP,
+        "pump-a",
+    )
+    assert verification.valid is True
+
+    expected_counts = {
+        "states": 2,
+        "proposals": 1,
+        "information-sets": 1,
+        "receipts": 1,
+        "events": 1,
+        "commits": 2,
+    }
+    for directory, expected_count in expected_counts.items():
+        assert len(tuple((run.repository.root / directory).glob("*.json"))) == expected_count
+
+
+def test_repository_rejects_content_moved_under_the_wrong_identity(tmp_path) -> None:
+    run = create_world_run(tmp_path / "run")
+    assert stat.S_IMODE(run.repository.root.stat().st_mode) == 0o700
+    proposal, information_set = bind_proposal(
+        run,
+        RequestConditionalDeferral,
+        "proposal-content-integrity",
+        pump_id="pump-a",
+    )
+    transition = run.apply(
+        proposal,
+        information_set=information_set,
+    )
+    receipt_path = next((run.repository.root / "receipts").glob("*.json"))
+    receipt_path.write_bytes(
+        pump_station_artifact_bytes(
+            replace(
+                transition.receipt,
+                execution=PumpStationExecutionOutcome.CANCELLED,
+            )
+        )
+    )
+
+    with pytest.raises(PumpStationWorldRunError, match="artifact-integrity"):
+        run.steps()
+
+
+def test_snapshot_preserves_elapsed_time_and_applied_event_identity(tmp_path) -> None:
+    run = create_world_run(tmp_path / "run")
+    proposals = (
+        (RequestConditionalDeferral, "proposal-deferral", {"pump_id": "pump-a"}),
+        (TransferDuty, "proposal-transfer", {}),
+        (RequestInspection, "proposal-inspection", {"pump_id": "pump-a"}),
+        (ContinueOperation, "proposal-continue", {}),
+    )
+    transition = None
+    for proposal_type, proposal_id, parameters in proposals:
+        proposal, information_set = bind_proposal(
+            run,
+            proposal_type,
+            proposal_id,
+            **parameters,
+        )
+        transition = run.apply(
+            proposal,
+            information_set=information_set,
+        )
+
+    assert transition is not None
+    snapshot = run.snapshot()
+    resumed = PumpStationWorldRun.resume(
+        repository=run.repository,
+        package=run.package,
+        model=run.model,
+        snapshot=snapshot,
+    )
+
+    assert resumed.state.physical.calendar_seconds == run.model.inflow.diagnostic_period_seconds
+    assert transition.receipt.clock_delta_seconds == run.model.inflow.diagnostic_period_seconds
+    assert transition.receipt.applied_event_ids
+    assert resumed.snapshot() == snapshot

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_world_run_serialization.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_world_run_serialization.py
@@ -1,0 +1,58 @@
+# ABOUTME: Tests strict canonical serialization for durable pump-station artifacts.
+# ABOUTME: Proves complete task records round-trip and malformed stored data fails closed.
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from world_run_support import create_world_run
+
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station import (
+    PumpStationStewardshipState,
+    PumpStationWorldRunError,
+    load_pump_station_artifact,
+    pump_station_artifact_bytes,
+)
+
+
+def test_complete_state_round_trips_as_canonical_task_owned_json(tmp_path) -> None:
+    run = create_world_run(tmp_path / "run")
+
+    payload = pump_station_artifact_bytes(run.state)
+    restored = load_pump_station_artifact(
+        payload,
+        PumpStationStewardshipState,
+    )
+
+    assert restored == run.state
+    assert pump_station_artifact_bytes(restored) == payload
+    assert payload.endswith(b"\n")
+
+
+def test_stored_state_rejects_unknown_fields_and_types(tmp_path) -> None:
+    run = create_world_run(tmp_path / "run")
+    document = json.loads(pump_station_artifact_bytes(run.state))
+    document["unexpected"] = "not permitted"
+
+    with pytest.raises(PumpStationWorldRunError, match="artifact-shape"):
+        load_pump_station_artifact(
+            json.dumps(document).encode(),
+            PumpStationStewardshipState,
+        )
+
+    document = json.loads(pump_station_artifact_bytes(run.state))
+    document["$type"] = "DifferentWorldState"
+    with pytest.raises(PumpStationWorldRunError, match="artifact-type"):
+        load_pump_station_artifact(
+            json.dumps(document).encode(),
+            PumpStationStewardshipState,
+        )
+
+    document = json.loads(pump_station_artifact_bytes(run.state))
+    document["physical"]["pumps"][0]["condition"]["obstruction"] = "NaN"
+    with pytest.raises(PumpStationWorldRunError, match="artifact-type"):
+        load_pump_station_artifact(
+            json.dumps(document).encode(),
+            PumpStationStewardshipState,
+        )

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/world_run_support.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/world_run_support.py
@@ -1,0 +1,105 @@
+# ABOUTME: Builds real pump-station world-run fixtures for persistence tests.
+# ABOUTME: Uses the certified package, task projector, and production state machine without mocks.
+
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station import (
+    ProposalContext,
+    PumpStationContinuityCarrier,
+    PumpStationCurrentContext,
+    PumpStationEnvironment,
+    PumpStationInformationSet,
+    PumpStationObservationHistory,
+    PumpStationProjectionContext,
+    PumpStationWorldRun,
+    PumpStationWorldRunRepository,
+    bind_information_set,
+    create_stewardship_state,
+    initial_pump_station_state,
+    load_reference_package,
+    project_actor_view,
+    pump_station_model_from_package,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_models import (
+    PumpStationProposal,
+)
+
+
+def create_world_run(root: Path) -> PumpStationWorldRun:
+    """Create one real durable run from the certified package."""
+    package = load_reference_package()
+    model = pump_station_model_from_package(package)
+    state = create_stewardship_state(
+        model,
+        initial_pump_station_state(model),
+        PumpStationEnvironment(
+            inflow_m3_s=Decimal("0.0155"),
+            wet_well_level_m=Decimal("1.65"),
+            isolated=False,
+        ),
+    )
+    return PumpStationWorldRun.create(
+        repository=PumpStationWorldRunRepository(root),
+        package=package,
+        model=model,
+        initial_state=state,
+        run_id="run-durable-1",
+        episode_id="episode-durable-1",
+        world_branch_id="branch-durable-1",
+    )
+
+
+def bind_proposal(
+    run: PumpStationWorldRun,
+    proposal_type: type[PumpStationProposal],
+    proposal_id: str,
+    **parameters: str,
+) -> tuple[PumpStationProposal, PumpStationInformationSet]:
+    """Bind one proposal to the run's exact current actor view."""
+    package = load_reference_package()
+    state = run.state
+    view = project_actor_view(
+        run.model,
+        state,
+        PumpStationProjectionContext(
+            episode_id=run.manifest.episode_id,
+            world_branch_id=run.manifest.world_branch_id,
+            actor_id="station-steward",
+            agent_tenure_id="tenure-1",
+            episode_started_at_seconds=0,
+            tenure_started_at_seconds=0,
+            projection_policy_id="pump-station-current-state-v1",
+            source_artifact_ids=(
+                package.package_content_id,
+                package.manifest_content_id,
+            ),
+        ),
+    )
+    information_set = bind_information_set(
+        view,
+        PumpStationObservationHistory(
+            agent_tenure_id="tenure-1",
+            view_ids=(view.view_id,),
+        ),
+        PumpStationCurrentContext(
+            continuity_carrier=PumpStationContinuityCarrier.CURRENT_ACTOR_VIEW,
+            conversation_prefix_id=None,
+            workspace_tool_ids=("propose-pump-station-action",),
+            visible_material_ids=(),
+        ),
+    )
+    proposal = proposal_type(
+        context=ProposalContext(
+            proposal_id=proposal_id,
+            agent_tenure_id="tenure-1",
+            based_on_sequence=state.sequence,
+            base_view_id=view.view_id,
+            information_set_id=information_set.information_set_id,
+            reason="Exercise durable world-run publication.",
+        ),
+        **parameters,
+    )
+    return proposal, information_set


### PR DESCRIPTION
## Summary

- add a task-local durable pump-station world run over a host-supplied filesystem root
- publish immutable state, proposal, information-set, receipt, event, and commit artifacts
- use one lock-serialised atomic current-state pointer for snapshot, resume, and exactly-once retry
- retain simulated duration and applied event identity across resume
- update the PRD and Ara research record for the accepted ASW-2B boundary

## Validation

- 55 pump-station tests passed
- 3 documentation-ownership tests passed
- Ruff lint and format passed for the pump-station production and test paths
- Mypy passed for 6 changed production modules
- Ara-lite validation passed with no diagnostics
- 4 changed Markdown files parsed successfully

## Boundary

This change does not add CLI, Harbor, TrialRecord, study-runner, provider, database, or shared stewardship-runtime behavior. ASW-2C remains the next host-session boundary.