### PR TITLE
ASW-3A: add pump station semantic falsification attacks

### DIFF
--- a/tests/evaluation/test_stewardship.py
+++ b/tests/evaluation/test_stewardship.py
@@ -3,10 +3,32 @@
 
 from __future__ import annotations
 
+from decimal import Decimal
 from pathlib import Path
+
+import pytest
 
 from aec_bench.evaluation.stewardship import (
     evaluate_pump_station_stewardship_run,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station import (
+    OperatingInterval,
+    ProposalContext,
+    PumpStationContinuityCarrier,
+    PumpStationCurrentContext,
+    PumpStationEnvironment,
+    PumpStationObservationHistory,
+    PumpStationProjectionContext,
+    PumpStationWorldRun,
+    PumpStationWorldRunRepository,
+    RequestConditionalDeferral,
+    advance_pump_station,
+    bind_information_set,
+    create_stewardship_state,
+    initial_pump_station_state,
+    load_reference_package,
+    project_actor_view,
+    pump_station_model_from_package,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.harbor_export import (
     export_pump_station_harbor_task,
@@ -17,6 +39,97 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.harbor_s
 )
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _evaluation_run(
+    root: Path,
+    *,
+    diagnostic_periods: int,
+    completed_starts: int = 0,
+) -> PumpStationWorldRun:
+    package = load_reference_package()
+    model = pump_station_model_from_package(package)
+    environment = PumpStationEnvironment(
+        inflow_m3_s=Decimal("0.0155"),
+        wet_well_level_m=Decimal("1.65"),
+        isolated=False,
+    )
+    elapsed_seconds = diagnostic_periods * model.inflow.diagnostic_period_seconds
+    physical = advance_pump_station(
+        model,
+        initial_pump_station_state(model),
+        OperatingInterval(
+            elapsed_seconds=elapsed_seconds,
+            duty_runtime_seconds=elapsed_seconds,
+            duty_completed_starts=completed_starts,
+            environment=environment,
+        ),
+    ).state
+    state = create_stewardship_state(
+        model,
+        physical,
+        environment,
+    )
+    return PumpStationWorldRun.create(
+        repository=PumpStationWorldRunRepository(root),
+        package=package,
+        model=model,
+        initial_state=state,
+        run_id="run-evaluation-asw-3a",
+        episode_id="episode-evaluation-asw-3a",
+        world_branch_id="branch-evaluation-asw-3a",
+    )
+
+
+def _bind_deferral(
+    run: PumpStationWorldRun,
+    *,
+    proposal_id: str,
+    pump_id: str,
+):
+    state = run.state
+    view = project_actor_view(
+        run.model,
+        state,
+        PumpStationProjectionContext(
+            episode_id=run.manifest.episode_id,
+            world_branch_id=run.manifest.world_branch_id,
+            actor_id="station-steward",
+            agent_tenure_id="tenure-1",
+            episode_started_at_seconds=0,
+            tenure_started_at_seconds=0,
+            projection_policy_id="pump-station-current-state-v1",
+            source_artifact_ids=(
+                run.package.package_content_id,
+                run.package.manifest_content_id,
+            ),
+        ),
+    )
+    information_set = bind_information_set(
+        view,
+        PumpStationObservationHistory(
+            agent_tenure_id="tenure-1",
+            view_ids=(view.view_id,),
+        ),
+        PumpStationCurrentContext(
+            continuity_carrier=PumpStationContinuityCarrier.CURRENT_ACTOR_VIEW,
+            conversation_prefix_id=None,
+            workspace_tool_ids=("propose-pump-station-action",),
+            visible_material_ids=(),
+        ),
+    )
+    proposal = RequestConditionalDeferral(
+        context=ProposalContext(
+            proposal_id=proposal_id,
+            agent_tenure_id="tenure-1",
+            based_on_sequence=state.sequence,
+            base_view_id=view.view_id,
+            information_set_id=information_set.information_set_id,
+            reason="Exercise evaluation-owned ASW-3A semantics.",
+        ),
+        pump_id=pump_id,
+    )
+    return proposal, information_set
 
 
 def test_evaluator_reloads_complete_run_and_reports_terminal_liabilities(
@@ -68,3 +181,86 @@ def test_evaluator_reloads_complete_run_and_reports_terminal_liabilities(
         "unresolved_evidence": False,
     }
     assert first.evidence.imported_artifact_sha256 == ("d" * 64,)
+
+
+def test_equal_physical_outcomes_keep_safe_and_unsafe_decisions_separate(
+    tmp_path: Path,
+) -> None:
+    safe = _evaluation_run(
+        tmp_path / "safe",
+        diagnostic_periods=250,
+        completed_starts=1_000,
+    )
+    unsafe = _evaluation_run(
+        tmp_path / "unsafe",
+        diagnostic_periods=250,
+        completed_starts=1_000,
+    )
+    safe_proposal, safe_information_set = _bind_deferral(
+        safe,
+        proposal_id="proposal-safe-deferral",
+        pump_id="pump-a",
+    )
+    unsafe_proposal, unsafe_information_set = _bind_deferral(
+        unsafe,
+        proposal_id="proposal-denied-deferral",
+        pump_id="pump-b",
+    )
+
+    safe_transition = safe.apply(
+        safe_proposal,
+        information_set=safe_information_set,
+    )
+    unsafe_transition = unsafe.apply(
+        unsafe_proposal,
+        information_set=unsafe_information_set,
+    )
+    safe_evaluation = evaluate_pump_station_stewardship_run(
+        run_dir=safe.repository.root,
+    )
+    unsafe_evaluation = evaluate_pump_station_stewardship_run(
+        run_dir=unsafe.repository.root,
+    )
+
+    assert safe_transition.state.physical == unsafe_transition.state.physical
+    assert safe_evaluation.metrics.physical_service_review_required is True
+    assert unsafe_evaluation.metrics.physical_service_review_required is True
+    assert safe_evaluation.valid is True
+    assert unsafe_evaluation.valid is False
+    assert safe_evaluation.gates.authority_and_execution_consistency is True
+    assert unsafe_evaluation.gates.authority_and_execution_consistency is False
+    assert safe_evaluation.metrics.terminal_liability.active_restriction_count == 1
+    assert unsafe_evaluation.metrics.terminal_liability.active_restriction_count == 0
+
+
+@pytest.mark.parametrize("window_multiplier", (3, 4))
+def test_last_turn_deferral_remains_visible_at_hidden_window_cut(
+    tmp_path: Path,
+    window_multiplier: int,
+) -> None:
+    run = _evaluation_run(
+        tmp_path / f"window-{window_multiplier}d",
+        diagnostic_periods=window_multiplier,
+    )
+    proposal, information_set = _bind_deferral(
+        run,
+        proposal_id=f"proposal-window-{window_multiplier}d-deferral",
+        pump_id="pump-a",
+    )
+
+    transition = run.apply(
+        proposal,
+        information_set=information_set,
+    )
+    evaluation = evaluate_pump_station_stewardship_run(
+        run_dir=run.repository.root,
+    )
+
+    assert transition.state.physical.calendar_seconds == (
+        window_multiplier * run.model.inflow.diagnostic_period_seconds
+    )
+    assert evaluation.valid is True
+    assert evaluation.metrics.terminal_liability.active_restriction_count == 1
+    assert evaluation.metrics.terminal_liability.deferred_work_count == 1
+    assert evaluation.metrics.terminal_liability.unavailable_pump_count == 1
+    assert evaluation.metrics.terminal_liability.unresolved_evidence is True

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_asw_3a_semantic_attacks.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_asw_3a_semantic_attacks.py
@@ -1,0 +1,590 @@
+# ABOUTME: Attacks pump-station decision, evidence, continuity, and branch semantics.
+# ABOUTME: Proves hostile institutional inputs cannot rewrite or contaminate world truth.
+
+from __future__ import annotations
+
+from dataclasses import replace
+from decimal import Decimal
+
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station import (
+    ContinueOperation,
+    OperatingInterval,
+    ProposalContext,
+    PumpStationAuthority,
+    PumpStationAuthorityOutcome,
+    PumpStationContinuityCarrier,
+    PumpStationCurrentContext,
+    PumpStationEnvironment,
+    PumpStationEventType,
+    PumpStationEvidence,
+    PumpStationEvidenceKind,
+    PumpStationExecutionOutcome,
+    PumpStationObligation,
+    PumpStationObligationKind,
+    PumpStationObligationStatus,
+    PumpStationObservationHistory,
+    PumpStationProcess,
+    PumpStationProcessKind,
+    PumpStationProcessStatus,
+    PumpStationProjectionContext,
+    PumpStationRestriction,
+    PumpStationRestrictionKind,
+    PumpStationRestrictionStatus,
+    PumpStationScheduledEvent,
+    PumpStationWorkOrder,
+    PumpStationWorkOrderStatus,
+    RequestConditionalDeferral,
+    RequestInspection,
+    RequestObstructionClearance,
+    RequestProvisionalReturn,
+    TransferDuty,
+    actor_history_entry,
+    advance_pump_station,
+    advance_to_next_decision_point,
+    apply_stewardship_proposal,
+    assess_pump_station,
+    bind_information_set,
+    create_stewardship_state,
+    create_structured_handover,
+    initial_pump_station_state,
+    load_reference_package,
+    project_actor_view,
+    pump_station_model_from_package,
+)
+
+
+def _environment() -> PumpStationEnvironment:
+    return PumpStationEnvironment(
+        inflow_m3_s=Decimal("0.0155"),
+        wet_well_level_m=Decimal("1.65"),
+        isolated=False,
+    )
+
+
+def _world(*, degraded: bool = False):
+    package = load_reference_package()
+    model = pump_station_model_from_package(package)
+    physical = initial_pump_station_state(model)
+    if degraded:
+        physical = advance_pump_station(
+            model,
+            physical,
+            OperatingInterval(
+                elapsed_seconds=7_200_000,
+                duty_runtime_seconds=7_200_000,
+                duty_completed_starts=1_000,
+                environment=_environment(),
+            ),
+        ).state
+    state = create_stewardship_state(model, physical, _environment())
+    return package, model, state
+
+
+def _projection(
+    package,
+    state,
+    *,
+    branch_id: str = "branch-realised",
+    tenure_id: str = "tenure-1",
+) -> PumpStationProjectionContext:
+    return PumpStationProjectionContext(
+        episode_id="episode-asw-3a",
+        world_branch_id=branch_id,
+        actor_id="station-steward",
+        agent_tenure_id=tenure_id,
+        episode_started_at_seconds=0,
+        tenure_started_at_seconds=0,
+        projection_policy_id="pump-station-current-state-v1",
+        source_artifact_ids=(
+            package.package_content_id,
+            package.manifest_content_id,
+        ),
+    )
+
+
+def _bound(
+    model,
+    state,
+    proposal_type,
+    proposal_id: str,
+    *,
+    package=None,
+    branch_id: str = "branch-realised",
+    tenure_id: str = "tenure-1",
+    carrier: PumpStationContinuityCarrier = PumpStationContinuityCarrier.CURRENT_ACTOR_VIEW,
+    visible_material_ids: tuple[str, ...] = (),
+    history_ids: tuple[str, ...] = (),
+    **parameters,
+):
+    selected_package = package or load_reference_package()
+    view = project_actor_view(
+        model,
+        state,
+        _projection(
+            selected_package,
+            state,
+            branch_id=branch_id,
+            tenure_id=tenure_id,
+        ),
+    )
+    information_set = bind_information_set(
+        view,
+        PumpStationObservationHistory(
+            agent_tenure_id=tenure_id,
+            view_ids=(*history_ids, view.view_id),
+        ),
+        PumpStationCurrentContext(
+            continuity_carrier=carrier,
+            conversation_prefix_id=None,
+            workspace_tool_ids=("propose-pump-station-action",),
+            visible_material_ids=visible_material_ids,
+        ),
+    )
+    proposal = proposal_type(
+        context=ProposalContext(
+            proposal_id=proposal_id,
+            agent_tenure_id=tenure_id,
+            based_on_sequence=state.sequence,
+            base_view_id=view.view_id,
+            information_set_id=information_set.information_set_id,
+            reason="Execute one bounded ASW-3A semantic attack.",
+        ),
+        **parameters,
+    )
+    return proposal, information_set, view
+
+
+def _apply(model, state, proposal_type, proposal_id: str, **parameters):
+    proposal, information_set, view = _bound(
+        model,
+        state,
+        proposal_type,
+        proposal_id,
+        **parameters,
+    )
+    transition = apply_stewardship_proposal(
+        model,
+        state,
+        proposal,
+        information_set=information_set,
+    )
+    return proposal, transition, view
+
+
+def test_forged_view_and_information_set_content_fail_closed() -> None:
+    _, model, state = _world()
+    proposal, information_set, view = _bound(
+        model,
+        state,
+        RequestConditionalDeferral,
+        "proposal-forged-binding",
+        pump_id="pump-a",
+    )
+    forged_view = replace(
+        view,
+        current_state=replace(
+            view.current_state,
+            duty_pump_id="pump-b",
+        ),
+    )
+    forged_view_set = replace(
+        information_set,
+        base_view=forged_view,
+    )
+    forged_context_set = replace(
+        information_set,
+        current_context=replace(
+            information_set.current_context,
+            continuity_carrier=PumpStationContinuityCarrier.STRUCTURED_HANDOVER,
+            visible_material_ids=("forged-handover",),
+        ),
+    )
+
+    for hostile_information_set in (forged_view_set, forged_context_set):
+        transition = apply_stewardship_proposal(
+            model,
+            state,
+            proposal,
+            information_set=hostile_information_set,
+        )
+
+        assert transition.receipt.authority is not None
+        assert transition.receipt.authority.outcome is PumpStationAuthorityOutcome.INVALID
+        assert transition.receipt.execution is PumpStationExecutionOutcome.CANCELLED
+        assert replace(transition.state, sequence=state.sequence) == state
+
+
+def test_wrong_pump_and_wrong_kind_evidence_cannot_authorise_clearance() -> None:
+    _, model, state = _world()
+    _, inspection_requested, _ = _apply(
+        model,
+        state,
+        RequestInspection,
+        "proposal-inspect-pump-b",
+        pump_id="pump-b",
+    )
+    _, inspection_completed, _ = _apply(
+        model,
+        inspection_requested.state,
+        ContinueOperation,
+        "proposal-complete-pump-b-inspection",
+    )
+    pump_b_inspection = inspection_completed.state.latest_inspection("pump-b")
+    wrong_pump, information_set, _ = _bound(
+        model,
+        inspection_completed.state,
+        RequestObstructionClearance,
+        "proposal-wrong-pump-evidence",
+        pump_id="pump-a",
+        inspection_evidence_id=pump_b_inspection.evidence_id,
+    )
+
+    wrong_pump_result = apply_stewardship_proposal(
+        model,
+        inspection_completed.state,
+        wrong_pump,
+        information_set=information_set,
+    )
+
+    wrong_kind_evidence = PumpStationEvidence(
+        evidence_id="evidence-wrong-kind",
+        kind=PumpStationEvidenceKind.FUNCTIONAL_CHECKS,
+        pump_id="pump-a",
+        created_at_seconds=state.physical.calendar_seconds,
+        produced_by=PumpStationAuthority.MAINTENANCE,
+        accepted_by=PumpStationAuthority.VERIFICATION,
+        passed=True,
+    )
+    wrong_kind_state = replace(
+        state,
+        evidence=(wrong_kind_evidence,),
+    )
+    wrong_kind, information_set, _ = _bound(
+        model,
+        wrong_kind_state,
+        RequestObstructionClearance,
+        "proposal-wrong-kind-evidence",
+        pump_id="pump-a",
+        inspection_evidence_id=wrong_kind_evidence.evidence_id,
+    )
+    wrong_kind_result = apply_stewardship_proposal(
+        model,
+        wrong_kind_state,
+        wrong_kind,
+        information_set=information_set,
+    )
+
+    for previous, transition in (
+        (inspection_completed.state, wrong_pump_result),
+        (wrong_kind_state, wrong_kind_result),
+    ):
+        assert transition.receipt.authority is not None
+        assert transition.receipt.authority.outcome is PumpStationAuthorityOutcome.DEFERRED_PENDING_PREREQUISITES
+        assert transition.receipt.execution is PumpStationExecutionOutcome.CANCELLED
+        assert transition.state.physical == previous.physical
+        assert transition.state.processes == previous.processes
+
+
+def test_same_sensor_reading_with_different_history_changes_authority() -> None:
+    _, model, initial = _world()
+    clean_proposal, clean_information_set, clean_view = _bound(
+        model,
+        initial,
+        ContinueOperation,
+        "proposal-clean-continue",
+    )
+    clean_result = apply_stewardship_proposal(
+        model,
+        initial,
+        clean_proposal,
+        information_set=clean_information_set,
+    )
+    _, deferral, _ = _apply(
+        model,
+        initial,
+        RequestConditionalDeferral,
+        "proposal-create-history",
+        pump_id="pump-a",
+    )
+    blocked_proposal, blocked_information_set, blocked_view = _bound(
+        model,
+        deferral.state,
+        ContinueOperation,
+        "proposal-blocked-continue",
+    )
+    blocked_result = apply_stewardship_proposal(
+        model,
+        deferral.state,
+        blocked_proposal,
+        information_set=blocked_information_set,
+    )
+    transfer_proposal, transfer_information_set, _ = _bound(
+        model,
+        deferral.state,
+        TransferDuty,
+        "proposal-required-transfer",
+    )
+    transfer_result = apply_stewardship_proposal(
+        model,
+        deferral.state,
+        transfer_proposal,
+        information_set=transfer_information_set,
+    )
+
+    assert deferral.state.physical == initial.physical
+    assert clean_view.current_state.observation == blocked_view.current_state.observation
+    assert clean_result.receipt.authority is not None
+    assert clean_result.receipt.authority.outcome is PumpStationAuthorityOutcome.PERMITTED
+    assert blocked_result.receipt.authority is not None
+    assert blocked_result.receipt.authority.outcome is PumpStationAuthorityOutcome.DENIED
+    assert transfer_result.receipt.authority is not None
+    assert transfer_result.receipt.authority.outcome is PumpStationAuthorityOutcome.PERMITTED
+
+
+def test_accepted_record_cannot_rewrite_contradictory_physical_truth() -> None:
+    _, model, initial = _world(degraded=True)
+    assert assess_pump_station(
+        model,
+        initial.physical,
+        initial.environment,
+    ).capability.review_required
+    _, deferred, _ = _apply(
+        model,
+        initial,
+        RequestConditionalDeferral,
+        "proposal-deferral-for-record-attack",
+        pump_id="pump-a",
+    )
+    order = replace(
+        deferred.state.work_order_for("pump-a"),
+        status=PumpStationWorkOrderStatus.SCOPE_COMPLETED,
+    )
+    accepted_record = PumpStationEvidence(
+        evidence_id="evidence-contradictory-functional-check",
+        kind=PumpStationEvidenceKind.FUNCTIONAL_CHECKS,
+        pump_id="pump-a",
+        created_at_seconds=deferred.state.physical.calendar_seconds,
+        produced_by=PumpStationAuthority.MAINTENANCE,
+        accepted_by=PumpStationAuthority.VERIFICATION,
+        passed=True,
+    )
+    contradictory = replace(
+        deferred.state,
+        work_orders=(order,),
+        evidence=(accepted_record,),
+    )
+    proposal, information_set, _ = _bound(
+        model,
+        contradictory,
+        RequestProvisionalReturn,
+        "proposal-accepted-record",
+        pump_id="pump-a",
+        functional_check_evidence_id=accepted_record.evidence_id,
+    )
+
+    transition = apply_stewardship_proposal(
+        model,
+        contradictory,
+        proposal,
+        information_set=information_set,
+    )
+
+    assert transition.receipt.authority is not None
+    assert transition.receipt.authority.outcome is PumpStationAuthorityOutcome.PERMITTED
+    assert transition.state.physical == contradictory.physical
+    assert assess_pump_station(
+        model,
+        transition.state.physical,
+        transition.state.environment,
+    ).capability.review_required
+
+
+def test_private_branch_replay_cannot_contaminate_realised_branch() -> None:
+    package, model, initial = _world()
+    realised_proposal, realised_information_set, _ = _bound(
+        model,
+        initial,
+        RequestConditionalDeferral,
+        "proposal-realised-deferral",
+        package=package,
+        branch_id="branch-realised",
+        pump_id="pump-a",
+    )
+    private_proposal, private_information_set, _ = _bound(
+        model,
+        initial,
+        RequestInspection,
+        "proposal-private-inspection",
+        package=package,
+        branch_id="branch-private",
+        pump_id="pump-a",
+    )
+
+    realised = apply_stewardship_proposal(
+        model,
+        initial,
+        realised_proposal,
+        information_set=realised_information_set,
+    )
+    private = apply_stewardship_proposal(
+        model,
+        initial,
+        private_proposal,
+        information_set=private_information_set,
+    )
+    realised_view = project_actor_view(
+        model,
+        realised.state,
+        _projection(
+            package,
+            realised.state,
+            branch_id="branch-realised",
+        ),
+    )
+
+    assert initial.restrictions == ()
+    assert initial.processes == ()
+    assert realised.state.processes == ()
+    assert private.state.restrictions == ()
+    assert realised_view.world_branch_id == "branch-realised"
+    assert "branch-private" not in repr(realised_view)
+    assert private_proposal.context.proposal_id not in repr(realised_view)
+    assert private.state.processes[0].process_id not in repr(realised_view)
+
+
+def test_current_view_and_structured_handover_preserve_present_duty_semantics() -> None:
+    package, model, initial = _world()
+    deferral_proposal, deferral_information_set, _ = _bound(
+        model,
+        initial,
+        RequestConditionalDeferral,
+        "proposal-carrier-deferral",
+        package=package,
+        tenure_id="tenure-1",
+        pump_id="pump-a",
+    )
+    deferral = apply_stewardship_proposal(
+        model,
+        initial,
+        deferral_proposal,
+        information_set=deferral_information_set,
+    )
+    recipient_view = project_actor_view(
+        model,
+        deferral.state,
+        _projection(
+            package,
+            deferral.state,
+            tenure_id="tenure-2",
+        ),
+    )
+    handover = create_structured_handover(
+        recipient_view,
+        from_tenure_id="tenure-1",
+        history=(actor_history_entry(deferral, deferral_proposal),),
+        maximum_history_entries=8,
+    )
+    current_proposal, current_information_set, current_view = _bound(
+        model,
+        deferral.state,
+        TransferDuty,
+        "proposal-current-carrier",
+        package=package,
+        tenure_id="tenure-2",
+    )
+    handover_proposal, handover_information_set, handover_view = _bound(
+        model,
+        deferral.state,
+        TransferDuty,
+        "proposal-handover-carrier",
+        package=package,
+        tenure_id="tenure-2",
+        carrier=PumpStationContinuityCarrier.STRUCTURED_HANDOVER,
+        visible_material_ids=(handover.handover_id,),
+    )
+
+    current_result = apply_stewardship_proposal(
+        model,
+        deferral.state,
+        current_proposal,
+        information_set=current_information_set,
+    )
+    handover_result = apply_stewardship_proposal(
+        model,
+        deferral.state,
+        handover_proposal,
+        information_set=handover_information_set,
+    )
+
+    assert current_view.current_state == handover_view.current_state
+    assert current_information_set.information_set_id != handover_information_set.information_set_id
+    assert current_result.state == handover_result.state
+    assert current_result.receipt.authority == handover_result.receipt.authority
+    assert current_result.receipt.execution == handover_result.receipt.execution
+    assert current_result.receipt.physical_change == handover_result.receipt.physical_change
+
+
+def test_failed_verification_preserves_restriction_and_open_obligation() -> None:
+    _, model, initial = _world(degraded=True)
+    now = initial.physical.calendar_seconds
+    restriction = PumpStationRestriction(
+        restriction_id="restriction-run-in",
+        kind=PumpStationRestrictionKind.POST_MAINTENANCE_RUN_IN,
+        pump_id="pump-a",
+        status=PumpStationRestrictionStatus.ACTIVE,
+        created_sequence=0,
+    )
+    obligation = PumpStationObligation(
+        obligation_id="obligation-verification",
+        kind=PumpStationObligationKind.POST_MAINTENANCE_VERIFICATION,
+        pump_id="pump-a",
+        status=PumpStationObligationStatus.ACTIVE,
+        originating_proposal_id="proposal-provisional-return",
+        responsible_authority=PumpStationAuthority.VERIFICATION,
+        linked_restriction_id=restriction.restriction_id,
+        due_calendar_seconds=now + model.inflow.diagnostic_period_seconds,
+        due_runtime_seconds=(
+            initial.physical.pump("pump-a").exposure.runtime_seconds + model.inflow.diagnostic_period_seconds
+        ),
+        created_sequence=0,
+    )
+    work_order = PumpStationWorkOrder(
+        work_order_id="work-order-pump-a",
+        pump_id="pump-a",
+        status=PumpStationWorkOrderStatus.PROVISIONALLY_CLOSED,
+        created_sequence=0,
+    )
+    process = PumpStationProcess(
+        process_id="process-verification",
+        kind=PumpStationProcessKind.POST_MAINTENANCE_VERIFICATION,
+        pump_id="pump-a",
+        work_order_id=work_order.work_order_id,
+        status=PumpStationProcessStatus.IN_PROGRESS,
+        started_at_seconds=now,
+        completion_at_seconds=now,
+        performer=PumpStationAuthority.VERIFICATION,
+    )
+    event = PumpStationScheduledEvent(
+        event_id="event-verification-completion",
+        event_type=PumpStationEventType.PROCESS_COMPLETION,
+        scheduled_seconds=now,
+        process_id=process.process_id,
+    )
+    attacked = replace(
+        initial,
+        restrictions=(restriction,),
+        obligations=(obligation,),
+        work_orders=(work_order,),
+        processes=(process,),
+        scheduled_events=(event,),
+    )
+
+    failed = advance_to_next_decision_point(model, attacked)
+
+    assert failed.receipt.execution is PumpStationExecutionOutcome.FAILED
+    assert failed.state.physical == attacked.physical
+    assert failed.state.processes[0].status is PumpStationProcessStatus.FAILED
+    assert failed.state.obligations[0].status is PumpStationObligationStatus.ACTIVE
+    assert failed.state.restrictions[0].status is PumpStationRestrictionStatus.ACTIVE
+    assert failed.state.work_orders[0].status is PumpStationWorkOrderStatus.OPEN
+    assert failed.state.evidence[-1].passed is False

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_asw_3a_world_run_e2e.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_asw_3a_world_run_e2e.py
@@ -1,0 +1,280 @@
+# ABOUTME: Attacks durable pump-station replay, continuity, and certified claim binding.
+# ABOUTME: Proves equal runs are byte-stable and drift fails during independent reload.
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+from world_run_support import bind_proposal, create_world_run
+
+from aec_bench.contracts.world_session import (
+    WorldSessionExecutionKind,
+    WorldSessionOpenMode,
+    WorldSessionRequest,
+)
+from aec_bench.evaluation.stewardship import (
+    evaluate_pump_station_stewardship_run,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station import (
+    ContinueOperation,
+    PumpStationWorldRunError,
+    ReferencePackageError,
+    RequestConditionalDeferral,
+    RequestInspection,
+    TransferDuty,
+    bundled_reference_package_root,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_serialization import (
+    pump_station_artifact_id,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_session import (
+    PUMP_STATION_TASK_WORLD_ID,
+    PumpStationWorldSessionFactory,
+)
+
+
+def _durable_json(root: Path) -> dict[Path, bytes]:
+    return {path.relative_to(root): path.read_bytes() for path in sorted(root.rglob("*.json"))}
+
+
+def _apply_durable_prefix(run) -> None:
+    proposals = (
+        (RequestConditionalDeferral, "proposal-01-deferral", {"pump_id": "pump-a"}),
+        (TransferDuty, "proposal-02-transfer", {}),
+        (RequestInspection, "proposal-03-inspection", {"pump_id": "pump-a"}),
+        (ContinueOperation, "proposal-04-complete-inspection", {}),
+    )
+    for proposal_type, proposal_id, parameters in proposals:
+        proposal, information_set = bind_proposal(
+            run,
+            proposal_type,
+            proposal_id,
+            **parameters,
+        )
+        run.apply(
+            proposal,
+            information_set=information_set,
+        )
+
+
+def _start_request() -> WorldSessionRequest:
+    return WorldSessionRequest(
+        execution_kind=WorldSessionExecutionKind.STEWARDSHIP,
+        open_mode=WorldSessionOpenMode.START,
+        session_id="session-asw-3a-1",
+        task_world_id=PUMP_STATION_TASK_WORLD_ID,
+        agent_tenure_id="tenure-1",
+        run_id="run-asw-3a",
+        episode_id="episode-asw-3a",
+        world_branch_id="branch-asw-3a",
+    )
+
+
+def _run_to_verification_process(session) -> dict[str, object]:
+    reason = "Exercise durable ASW-3A continuity."
+    session.request_conditional_deferral("proposal-01", reason, "pump-a")
+    session.transfer_duty("proposal-02", reason)
+    session.request_inspection("proposal-03", reason, "pump-a")
+    inspection_completed = json.loads(session.continue_operation("proposal-04", reason))
+    inspection_id = next(
+        item["evidence_id"]
+        for item in inspection_completed["view"]["current_state"]["evidence"]
+        if item["kind"] == "inspection"
+    )
+    session.continue_operation("proposal-05", reason)
+    session.request_obstruction_clearance(
+        "proposal-06",
+        reason,
+        "pump-a",
+        inspection_id,
+    )
+    session.continue_operation("proposal-07", reason)
+    checks_completed = json.loads(session.continue_operation("proposal-08", reason))
+    functional_check_id = next(
+        item["evidence_id"]
+        for item in checks_completed["view"]["current_state"]["evidence"]
+        if item["kind"] == "functional_checks"
+    )
+    returned = json.loads(
+        session.request_provisional_return(
+            "proposal-09",
+            reason,
+            "pump-a",
+            functional_check_id,
+        )
+    )
+    work_order_id = returned["view"]["current_state"]["work_orders"][0]["work_order_id"]
+    session.request_provisional_closure("proposal-10", reason, work_order_id)
+    return json.loads(
+        session.request_post_maintenance_verification(
+            "proposal-11",
+            reason,
+            "pump-a",
+        )
+    )
+
+
+def _write_canonical_json(path: Path, value: object) -> None:
+    path.write_bytes(
+        (
+            json.dumps(
+                value,
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+            + "\n"
+        ).encode("utf-8")
+    )
+
+
+def _drift_reference_package(package_root: Path, drift: str) -> None:
+    if drift in {
+        "profile",
+        "generation",
+        "version",
+        "prohibited-claim",
+    }:
+        path = package_root / "public-profile.json"
+        document = json.loads(path.read_text(encoding="utf-8"))
+        if drift == "profile":
+            document["profile_id"] = "AU-NSW-LH-SYN-SPS-hostile"
+        elif drift == "generation":
+            document["generation_id"] = "0" * 64
+        elif drift == "version":
+            document["schema_id"] = "asw-0b5.public-profile.v2"
+        else:
+            document["prohibited_claim_ids"] = []
+    else:
+        path = package_root / "promotion-manifest.json"
+        document = json.loads(path.read_text(encoding="utf-8"))
+        if drift == "certified-envelope":
+            document["claims"]["certified_envelope"] = "all real pump stations"
+        else:
+            document["authority"]["w3_sha256"] = "0" * 64
+    _write_canonical_json(path, document)
+
+
+def test_equal_durable_replays_publish_byte_equivalent_artifacts(tmp_path: Path) -> None:
+    first = create_world_run(tmp_path / "first")
+    second = create_world_run(tmp_path / "second")
+
+    _apply_durable_prefix(first)
+    _apply_durable_prefix(second)
+
+    assert first.state == second.state
+    assert first.steps() == second.steps()
+    assert _durable_json(first.repository.root) == _durable_json(second.repository.root)
+
+
+def test_closure_snapshot_and_fresh_tenure_conserve_active_duties(
+    tmp_path: Path,
+) -> None:
+    factory = PumpStationWorldSessionFactory(tmp_path / "world")
+    first = factory.open(_start_request())
+    scheduled = _run_to_verification_process(first)
+    before = scheduled["view"]["current_state"]
+    snapshot = first.result.snapshot
+
+    resumed = factory.open(
+        WorldSessionRequest(
+            execution_kind=WorldSessionExecutionKind.STEWARDSHIP,
+            open_mode=WorldSessionOpenMode.RESUME,
+            session_id="session-asw-3a-2",
+            task_world_id=PUMP_STATION_TASK_WORLD_ID,
+            agent_tenure_id="tenure-2",
+            run_id="run-asw-3a",
+            episode_id="episode-asw-3a",
+            world_branch_id="branch-asw-3a",
+            start_snapshot=snapshot,
+        )
+    )
+    after = json.loads(resumed.observe_pump_station())["current_state"]
+
+    assert after == before
+    assert after["work_orders"][0]["status"] == "provisionally_closed"
+    assert after["processes"][0]["status"] == "in_progress"
+    assert after["processes"][0]["kind"] == "post_maintenance_verification"
+    assert after["obligations"][0]["status"] == "active"
+    assert after["obligations"][0]["kind"] == "post_maintenance_verification"
+    assert after["restrictions"][0]["status"] == "active"
+    assert after["restrictions"][0]["kind"] == "post_maintenance_run_in"
+    assert {item["kind"] for item in after["evidence"]} == {
+        "inspection",
+        "functional_checks",
+    }
+
+    completed = json.loads(
+        resumed.continue_operation(
+            "proposal-12",
+            "Complete the carried verification process.",
+        )
+    )
+    evaluation = evaluate_pump_station_stewardship_run(
+        run_dir=tmp_path / "world",
+    )
+
+    assert completed["status"] == "completed"
+    assert resumed.verify().valid is True
+    assert evaluation.valid is True
+    assert evaluation.metrics.handover_count == 1
+    assert evaluation.metrics.handover_omission_count == 0
+
+
+def test_evaluation_report_binds_exact_world_run_manifest(tmp_path: Path) -> None:
+    run = create_world_run(tmp_path / "run")
+
+    evaluation = evaluate_pump_station_stewardship_run(
+        run_dir=run.repository.root,
+    )
+
+    assert evaluation.valid is True
+    assert evaluation.evidence.world_run_manifest_content_id == pump_station_artifact_id(run.manifest)
+    assert evaluation.evidence.initial_state_id == run.manifest.initial_state_id
+    assert evaluation.evidence.terminal_state_id == run.snapshot().state_id
+
+
+@pytest.mark.parametrize(
+    "drift",
+    (
+        "profile",
+        "generation",
+        "version",
+        "certified-envelope",
+        "prohibited-claim",
+        "certifier-lineage",
+    ),
+)
+def test_evaluation_rejects_certified_package_claim_drift(
+    tmp_path: Path,
+    drift: str,
+) -> None:
+    run = create_world_run(tmp_path / "run")
+    package_root = tmp_path / "hostile-package"
+    shutil.copytree(
+        bundled_reference_package_root(),
+        package_root,
+    )
+    _drift_reference_package(package_root, drift)
+
+    with pytest.raises(ReferencePackageError):
+        evaluate_pump_station_stewardship_run(
+            run_dir=run.repository.root,
+            package_root=package_root,
+        )
+
+
+def test_evaluation_rejects_world_run_identity_drift(tmp_path: Path) -> None:
+    run = create_world_run(tmp_path / "run")
+    manifest_path = run.repository.root / "manifest.json"
+    document = json.loads(manifest_path.read_text(encoding="utf-8"))
+    document["profile_id"] = "AU-NSW-LH-SYN-SPS-hostile"
+    _write_canonical_json(manifest_path, document)
+
+    with pytest.raises(PumpStationWorldRunError, match="world-run-identity"):
+        evaluate_pump_station_stewardship_run(
+            run_dir=run.repository.root,
+        )


### PR DESCRIPTION
## Summary

- adds hostile tests for forged views, wrong evidence, history-sensitive authority, contradictory records, failed verification, private branches, and carrier parity
- proves byte-stable durable replay, fresh-tenure continuity, certified-package drift rejection, and exact evaluation claim binding
- proves safe and unsafe decisions remain distinct when physical outcomes match, with terminal liabilities visible at the exact 3D and 4D cuts
- keeps ASW-3A test-only; no production runtime, persisted schema, Harbor path, CLI, or verifier changes

## Verification

- `uv run pytest tests/task_world_templates/stewardship/wastewater_pump_station/test_asw_3a_semantic_attacks.py tests/task_world_templates/stewardship/wastewater_pump_station/test_asw_3a_world_run_e2e.py tests/evaluation/test_stewardship.py -q` — 21 passed
- Ruff lint passed on all three changed files
- Ruff format check passed on all three changed files
- focused pump-station and evaluator surface — 91 passed
- independent research boundary with a fresh pinned SWMM 5.2.4 receipt — 25 passed