### PR TITLE
ASW-2C: add direct pump-station world sessions

### DIFF
--- a/research/asset-stewardship/asset-stewardship-worlds-prd.md
+++ b/research/asset-stewardship/asset-stewardship-worlds-prd.md
@@ -580,6 +580,14 @@ Each exogenous event declares:
 
 ASW-2 uses a fixed event schedule. Later treatments change one declared source class at a time.
 
+Future design work should expand the declared event catalogue to increase
+interaction diversity and operational realism. Candidate families include
+physical loading and degradation changes, observation arrival or loss,
+operational demand and duty changes, resource and access changes, and
+institutional events such as handovers or revised restrictions. Each addition
+must preserve deterministic replay, explicit visibility, and controlled
+variation of one source class at a time.
+
 ### 9.4 Action, authority, and execution
 
 An agent proposal includes:
@@ -1843,15 +1851,14 @@ An external engine-research lane may run beside ASW-0A, but it converges only at
 | 2026-07-29 | Model episode time and actor-tenure time separately and keep handover inside the continuing episode. | The environment needs real simulated duration without treating a new actor or conversation as a physical reset. |
 | 2026-07-29 | Compute actor-facing identities from visible projection content only. | A full-state fingerprint in an actor view could reveal that hidden latent or future state differs even when permitted observations are equal. |
 | 2026-07-29 | Publish ASW-2B transitions as immutable task artifacts followed by one lock-serialised atomic current-state pointer. | This gives snapshot, resume, strict replay, and exactly-once physical and resource effects without a database, shared stewardship runtime, or hand-authored hashes. |
+| 2026-07-29 | Keep the ASW-2C host boundary minimal and provider-neutral while the pump-station package owns its native tools. | The host needs strict start and resume contracts without owning task physics, action names, evaluation policy, or model-provider calls. |
 
 ## 24. Immediate next action
 
-Complete and review **ASW-2B — durable world run** against
-[ASW-0C-3](asw-0c-research-charter.md), then start **ASW-2C — direct host
-session**.
+Complete and review **ASW-2C — direct host session**, then start **ASW-2D —
+Harbor and experimental root**.
 
-ASW-2C may add only the minimum promoted host-execution types, provider-neutral
-world-session bridge, native typed tools, installed CLI start/resume/verify, and
-capability-disabled lifecycle regression. It must use the accepted ASW-2B
-repository and task semantics. It does not add Harbor import, `TrialRecord`
-changes, study contracts, or model-provider calls.
+ASW-2D adds the entrypoint execution discriminator, sibling stewardship
+exporter, local Harbor job, strict importer, immutable artifact reconciliation,
+and the minimum additive `TrialRecord` stewardship fragment. It does not add
+evaluation report contracts, study execution, or model-provider calls.

