### PR TITLE
Restore packaged lifecycle ablation example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,6 +188,8 @@ examples/
 !docs/examples/
 !docs/examples/meta-harness/
 !docs/examples/meta-harness/**
+!src/aec_bench/init/skill_data/meta-harness/examples/
+!src/aec_bench/init/skill_data/meta-harness/examples/lifecycle-ablation.yaml
 packages/
 task_decompositions/
 task_genomes/

--- a/src/aec_bench/init/skill_data/meta-harness/examples/lifecycle-ablation.yaml
+++ b/src/aec_bench/init/skill_data/meta-harness/examples/lifecycle-ablation.yaml
@@ -1,0 +1,29 @@
+# ABOUTME: Provides the installed public-calibration example for the SSC-03 evidence lifecycle.
+# ABOUTME: Supports provider-free plan review before a real model and execution paths are selected.
+schema_version: "1"
+experiment_id: ssc03-public-calibration
+lifecycle_template_id: drainage-model-evidence-lifecycle-review
+study_design:
+  interpretation: descriptive_calibration
+  turn_budget_scope: per_session
+  execution_order: deterministic_sequential_plan_order
+  randomized: false
+  counterbalanced: false
+  causal_effects_supported: false
+variants:
+  - staged_full_correction
+  - semantic_no_op_release
+  - response_assertion_only
+  - memo_closeout_missing
+agents:
+  - name: tool-loop-model
+    adapter: tool_loop
+    model: replace-with-your-model
+    parameters:
+      max_turns_per_session: 60
+repetitions: 1
+output_root: artefacts/ssc03-public-calibration/runs
+ledger_root: artefacts/ssc03-public-calibration/ledger
+limits:
+  max_trials: 16
+  max_concurrency: 1


### PR DESCRIPTION
## Summary

- restore the lifecycle ablation example documented by the packaged meta-harness skill
- exempt that single packaged example from the repository-wide examples ignore rule
- keep the installed template provider-free until a real model is selected

## Checks

- 17 init tests passed
- lifecycle-ablation dry run passed
- wheel and source package both contain the example

## Full-suite note

A full run was stopped at Theo's request after 2,469 passes and 8 skips. It exposed the existing order-dependent Azure reviewer test failure, which is outside this repair.