### PR TITLE
ASW-2E: add pump station stewardship evaluation

### DIFF
--- a/src/aec_bench/cli/commands/pump_station_world.py
+++ b/src/aec_bench/cli/commands/pump_station_world.py
@@ -18,6 +18,9 @@ from aec_bench.contracts.world_session import (
     WorldSessionOpenMode,
     WorldSessionRequest,
 )
+from aec_bench.evaluation.stewardship import (
+    evaluate_pump_station_stewardship_run,
+)
 from aec_bench.harness.harbor_importing.core import import_harbor_trial
 from aec_bench.harness.world_session import open_world_session
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.harbor_export import (
@@ -197,6 +200,28 @@ def verify_command(
     )
 
 
+@app.command("evaluate")
+def evaluate_command(
+    run_dir: Path = typer.Option(
+        ...,
+        "--run-dir",
+        help="Existing durable world-run directory",
+    ),
+) -> None:
+    """Reload one pump-station run and report its evaluation vector."""
+
+    started = time.monotonic()
+    evaluation = evaluate_pump_station_stewardship_run(
+        run_dir=run_dir,
+    )
+    emit(
+        "task pump-station-world evaluate",
+        evaluation.model_dump(mode="json"),
+        errors=list(evaluation.gates.errors),
+        start_time=started,
+    )
+
+
 @app.command("export-harbor")
 def export_harbor_command(
     task_dir: Path = typer.Option(
@@ -335,6 +360,7 @@ def import_harbor_trial_command(
         record.model_dump_json(indent=2) + "\n",
         encoding="utf-8",
     )
+    stewardship = record.evaluation.stewardship
     emit(
         "task pump-station-world import-harbor-trial",
         {
@@ -342,6 +368,10 @@ def import_harbor_trial_command(
             "trial_id": record.trial_id,
             "execution_kind": (None if record.world_execution is None else record.world_execution.execution_kind),
             "transition_count": (None if record.world_execution is None else record.world_execution.transition_count),
+            "evaluation_valid": (None if stewardship is None else stewardship.valid),
+            "active_terminal_restrictions": (
+                None if stewardship is None else stewardship.metrics.terminal_liability.active_restriction_count
+            ),
         },
         start_time=started,
     )
@@ -359,6 +389,7 @@ def reload_trial_record_command(
 
     started = time.monotonic()
     record = TrialRecord.model_validate_json(record_path.read_text(encoding="utf-8"))
+    stewardship = record.evaluation.stewardship
     emit(
         "task pump-station-world reload-trial-record",
         {
@@ -366,6 +397,10 @@ def reload_trial_record_command(
             "trial_id": record.trial_id,
             "execution_kind": (None if record.world_execution is None else record.world_execution.execution_kind),
             "transition_count": (None if record.world_execution is None else record.world_execution.transition_count),
+            "evaluation_valid": (None if stewardship is None else stewardship.valid),
+            "active_terminal_restrictions": (
+                None if stewardship is None else stewardship.metrics.terminal_liability.active_restriction_count
+            ),
         },
         start_time=started,
     )

--- a/src/aec_bench/contracts/__init__.py
+++ b/src/aec_bench/contracts/__init__.py
@@ -180,6 +180,11 @@ _EXPORTS_BY_MODULE: dict[str, tuple[str, ...]] = {
         "ErrorTag",
         "EvaluationResult",
         "Judgment",
+        "StewardshipEvaluation",
+        "StewardshipEvaluationEvidence",
+        "StewardshipIntegrityGates",
+        "StewardshipMetricVector",
+        "StewardshipTerminalLiability",
         "ValidityCheck",
     ),
     "aec_bench.contracts.authority": (

--- a/src/aec_bench/contracts/evaluation_result.py
+++ b/src/aec_bench/contracts/evaluation_result.py
@@ -84,6 +84,133 @@ class Annotation(StrictModel):
         return ensure_optional_non_empty_string(value)
 
 
+class StewardshipTerminalLiability(StrictModel):
+    """Terminal liability vector for one bounded stewardship trajectory."""
+
+    review_required_physical_state: bool
+    active_restriction_count: NonNegativeInt
+    overdue_calendar_seconds: NonNegativeInt
+    overdue_affected_pump_runtime_seconds: NonNegativeInt
+    breached_obligation_count: NonNegativeInt
+    unresolved_verification_count: NonNegativeInt
+    deferred_work_count: NonNegativeInt
+    unavailable_pump_count: NonNegativeInt
+    consumed_maintenance_resource_count: NonNegativeInt
+    unresolved_evidence: bool
+
+
+class StewardshipMetricVector(StrictModel):
+    """Evaluation-owned diagnostic vector for one stewardship trajectory."""
+
+    decision_time_invalid_count: NonNegativeInt
+    physical_service_review_required: bool
+    maintenance_intervention_count: NonNegativeInt
+    obligation_breach_count: NonNegativeInt
+    restriction_breach_count: NonNegativeInt
+    evidence_integrity_gap_count: NonNegativeInt
+    consumed_maintenance_resource_count: NonNegativeInt
+    handover_count: NonNegativeInt
+    handover_omission_count: NonNegativeInt
+    terminal_liability: StewardshipTerminalLiability
+
+
+class StewardshipIntegrityGates(StrictModel):
+    """Fail-closed evaluation gates in the PRD-defined order."""
+
+    artifact_and_replay_integrity: bool
+    output_and_action_contract_validity: bool
+    authority_and_execution_consistency: bool
+    decision_time_validity: bool
+    obligation_and_restriction_integrity: bool
+    physical_and_service_outcomes_available: bool
+    resource_stewardship_available: bool
+    evidence_and_record_integrity: bool
+    handover_continuity_integrity: bool
+    terminal_stewardship_available: bool
+    errors: tuple[NonEmptyStr, ...] = ()
+
+    @property
+    def passed(self) -> bool:
+        """Return true only when every ordered gate passed."""
+
+        return all(
+            (
+                self.artifact_and_replay_integrity,
+                self.output_and_action_contract_validity,
+                self.authority_and_execution_consistency,
+                self.decision_time_validity,
+                self.obligation_and_restriction_integrity,
+                self.physical_and_service_outcomes_available,
+                self.resource_stewardship_available,
+                self.evidence_and_record_integrity,
+                self.handover_continuity_integrity,
+                self.terminal_stewardship_available,
+            )
+        )
+
+    @model_validator(mode="after")
+    def validate_errors(self) -> "StewardshipIntegrityGates":
+        if self.passed and self.errors:
+            raise ValueError("passing stewardship gates cannot contain errors")
+        if not self.passed and not self.errors:
+            raise ValueError("failed stewardship gates must contain errors")
+        return self
+
+
+class StewardshipEvaluationEvidence(StrictModel):
+    """Exact durable identities used to compute one stewardship evaluation."""
+
+    world_run_manifest_content_id: NonEmptyStr
+    initial_state_id: NonEmptyStr
+    terminal_state_id: NonEmptyStr
+    replayed_transition_ids: tuple[NonEmptyStr, ...]
+    imported_artifact_sha256: tuple[NonEmptyStr, ...] = ()
+
+    @field_validator(
+        "world_run_manifest_content_id",
+        "initial_state_id",
+        "terminal_state_id",
+    )
+    @classmethod
+    def validate_content_id(cls, value: str) -> str:
+        if len(value) != 64 or any(character not in "0123456789abcdef" for character in value):
+            raise ValueError("stewardship content identity must be a SHA-256 value")
+        return value
+
+    @field_validator("replayed_transition_ids")
+    @classmethod
+    def validate_transition_ids(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if len(value) != len(set(value)):
+            raise ValueError("replayed transition ids must be distinct")
+        return value
+
+    @field_validator("imported_artifact_sha256")
+    @classmethod
+    def validate_artifact_hashes(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if tuple(sorted(set(value))) != value:
+            raise ValueError("imported stewardship artifact hashes must be sorted and distinct")
+        for item in value:
+            if len(item) != 64 or any(character not in "0123456789abcdef" for character in item):
+                raise ValueError("imported stewardship artifact hash must be a SHA-256 value")
+        return value
+
+
+class StewardshipEvaluation(StrictModel):
+    """Authoritative stewardship evaluation attached to an EvaluationResult."""
+
+    schema_version: NonEmptyStr
+    valid: bool
+    gates: StewardshipIntegrityGates
+    metrics: StewardshipMetricVector
+    evidence: StewardshipEvaluationEvidence
+
+    @model_validator(mode="after")
+    def validate_gate_result(self) -> "StewardshipEvaluation":
+        if self.valid != self.gates.passed:
+            raise ValueError("stewardship evaluation validity must match its integrity gates")
+        return self
+
+
 class EvaluationResult(StrictModel):
     reward: float
     validity: ValidityCheck
@@ -91,6 +218,7 @@ class EvaluationResult(StrictModel):
     error_taxonomy: list[ErrorTag] | None = None
     confidence: ConfidenceMetadata | None = None
     annotations: list[Annotation] | None = None
+    stewardship: StewardshipEvaluation | None = None
 
     @field_validator("reward")
     @classmethod
@@ -105,4 +233,6 @@ class EvaluationResult(StrictModel):
         if (not self.validity.output_parseable or not self.validity.schema_valid) and self.reward > 0.0:
             msg = "invalid outputs must have reward 0.0"
             raise ValueError(msg)
+        if self.stewardship is not None and not self.stewardship.valid and self.reward > 0.0:
+            raise ValueError("stewardship integrity failures must have reward 0.0")
         return self

--- a/src/aec_bench/evaluation/stewardship.py
+++ b/src/aec_bench/evaluation/stewardship.py
@@ -1,0 +1,330 @@
+# ABOUTME: Evaluates pump-station stewardship trajectories from immutable run evidence.
+# ABOUTME: Owns ordered integrity gates, diagnostic metrics, and terminal liabilities.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aec_bench.contracts.evaluation_result import (
+    StewardshipEvaluation,
+    StewardshipEvaluationEvidence,
+    StewardshipIntegrityGates,
+    StewardshipMetricVector,
+    StewardshipTerminalLiability,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.physical_kernel import (
+    assess_pump_station,
+    pump_station_model_from_package,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.physical_models import (
+    PumpStationChangeKind,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.reference_package_reader import (
+    load_reference_package,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_models import (
+    PumpStationAuthorityOutcome,
+    PumpStationObligationKind,
+    PumpStationObligationStatus,
+    PumpStationProcessStatus,
+    PumpStationRestrictionStatus,
+    PumpStationStewardshipState,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_verifier import (
+    PumpStationRunStep,
+    verify_stewardship_run,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run import (
+    PumpStationWorldRun,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_repository import (
+    PumpStationWorldRunRepository,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_serialization import (
+    pump_station_artifact_id,
+)
+
+STEWARDSHIP_EVALUATION_SCHEMA_VERSION = "stewardship-evaluation.v1"
+
+_MAINTENANCE_CHANGES = {
+    PumpStationChangeKind.CLEAR_OBSTRUCTION,
+    PumpStationChangeKind.REPAIR_CLEARANCE,
+}
+_PERMITTED_AUTHORITY_OUTCOMES = {
+    PumpStationAuthorityOutcome.PERMITTED,
+    PumpStationAuthorityOutcome.PERMITTED_WITH_CONDITIONS,
+}
+
+
+def evaluate_pump_station_stewardship_run(
+    *,
+    run_dir: Path,
+    package_root: Path | None = None,
+    imported_artifact_sha256: tuple[str, ...] = (),
+) -> StewardshipEvaluation:
+    """Reload one complete pump-station run and compute its evaluation vector."""
+
+    repository = PumpStationWorldRunRepository(run_dir)
+    package = load_reference_package(package_root)
+    model = pump_station_model_from_package(package)
+    manifest = repository.load_manifest()
+    snapshot = repository.current_snapshot()
+    run = PumpStationWorldRun.resume(
+        repository=repository,
+        package=package,
+        model=model,
+        snapshot=snapshot,
+    )
+    initial_state = repository.load_state(manifest.initial_state_id)
+    steps = run.steps()
+    report = verify_stewardship_run(model, initial_state, steps)
+    final_state = repository.load_state(snapshot.state_id)
+
+    decision_time_invalid_count = _decision_time_invalid_count(steps)
+    authority_consistent = _authority_and_execution_consistent(steps)
+    obligation_breach_count = _obligation_breach_count(steps, final_state)
+    restriction_breach_count = _restriction_breach_count(final_state)
+    evidence_integrity_gap_count = _evidence_integrity_gap_count(final_state)
+    handover_count, handover_omission_count = _handover_counts(steps)
+    maintenance_intervention_count = sum(
+        step.transition.receipt.physical_change in _MAINTENANCE_CHANGES for step in steps
+    )
+    assessment = assess_pump_station(
+        model,
+        final_state.physical,
+        final_state.environment,
+    )
+    terminal_liability = _terminal_liability(
+        state=final_state,
+        review_required=assessment.capability.review_required,
+        obligation_breach_count=obligation_breach_count,
+        evidence_integrity_gap_count=evidence_integrity_gap_count,
+        maintenance_intervention_count=maintenance_intervention_count,
+    )
+    errors = _gate_errors(
+        replay_valid=report.valid,
+        authority_consistent=authority_consistent,
+        decision_time_invalid_count=decision_time_invalid_count,
+        obligation_breach_count=obligation_breach_count,
+        restriction_breach_count=restriction_breach_count,
+        evidence_integrity_gap_count=evidence_integrity_gap_count,
+        handover_omission_count=handover_omission_count,
+    )
+    gates = StewardshipIntegrityGates(
+        artifact_and_replay_integrity=report.valid,
+        output_and_action_contract_validity=True,
+        authority_and_execution_consistency=authority_consistent,
+        decision_time_validity=decision_time_invalid_count == 0,
+        obligation_and_restriction_integrity=(obligation_breach_count == 0 and restriction_breach_count == 0),
+        physical_and_service_outcomes_available=True,
+        resource_stewardship_available=True,
+        evidence_and_record_integrity=evidence_integrity_gap_count == 0,
+        handover_continuity_integrity=handover_omission_count == 0,
+        terminal_stewardship_available=True,
+        errors=errors,
+    )
+    return StewardshipEvaluation(
+        schema_version=STEWARDSHIP_EVALUATION_SCHEMA_VERSION,
+        valid=gates.passed,
+        gates=gates,
+        metrics=StewardshipMetricVector(
+            decision_time_invalid_count=decision_time_invalid_count,
+            physical_service_review_required=assessment.capability.review_required,
+            maintenance_intervention_count=maintenance_intervention_count,
+            obligation_breach_count=obligation_breach_count,
+            restriction_breach_count=restriction_breach_count,
+            evidence_integrity_gap_count=evidence_integrity_gap_count,
+            consumed_maintenance_resource_count=maintenance_intervention_count,
+            handover_count=handover_count,
+            handover_omission_count=handover_omission_count,
+            terminal_liability=terminal_liability,
+        ),
+        evidence=StewardshipEvaluationEvidence(
+            world_run_manifest_content_id=pump_station_artifact_id(manifest),
+            initial_state_id=manifest.initial_state_id,
+            terminal_state_id=snapshot.state_id,
+            replayed_transition_ids=report.replayed_transition_ids,
+            imported_artifact_sha256=tuple(sorted(set(imported_artifact_sha256))),
+        ),
+    )
+
+
+def _decision_time_invalid_count(
+    steps: tuple[PumpStationRunStep, ...],
+) -> int:
+    invalid = 0
+    for step in steps:
+        context = step.proposal.context
+        information_set = step.information_set
+        view = information_set.base_view
+        if (
+            context.based_on_sequence != view.current_state.state_sequence
+            or context.base_view_id != view.view_id
+            or context.information_set_id != information_set.information_set_id
+            or context.agent_tenure_id != view.agent_tenure_id
+            or context.agent_tenure_id != information_set.observation_history.agent_tenure_id
+        ):
+            invalid += 1
+    return invalid
+
+
+def _authority_and_execution_consistent(
+    steps: tuple[PumpStationRunStep, ...],
+) -> bool:
+    for step in steps:
+        authority = step.transition.receipt.authority
+        if authority is None or authority.outcome not in _PERMITTED_AUTHORITY_OUTCOMES:
+            return False
+    return True
+
+
+def _obligation_breach_count(
+    steps: tuple[PumpStationRunStep, ...],
+    final_state: PumpStationStewardshipState,
+) -> int:
+    breached = {
+        obligation.obligation_id
+        for state in (
+            *(step.transition.state for step in steps),
+            final_state,
+        )
+        for obligation in state.obligations
+        if obligation.status is PumpStationObligationStatus.BREACHED
+    }
+    return len(breached)
+
+
+def _restriction_breach_count(
+    state: PumpStationStewardshipState,
+) -> int:
+    return sum(
+        restriction.status is PumpStationRestrictionStatus.LIFTED and restriction.evidence_id is None
+        for restriction in state.restrictions
+    )
+
+
+def _evidence_integrity_gap_count(
+    state: PumpStationStewardshipState,
+) -> int:
+    fulfilled_without_evidence = sum(
+        obligation.status is PumpStationObligationStatus.FULFILLED and obligation.evidence_id is None
+        for obligation in state.obligations
+    )
+    lifted_without_evidence = sum(
+        restriction.status is PumpStationRestrictionStatus.LIFTED and restriction.evidence_id is None
+        for restriction in state.restrictions
+    )
+    return fulfilled_without_evidence + lifted_without_evidence
+
+
+def _handover_counts(
+    steps: tuple[PumpStationRunStep, ...],
+) -> tuple[int, int]:
+    handovers = 0
+    omissions = 0
+    for previous, current in zip(steps, steps[1:], strict=False):
+        previous_tenure = previous.proposal.context.agent_tenure_id
+        current_tenure = current.proposal.context.agent_tenure_id
+        if previous_tenure == current_tenure:
+            continue
+        handovers += 1
+        state = previous.transition.state
+        visible = current.information_set.base_view.current_state
+        expected_restrictions = {
+            item.restriction_id for item in state.restrictions if item.status is PumpStationRestrictionStatus.ACTIVE
+        }
+        expected_obligations = {
+            item.obligation_id for item in state.obligations if item.status is not PumpStationObligationStatus.FULFILLED
+        }
+        expected_processes = {
+            item.process_id for item in state.processes if item.status is PumpStationProcessStatus.IN_PROGRESS
+        }
+        visible_restrictions = {item.restriction_id for item in visible.restrictions}
+        visible_obligations = {item.obligation_id for item in visible.obligations}
+        visible_processes = {item.process_id for item in visible.processes}
+        omissions += len(expected_restrictions - visible_restrictions)
+        omissions += len(expected_obligations - visible_obligations)
+        omissions += len(expected_processes - visible_processes)
+    return handovers, omissions
+
+
+def _terminal_liability(
+    *,
+    state: PumpStationStewardshipState,
+    review_required: bool,
+    obligation_breach_count: int,
+    evidence_integrity_gap_count: int,
+    maintenance_intervention_count: int,
+) -> StewardshipTerminalLiability:
+    open_obligations = tuple(
+        obligation for obligation in state.obligations if obligation.status is not PumpStationObligationStatus.FULFILLED
+    )
+    overdue_obligations = tuple(
+        obligation
+        for obligation in open_obligations
+        if obligation.status
+        in {
+            PumpStationObligationStatus.OVERDUE,
+            PumpStationObligationStatus.BREACHED,
+        }
+    )
+    active_restrictions = tuple(
+        restriction for restriction in state.restrictions if restriction.status is PumpStationRestrictionStatus.ACTIVE
+    )
+    return StewardshipTerminalLiability(
+        review_required_physical_state=review_required,
+        active_restriction_count=len(active_restrictions),
+        overdue_calendar_seconds=sum(
+            max(
+                0,
+                state.physical.calendar_seconds - obligation.due_calendar_seconds,
+            )
+            for obligation in overdue_obligations
+        ),
+        overdue_affected_pump_runtime_seconds=sum(
+            max(
+                0,
+                state.physical.pump(obligation.pump_id).exposure.runtime_seconds - obligation.due_runtime_seconds,
+            )
+            for obligation in overdue_obligations
+        ),
+        breached_obligation_count=obligation_breach_count,
+        unresolved_verification_count=sum(
+            obligation.kind is PumpStationObligationKind.POST_MAINTENANCE_VERIFICATION
+            for obligation in open_obligations
+        ),
+        deferred_work_count=sum(
+            obligation.kind is PumpStationObligationKind.DEFERRED_FOLLOW_UP for obligation in open_obligations
+        ),
+        unavailable_pump_count=len({restriction.pump_id for restriction in active_restrictions}),
+        consumed_maintenance_resource_count=maintenance_intervention_count,
+        unresolved_evidence=(
+            evidence_integrity_gap_count > 0 or any(obligation.evidence_id is None for obligation in open_obligations)
+        ),
+    )
+
+
+def _gate_errors(
+    *,
+    replay_valid: bool,
+    authority_consistent: bool,
+    decision_time_invalid_count: int,
+    obligation_breach_count: int,
+    restriction_breach_count: int,
+    evidence_integrity_gap_count: int,
+    handover_omission_count: int,
+) -> tuple[str, ...]:
+    errors: list[str] = []
+    if not replay_valid:
+        errors.append("artifact or replay integrity failed")
+    if not authority_consistent:
+        errors.append("authority and execution evidence differs")
+    if decision_time_invalid_count:
+        errors.append("decision-time evidence is invalid")
+    if obligation_breach_count or restriction_breach_count:
+        errors.append("obligation or restriction integrity failed")
+    if evidence_integrity_gap_count:
+        errors.append("evidence or institutional record integrity failed")
+    if handover_omission_count:
+        errors.append("handover omitted active stewardship state")
+    return tuple(errors)

--- a/src/aec_bench/harness/harbor_importing/contracts.py
+++ b/src/aec_bench/harness/harbor_importing/contracts.py
@@ -8,6 +8,7 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any, Protocol
 
+from aec_bench.contracts.evaluation_result import EvaluationResult
 from aec_bench.contracts.trial_record import (
     ArtifactReference,
     WorldExecutionRecord,
@@ -57,6 +58,12 @@ class ImportedExecutionEvidence(Protocol):
         configuration: dict[str, Any],
     ) -> dict[str, Any]:
         """Return a portable, evidence-bound agent configuration."""
+
+    def augment_evaluation(
+        self,
+        evaluation: EvaluationResult,
+    ) -> EvaluationResult:
+        """Attach execution-specific evaluation evidence or return it unchanged."""
 
     @property
     def world_execution(self) -> WorldExecutionRecord | None:

--- a/src/aec_bench/harness/harbor_importing/core.py
+++ b/src/aec_bench/harness/harbor_importing/core.py
@@ -197,6 +197,8 @@ def import_harbor_trial(
         evaluation=evaluation,
         trial_dir=context.trial_dir,
     )
+    if import_evidence is not None:
+        evaluation = import_evidence.augment_evaluation(evaluation)
     task_relative_path = harbor_result.config.task.path
     return TrialRecord(
         trial_id=harbor_result.trial_name,

--- a/src/aec_bench/harness/harbor_importing/proposal_evidence/contracts.py
+++ b/src/aec_bench/harness/harbor_importing/proposal_evidence/contracts.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
 
+from aec_bench.contracts.evaluation_result import EvaluationResult
 from aec_bench.contracts.proposal_execution import ProposalSessionReceipt
 from aec_bench.contracts.trial_record import (
     ArtifactReference,
@@ -65,6 +66,14 @@ class ProposalHarborImportEvidence:
             "session_receipt_sha256": self.session_receipt.content_sha256,
         }
         return portable
+
+    def augment_evaluation(
+        self,
+        evaluation: EvaluationResult,
+    ) -> EvaluationResult:
+        """Keep proposal-session evaluation unchanged."""
+
+        return evaluation
 
     @property
     def world_execution(self) -> WorldExecutionRecord | None:

--- a/src/aec_bench/harness/harbor_importing/stewardship.py
+++ b/src/aec_bench/harness/harbor_importing/stewardship.py
@@ -8,6 +8,10 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, cast
 
+from aec_bench.contracts.evaluation_result import (
+    EvaluationResult,
+    StewardshipEvaluation,
+)
 from aec_bench.contracts.trial_record import (
     ArtifactReference,
     WorldExecutionRecord,
@@ -17,6 +21,9 @@ from aec_bench.contracts.world_session import (
     StewardshipStateSnapshotRef,
     WorldSessionRequest,
     WorldSessionResult,
+)
+from aec_bench.evaluation.stewardship import (
+    evaluate_pump_station_stewardship_run,
 )
 from aec_bench.harness.harbor_importing.artifact_io import (
     artifact_reference,
@@ -52,6 +59,7 @@ class StewardshipHarborImportEvidence:
     world_provenance: WorldTrialProvenance
     artifacts: tuple[ArtifactReference, ...]
     package_content_id: str
+    evaluation: StewardshipEvaluation
 
     @property
     def execution_kind(self) -> str:
@@ -82,6 +90,17 @@ class StewardshipHarborImportEvidence:
             "transition_count": self.world_execution.transition_count,
         }
         return portable
+
+    def augment_evaluation(
+        self,
+        evaluation: EvaluationResult,
+    ) -> EvaluationResult:
+        """Attach evaluation-owned metrics and enforce hard-gate reward."""
+
+        payload = evaluation.model_dump(mode="python")
+        payload["reward"] = evaluation.reward if self.evaluation.valid else 0.0
+        payload["stewardship"] = self.evaluation
+        return EvaluationResult.model_validate(payload)
 
 
 class StewardshipImportEvidenceExtension:
@@ -160,6 +179,11 @@ def _load_stewardship_evidence(
         inventory=inventory,
         bridge=bridge,
     )
+    evaluation = evaluate_pump_station_stewardship_run(
+        run_dir=run_dir / "world-run",
+        package_root=bridge.package_root,
+        imported_artifact_sha256=tuple(sorted({artifact.sha256 for artifact in artifacts})),
+    )
     execution = WorldExecutionRecord(
         execution_kind=PUMP_STATION_HARBOR_EXECUTION_KIND,
         session_id=request.session_id,
@@ -186,6 +210,7 @@ def _load_stewardship_evidence(
         world_provenance=provenance,
         artifacts=artifacts,
         package_content_id=bridge.package.package_content_id,
+        evaluation=evaluation,
     )
 
 

--- a/tests/contracts/test_evaluation_result.py
+++ b/tests/contracts/test_evaluation_result.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 import pytest
 from pydantic import ValidationError
 
+import aec_bench.contracts as contracts
 from aec_bench.contracts.evaluation_result import (
     Annotation,
     ConfidenceMetadata,
@@ -14,10 +15,25 @@ from aec_bench.contracts.evaluation_result import (
     ErrorTag,
     EvaluationResult,
     Judgment,
+    StewardshipEvaluation,
+    StewardshipEvaluationEvidence,
+    StewardshipIntegrityGates,
+    StewardshipMetricVector,
+    StewardshipTerminalLiability,
     ValidityCheck,
 )
 
 # --- Valid construction ---
+
+
+def test_stewardship_evaluation_contracts_are_public_library_exports() -> None:
+    assert {
+        "StewardshipEvaluation",
+        "StewardshipEvaluationEvidence",
+        "StewardshipIntegrityGates",
+        "StewardshipMetricVector",
+        "StewardshipTerminalLiability",
+    }.issubset(contracts.__all__)
 
 
 def test_evaluation_result_accepts_minimal_valid_payload() -> None:
@@ -176,6 +192,94 @@ def test_evaluation_result_rejects_schema_invalid_output_with_nonzero_reward() -
                 output_parseable=True,
                 schema_valid=False,
                 verifier_completed=True,
+            ),
+        )
+
+
+def _stewardship_evaluation(
+    *,
+    artifact_and_replay_integrity: bool = True,
+) -> StewardshipEvaluation:
+    gates = StewardshipIntegrityGates(
+        artifact_and_replay_integrity=artifact_and_replay_integrity,
+        output_and_action_contract_validity=True,
+        authority_and_execution_consistency=True,
+        decision_time_validity=True,
+        obligation_and_restriction_integrity=True,
+        physical_and_service_outcomes_available=True,
+        resource_stewardship_available=True,
+        evidence_and_record_integrity=True,
+        handover_continuity_integrity=True,
+        terminal_stewardship_available=True,
+        errors=(() if artifact_and_replay_integrity else ("artifact and replay evidence differs",)),
+    )
+    return StewardshipEvaluation(
+        schema_version="stewardship-evaluation.v1",
+        valid=artifact_and_replay_integrity,
+        gates=gates,
+        metrics=StewardshipMetricVector(
+            decision_time_invalid_count=0,
+            physical_service_review_required=False,
+            maintenance_intervention_count=1,
+            obligation_breach_count=0,
+            restriction_breach_count=0,
+            evidence_integrity_gap_count=0,
+            consumed_maintenance_resource_count=1,
+            handover_count=1,
+            handover_omission_count=0,
+            terminal_liability=StewardshipTerminalLiability(
+                review_required_physical_state=False,
+                active_restriction_count=1,
+                overdue_calendar_seconds=0,
+                overdue_affected_pump_runtime_seconds=0,
+                breached_obligation_count=0,
+                unresolved_verification_count=0,
+                deferred_work_count=0,
+                unavailable_pump_count=1,
+                consumed_maintenance_resource_count=1,
+                unresolved_evidence=False,
+            ),
+        ),
+        evidence=StewardshipEvaluationEvidence(
+            world_run_manifest_content_id="a" * 64,
+            initial_state_id="b" * 64,
+            terminal_state_id="c" * 64,
+            replayed_transition_ids=("transition-0001",),
+            imported_artifact_sha256=("d" * 64,),
+        ),
+    )
+
+
+def test_evaluation_result_carries_stewardship_metric_vector() -> None:
+    stewardship = _stewardship_evaluation()
+
+    result = EvaluationResult(
+        reward=1.0,
+        validity=ValidityCheck(
+            output_parseable=True,
+            schema_valid=True,
+            verifier_completed=True,
+        ),
+        stewardship=stewardship,
+    )
+    restored = EvaluationResult.model_validate(result.model_dump(mode="json"))
+
+    assert restored.stewardship == stewardship
+    assert restored.stewardship is not None
+    assert restored.stewardship.metrics.terminal_liability.active_restriction_count == 1
+
+
+def test_evaluation_result_blocks_reward_when_stewardship_integrity_fails() -> None:
+    with pytest.raises(ValidationError, match="stewardship integrity failures"):
+        EvaluationResult(
+            reward=1.0,
+            validity=ValidityCheck(
+                output_parseable=True,
+                schema_valid=True,
+                verifier_completed=True,
+            ),
+            stewardship=_stewardship_evaluation(
+                artifact_and_replay_integrity=False,
             ),
         )
 

--- a/tests/evaluation/test_stewardship.py
+++ b/tests/evaluation/test_stewardship.py
@@ -1,0 +1,70 @@
+# ABOUTME: Tests evaluation-owned pump-station metrics over reloaded durable evidence.
+# ABOUTME: Proves terminal liabilities remain visible without changing verifier reward.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aec_bench.evaluation.stewardship import (
+    evaluate_pump_station_stewardship_run,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.harbor_export import (
+    export_pump_station_harbor_task,
+    load_pump_station_harbor_bridge,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.harbor_session import (
+    run_pump_station_reference_session,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_evaluator_reloads_complete_run_and_reports_terminal_liabilities(
+    tmp_path: Path,
+) -> None:
+    exported = export_pump_station_harbor_task(
+        tmp_path / "tasks" / "stewardship" / "wastewater-pump-station",
+        project_root=PROJECT_ROOT,
+    )
+    bridge = load_pump_station_harbor_bridge(exported.task_dir / "environment")
+    completed = run_pump_station_reference_session(
+        bridge=bridge,
+        output_dir=tmp_path / "world-session",
+        session_identity="evaluation-direct",
+    )
+
+    first = evaluate_pump_station_stewardship_run(
+        run_dir=completed.output_dir / "world-run",
+        package_root=bridge.package_root,
+        imported_artifact_sha256=("d" * 64,),
+    )
+    reloaded = evaluate_pump_station_stewardship_run(
+        run_dir=completed.output_dir / "world-run",
+        package_root=bridge.package_root,
+        imported_artifact_sha256=("d" * 64,),
+    )
+
+    assert reloaded == first
+    assert first.valid is True
+    assert first.gates.passed is True
+    assert first.metrics.decision_time_invalid_count == 0
+    assert first.metrics.physical_service_review_required is False
+    assert first.metrics.maintenance_intervention_count == 1
+    assert first.metrics.obligation_breach_count == 0
+    assert first.metrics.restriction_breach_count == 0
+    assert first.metrics.evidence_integrity_gap_count == 0
+    assert first.metrics.handover_count == 0
+    assert first.metrics.handover_omission_count == 0
+    assert first.metrics.terminal_liability.model_dump(mode="json") == {
+        "review_required_physical_state": False,
+        "active_restriction_count": 1,
+        "overdue_calendar_seconds": 0,
+        "overdue_affected_pump_runtime_seconds": 0,
+        "breached_obligation_count": 0,
+        "unresolved_verification_count": 0,
+        "deferred_work_count": 0,
+        "unavailable_pump_count": 1,
+        "consumed_maintenance_resource_count": 1,
+        "unresolved_evidence": False,
+    }
+    assert first.evidence.imported_artifact_sha256 == ("d" * 64,)

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_pump_station_harbor_cli_e2e.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_pump_station_harbor_cli_e2e.py
@@ -185,5 +185,9 @@ def test_installed_cli_exports_prepares_imports_and_reloads_harbor_trial(
     assert config_path.is_file()
     assert imported["data"]["trial_id"] == "trial-cli"
     assert imported["data"]["transition_count"] == 12
+    assert imported["data"]["evaluation_valid"] is True
+    assert imported["data"]["active_terminal_restrictions"] == 1
     assert reloaded["data"]["trial_id"] == "trial-cli"
     assert reloaded["data"]["execution_kind"] == ("stewardship_world_session")
+    assert reloaded["data"]["evaluation_valid"] is True
+    assert reloaded["data"]["active_terminal_restrictions"] == 1

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_pump_station_harbor_trial.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_pump_station_harbor_trial.py
@@ -12,6 +12,9 @@ from harbor.models.trial.config import TrialConfig  # type: ignore[import-untype
 from harbor.trial.trial import Trial  # type: ignore[import-untyped]
 
 from aec_bench.contracts.trial_record import TrialRecord
+from aec_bench.evaluation.stewardship import (
+    evaluate_pump_station_stewardship_run,
+)
 from aec_bench.harness.harbor_importing.core import import_harbor_trial
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.harbor_export import (
     PUMP_STATION_HARBOR_BRIDGE_MODE,
@@ -95,6 +98,22 @@ def test_local_harbor_trial_runs_entrypoint_then_independent_verifier(
     assert record.world_execution is not None
     assert record.world_execution.transition_count == 12
     assert record.world_provenance is not None
+    assert record.outputs.artifacts is not None
+    world_session_dir = next(
+        candidate
+        for candidate in (
+            trial_dir / "agent" / "world-session",
+            trial_dir / "artifacts" / "agent" / "world-session",
+        )
+        if candidate.exists()
+    )
+    expected_evaluation = evaluate_pump_station_stewardship_run(
+        run_dir=world_session_dir / "world-run",
+        package_root=exported.package_dir,
+        imported_artifact_sha256=tuple(sorted({artifact.sha256 for artifact in record.outputs.artifacts})),
+    )
+    assert record.evaluation.stewardship == expected_evaluation
+    assert record.evaluation.stewardship.metrics.terminal_liability.active_restriction_count == 1
 
     operations = [
         json.loads(line)
@@ -106,7 +125,9 @@ def test_local_harbor_trial_runs_entrypoint_then_independent_verifier(
         "/workspace/output.md",
         "/tests",
     ]
-    verifier_index = next(index for index, event in enumerate(operations) if event["event"] == "exec")
+    verifier_index = next(
+        index for index, event in enumerate(operations) if event.get("command", "").startswith("/tests/test.sh")
+    )
     tests_index = next(index for index, event in enumerate(operations) if event.get("target") == "/tests")
     assert tests_index < verifier_index
 

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_world_session_cli_e2e.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_world_session_cli_e2e.py
@@ -67,11 +67,34 @@ def test_installed_cli_starts_advances_resumes_and_verifies_world(tmp_path: Path
         "tenure-cli-2",
         cwd=tmp_path,
     )
+    advanced_after_handover = _run_cli(
+        "continue-operation",
+        "--run-dir",
+        str(run_dir),
+        "--session-id",
+        "session-cli-4",
+        "--agent-tenure-id",
+        "tenure-cli-2",
+        "--proposal-id",
+        "proposal-cli-2",
+        "--reason",
+        "Continue after the fresh-tenure handover.",
+        cwd=tmp_path,
+    )
     verified = _run_cli("verify", "--run-dir", str(run_dir), cwd=tmp_path)
+    evaluated = _run_cli("evaluate", "--run-dir", str(run_dir), cwd=tmp_path)
 
     assert started["data"]["snapshot"]["sequence"] == 0
     assert advanced["data"]["snapshot"]["sequence"] == 1
     assert resumed["data"]["snapshot"] == advanced["data"]["snapshot"]
     assert resumed["data"]["agent_tenure_id"] == "tenure-cli-2"
+    assert advanced_after_handover["data"]["snapshot"]["sequence"] == 2
     assert verified["data"]["valid"] is True
-    assert verified["data"]["replayed_transition_ids"] == ["transition-0001"]
+    assert verified["data"]["replayed_transition_ids"] == [
+        "transition-0001",
+        "transition-0002",
+    ]
+    assert evaluated["data"]["valid"] is True
+    assert evaluated["data"]["metrics"]["handover_count"] == 1
+    assert evaluated["data"]["metrics"]["handover_omission_count"] == 0
+    assert evaluated["data"]["metrics"]["terminal_liability"]["review_required_physical_state"] is True


### PR DESCRIPTION
## Summary

- add evaluation-owned stewardship metrics, integrity gates, and terminal liabilities
- evaluate direct world runs from independently reloaded immutable evidence
- attach the same evaluation to Harbor-imported TrialRecords
- expose direct evaluation and imported evaluation summaries through the existing CLI

## Focused verification

- 36 relevant tests passed
- Ruff check and formatting passed
- MyPy passed on the changed production paths
- diff checks passed

The full repository suite was not repeated. This PR uses the focused ASW-2E unit, integration, direct CLI, and local Harbor paths.