--- a/src/aec_bench/cli/commands/pump_station_world.py
+++ b/src/aec_bench/cli/commands/pump_station_world.py
@@ -1,0 +1,185 @@
+# ABOUTME: Provides installed CLI commands for direct pump-station world sessions.
+# ABOUTME: Starts, advances, resumes, and independently verifies one durable task-owned run.
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import cast
+
+import typer
+
+from aec_bench.cli.output import emit
+from aec_bench.contracts.world_session import (
+    StewardshipStateSnapshotRef,
+    WorldSessionExecutionKind,
+    WorldSessionOpenMode,
+    WorldSessionRequest,
+)
+from aec_bench.harness.world_session import open_world_session
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_repository import (
+    PumpStationWorldRunRepository,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_session import (
+    PUMP_STATION_TASK_WORLD_ID,
+    PumpStationWorldSession,
+    PumpStationWorldSessionFactory,
+)
+
+app = typer.Typer(help="Run the synthetic wastewater pump-station stewardship world.")
+
+
+def _factory(run_dir: Path) -> PumpStationWorldSessionFactory:
+    return PumpStationWorldSessionFactory(run_dir)
+
+
+def _resume_request(
+    run_dir: Path,
+    *,
+    session_id: str,
+    agent_tenure_id: str,
+) -> WorldSessionRequest:
+    repository = PumpStationWorldRunRepository(run_dir)
+    manifest = repository.load_manifest()
+    snapshot = repository.current_snapshot()
+    return WorldSessionRequest(
+        execution_kind=WorldSessionExecutionKind.STEWARDSHIP,
+        open_mode=WorldSessionOpenMode.RESUME,
+        session_id=session_id,
+        task_world_id=PUMP_STATION_TASK_WORLD_ID,
+        agent_tenure_id=agent_tenure_id,
+        run_id=manifest.run_id,
+        episode_id=manifest.episode_id,
+        world_branch_id=manifest.world_branch_id,
+        start_snapshot=StewardshipStateSnapshotRef(
+            run_id=snapshot.run_id,
+            episode_id=snapshot.episode_id,
+            world_branch_id=snapshot.world_branch_id,
+            sequence=snapshot.sequence,
+            state_id=snapshot.state_id,
+            commit_id=snapshot.commit_id,
+        ),
+    )
+
+
+def _open(
+    run_dir: Path,
+    request: WorldSessionRequest,
+) -> PumpStationWorldSession:
+    return cast(
+        PumpStationWorldSession,
+        open_world_session(request, _factory(run_dir)),
+    )
+
+
+@app.command("start")
+def start_command(
+    run_dir: Path = typer.Option(..., "--run-dir", help="Empty directory for the durable world run"),
+    run_id: str = typer.Option(..., "--run-id", help="Stable world-run identity"),
+    episode_id: str = typer.Option(..., "--episode-id", help="Stable episode identity"),
+    world_branch_id: str = typer.Option(..., "--world-branch-id", help="Stable continuing branch identity"),
+    session_id: str = typer.Option(..., "--session-id", help="Direct host-session identity"),
+    agent_tenure_id: str = typer.Option(..., "--agent-tenure-id", help="Current actor-tenure identity"),
+) -> None:
+    """Start one direct session over a new durable pump-station run."""
+    started = time.monotonic()
+    request = WorldSessionRequest(
+        execution_kind=WorldSessionExecutionKind.STEWARDSHIP,
+        open_mode=WorldSessionOpenMode.START,
+        session_id=session_id,
+        task_world_id=PUMP_STATION_TASK_WORLD_ID,
+        agent_tenure_id=agent_tenure_id,
+        run_id=run_id,
+        episode_id=episode_id,
+        world_branch_id=world_branch_id,
+    )
+    session = _open(run_dir, request)
+    emit(
+        "task pump-station-world start",
+        session.result.model_dump(mode="json"),
+        start_time=started,
+    )
+
+
+@app.command("resume")
+def resume_command(
+    run_dir: Path = typer.Option(..., "--run-dir", help="Existing durable world-run directory"),
+    session_id: str = typer.Option(..., "--session-id", help="Direct host-session identity"),
+    agent_tenure_id: str = typer.Option(..., "--agent-tenure-id", help="Fresh or continuing actor tenure"),
+) -> None:
+    """Resume the exact selected world state under one actor tenure."""
+    started = time.monotonic()
+    session = _open(
+        run_dir,
+        _resume_request(
+            run_dir,
+            session_id=session_id,
+            agent_tenure_id=agent_tenure_id,
+        ),
+    )
+    emit(
+        "task pump-station-world resume",
+        session.result.model_dump(mode="json"),
+        start_time=started,
+    )
+
+
+@app.command("continue-operation")
+def continue_operation_command(
+    run_dir: Path = typer.Option(..., "--run-dir", help="Existing durable world-run directory"),
+    session_id: str = typer.Option(..., "--session-id", help="Direct host-session identity"),
+    agent_tenure_id: str = typer.Option(..., "--agent-tenure-id", help="Current actor-tenure identity"),
+    proposal_id: str = typer.Option(..., "--proposal-id", help="Stable proposal identity"),
+    reason: str = typer.Option(..., "--reason", help="Actor reason for continuing operation"),
+) -> None:
+    """Apply the explicit no-intervention proposal and advance simulated time."""
+    started = time.monotonic()
+    session = _open(
+        run_dir,
+        _resume_request(
+            run_dir,
+            session_id=session_id,
+            agent_tenure_id=agent_tenure_id,
+        ),
+    )
+    result = json.loads(
+        session.continue_operation(
+            proposal_id=proposal_id,
+            reason=reason,
+        )
+    )
+    emit(
+        "task pump-station-world continue-operation",
+        result,
+        start_time=started,
+    )
+
+
+@app.command("verify")
+def verify_command(
+    run_dir: Path = typer.Option(..., "--run-dir", help="Existing durable world-run directory"),
+) -> None:
+    """Reload and independently replay all committed pump-station transitions."""
+    started = time.monotonic()
+    session = _open(
+        run_dir,
+        _resume_request(
+            run_dir,
+            session_id="verification-session",
+            agent_tenure_id="verification-tenure",
+        ),
+    )
+    report = session.verify()
+    emit(
+        "task pump-station-world verify",
+        {
+            "valid": report.valid,
+            "issues": list(report.issues),
+            "replayed_transition_ids": list(report.replayed_transition_ids),
+            "final_state_id": report.final_state_id,
+            "active_restriction_ids": list(report.active_restriction_ids),
+            "open_obligation_ids": list(report.open_obligation_ids),
+        },
+        start_time=started,
+    )

--- a/src/aec_bench/cli/commands/task.py
+++ b/src/aec_bench/cli/commands/task.py
@@ -10,12 +10,14 @@ import typer
 import yaml
 
 from aec_bench.cli.commands.hydraulic_world import app as hydraulic_world_app
+from aec_bench.cli.commands.pump_station_world import app as pump_station_world_app
 from aec_bench.cli.commands.task_world_templates import app as composite_template_app
 from aec_bench.cli.output import console, emit
 
 app = typer.Typer(help="Task management commands.")
 app.add_typer(composite_template_app, name="composite-template")
 app.add_typer(hydraulic_world_app, name="hydraulic-world")
+app.add_typer(pump_station_world_app, name="pump-station-world")
 
 _SEVERITY_ICONS = {"error": "[red]✗[/red]", "warning": "[yellow]⚠[/yellow]", "info": "[dim]✓[/dim]"}
 

--- a/src/aec_bench/contracts/__init__.py
+++ b/src/aec_bench/contracts/__init__.py
@@ -377,6 +377,14 @@ _EXPORTS_BY_MODULE: dict[str, tuple[str, ...]] = {
         "TaskSnapshotRef",
         "WorldSnapshotRef",
     ),
+    "aec_bench.contracts.world_session": (
+        "StewardshipStateSnapshotRef",
+        "WORLD_SESSION_SCHEMA_VERSION",
+        "WorldSessionExecutionKind",
+        "WorldSessionOpenMode",
+        "WorldSessionRequest",
+        "WorldSessionResult",
+    ),
     "aec_bench.contracts.validators": (
         "LenientModel",
         "NonEmptyStr",

--- a/src/aec_bench/contracts/world_session.py
+++ b/src/aec_bench/contracts/world_session.py
@@ -1,0 +1,103 @@
+# ABOUTME: Defines the minimal shared request, result, and dynamic snapshot contract for world sessions.
+# ABOUTME: Keeps asset clocks, actions, views, and physical state outside the host-execution envelope.
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Self
+
+from pydantic import model_validator
+
+from aec_bench.contracts.validators import FrozenStrictModel, NonEmptyStr
+
+WORLD_SESSION_SCHEMA_VERSION = "aecbench.world-session.v1"
+
+
+class WorldSessionExecutionKind(StrEnum):
+    """Host execution kind for a persistent stewardship interaction."""
+
+    STEWARDSHIP = "stewardship_world_session"
+
+
+class WorldSessionOpenMode(StrEnum):
+    """Supported ways to open one direct world session."""
+
+    START = "start"
+    RESUME = "resume"
+
+
+class StewardshipStateSnapshotRef(FrozenStrictModel):
+    """Task-neutral identity of one selected dynamic stewardship state."""
+
+    run_id: NonEmptyStr
+    episode_id: NonEmptyStr
+    world_branch_id: NonEmptyStr
+    sequence: int
+    state_id: NonEmptyStr
+    commit_id: NonEmptyStr
+
+    @model_validator(mode="after")
+    def validate_sequence(self) -> Self:
+        if self.sequence < 0:
+            raise ValueError("snapshot sequence must be non-negative")
+        return self
+
+
+class WorldSessionRequest(FrozenStrictModel):
+    """Minimum host request shared by a session controller and one task world."""
+
+    schema_version: str = WORLD_SESSION_SCHEMA_VERSION
+    execution_kind: WorldSessionExecutionKind
+    open_mode: WorldSessionOpenMode
+    session_id: NonEmptyStr
+    task_world_id: NonEmptyStr
+    agent_tenure_id: NonEmptyStr
+    run_id: NonEmptyStr
+    episode_id: NonEmptyStr
+    world_branch_id: NonEmptyStr
+    start_snapshot: StewardshipStateSnapshotRef | None = None
+
+    @model_validator(mode="after")
+    def validate_open_mode(self) -> Self:
+        if self.schema_version != WORLD_SESSION_SCHEMA_VERSION:
+            raise ValueError("unsupported world-session schema version")
+        if self.open_mode is WorldSessionOpenMode.START and self.start_snapshot is not None:
+            raise ValueError("start request must not contain a prior snapshot")
+        if self.open_mode is WorldSessionOpenMode.RESUME and self.start_snapshot is None:
+            raise ValueError("resume request requires an exact start snapshot")
+        if self.start_snapshot is not None and (
+            self.start_snapshot.run_id,
+            self.start_snapshot.episode_id,
+            self.start_snapshot.world_branch_id,
+        ) != (
+            self.run_id,
+            self.episode_id,
+            self.world_branch_id,
+        ):
+            raise ValueError("start snapshot identity differs from the requested world")
+        return self
+
+
+class WorldSessionResult(FrozenStrictModel):
+    """Current public host result for one opened world session."""
+
+    schema_version: str = WORLD_SESSION_SCHEMA_VERSION
+    execution_kind: WorldSessionExecutionKind
+    open_mode: WorldSessionOpenMode
+    session_id: NonEmptyStr
+    task_world_id: NonEmptyStr
+    agent_tenure_id: NonEmptyStr
+    snapshot: StewardshipStateSnapshotRef
+    actor_view_id: NonEmptyStr
+    information_set_id: NonEmptyStr
+    tool_names: tuple[NonEmptyStr, ...]
+
+    @model_validator(mode="after")
+    def validate_result(self) -> Self:
+        if self.schema_version != WORLD_SESSION_SCHEMA_VERSION:
+            raise ValueError("unsupported world-session schema version")
+        if not self.tool_names:
+            raise ValueError("world session must declare at least one tool")
+        if len(set(self.tool_names)) != len(self.tool_names):
+            raise ValueError("tool names must be distinct")
+        return self

--- a/src/aec_bench/harness/world_session.py
+++ b/src/aec_bench/harness/world_session.py
@@ -1,0 +1,65 @@
+# ABOUTME: Validates the provider-neutral host boundary used to open direct world sessions.
+# ABOUTME: Delegates all asset actions, state semantics, projections, and verification to the task world.
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from aec_bench.contracts.world_session import WorldSessionRequest, WorldSessionResult
+
+
+class WorldSessionHostError(RuntimeError):
+    """Raised when a world-session producer violates the shared host contract."""
+
+
+class HostWorldSession(Protocol):
+    """Minimum session result visible to provider-neutral host orchestration."""
+
+    @property
+    def result(self) -> WorldSessionResult: ...
+
+
+class WorldSessionFactory(Protocol):
+    """Task-world producer consumed by the generic session host."""
+
+    task_world_id: str
+
+    def open(self, request: WorldSessionRequest) -> HostWorldSession: ...
+
+
+def open_world_session(
+    request: WorldSessionRequest,
+    factory: WorldSessionFactory,
+) -> HostWorldSession:
+    """Open one task-owned session and validate its shared result binding."""
+    if request.task_world_id != factory.task_world_id:
+        raise WorldSessionHostError("world-session task identity differs from the selected factory")
+    session = factory.open(request)
+    result = session.result
+    if (
+        result.execution_kind,
+        result.open_mode,
+        result.session_id,
+        result.task_world_id,
+        result.agent_tenure_id,
+    ) != (
+        request.execution_kind,
+        request.open_mode,
+        request.session_id,
+        request.task_world_id,
+        request.agent_tenure_id,
+    ):
+        raise WorldSessionHostError("world-session result does not bind the exact request")
+    if (
+        result.snapshot.run_id,
+        result.snapshot.episode_id,
+        result.snapshot.world_branch_id,
+    ) != (
+        request.run_id,
+        request.episode_id,
+        request.world_branch_id,
+    ):
+        raise WorldSessionHostError("world-session result belongs to another world")
+    if request.start_snapshot is not None and result.snapshot != request.start_snapshot:
+        raise WorldSessionHostError("resumed world-session result differs from the requested snapshot")
+    return session

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/__init__.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/__init__.py
@@ -124,6 +124,12 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_ru
     load_pump_station_artifact,
     pump_station_artifact_bytes,
 )
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_session import (
+    PUMP_STATION_TASK_WORLD_ID,
+    PUMP_STATION_TOOL_NAMES,
+    PumpStationWorldSession,
+    PumpStationWorldSessionFactory,
+)
 
 __all__ = [
     "EXPECTED_MANIFEST_CONTENT_ID",
@@ -194,7 +200,11 @@ __all__ = [
     "PumpStationWorldRunError",
     "PumpStationWorldRunManifest",
     "PumpStationWorldRunRepository",
+    "PumpStationWorldSession",
+    "PumpStationWorldSessionFactory",
     "PUMP_STATION_SERIALIZATION_VERSION",
+    "PUMP_STATION_TASK_WORLD_ID",
+    "PUMP_STATION_TOOL_NAMES",
     "PUMP_STATION_TRANSPORT_FIELD_EXCLUSIONS",
     "REFERENCE_PACKAGE_FILE_NAMES",
     "ReferencePackage",

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_session.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_session.py
@@ -1,0 +1,409 @@
+# ABOUTME: Exposes the pump-station world as a direct host session with closed typed tools.
+# ABOUTME: Composes durable runs, actor projections, information binding, actions, snapshots, and replay.
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from aec_bench.contracts.task_definition import ToolSpec
+from aec_bench.contracts.world_session import (
+    StewardshipStateSnapshotRef,
+    WorldSessionOpenMode,
+    WorldSessionRequest,
+    WorldSessionResult,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.physical_kernel import (
+    advance_pump_station,
+    initial_pump_station_state,
+    pump_station_model_from_package,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.physical_models import (
+    OperatingInterval,
+    PumpStationEnvironment,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.reference_package_reader import (
+    load_reference_package,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_models import (
+    ContinueOperation,
+    ProposalContext,
+    PumpStationProposal,
+    RequestConditionalDeferral,
+    RequestInspection,
+    RequestObstructionClearance,
+    RequestProvisionalClosure,
+    RequestProvisionalReturn,
+    RequestVerification,
+    TransferDuty,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_state_machine import (
+    create_stewardship_state,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_verifier import (
+    PumpStationVerificationReport,
+    verify_stewardship_run,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_views import (
+    PumpStationActorView,
+    PumpStationContinuityCarrier,
+    PumpStationCurrentContext,
+    PumpStationInformationSet,
+    PumpStationObservationHistory,
+    PumpStationProjectionContext,
+    bind_information_set,
+    project_actor_view,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run import (
+    PumpStationWorldRun,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_models import (
+    PumpStationStateSnapshotRef,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_repository import (
+    PumpStationWorldRunRepository,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_serialization import (
+    pump_station_artifact_bytes,
+)
+
+PUMP_STATION_TASK_WORLD_ID = "wastewater-pump-station-stewardship.v1"
+PUMP_STATION_PROJECTION_POLICY_ID = "pump-station-current-state.v1"
+PUMP_STATION_REVIEW_RUNTIME_SECONDS = 7_200_000
+PUMP_STATION_REVIEW_COMPLETED_STARTS = 1_000
+PUMP_STATION_TOOL_NAMES = (
+    "observe_pump_station",
+    "continue_operation",
+    "transfer_duty",
+    "request_inspection",
+    "request_conditional_deferral",
+    "request_obstruction_clearance",
+    "request_provisional_return",
+    "request_provisional_closure",
+    "request_post_maintenance_verification",
+    "snapshot_pump_station",
+)
+
+
+def _snapshot_ref(snapshot: PumpStationStateSnapshotRef) -> StewardshipStateSnapshotRef:
+    return StewardshipStateSnapshotRef(
+        run_id=snapshot.run_id,
+        episode_id=snapshot.episode_id,
+        world_branch_id=snapshot.world_branch_id,
+        sequence=snapshot.sequence,
+        state_id=snapshot.state_id,
+        commit_id=snapshot.commit_id,
+    )
+
+
+def _pump_station_snapshot(snapshot: StewardshipStateSnapshotRef) -> PumpStationStateSnapshotRef:
+    return PumpStationStateSnapshotRef(
+        run_id=snapshot.run_id,
+        episode_id=snapshot.episode_id,
+        world_branch_id=snapshot.world_branch_id,
+        sequence=snapshot.sequence,
+        state_id=snapshot.state_id,
+        commit_id=snapshot.commit_id,
+    )
+
+
+def _artifact_payload(value: object) -> dict[str, Any]:
+    payload = json.loads(pump_station_artifact_bytes(value))
+    if not isinstance(payload, dict):
+        raise TypeError("pump-station session artifact must serialize to an object")
+    return payload
+
+
+class PumpStationWorldSession:
+    """One opened actor tenure over a continuing durable pump-station run."""
+
+    def __init__(
+        self,
+        *,
+        request: WorldSessionRequest,
+        run: PumpStationWorldRun,
+    ) -> None:
+        self._request = request
+        self._run = run
+        state = run.state
+        initial_state = run.repository.load_state(run.manifest.initial_state_id)
+        episode_started_at_seconds = initial_state.physical.calendar_seconds
+        tenure_started_at_seconds = (
+            episode_started_at_seconds
+            if request.open_mode is WorldSessionOpenMode.START
+            else state.physical.calendar_seconds
+        )
+        self._projection_context = PumpStationProjectionContext(
+            episode_id=request.episode_id,
+            world_branch_id=request.world_branch_id,
+            actor_id="station-steward",
+            agent_tenure_id=request.agent_tenure_id,
+            episode_started_at_seconds=episode_started_at_seconds,
+            tenure_started_at_seconds=tenure_started_at_seconds,
+            projection_policy_id=PUMP_STATION_PROJECTION_POLICY_ID,
+            source_artifact_ids=(
+                run.package.package_content_id,
+                run.package.manifest_content_id,
+            ),
+        )
+        self._current_context = PumpStationCurrentContext(
+            continuity_carrier=PumpStationContinuityCarrier.CURRENT_ACTOR_VIEW,
+            conversation_prefix_id=None,
+            workspace_tool_ids=PUMP_STATION_TOOL_NAMES,
+            visible_material_ids=(),
+        )
+        self._view = self._project()
+        self._view_ids: tuple[str, ...] = (self._view.view_id,)
+        self._information_set = self._bind_information_set()
+
+    @property
+    def result(self) -> WorldSessionResult:
+        """Return the current shared host result without task-private state."""
+        return WorldSessionResult(
+            execution_kind=self._request.execution_kind,
+            open_mode=self._request.open_mode,
+            session_id=self._request.session_id,
+            task_world_id=self._request.task_world_id,
+            agent_tenure_id=self._request.agent_tenure_id,
+            snapshot=_snapshot_ref(self._run.snapshot()),
+            actor_view_id=self._view.view_id,
+            information_set_id=self._information_set.information_set_id,
+            tool_names=PUMP_STATION_TOOL_NAMES,
+        )
+
+    @property
+    def tool_specs(self) -> tuple[ToolSpec, ...]:
+        """Return the closed agent-visible tool catalogue."""
+        return tuple(
+            ToolSpec(
+                name=name,
+                source="builtin",
+                description=getattr(self, name).__doc__ or name.replace("_", " "),
+            )
+            for name in PUMP_STATION_TOOL_NAMES
+        )
+
+    @property
+    def native_tools(self) -> tuple[Callable[..., str], ...]:
+        """Return the bound native functions in the declared tool order."""
+        return tuple(getattr(self, name) for name in PUMP_STATION_TOOL_NAMES)
+
+    def observe_pump_station(self) -> str:
+        """Read the complete current actor view without latent or future state."""
+        return pump_station_artifact_bytes(self._view).decode("utf-8")
+
+    def continue_operation(self, proposal_id: str, reason: str) -> str:
+        """Continue the permitted operating mode to the next declared decision event."""
+        return self._apply(
+            ContinueOperation(
+                context=self._proposal_context(proposal_id, reason),
+            )
+        )
+
+    def transfer_duty(self, proposal_id: str, reason: str) -> str:
+        """Request the one permitted transfer from duty to standby pump."""
+        return self._apply(
+            TransferDuty(
+                context=self._proposal_context(proposal_id, reason),
+            )
+        )
+
+    def request_inspection(self, proposal_id: str, reason: str, pump_id: str) -> str:
+        """Request a scheduled inspection of one named pump."""
+        return self._apply(
+            RequestInspection(
+                context=self._proposal_context(proposal_id, reason),
+                pump_id=pump_id,
+            )
+        )
+
+    def request_conditional_deferral(self, proposal_id: str, reason: str, pump_id: str) -> str:
+        """Request the fixed transfer-then-isolate conditional deferral."""
+        return self._apply(
+            RequestConditionalDeferral(
+                context=self._proposal_context(proposal_id, reason),
+                pump_id=pump_id,
+            )
+        )
+
+    def request_obstruction_clearance(
+        self,
+        proposal_id: str,
+        reason: str,
+        pump_id: str,
+        inspection_evidence_id: str,
+    ) -> str:
+        """Request obstruction clearance against named inspection evidence."""
+        return self._apply(
+            RequestObstructionClearance(
+                context=self._proposal_context(proposal_id, reason),
+                pump_id=pump_id,
+                inspection_evidence_id=inspection_evidence_id,
+            )
+        )
+
+    def request_provisional_return(
+        self,
+        proposal_id: str,
+        reason: str,
+        pump_id: str,
+        functional_check_evidence_id: str,
+    ) -> str:
+        """Request provisional return against accepted functional-check evidence."""
+        return self._apply(
+            RequestProvisionalReturn(
+                context=self._proposal_context(proposal_id, reason),
+                pump_id=pump_id,
+                functional_check_evidence_id=functional_check_evidence_id,
+            )
+        )
+
+    def request_provisional_closure(
+        self,
+        proposal_id: str,
+        reason: str,
+        work_order_id: str,
+    ) -> str:
+        """Request administrative closure while verification duties remain open."""
+        return self._apply(
+            RequestProvisionalClosure(
+                context=self._proposal_context(proposal_id, reason),
+                work_order_id=work_order_id,
+            )
+        )
+
+    def request_post_maintenance_verification(
+        self,
+        proposal_id: str,
+        reason: str,
+        pump_id: str,
+    ) -> str:
+        """Request independent post-maintenance verification for one pump."""
+        return self._apply(
+            RequestVerification(
+                context=self._proposal_context(proposal_id, reason),
+                pump_id=pump_id,
+            )
+        )
+
+    def snapshot_pump_station(self) -> str:
+        """Read the exact current dynamic snapshot reference."""
+        return self.result.snapshot.model_dump_json()
+
+    def verify(self) -> PumpStationVerificationReport:
+        """Replay the durable transition chain through the independent task verifier."""
+        initial_state = self._run.repository.load_state(
+            self._run.manifest.initial_state_id,
+        )
+        return verify_stewardship_run(
+            self._run.model,
+            initial_state,
+            self._run.steps(),
+        )
+
+    def _proposal_context(self, proposal_id: str, reason: str) -> ProposalContext:
+        return ProposalContext(
+            proposal_id=proposal_id,
+            agent_tenure_id=self._request.agent_tenure_id,
+            based_on_sequence=self._run.state.sequence,
+            base_view_id=self._view.view_id,
+            information_set_id=self._information_set.information_set_id,
+            reason=reason,
+        )
+
+    def _apply(self, proposal: PumpStationProposal) -> str:
+        transition = self._run.apply(
+            proposal,
+            information_set=self._information_set,
+        )
+        self._refresh_projection()
+        return json.dumps(
+            {
+                "status": transition.receipt.execution.value,
+                "snapshot": self.result.snapshot.model_dump(mode="json"),
+                "receipt": _artifact_payload(transition.receipt),
+                "view": _artifact_payload(self._view),
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+    def _project(self) -> PumpStationActorView:
+        return project_actor_view(
+            self._run.model,
+            self._run.state,
+            self._projection_context,
+        )
+
+    def _bind_information_set(self) -> PumpStationInformationSet:
+        return bind_information_set(
+            self._view,
+            PumpStationObservationHistory(
+                agent_tenure_id=self._request.agent_tenure_id,
+                view_ids=self._view_ids,
+            ),
+            self._current_context,
+        )
+
+    def _refresh_projection(self) -> None:
+        self._view = self._project()
+        self._view_ids = (*self._view_ids, self._view.view_id)
+        self._information_set = self._bind_information_set()
+
+
+class PumpStationWorldSessionFactory:
+    """Create or resume pump-station sessions from one host-supplied repository."""
+
+    task_world_id = PUMP_STATION_TASK_WORLD_ID
+
+    def __init__(self, repository_root: Path) -> None:
+        self._repository = PumpStationWorldRunRepository(repository_root)
+
+    def open(self, request: WorldSessionRequest) -> PumpStationWorldSession:
+        """Open a new or exact resumed session for the requested actor tenure."""
+        if request.task_world_id != self.task_world_id:
+            raise ValueError("world-session request belongs to another task world")
+        package = load_reference_package()
+        model = pump_station_model_from_package(package)
+        if request.open_mode is WorldSessionOpenMode.START:
+            environment = PumpStationEnvironment(
+                inflow_m3_s=model.inflow.assessment_m3_s,
+                wet_well_level_m=model.wet_well.start_level_m,
+                isolated=False,
+            )
+            physical = advance_pump_station(
+                model,
+                initial_pump_station_state(model),
+                OperatingInterval(
+                    elapsed_seconds=PUMP_STATION_REVIEW_RUNTIME_SECONDS,
+                    duty_runtime_seconds=PUMP_STATION_REVIEW_RUNTIME_SECONDS,
+                    duty_completed_starts=PUMP_STATION_REVIEW_COMPLETED_STARTS,
+                    environment=environment,
+                ),
+            ).state
+            state = create_stewardship_state(
+                model,
+                physical,
+                environment,
+            )
+            run = PumpStationWorldRun.create(
+                repository=self._repository,
+                package=package,
+                model=model,
+                initial_state=state,
+                run_id=request.run_id,
+                episode_id=request.episode_id,
+                world_branch_id=request.world_branch_id,
+            )
+        else:
+            if request.start_snapshot is None:
+                raise ValueError("resume request has no start snapshot")
+            run = PumpStationWorldRun.resume(
+                repository=self._repository,
+                package=package,
+                model=model,
+                snapshot=_pump_station_snapshot(request.start_snapshot),
+            )
+        return PumpStationWorldSession(request=request, run=run)

--- a/tests/contracts/test_world_session.py
+++ b/tests/contracts/test_world_session.py
@@ -1,0 +1,83 @@
+# ABOUTME: Defines the strict shared request, result, and dynamic snapshot expectations for world sessions.
+# ABOUTME: Keeps asset actions and physical state outside the promoted host-execution contract.
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from aec_bench.contracts.world_session import (
+    StewardshipStateSnapshotRef,
+    WorldSessionExecutionKind,
+    WorldSessionOpenMode,
+    WorldSessionRequest,
+    WorldSessionResult,
+)
+
+
+def _snapshot() -> StewardshipStateSnapshotRef:
+    return StewardshipStateSnapshotRef(
+        run_id="run-1",
+        episode_id="episode-1",
+        world_branch_id="branch-1",
+        sequence=3,
+        state_id="state-3",
+        commit_id="commit-3",
+    )
+
+
+def test_world_session_request_requires_exact_resume_snapshot() -> None:
+    request = WorldSessionRequest(
+        execution_kind=WorldSessionExecutionKind.STEWARDSHIP,
+        open_mode=WorldSessionOpenMode.RESUME,
+        session_id="session-2",
+        task_world_id="wastewater-pump-station-stewardship.v1",
+        agent_tenure_id="tenure-2",
+        run_id="run-1",
+        episode_id="episode-1",
+        world_branch_id="branch-1",
+        start_snapshot=_snapshot(),
+    )
+
+    assert request.start_snapshot == _snapshot()
+    with pytest.raises(ValidationError, match="resume request requires"):
+        WorldSessionRequest(
+            execution_kind=WorldSessionExecutionKind.STEWARDSHIP,
+            open_mode=WorldSessionOpenMode.RESUME,
+            session_id="session-2",
+            task_world_id="wastewater-pump-station-stewardship.v1",
+            agent_tenure_id="tenure-2",
+            run_id="run-1",
+            episode_id="episode-1",
+            world_branch_id="branch-1",
+        )
+
+
+def test_world_session_contract_rejects_unused_fields_and_duplicate_tools() -> None:
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        WorldSessionRequest.model_validate(
+            {
+                "execution_kind": "stewardship_world_session",
+                "open_mode": "start",
+                "session_id": "session-1",
+                "task_world_id": "wastewater-pump-station-stewardship.v1",
+                "agent_tenure_id": "tenure-1",
+                "run_id": "run-1",
+                "episode_id": "episode-1",
+                "world_branch_id": "branch-1",
+                "future_options": {},
+            }
+        )
+
+    with pytest.raises(ValidationError, match="tool names must be distinct"):
+        WorldSessionResult(
+            execution_kind=WorldSessionExecutionKind.STEWARDSHIP,
+            open_mode=WorldSessionOpenMode.START,
+            session_id="session-1",
+            task_world_id="wastewater-pump-station-stewardship.v1",
+            agent_tenure_id="tenure-1",
+            snapshot=_snapshot(),
+            actor_view_id="view-1",
+            information_set_id="information-1",
+            tool_names=("observe_pump_station", "observe_pump_station"),
+        )

--- a/tests/harness/test_direct_world_session.py
+++ b/tests/harness/test_direct_world_session.py
@@ -1,0 +1,60 @@
+# ABOUTME: Exercises the provider-neutral host seam against the real pump-station session factory.
+# ABOUTME: Proves lifecycle sessions do not receive stewardship tools when the capability is absent.
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from aec_bench.contracts.world_session import (
+    WorldSessionExecutionKind,
+    WorldSessionOpenMode,
+    WorldSessionRequest,
+)
+from aec_bench.harness.world_session import open_world_session
+from aec_bench.meta_harness.evidence_lifecycle_local import build_lifecycle_tool_schema
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_session import (
+    PUMP_STATION_TASK_WORLD_ID,
+    PUMP_STATION_TOOL_NAMES,
+    PumpStationWorldSessionFactory,
+)
+
+
+def test_host_opens_real_provider_neutral_pump_station_session(tmp_path: Path) -> None:
+    request = WorldSessionRequest(
+        execution_kind=WorldSessionExecutionKind.STEWARDSHIP,
+        open_mode=WorldSessionOpenMode.START,
+        session_id="session-1",
+        task_world_id=PUMP_STATION_TASK_WORLD_ID,
+        agent_tenure_id="tenure-1",
+        run_id="run-1",
+        episode_id="episode-1",
+        world_branch_id="branch-1",
+    )
+
+    session = open_world_session(
+        request,
+        PumpStationWorldSessionFactory(tmp_path / "world"),
+    )
+    response = json.loads(
+        session.continue_operation(
+            proposal_id="proposal-1",
+            reason="Continue to the next declared event.",
+        )
+    )
+
+    assert session.result.execution_kind is WorldSessionExecutionKind.STEWARDSHIP
+    assert session.result.snapshot.sequence == 1
+    assert response["status"] == "completed"
+    assert response["snapshot"]["sequence"] == 1
+
+
+def test_lifecycle_tool_schema_excludes_stewardship_tools_without_capability() -> None:
+    lifecycle_tools = build_lifecycle_tool_schema(
+        "persistent_context",
+        supports_evidence_requests=False,
+        supports_lifecycle_operations=False,
+    )
+
+    lifecycle_tool_names = {item["name"] for item in lifecycle_tools}
+    assert lifecycle_tool_names.isdisjoint(PUMP_STATION_TOOL_NAMES)

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_pump_station_world_session.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_pump_station_world_session.py
@@ -1,0 +1,129 @@
+# ABOUTME: Tests the pump-station session tools over the real durable world-run repository.
+# ABOUTME: Covers typed actions, exact snapshot resume, actor projection, and independent replay.
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from aec_bench.contracts.world_session import (
+    WorldSessionExecutionKind,
+    WorldSessionOpenMode,
+    WorldSessionRequest,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_session import (
+    PUMP_STATION_TASK_WORLD_ID,
+    PUMP_STATION_TOOL_NAMES,
+    PumpStationWorldSessionFactory,
+)
+
+
+def _start_request() -> WorldSessionRequest:
+    return WorldSessionRequest(
+        execution_kind=WorldSessionExecutionKind.STEWARDSHIP,
+        open_mode=WorldSessionOpenMode.START,
+        session_id="session-1",
+        task_world_id=PUMP_STATION_TASK_WORLD_ID,
+        agent_tenure_id="tenure-1",
+        run_id="run-1",
+        episode_id="episode-1",
+        world_branch_id="branch-1",
+    )
+
+
+def test_session_exposes_closed_typed_tool_catalogue_and_replays_run(tmp_path: Path) -> None:
+    factory = PumpStationWorldSessionFactory(tmp_path / "world")
+    session = factory.open(_start_request())
+
+    assert tuple(tool.name for tool in session.tool_specs) == PUMP_STATION_TOOL_NAMES
+    assert tuple(tool.__name__ for tool in session.native_tools) == PUMP_STATION_TOOL_NAMES
+    assert json.loads(session.observe_pump_station())["current_state"]["state_sequence"] == 0
+
+    transition = json.loads(
+        session.continue_operation(
+            proposal_id="proposal-1",
+            reason="Continue to the next declared event.",
+        )
+    )
+
+    assert transition["status"] == "completed"
+    assert transition["snapshot"]["sequence"] == 1
+    assert session.verify().valid is True
+
+
+def test_session_resumes_exact_selected_snapshot_under_fresh_tenure(tmp_path: Path) -> None:
+    factory = PumpStationWorldSessionFactory(tmp_path / "world")
+    first = factory.open(_start_request())
+    first.continue_operation(
+        proposal_id="proposal-1",
+        reason="Continue to the next declared event.",
+    )
+    snapshot = first.result.snapshot
+
+    resumed = factory.open(
+        WorldSessionRequest(
+            execution_kind=WorldSessionExecutionKind.STEWARDSHIP,
+            open_mode=WorldSessionOpenMode.RESUME,
+            session_id="session-2",
+            task_world_id=PUMP_STATION_TASK_WORLD_ID,
+            agent_tenure_id="tenure-2",
+            run_id="run-1",
+            episode_id="episode-1",
+            world_branch_id="branch-1",
+            start_snapshot=snapshot,
+        )
+    )
+
+    assert resumed.result.snapshot == snapshot
+    assert resumed.result.agent_tenure_id == "tenure-2"
+    assert json.loads(resumed.observe_pump_station())["agent_tenure_id"] == "tenure-2"
+    assert resumed.verify().valid is True
+
+
+def test_session_tools_execute_complete_reference_stewardship_journey(tmp_path: Path) -> None:
+    session = PumpStationWorldSessionFactory(tmp_path / "world").open(_start_request())
+    reason = "Execute the deterministic reference stewardship journey."
+
+    session.request_conditional_deferral("proposal-01", reason, "pump-a")
+    session.transfer_duty("proposal-02", reason)
+    session.request_inspection("proposal-03", reason, "pump-a")
+    inspection_completed = json.loads(session.continue_operation("proposal-04", reason))
+    inspection_id = next(
+        item["evidence_id"]
+        for item in inspection_completed["view"]["current_state"]["evidence"]
+        if item["kind"] == "inspection"
+    )
+    session.continue_operation("proposal-05", reason)
+    session.request_obstruction_clearance(
+        "proposal-06",
+        reason,
+        "pump-a",
+        inspection_id,
+    )
+    session.continue_operation("proposal-07", reason)
+    checks_completed = json.loads(session.continue_operation("proposal-08", reason))
+    functional_check_id = next(
+        item["evidence_id"]
+        for item in checks_completed["view"]["current_state"]["evidence"]
+        if item["kind"] == "functional_checks"
+    )
+    returned = json.loads(
+        session.request_provisional_return(
+            "proposal-09",
+            reason,
+            "pump-a",
+            functional_check_id,
+        )
+    )
+    work_order_id = returned["view"]["current_state"]["work_orders"][0]["work_order_id"]
+    session.request_provisional_closure("proposal-10", reason, work_order_id)
+    session.request_post_maintenance_verification(
+        "proposal-11",
+        reason,
+        "pump-a",
+    )
+    verified = json.loads(session.continue_operation("proposal-12", reason))
+
+    assert verified["status"] == "completed"
+    assert session.result.snapshot.sequence == 12
+    assert session.verify().valid is True

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_world_session_cli_e2e.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_world_session_cli_e2e.py
@@ -1,0 +1,77 @@
+# ABOUTME: Exercises the installed CLI across a real pump-station start, action, resume, and verify journey.
+# ABOUTME: Runs outside the repository working directory without research files or provider calls.
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+
+def _run_cli(*args: str, cwd: Path) -> dict[str, Any]:
+    executable = Path(sys.executable).parent / "aec-bench"
+    completed = subprocess.run(
+        [str(executable), "--json", "task", "pump-station-world", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr or completed.stdout
+    return cast(dict[str, Any], json.loads(completed.stdout))
+
+
+def test_installed_cli_starts_advances_resumes_and_verifies_world(tmp_path: Path) -> None:
+    run_dir = tmp_path / "pump-station-run"
+
+    started = _run_cli(
+        "start",
+        "--run-dir",
+        str(run_dir),
+        "--run-id",
+        "run-cli-1",
+        "--episode-id",
+        "episode-cli-1",
+        "--world-branch-id",
+        "branch-cli-1",
+        "--session-id",
+        "session-cli-1",
+        "--agent-tenure-id",
+        "tenure-cli-1",
+        cwd=tmp_path,
+    )
+    advanced = _run_cli(
+        "continue-operation",
+        "--run-dir",
+        str(run_dir),
+        "--session-id",
+        "session-cli-2",
+        "--agent-tenure-id",
+        "tenure-cli-1",
+        "--proposal-id",
+        "proposal-cli-1",
+        "--reason",
+        "Continue to the next declared event.",
+        cwd=tmp_path,
+    )
+    resumed = _run_cli(
+        "resume",
+        "--run-dir",
+        str(run_dir),
+        "--session-id",
+        "session-cli-3",
+        "--agent-tenure-id",
+        "tenure-cli-2",
+        cwd=tmp_path,
+    )
+    verified = _run_cli("verify", "--run-dir", str(run_dir), cwd=tmp_path)
+
+    assert started["data"]["snapshot"]["sequence"] == 0
+    assert advanced["data"]["snapshot"]["sequence"] == 1
+    assert resumed["data"]["snapshot"] == advanced["data"]["snapshot"]
+    assert resumed["data"]["agent_tenure_id"] == "tenure-cli-2"
+    assert verified["data"]["valid"] is True
+    assert verified["data"]["replayed_transition_ids"] == ["transition-0001"]


### PR DESCRIPTION
## Summary

- add the minimum shared start, resume, result, and snapshot contracts for stewardship world sessions
- add a provider-neutral host bridge while keeping pump-station physics, tools, projections, and verification task-owned
- expose typed pump-station tools and installed CLI start, resume, action, and verify commands
- preserve lifecycle separation when stewardship capability is absent
- record the future event-diversity note and advance the PRD next action to ASW-2D

## Checks

- 9 focused tests passed, including the installed CLI journey and repaired package-copy test
- Ruff format and lint passed for changed Python files
- mypy passed for the new production boundary
- diff check passed

## Scope boundary

This PR does not add Harbor import, TrialRecord changes, study contracts, evaluation contracts, or model-provider calls.

The full repository suite was not rerun. An interrupted baseline run exposed the existing order-dependent Azure reviewer test failure, which is outside ASW-2C.