### PR TITLE
ASW-3B: falsify persistence and version boundaries

### DIFF
--- a/src/aec_bench/contracts/world_session.py
+++ b/src/aec_bench/contracts/world_session.py
@@ -11,6 +11,7 @@ from pydantic import model_validator
 from aec_bench.contracts.validators import FrozenStrictModel, NonEmptyStr
 
 WORLD_SESSION_SCHEMA_VERSION = "aecbench.world-session.v1"
+STEWARDSHIP_STATE_SNAPSHOT_SCHEMA_VERSION = "aecbench.stewardship-state-snapshot.v1"
 
 
 class WorldSessionExecutionKind(StrEnum):
@@ -29,6 +30,7 @@ class WorldSessionOpenMode(StrEnum):
 class StewardshipStateSnapshotRef(FrozenStrictModel):
     """Task-neutral identity of one selected dynamic stewardship state."""
 
+    schema_version: str = STEWARDSHIP_STATE_SNAPSHOT_SCHEMA_VERSION
     run_id: NonEmptyStr
     episode_id: NonEmptyStr
     world_branch_id: NonEmptyStr
@@ -37,7 +39,9 @@ class StewardshipStateSnapshotRef(FrozenStrictModel):
     commit_id: NonEmptyStr
 
     @model_validator(mode="after")
-    def validate_sequence(self) -> Self:
+    def validate_snapshot(self) -> Self:
+        if self.schema_version != STEWARDSHIP_STATE_SNAPSHOT_SCHEMA_VERSION:
+            raise ValueError("unsupported stewardship snapshot schema version")
         if self.sequence < 0:
             raise ValueError("snapshot sequence must be non-negative")
         return self

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/__init__.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/__init__.py
@@ -43,6 +43,9 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.referenc
     load_reference_package,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_models import (
+    PUMP_STATION_AUTHORITY_POLICY_VERSION,
+    PUMP_STATION_RECEIPT_VERSION,
+    PUMP_STATION_TRANSITION_RULE_VERSION,
     ContinueOperation,
     ProposalContext,
     PumpStationAuthority,
@@ -109,6 +112,8 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_ru
     PumpStationWorldRun,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_models import (
+    PUMP_STATION_SERIALIZATION_VERSION,
+    PUMP_STATION_SNAPSHOT_VERSION,
     PumpStationAppliedEventBatch,
     PumpStationStagedTransition,
     PumpStationStateSnapshotRef,
@@ -119,7 +124,6 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_ru
     PumpStationWorldRunRepository,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_serialization import (
-    PUMP_STATION_SERIALIZATION_VERSION,
     PUMP_STATION_TRANSPORT_FIELD_EXCLUSIONS,
     load_pump_station_artifact,
     pump_station_artifact_bytes,
@@ -202,9 +206,13 @@ __all__ = [
     "PumpStationWorldRunRepository",
     "PumpStationWorldSession",
     "PumpStationWorldSessionFactory",
+    "PUMP_STATION_AUTHORITY_POLICY_VERSION",
+    "PUMP_STATION_RECEIPT_VERSION",
     "PUMP_STATION_SERIALIZATION_VERSION",
+    "PUMP_STATION_SNAPSHOT_VERSION",
     "PUMP_STATION_TASK_WORLD_ID",
     "PUMP_STATION_TOOL_NAMES",
+    "PUMP_STATION_TRANSITION_RULE_VERSION",
     "PUMP_STATION_TRANSPORT_FIELD_EXCLUSIONS",
     "REFERENCE_PACKAGE_FILE_NAMES",
     "ReferencePackage",

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/harbor_export.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/harbor_export.py
@@ -47,6 +47,24 @@ PUMP_STATION_CONTROLLER_MODES = (
 _MANIFEST_NAME = "world-session-export.json"
 _PACKAGE_PATH = "tests/reference-package"
 _MAX_MANIFEST_BYTES = 1024 * 1024
+_NON_AUTHORITY_ARTIFACT_NAMES = frozenset(
+    {
+        ".world-run.lock",
+        "artifact-inventory.json",
+        "current.json",
+    }
+)
+
+
+def is_pump_station_harbor_inventory_artifact(
+    root: Path,
+    path: Path,
+) -> bool:
+    """Return whether one session file is eligible for the Harbor inventory."""
+    relative = path.relative_to(root)
+    if path.name in _NON_AUTHORITY_ARTIFACT_NAMES:
+        return False
+    return not (relative.parts and relative.parts[0] == "world-run" and path.name.startswith("."))
 
 
 @dataclass(frozen=True)
@@ -423,5 +441,6 @@ __all__ = (
     "PUMP_STATION_HARBOR_OUTPUT_PATH",
     "PumpStationHarborBridge",
     "export_pump_station_harbor_task",
+    "is_pump_station_harbor_inventory_artifact",
     "load_pump_station_harbor_bridge",
 )

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/harbor_session.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/harbor_session.py
@@ -20,6 +20,7 @@ from aec_bench.harness.world_session import open_world_session
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.harbor_export import (
     PUMP_STATION_HARBOR_EXECUTION_KIND,
     PumpStationHarborBridge,
+    is_pump_station_harbor_inventory_artifact,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_verifier import (
     PumpStationVerificationReport,
@@ -274,11 +275,10 @@ def _artifact_inventory(
 ) -> dict[str, Any]:
     artifacts: list[dict[str, Any]] = []
     for path in sorted(output_dir.rglob("*")):
-        if not path.is_file() or path.name in {
-            ".world-run.lock",
-            "artifact-inventory.json",
-            "current.json",
-        }:
+        if not path.is_file() or not is_pump_station_harbor_inventory_artifact(
+            output_dir,
+            path,
+        ):
             continue
         payload = path.read_bytes()
         artifacts.append(

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/harbor_verifier.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/harbor_verifier.py
@@ -24,6 +24,7 @@ from aec_bench.task_world_templates.harbor_exporting.stable_io import (
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.harbor_export import (
     PUMP_STATION_HARBOR_EXECUTION_KIND,
     PUMP_STATION_HARBOR_EXPORT_SCHEMA_VERSION,
+    is_pump_station_harbor_inventory_artifact,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.harbor_session import (
     PUMP_STATION_HARBOR_RUN_SCHEMA_VERSION,
@@ -183,22 +184,13 @@ def _verify_stewardship_objective(
     evidence = state.get("evidence")
     work_orders = state.get("work_orders")
     verification_passed = isinstance(evidence, list) and any(
-        isinstance(item, dict)
-        and item.get("kind") == "post_maintenance_verification"
-        and item.get("passed") is True
+        isinstance(item, dict) and item.get("kind") == "post_maintenance_verification" and item.get("passed") is True
         for item in evidence
     )
     closure_recorded = isinstance(work_orders, list) and any(
-        isinstance(item, dict)
-        and item.get("status") == "provisionally_closed"
-        for item in work_orders
+        isinstance(item, dict) and item.get("status") == "provisionally_closed" for item in work_orders
     )
-    if (
-        transition_count < 1
-        or report.open_obligation_ids
-        or not verification_passed
-        or not closure_recorded
-    ):
+    if transition_count < 1 or report.open_obligation_ids or not verification_passed or not closure_recorded:
         raise ValueError("pump-station stewardship objective is incomplete")
 
 
@@ -208,11 +200,10 @@ def _verify_inventory(root: Path, inventory: dict[str, Any]) -> None:
         raise ValueError("pump-station Harbor artifact inventory is not a list")
     expected: list[dict[str, Any]] = []
     for path in sorted(root.rglob("*")):
-        if not path.is_file() or path.name in {
-            ".world-run.lock",
-            "artifact-inventory.json",
-            "current.json",
-        }:
+        if not path.is_file() or not is_pump_station_harbor_inventory_artifact(
+            root,
+            path,
+        ):
             continue
         payload = path.read_bytes()
         expected.append(

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/stewardship_models.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/stewardship_models.py
@@ -14,6 +14,10 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.physical
     PumpStationState,
 )
 
+PUMP_STATION_RECEIPT_VERSION = "pump-station-transition-receipt.v1"
+PUMP_STATION_AUTHORITY_POLICY_VERSION = "pump-station-authority-policy.v1"
+PUMP_STATION_TRANSITION_RULE_VERSION = "pump-station-transition-rules.v1"
+
 
 class PumpStationProposalError(ValueError):
     """Raised when a proposal or scheduled transition leaves the task contract."""
@@ -468,6 +472,9 @@ class PumpStationStewardshipState:
 class PumpStationTransitionReceipt:
     """Immutable in-memory record of one applied state-machine transition."""
 
+    receipt_version: str
+    authority_policy_version: str
+    transition_rule_version: str
     transition_id: str
     sequence: int
     trigger: str
@@ -485,6 +492,14 @@ class PumpStationTransitionReceipt:
     work_orders_changed: tuple[str, ...]
     evidence_created: tuple[str, ...]
     physical_change: PumpStationChangeKind | None
+
+    def __post_init__(self) -> None:
+        if self.receipt_version != PUMP_STATION_RECEIPT_VERSION:
+            _fail("receipt-version", self.receipt_version)
+        if self.authority_policy_version != PUMP_STATION_AUTHORITY_POLICY_VERSION:
+            _fail("authority-policy-version", self.authority_policy_version)
+        if self.transition_rule_version != PUMP_STATION_TRANSITION_RULE_VERSION:
+            _fail("transition-rule-version", self.transition_rule_version)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/stewardship_state_machine.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/stewardship_state_machine.py
@@ -45,6 +45,9 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewards
     stewardship_state_id as _state_id,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_models import (
+    PUMP_STATION_AUTHORITY_POLICY_VERSION,
+    PUMP_STATION_RECEIPT_VERSION,
+    PUMP_STATION_TRANSITION_RULE_VERSION,
     ContinueOperation,
     PumpStationAuthority,
     PumpStationAuthorityDecision,
@@ -123,6 +126,9 @@ def _finish_transition(
     return PumpStationTransition(
         state=state,
         receipt=PumpStationTransitionReceipt(
+            receipt_version=PUMP_STATION_RECEIPT_VERSION,
+            authority_policy_version=PUMP_STATION_AUTHORITY_POLICY_VERSION,
+            transition_rule_version=PUMP_STATION_TRANSITION_RULE_VERSION,
             transition_id=_transition_id(sequence),
             sequence=sequence,
             trigger=trigger,

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run.py
@@ -14,6 +14,9 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewards
     stewardship_state_id,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_models import (
+    PUMP_STATION_AUTHORITY_POLICY_VERSION,
+    PUMP_STATION_RECEIPT_VERSION,
+    PUMP_STATION_TRANSITION_RULE_VERSION,
     PumpStationProposal,
     PumpStationStewardshipState,
     PumpStationTransition,
@@ -28,6 +31,8 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewards
     PumpStationInformationSet,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_models import (
+    PUMP_STATION_SERIALIZATION_VERSION,
+    PUMP_STATION_SNAPSHOT_VERSION,
     PumpStationStagedTransition,
     PumpStationStateSnapshotRef,
     PumpStationWorldRunError,
@@ -35,9 +40,6 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_ru
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_repository import (
     PumpStationWorldRunRepository,
-)
-from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_serialization import (
-    PUMP_STATION_SERIALIZATION_VERSION,
 )
 
 
@@ -76,6 +78,10 @@ class PumpStationWorldRun:
         """Create and atomically select one durable initial state."""
         manifest = PumpStationWorldRunManifest(
             serialization_version=PUMP_STATION_SERIALIZATION_VERSION,
+            snapshot_version=PUMP_STATION_SNAPSHOT_VERSION,
+            receipt_version=PUMP_STATION_RECEIPT_VERSION,
+            authority_policy_version=PUMP_STATION_AUTHORITY_POLICY_VERSION,
+            transition_rule_version=PUMP_STATION_TRANSITION_RULE_VERSION,
             run_id=run_id,
             episode_id=episode_id,
             world_branch_id=world_branch_id,

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_models.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_models.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_models import (
+    PUMP_STATION_AUTHORITY_POLICY_VERSION,
+    PUMP_STATION_RECEIPT_VERSION,
+    PUMP_STATION_TRANSITION_RULE_VERSION,
     PumpStationEventType,
     PumpStationProposal,
     PumpStationTransition,
@@ -13,6 +16,9 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewards
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_views import (
     PumpStationInformationSet,
 )
+
+PUMP_STATION_SERIALIZATION_VERSION = "pump-station-world-run.v1"
+PUMP_STATION_SNAPSHOT_VERSION = "pump-station-state-snapshot.v1"
 
 
 class PumpStationWorldRunError(RuntimeError):
@@ -32,11 +38,21 @@ def require_world_run_text(value: str, field_name: str) -> None:
         )
 
 
+def require_world_run_version(value: str, expected: str, code: str) -> None:
+    """Reject one unsupported durable artifact version."""
+    if value != expected:
+        raise PumpStationWorldRunError(code, value)
+
+
 @dataclass(frozen=True, slots=True)
 class PumpStationWorldRunManifest:
     """Immutable identity and initial state for one continuing world branch."""
 
     serialization_version: str
+    snapshot_version: str
+    receipt_version: str
+    authority_policy_version: str
+    transition_rule_version: str
     run_id: str
     episode_id: str
     world_branch_id: str
@@ -69,12 +85,38 @@ class PumpStationWorldRunManifest:
                 "world-run-shape",
                 "initial sequence must be non-negative",
             )
+        require_world_run_version(
+            self.serialization_version,
+            PUMP_STATION_SERIALIZATION_VERSION,
+            "serialization-version",
+        )
+        require_world_run_version(
+            self.snapshot_version,
+            PUMP_STATION_SNAPSHOT_VERSION,
+            "snapshot-version",
+        )
+        require_world_run_version(
+            self.receipt_version,
+            PUMP_STATION_RECEIPT_VERSION,
+            "receipt-version",
+        )
+        require_world_run_version(
+            self.authority_policy_version,
+            PUMP_STATION_AUTHORITY_POLICY_VERSION,
+            "authority-policy-version",
+        )
+        require_world_run_version(
+            self.transition_rule_version,
+            PUMP_STATION_TRANSITION_RULE_VERSION,
+            "transition-rule-version",
+        )
 
 
 @dataclass(frozen=True, slots=True)
 class PumpStationStateSnapshotRef:
     """Exact dynamic state selected for one durable pump-station run."""
 
+    snapshot_version: str
     run_id: str
     episode_id: str
     world_branch_id: str
@@ -96,6 +138,11 @@ class PumpStationStateSnapshotRef:
                 "world-run-shape",
                 "snapshot sequence must be non-negative",
             )
+        require_world_run_version(
+            self.snapshot_version,
+            PUMP_STATION_SNAPSHOT_VERSION,
+            "snapshot-version",
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -123,6 +170,13 @@ class PumpStationWorldRunCommit:
     receipt_content_id: str | None
     event_batch_content_id: str | None
 
+    def __post_init__(self) -> None:
+        require_world_run_version(
+            self.serialization_version,
+            PUMP_STATION_SERIALIZATION_VERSION,
+            "serialization-version",
+        )
+
 
 @dataclass(frozen=True, slots=True)
 class PumpStationCurrentRunPointer:
@@ -133,6 +187,13 @@ class PumpStationCurrentRunPointer:
     sequence: int
     state_id: str
     commit_id: str
+
+    def __post_init__(self) -> None:
+        require_world_run_version(
+            self.serialization_version,
+            PUMP_STATION_SERIALIZATION_VERSION,
+            "serialization-version",
+        )
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_repository.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_repository.py
@@ -38,6 +38,8 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewards
     PumpStationInformationSet,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_models import (
+    PUMP_STATION_SERIALIZATION_VERSION,
+    PUMP_STATION_SNAPSHOT_VERSION,
     PumpStationAppliedEventBatch,
     PumpStationCurrentRunPointer,
     PumpStationStagedTransition,
@@ -47,7 +49,6 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_ru
     PumpStationWorldRunManifest,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_serialization import (
-    PUMP_STATION_SERIALIZATION_VERSION,
     load_pump_station_artifact,
     pump_station_artifact_bytes,
     pump_station_artifact_id,
@@ -147,8 +148,17 @@ class PumpStationWorldRunRepository:
     ) -> PumpStationStateSnapshotRef:
         """Publish an immutable initial state and select it atomically."""
         with self.locked():
+            if stewardship_state_id(initial_state) != manifest.initial_state_id:
+                _fail("world-run-identity", "initial state differs from manifest")
             if (self._root / "current.json").exists():
-                _fail("world-run-exists", manifest.run_id)
+                if self.load_manifest() != manifest:
+                    _fail("world-run-exists", f"{manifest.run_id} has different identity")
+                if self.load_state(manifest.initial_state_id) != initial_state:
+                    _fail("world-run-exists", f"{manifest.run_id} has different initial state")
+                current = self.current_snapshot()
+                if current.sequence != manifest.initial_sequence or current.state_id != manifest.initial_state_id:
+                    _fail("world-run-exists", f"{manifest.run_id} has already advanced")
+                return current
             self._publish_root_immutable("manifest.json", manifest)
             self._publish_state(initial_state)
             commit = PumpStationWorldRunCommit(
@@ -275,6 +285,7 @@ class PumpStationWorldRunRepository:
         commit_id = pump_station_artifact_id(commit)
         self._publish_content("commits", commit_id, commit)
         snapshot = PumpStationStateSnapshotRef(
+            snapshot_version=PUMP_STATION_SNAPSHOT_VERSION,
             run_id=manifest.run_id,
             episode_id=manifest.episode_id,
             world_branch_id=manifest.world_branch_id,
@@ -587,6 +598,7 @@ class PumpStationWorldRunRepository:
         pointer: PumpStationCurrentRunPointer,
     ) -> PumpStationStateSnapshotRef:
         return PumpStationStateSnapshotRef(
+            snapshot_version=PUMP_STATION_SNAPSHOT_VERSION,
             run_id=manifest.run_id,
             episode_id=manifest.episode_id,
             world_branch_id=manifest.world_branch_id,

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_serialization.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_serialization.py
@@ -12,10 +12,13 @@ from enum import Enum
 from typing import Any, NoReturn, TypeVar, cast, get_args, get_origin, get_type_hints, overload
 
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_models import (
+    PUMP_STATION_SERIALIZATION_VERSION as _PUMP_STATION_SERIALIZATION_VERSION,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_models import (
     PumpStationWorldRunError,
 )
 
-PUMP_STATION_SERIALIZATION_VERSION = "pump-station-world-run.v1"
+PUMP_STATION_SERIALIZATION_VERSION = _PUMP_STATION_SERIALIZATION_VERSION
 PUMP_STATION_TRANSPORT_FIELD_EXCLUSIONS: tuple[str, ...] = ()
 
 ArtifactT = TypeVar("ArtifactT")

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_session.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_session.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from aec_bench.contracts.task_definition import ToolSpec
 from aec_bench.contracts.world_session import (
+    STEWARDSHIP_STATE_SNAPSHOT_SCHEMA_VERSION,
     StewardshipStateSnapshotRef,
     WorldSessionOpenMode,
     WorldSessionRequest,
@@ -60,6 +61,7 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_ru
     PumpStationWorldRun,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_models import (
+    PUMP_STATION_SNAPSHOT_VERSION,
     PumpStationStateSnapshotRef,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_repository import (
@@ -89,6 +91,7 @@ PUMP_STATION_TOOL_NAMES = (
 
 def _snapshot_ref(snapshot: PumpStationStateSnapshotRef) -> StewardshipStateSnapshotRef:
     return StewardshipStateSnapshotRef(
+        schema_version=STEWARDSHIP_STATE_SNAPSHOT_SCHEMA_VERSION,
         run_id=snapshot.run_id,
         episode_id=snapshot.episode_id,
         world_branch_id=snapshot.world_branch_id,
@@ -100,6 +103,7 @@ def _snapshot_ref(snapshot: PumpStationStateSnapshotRef) -> StewardshipStateSnap
 
 def _pump_station_snapshot(snapshot: StewardshipStateSnapshotRef) -> PumpStationStateSnapshotRef:
     return PumpStationStateSnapshotRef(
+        snapshot_version=PUMP_STATION_SNAPSHOT_VERSION,
         run_id=snapshot.run_id,
         episode_id=snapshot.episode_id,
         world_branch_id=snapshot.world_branch_id,

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_asw_3b_crash_recovery_e2e.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_asw_3b_crash_recovery_e2e.py
@@ -1,0 +1,231 @@
+# ABOUTME: Kills real pump-station processes after each durable publication boundary.
+# ABOUTME: Proves retry and reconciliation prevent torn authority and duplicate effects.
+
+from __future__ import annotations
+
+import multiprocessing
+import os
+from collections.abc import Callable
+from pathlib import Path
+from typing import Never
+
+import pytest
+
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station import (
+    PumpStationInformationSet,
+    PumpStationWorldRun,
+    PumpStationWorldRunRepository,
+    RequestConditionalDeferral,
+    TransferDuty,
+    load_reference_package,
+    pump_station_model_from_package,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_models import (
+    PumpStationProposal,
+)
+from tests.task_world_templates.stewardship.wastewater_pump_station.world_run_support import (
+    bind_proposal,
+    create_world_run,
+)
+
+_CRASH_EXIT_CODE = 93
+_INITIALIZATION_ARTIFACTS = ("manifest", "state", "commit")
+_TRANSITION_ARTIFACTS = (
+    "state",
+    "proposal",
+    "information-set",
+    "receipt",
+    "event",
+    "commit",
+)
+_LINK_PHASES = ("before-link", "after-link")
+_INITIALIZATION_BOUNDARIES = tuple(
+    f"{artifact}-{phase}" for artifact in _INITIALIZATION_ARTIFACTS for phase in _LINK_PHASES
+) + (
+    "current-before-replace",
+    "current-after-replace",
+)
+_TRANSITION_BOUNDARIES = tuple(
+    f"{artifact}-{phase}" for artifact in _TRANSITION_ARTIFACTS for phase in _LINK_PHASES
+) + (
+    "current-before-replace",
+    "current-after-replace",
+)
+type _PathArgument = str | bytes | os.PathLike[str] | os.PathLike[bytes]
+_ORIGINAL_LINK = os.link
+_ORIGINAL_REPLACE = os.replace
+
+
+def _crash() -> Never:
+    os._exit(_CRASH_EXIT_CODE)
+
+
+def _artifact_for_path(root: Path, path: _PathArgument) -> str | None:
+    relative = Path(os.fsdecode(path)).relative_to(root)
+    key = relative.name if len(relative.parts) == 1 else relative.parts[0]
+    return {
+        "manifest.json": "manifest",
+        "states": "state",
+        "proposals": "proposal",
+        "information-sets": "information-set",
+        "receipts": "receipt",
+        "events": "event",
+        "commits": "commit",
+    }.get(key)
+
+
+def _install_publication_crash(root: Path, boundary: str) -> None:
+    def crash_link(
+        src: _PathArgument,
+        dst: _PathArgument,
+        *,
+        src_dir_fd: int | None = None,
+        dst_dir_fd: int | None = None,
+        follow_symlinks: bool = True,
+    ) -> None:
+        artifact = _artifact_for_path(root, dst)
+        if boundary == f"{artifact}-before-link":
+            _crash()
+        _ORIGINAL_LINK(
+            src,
+            dst,
+            src_dir_fd=src_dir_fd,
+            dst_dir_fd=dst_dir_fd,
+            follow_symlinks=follow_symlinks,
+        )
+        if boundary == f"{artifact}-after-link":
+            _crash()
+
+    def crash_replace(
+        src: _PathArgument,
+        dst: _PathArgument,
+        *,
+        src_dir_fd: int | None = None,
+        dst_dir_fd: int | None = None,
+    ) -> None:
+        if Path(os.fsdecode(dst)) == root / "current.json":
+            if boundary == "current-before-replace":
+                _crash()
+            _ORIGINAL_REPLACE(
+                src,
+                dst,
+                src_dir_fd=src_dir_fd,
+                dst_dir_fd=dst_dir_fd,
+            )
+            if boundary == "current-after-replace":
+                _crash()
+            return
+        _ORIGINAL_REPLACE(
+            src,
+            dst,
+            src_dir_fd=src_dir_fd,
+            dst_dir_fd=dst_dir_fd,
+        )
+
+    os.link = crash_link
+    os.replace = crash_replace
+
+
+def _crash_during_initialization(root: Path, boundary: str) -> None:
+    _install_publication_crash(root, boundary)
+    create_world_run(root)
+
+
+def _crash_during_transition(
+    root: Path,
+    boundary: str,
+    proposal: PumpStationProposal,
+    information_set: PumpStationInformationSet,
+) -> None:
+    package = load_reference_package()
+    model = pump_station_model_from_package(package)
+    repository = PumpStationWorldRunRepository(root)
+    run = PumpStationWorldRun.resume(
+        repository=repository,
+        package=package,
+        model=model,
+        snapshot=repository.current_snapshot(),
+    )
+    _install_publication_crash(root, boundary)
+    run.apply(proposal, information_set=information_set)
+
+
+def _assert_expected_crash(target: Callable[..., object], *args: object) -> None:
+    context = multiprocessing.get_context("spawn")
+    process = context.Process(target=target, args=args)
+    process.start()
+    process.join(20)
+    if process.is_alive():
+        process.kill()
+        process.join()
+        pytest.fail("fault-injection process did not stop")
+    assert process.exitcode == _CRASH_EXIT_CODE
+
+
+@pytest.mark.parametrize("boundary", _INITIALIZATION_BOUNDARIES)
+def test_initialization_recovers_at_every_publication_boundary(
+    tmp_path: Path,
+    boundary: str,
+) -> None:
+    root = tmp_path / "run"
+
+    _assert_expected_crash(_crash_during_initialization, root, boundary)
+    recovered = create_world_run(root)
+
+    assert recovered.snapshot().sequence == 0
+    assert len(recovered.repository.commits()) == 1
+    assert recovered.steps() == ()
+
+
+@pytest.mark.parametrize("boundary", _TRANSITION_BOUNDARIES)
+@pytest.mark.parametrize(
+    ("proposal_type", "proposal_id"),
+    (
+        (RequestConditionalDeferral, "proposal-resource-effect"),
+        (TransferDuty, "proposal-physical-effect"),
+    ),
+)
+def test_transition_recovers_once_at_every_publication_boundary(
+    tmp_path: Path,
+    boundary: str,
+    proposal_type: type[PumpStationProposal],
+    proposal_id: str,
+) -> None:
+    root = tmp_path / "run"
+    run = create_world_run(root)
+    proposal, information_set = bind_proposal(
+        run,
+        proposal_type,
+        proposal_id,
+        **({"pump_id": "pump-a"} if proposal_type is RequestConditionalDeferral else {}),
+    )
+
+    _assert_expected_crash(
+        _crash_during_transition,
+        root,
+        boundary,
+        proposal,
+        information_set,
+    )
+    package = load_reference_package()
+    model = pump_station_model_from_package(package)
+    repository = PumpStationWorldRunRepository(root)
+    recovered = PumpStationWorldRun.resume(
+        repository=repository,
+        package=package,
+        model=model,
+        snapshot=repository.current_snapshot(),
+    )
+    first = recovered.apply(proposal, information_set=information_set)
+    repeated = recovered.apply(proposal, information_set=information_set)
+
+    assert repeated == first
+    assert recovered.state.sequence == 1
+    assert len(recovered.steps()) == 1
+    if proposal_type is RequestConditionalDeferral:
+        assert len(recovered.state.restrictions) == 1
+        assert len(recovered.state.obligations) == 1
+        assert len(recovered.state.work_orders) == 1
+    else:
+        assert recovered.state.physical.duty_pump_id == "pump-b"
+        assert recovered.state.physical.duty_transfer_count == 1

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_asw_3b_persistence.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_asw_3b_persistence.py
@@ -1,0 +1,304 @@
+# ABOUTME: Attacks durable pump-station reload with hostile versions and damaged files.
+# ABOUTME: Proves only the selected immutable chain can provide run and Harbor authority.
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station import (
+    PUMP_STATION_SERIALIZATION_VERSION,
+    PumpStationWorldRun,
+    PumpStationWorldRunError,
+    PumpStationWorldRunRepository,
+    RequestConditionalDeferral,
+    load_reference_package,
+    pump_station_artifact_bytes,
+    pump_station_model_from_package,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.harbor_export import (
+    export_pump_station_harbor_task,
+    load_pump_station_harbor_bridge,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.harbor_session import (
+    _artifact_inventory,
+    run_pump_station_reference_session,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.harbor_verifier import (
+    verify_pump_station_harbor_run,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_models import (
+    PumpStationCurrentRunPointer,
+)
+from tests.task_world_templates.stewardship.wastewater_pump_station.world_run_support import (
+    bind_proposal,
+    create_world_run,
+)
+
+_VERSION_ATTACKS = (
+    (
+        "manifest",
+        "serialization_version",
+        "pump-station-world-run.unknown",
+        "serialization-version",
+    ),
+    (
+        "manifest",
+        "snapshot_version",
+        "pump-station-state-snapshot.unknown",
+        "snapshot-version",
+    ),
+    (
+        "manifest",
+        "receipt_version",
+        "pump-station-transition-receipt.unknown",
+        "receipt-version",
+    ),
+    (
+        "manifest",
+        "authority_policy_version",
+        "pump-station-authority-policy.unknown",
+        "authority-policy-version",
+    ),
+    (
+        "manifest",
+        "transition_rule_version",
+        "pump-station-transition-rules.unknown",
+        "transition-rule-version",
+    ),
+    (
+        "current",
+        "serialization_version",
+        "pump-station-world-run.unknown",
+        "serialization-version",
+    ),
+    (
+        "commit",
+        "serialization_version",
+        "pump-station-world-run.unknown",
+        "serialization-version",
+    ),
+    (
+        "receipt",
+        "receipt_version",
+        "pump-station-transition-receipt.unknown",
+        "receipt-version",
+    ),
+    (
+        "receipt",
+        "authority_policy_version",
+        "pump-station-authority-policy.unknown",
+        "authority-policy-version",
+    ),
+    (
+        "receipt",
+        "transition_rule_version",
+        "pump-station-transition-rules.unknown",
+        "transition-rule-version",
+    ),
+)
+_TRUNCATED_ARTIFACTS = (
+    "manifest",
+    "current",
+    "state",
+    "proposal",
+    "information-set",
+    "receipt",
+    "event",
+    "commit",
+)
+
+
+def _run_with_transition(root: Path) -> PumpStationWorldRun:
+    run = create_world_run(root)
+    proposal, information_set = bind_proposal(
+        run,
+        RequestConditionalDeferral,
+        "proposal-persistence-attack",
+        pump_id="pump-a",
+    )
+    run.apply(proposal, information_set=information_set)
+    return run
+
+
+def _artifact_paths(run: PumpStationWorldRun) -> dict[str, Path]:
+    snapshot = run.snapshot()
+    commit = run.repository.load_commit(snapshot.commit_id)
+    assert commit.proposal_content_id is not None
+    assert commit.information_set_content_id is not None
+    assert commit.receipt_content_id is not None
+    assert commit.event_batch_content_id is not None
+    root = run.repository.root
+    return {
+        "manifest": root / "manifest.json",
+        "current": root / "current.json",
+        "state": root / "states" / f"{commit.state_id}.json",
+        "proposal": root / "proposals" / f"{commit.proposal_content_id}.json",
+        "information-set": (root / "information-sets" / f"{commit.information_set_content_id}.json"),
+        "receipt": root / "receipts" / f"{commit.receipt_content_id}.json",
+        "event": root / "events" / f"{commit.event_batch_content_id}.json",
+        "commit": root / "commits" / f"{snapshot.commit_id}.json",
+    }
+
+
+def _rewrite_json_field(path: Path, field: str, value: str) -> None:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    payload[field] = value
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _reload_action(
+    run: PumpStationWorldRun,
+    artifact: str,
+) -> Callable[[], object]:
+    if artifact in {"proposal", "information-set", "receipt", "event"}:
+        return run.repository.steps
+    return run.repository.current_snapshot
+
+
+@pytest.mark.parametrize(
+    ("artifact", "field", "hostile_value", "error_code"),
+    _VERSION_ATTACKS,
+)
+def test_repository_reload_rejects_every_unknown_durable_version(
+    tmp_path: Path,
+    artifact: str,
+    field: str,
+    hostile_value: str,
+    error_code: str,
+) -> None:
+    run = _run_with_transition(tmp_path / "run")
+    path = _artifact_paths(run)[artifact]
+    _rewrite_json_field(path, field, hostile_value)
+
+    with pytest.raises(PumpStationWorldRunError, match=error_code):
+        _reload_action(run, artifact)()
+
+
+@pytest.mark.parametrize("artifact", _TRUNCATED_ARTIFACTS)
+def test_repository_reload_never_accepts_silent_truncation(
+    tmp_path: Path,
+    artifact: str,
+) -> None:
+    run = _run_with_transition(tmp_path / "run")
+    path = _artifact_paths(run)[artifact]
+    payload = path.read_bytes()
+    path.write_bytes(payload[: len(payload) // 2])
+
+    with pytest.raises(PumpStationWorldRunError):
+        _reload_action(run, artifact)()
+
+
+def test_fresh_reload_ignores_forged_working_pointer_and_reconciles_once(
+    tmp_path: Path,
+) -> None:
+    run = create_world_run(tmp_path / "run")
+    proposal, information_set = bind_proposal(
+        run,
+        RequestConditionalDeferral,
+        "proposal-working-file",
+        pump_id="pump-a",
+    )
+    before = run.snapshot()
+    staged = run.stage(proposal, information_set=information_set)
+    working_pointer = PumpStationCurrentRunPointer(
+        serialization_version=PUMP_STATION_SERIALIZATION_VERSION,
+        run_id=staged.snapshot.run_id,
+        sequence=staged.snapshot.sequence,
+        state_id=staged.snapshot.state_id,
+        commit_id=staged.snapshot.commit_id,
+    )
+    working_path = run.repository.root / ".current.forged.tmp"
+    working_path.write_bytes(pump_station_artifact_bytes(working_pointer))
+    working_path.chmod(0o600)
+
+    repository = PumpStationWorldRunRepository(run.repository.root)
+    assert repository.current_snapshot() == before
+    assert len(repository.commits()) == 1
+    assert repository.steps() == ()
+
+    package = load_reference_package()
+    model = pump_station_model_from_package(package)
+    recovered = PumpStationWorldRun.resume(
+        repository=repository,
+        package=package,
+        model=model,
+        snapshot=before,
+    )
+    first = recovered.apply(proposal, information_set=information_set)
+    repeated = recovered.apply(proposal, information_set=information_set)
+
+    assert repeated == first
+    assert recovered.state.sequence == 1
+    assert len(recovered.steps()) == 1
+    assert len(recovered.state.restrictions) == 1
+    assert len(recovered.state.obligations) == 1
+    assert len(recovered.state.work_orders) == 1
+
+
+def test_initialization_retry_never_reopens_an_advanced_run(tmp_path: Path) -> None:
+    root = tmp_path / "run"
+    run = create_world_run(root)
+
+    assert create_world_run(root).snapshot() == run.snapshot()
+
+    proposal, information_set = bind_proposal(
+        run,
+        RequestConditionalDeferral,
+        "proposal-before-late-start",
+        pump_id="pump-a",
+    )
+    run.apply(proposal, information_set=information_set)
+
+    with pytest.raises(PumpStationWorldRunError, match="world-run-exists"):
+        create_world_run(root)
+
+
+def test_harbor_provenance_ignores_repository_working_files(tmp_path: Path) -> None:
+    task_dir = tmp_path / "tasks" / "stewardship" / "wastewater-pump-station"
+    exported = export_pump_station_harbor_task(
+        task_dir,
+        project_root=Path(__file__).resolve().parents[4],
+    )
+    bridge = load_pump_station_harbor_bridge(task_dir / "environment")
+    run_dir = tmp_path / "world-session"
+    run_pump_station_reference_session(
+        bridge=bridge,
+        output_dir=run_dir,
+        session_identity="working-file-provenance",
+    )
+    stored_inventory = json.loads((run_dir / "artifact-inventory.json").read_text(encoding="utf-8"))
+    world_run = run_dir / "world-run"
+    current_payload = (world_run / "current.json").read_bytes()
+    working_paths = (
+        world_run / ".current.response-lost.tmp",
+        world_run / "states" / ".state.response-lost.tmp",
+    )
+    for path in working_paths:
+        path.write_bytes(current_payload)
+        path.chmod(0o600)
+
+    regenerated = _artifact_inventory(
+        bridge=bridge,
+        output_dir=run_dir,
+        start_snapshot=stored_inventory["start_snapshot"],
+        end_snapshot=stored_inventory["end_snapshot"],
+    )
+    artifact_paths = {item["path"] for item in regenerated["artifacts"]}
+
+    assert not artifact_paths.intersection(path.relative_to(run_dir).as_posix() for path in working_paths)
+    assert (
+        verify_pump_station_harbor_run(
+            run_dir=run_dir,
+            export_manifest_path=exported.manifest_path,
+            package_dir=exported.package_dir,
+        )["valid"]
+        is True
+    )

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_asw_3b_versions.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_asw_3b_versions.py
@@ -1,0 +1,110 @@
+# ABOUTME: Defines the ASW-3B snapshot, serializer, rule, and receipt version contract.
+# ABOUTME: Proves every unsupported durable version fails before it can become authority.
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from aec_bench.contracts.world_session import (
+    STEWARDSHIP_STATE_SNAPSHOT_SCHEMA_VERSION,
+    StewardshipStateSnapshotRef,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station import (
+    PUMP_STATION_AUTHORITY_POLICY_VERSION,
+    PUMP_STATION_RECEIPT_VERSION,
+    PUMP_STATION_SERIALIZATION_VERSION,
+    PUMP_STATION_SNAPSHOT_VERSION,
+    PUMP_STATION_TRANSITION_RULE_VERSION,
+    PumpStationProposalError,
+    PumpStationWorldRunError,
+    RequestConditionalDeferral,
+    load_pump_station_artifact,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_models import (
+    PumpStationCurrentRunPointer,
+)
+from tests.task_world_templates.stewardship.wastewater_pump_station.world_run_support import (
+    bind_proposal,
+    create_world_run,
+)
+
+
+def test_snapshot_versions_are_explicit_and_fail_closed(tmp_path: Path) -> None:
+    run = create_world_run(tmp_path / "run")
+    snapshot = run.snapshot()
+
+    assert snapshot.snapshot_version == PUMP_STATION_SNAPSHOT_VERSION
+    with pytest.raises(PumpStationWorldRunError, match="snapshot-version"):
+        replace(snapshot, snapshot_version="pump-station-state-snapshot.unknown")
+
+    host_snapshot = StewardshipStateSnapshotRef(
+        schema_version=STEWARDSHIP_STATE_SNAPSHOT_SCHEMA_VERSION,
+        run_id=snapshot.run_id,
+        episode_id=snapshot.episode_id,
+        world_branch_id=snapshot.world_branch_id,
+        sequence=snapshot.sequence,
+        state_id=snapshot.state_id,
+        commit_id=snapshot.commit_id,
+    )
+    hostile_payload = host_snapshot.model_dump(mode="json")
+    hostile_payload["schema_version"] = "aecbench.stewardship-state-snapshot.unknown"
+
+    with pytest.raises(ValidationError, match="unsupported stewardship snapshot schema version"):
+        StewardshipStateSnapshotRef.model_validate(hostile_payload)
+
+
+def test_run_artifact_versions_are_explicit_and_fail_closed(tmp_path: Path) -> None:
+    run = create_world_run(tmp_path / "run")
+    manifest = run.manifest
+    initial_commit = run.repository.commits()[0]
+    current_pointer = load_pump_station_artifact(
+        (run.repository.root / "current.json").read_bytes(),
+        PumpStationCurrentRunPointer,
+    )
+
+    assert manifest.serialization_version == PUMP_STATION_SERIALIZATION_VERSION
+    assert manifest.snapshot_version == PUMP_STATION_SNAPSHOT_VERSION
+    assert manifest.receipt_version == PUMP_STATION_RECEIPT_VERSION
+    assert manifest.authority_policy_version == PUMP_STATION_AUTHORITY_POLICY_VERSION
+    assert manifest.transition_rule_version == PUMP_STATION_TRANSITION_RULE_VERSION
+
+    with pytest.raises(PumpStationWorldRunError, match="serialization-version"):
+        replace(manifest, serialization_version="pump-station-world-run.unknown")
+    with pytest.raises(PumpStationWorldRunError, match="snapshot-version"):
+        replace(manifest, snapshot_version="pump-station-state-snapshot.unknown")
+    with pytest.raises(PumpStationWorldRunError, match="receipt-version"):
+        replace(manifest, receipt_version="pump-station-transition-receipt.unknown")
+    with pytest.raises(PumpStationWorldRunError, match="authority-policy-version"):
+        replace(manifest, authority_policy_version="pump-station-authority-policy.unknown")
+    with pytest.raises(PumpStationWorldRunError, match="transition-rule-version"):
+        replace(manifest, transition_rule_version="pump-station-transition-rules.unknown")
+    with pytest.raises(PumpStationWorldRunError, match="serialization-version"):
+        replace(initial_commit, serialization_version="pump-station-world-run.unknown")
+    with pytest.raises(PumpStationWorldRunError, match="serialization-version"):
+        replace(current_pointer, serialization_version="pump-station-world-run.unknown")
+
+
+def test_transition_receipt_versions_are_explicit_and_fail_closed(tmp_path: Path) -> None:
+    run = create_world_run(tmp_path / "run")
+    proposal, information_set = bind_proposal(
+        run,
+        RequestConditionalDeferral,
+        "proposal-version-contract",
+        pump_id="pump-a",
+    )
+    receipt = run.apply(proposal, information_set=information_set).receipt
+
+    assert receipt.receipt_version == PUMP_STATION_RECEIPT_VERSION
+    assert receipt.authority_policy_version == PUMP_STATION_AUTHORITY_POLICY_VERSION
+    assert receipt.transition_rule_version == PUMP_STATION_TRANSITION_RULE_VERSION
+
+    with pytest.raises(PumpStationProposalError, match="receipt-version"):
+        replace(receipt, receipt_version="pump-station-transition-receipt.unknown")
+    with pytest.raises(PumpStationProposalError, match="authority-policy-version"):
+        replace(receipt, authority_policy_version="pump-station-authority-policy.unknown")
+    with pytest.raises(PumpStationProposalError, match="transition-rule-version"):
+        replace(receipt, transition_rule_version="pump-station-transition-rules.unknown")


### PR DESCRIPTION
## Summary

- Bind snapshots, run artifacts, transition receipts, authority policy, and transition rules to explicit versions.
- Reject unknown versions and truncated durable files during independent reload.
- Reconcile an identical START retry only while the selected run is still at its initial snapshot.
- Keep advanced runs behind RESUME and prevent a late START from reopening them.
- Exclude repository lock, current-pointer, and crash-residue files from Harbor provenance.
- Add focused process-death attacks before and after every immutable link and current-pointer replacement.

## Defects exposed by the red tests

1. Snapshot, receipt, policy, and rule versions were not bound to durable evidence.
2. A lost START response left a valid run that could not be retried.
3. The first retry fix also allowed START to reopen an advanced run.
4. Harbor included temporary repository files in its artifact inventory.

## Runtime contract

- An exact initialization retry can reconcile the same manifest and initial state.
- The retry succeeds only when the selected state is still the initial state.
- A different identity, different initial state, unknown version, or advanced run fails closed.
- Temporary files never select world state and cannot enter Harbor provenance.
- No snapshot migration or compatibility layer is added.

## Focused verification

- `60 passed` — ASW-3B version, persistence, provenance, and crash-boundary tests.
- `28 passed` — shared snapshot, durable repository, direct session, CLI, ASW-3A, and evaluation regressions.
- `10 passed` — Harbor execution, verification, TrialRecord import, and strict reload regressions.
- `ruff format --check` passed for the changed surface.
- `ruff check` passed for the changed surface.
- Strict `mypy` passed for 25 source files.

The full project test suite was not run.
