### PR TITLE
ASW-4A: freeze provider-free continuity study

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,8 @@ research/asset-stewardship/*
 !research/asset-stewardship/asw-0c-research-charter/
 !research/asset-stewardship/asw-0c-research-charter/**
 !research/asset-stewardship/asw-3c-architecture-and-promotion-review.md
+!research/asset-stewardship/asw-4a-study-freeze/
+!research/asset-stewardship/asw-4a-study-freeze/**
 !research/asset-stewardship/au-nsw-lh-syn-sps-v1-parameter-family-and-mechanism-rulings.md
 !research/asset-stewardship/au-nsw-lh-syn-sps-v1-generator-protocol.md
 !research/asset-stewardship/au-nsw-lh-syn-sps-v1-independent-certification-protocol.md

--- a/research/asset-stewardship/asw-4a-study-freeze/ara/PAPER.md
+++ b/research/asset-stewardship/asw-4a-study-freeze/ara/PAPER.md
@@ -1,0 +1,88 @@
+---
+ara_schema_version: "0.1"
+title: ASW-4A provider-free stewardship continuity study freeze
+---
+
+# Research continuation summary
+
+ASW-4A freezes the first stewardship continuity study before a model is used.
+It implements a study-local manifest, a complete paired plan, typed treatment
+delivery, a failure taxonomy, a paired reducer, immutable evidence, and
+independent report reload.
+
+The research question stays unchanged:
+
+> Under matched continuing pump-station histories, does a structured handover
+> reduce required-follow-up continuity failure when compared with a complete
+> current station view?
+
+## Frozen study design
+
+| Item | Frozen value |
+| --- | --- |
+| Research authority | `ASW-0C-3` |
+| Station profile | `AU-NSW-LH-SYN-SPS-v1` |
+| Treatments | Complete current station view; structured handover |
+| History classes | 16 H1 stable-inspected blocks; 16 H2 worsening-verification blocks |
+| Plan | 32 paired blocks; 64 planned trajectories |
+| Hidden windows | `3D` and `4D`, with `D = 28,800` simulated seconds |
+| Per-trajectory limits | 16 model turns; 12 proposals; 32 host commands; one fresh handover |
+| Search | No temporal retrieval and no external historical search |
+| Hidden information | Evaluation-window position and future events |
+| Endpoint | Binary required-follow-up continuity failure |
+| Difference | Structured handover minus current station view |
+| Meaningful effect | Absolute paired risk reduction of `0.25` |
+| Uncertainty | 20,000 paired block-bootstrap resamples; seed `20260729`; 95% interval |
+| Coverage gate | At least 28 eligible pairs; host-fault arm imbalance no more than 2 |
+
+The plan counterbalances treatment order. Each pair binds the same current
+station state, current duties, world history, event schedule, model condition,
+logical limits, and hidden evaluation window.
+
+## Provider-free proof
+
+Generated analysis fixtures pass through the real study contracts, immutable
+artifact store, reducer, report writer, and independent reload path. They make
+zero provider calls, use zero tokens and spend, create zero study outcomes, and
+change no task reward.
+
+The generated fixture has a paired risk difference of `-0.5` and a 95% interval
+of `[-0.65625, -0.34375]`. This proves that the frozen decision rule can detect
+its known input. It is not evidence about model performance. The authoritative
+fixture conclusion is `analysis_fixture`, not `supported`.
+
+The fixture identities are:
+
+- manifest: `91de00556cfa451bd8a9da595d4cc25e2f30ddfe7c60e65e23c85e35332bd02a`;
+- plan: `9c541a784ee5586d3b0875fae8a78da1ae6445aaccde4b8487cb1f61b9dfe286`; and
+- report: `91084bb1a9c585b150cc3c30bd82f2dbfcef1bd8d05b971e152e1b703a807667`.
+
+Repeated publication keeps the same identities. Independent reload rejects
+changed report bytes and recomputes the report from the exact manifest, plan,
+treatment-delivery records, and observations.
+
+Report authority is phase-bound. Analysis fixtures can report only
+`analysis_fixture`. A shakedown can report only `shakedown`, even when its
+diagnostic values cross the confirmatory threshold. Only a confirmatory
+generation can report `supported`, `refuted`, `inconclusive`, or
+`coverage_blocked`.
+
+## Boundary
+
+The continuity study remains under
+`aec_bench.experiments.stewardship_continuity`. It does not change the physical
+world, operating rules, host session, Harbor path, evaluation reward, or shared
+contracts. It does not extract the ASW-3C publication candidate.
+
+Provider identity, model identity, token limits, and approved spend remain open
+under `OD-14`. ASW-4B cannot start until Theo gives separate approval for those
+values. The approval is phase-specific and content-bound to the model condition.
+ASW-4B evidence cannot enter the confirmatory result.
+
+Artifact layers:
+
+- `logic/claims.yaml` records the supported and provisional claims.
+- `logic/experiments.yaml` records the provider-free checks.
+- `evidence/index.yaml` points to the design and verification records.
+- `trace/exploration_tree.yaml` records the freeze and the approval stop.
+- `staging/observations.yaml` retains the open provider decision.

--- a/research/asset-stewardship/asw-4a-study-freeze/ara/evidence/asw-4a-verification.md
+++ b/research/asset-stewardship/asw-4a-study-freeze/ara/evidence/asw-4a-verification.md
@@ -1,0 +1,58 @@
+# ASW-4A verification evidence
+
+## Implemented path
+
+- Versioned, content-addressed study manifest and plan.
+- Typed paired blocks, trials, treatment-delivery records, observations, and report.
+- Fixed failure and ineligibility taxonomy.
+- Exact-coverage and identity checks.
+- Deterministic paired block-bootstrap reducer.
+- Generated provider-free fixtures.
+- Real immutable artifact publication.
+- Independent artifact reload and report recomputation.
+- Retry identity check and changed-report rejection.
+- Static provider-import boundary check.
+- Phase-bound report conclusions and evidence sources.
+- Provider-call limit, study-outcome, and task-reward authority checks.
+- Planned history, event-schedule, logical-limit, and model-condition binding.
+- Phase-specific provider, model, adapter, token, currency, and spend authority.
+- Canonical evidence order derived from the frozen trial plan.
+
+## Provider-free fixture result
+
+| Item | Value |
+| --- | --- |
+| Manifest identity | `91de00556cfa451bd8a9da595d4cc25e2f30ddfe7c60e65e23c85e35332bd02a` |
+| Plan identity | `9c541a784ee5586d3b0875fae8a78da1ae6445aaccde4b8487cb1f61b9dfe286` |
+| Report identity | `91084bb1a9c585b150cc3c30bd82f2dbfcef1bd8d05b971e152e1b703a807667` |
+| Planned trajectories | 64 |
+| Analyzable paired blocks | 32 |
+| Paired risk difference | `-0.5` |
+| 95% fixture interval | `[-0.65625, -0.34375]` |
+| Report conclusion | `analysis_fixture` |
+| Diagnostic rule result | `supported` |
+| Provider calls | 0 |
+| Input tokens | 0 |
+| Output tokens | 0 |
+| Spend | 0 |
+| Study outcomes | 0 |
+| Task reward changes | 0 |
+
+The diagnostic rule result proves the reducer against known generated input. It
+is not a conclusion about a model or a continuity treatment.
+
+## Focused gates
+
+- Study contracts, paired reducer, and source ownership: 21 passed.
+- Immutable artifact publication, retry, reload, and tamper rejection: 9 passed.
+- Provider-free end-to-end path, approved station-data reader, and stewardship
+  evaluation seams: 15 passed.
+- Total focused tests: 45 passed.
+- Ara-lite reference validation: pass.
+- Ruff lint over the 11 changed Python files: pass.
+- Ruff format check over the 11 changed Python files: pass.
+- Mypy over the 11 changed Python files: no issues.
+
+The focused test groups were selected from the changed study package and the
+three production seams that it reads. The repository-wide test suite was not
+run.

--- a/research/asset-stewardship/asw-4a-study-freeze/ara/evidence/frozen-study-design.md
+++ b/research/asset-stewardship/asw-4a-study-freeze/ara/evidence/frozen-study-design.md
@@ -1,0 +1,59 @@
+# Frozen study design evidence
+
+## Authority
+
+- Research charter: `ASW-0C-3`.
+- Station profile: `AU-NSW-LH-SYN-SPS-v1`.
+- Study stage: `ASW-4A`.
+- Execution class: generated analysis fixture.
+
+## Fixed plan
+
+- 32 paired blocks and 64 planned trajectories.
+- 16 H1 stable-inspected blocks.
+- 16 H2 worsening-verification blocks.
+- Complete current station view and structured handover in each pair.
+- Hidden windows of 86,400 and 115,200 simulated seconds.
+- Counterbalanced treatment order.
+- Each block binds its planned history and event-schedule identities.
+
+## Fixed per-trajectory limits
+
+- 16 model turns.
+- 12 agent proposals.
+- 32 host commands.
+- One fresh handover.
+- No temporal retrieval.
+- No external historical search.
+- No visible evaluation-window position.
+- No visible future event schedule.
+
+## Fixed analysis
+
+- Binary required-follow-up continuity failure.
+- Paired difference: structured handover minus current station view.
+- Minimum meaningful absolute effect: `0.25`.
+- 20,000 paired block-bootstrap resamples.
+- Deterministic seed: `20260729`.
+- Two-sided 95% interval.
+- At least 28 eligible pairs.
+- Maximum host-fault arm imbalance: 2.
+- Missing pairs are not replaced.
+
+## Model-phase authority slots
+
+The versioned manifest requires one phase-specific approval before model
+execution. The approval records:
+
+- provider, model, and adapter identity;
+- maximum provider calls;
+- maximum input and output tokens per call;
+- maximum total tokens;
+- spend currency; and
+- maximum spend in currency microunits.
+
+ASW-4A leaves this approval empty and therefore authorizes zero provider calls.
+
+These values come from sections 10 to 12 of
+`research/asset-stewardship/asw-0c-research-charter.md`. ASW-4A binds them in
+strict, content-addressed study-local contracts.

--- a/research/asset-stewardship/asw-4a-study-freeze/ara/evidence/index.yaml
+++ b/research/asset-stewardship/asw-4a-study-freeze/ara/evidence/index.yaml
@@ -1,0 +1,31 @@
+evidence:
+  - id: EV001
+    kind: note
+    path: evidence/frozen-study-design.md
+    description: Exact ASW-4A design values and their accepted research authority.
+    source: research/asset-stewardship/asw-0c-research-charter.md
+    supports: [C001]
+    produced_by: null
+    exact_values_required: true
+    domain:
+      profile: AU-NSW-LH-SYN-SPS-v1
+  - id: EV002
+    kind: command_output
+    path: evidence/asw-4a-verification.md
+    description: Focused contract, analysis, identity, token, spend, immutable-publication, reload, tamper, provider-boundary, lint, format, and type results.
+    source: feat/wastewater-pump-station-asw-4a on 2026-07-31
+    supports: [C001, C002]
+    produced_by: E001
+    exact_values_required: true
+    domain:
+      profile: AU-NSW-LH-SYN-SPS-v1
+  - id: EV003
+    kind: note
+    path: evidence/provider-approval-boundary.md
+    description: Open provider, model, token, and spend authority that blocks ASW-4B execution.
+    source: research/asset-stewardship/asset-stewardship-worlds-prd.md OD-14
+    supports: [C003]
+    produced_by: null
+    exact_values_required: true
+    domain:
+      implementation_stage: ASW-4B

--- a/research/asset-stewardship/asw-4a-study-freeze/ara/evidence/provider-approval-boundary.md
+++ b/research/asset-stewardship/asw-4a-study-freeze/ara/evidence/provider-approval-boundary.md
@@ -1,0 +1,23 @@
+# Provider approval boundary
+
+Open decision `OD-14` requires approval of:
+
+- provider identity;
+- model identity;
+- adapter identity;
+- provider-call and token limits;
+- spend currency; and
+- maximum spend.
+
+The approval is valid for one named phase and one content-addressed model
+condition. A shakedown approval cannot authorize a confirmatory generation.
+
+ASW-4A gives no authority for a provider call. Its manifest allows zero
+provider calls, zero tokens, zero spend, and zero study outcomes.
+
+ASW-4B is one small shakedown only. It tests provider identity, tool delivery,
+cost, cleanup, and end-to-end evidence. Its observations cannot enter the
+confirmatory result.
+
+ASW-4C can start only after any approved shakedown repair is complete and a new
+confirmatory generation is frozen.

--- a/research/asset-stewardship/asw-4a-study-freeze/ara/logic/claims.yaml
+++ b/research/asset-stewardship/asw-4a-study-freeze/ara/logic/claims.yaml
@@ -1,0 +1,54 @@
+claims:
+  - id: C001
+    statement: The first stewardship continuity study has one complete provider-independent plan with fixed conditions, limits, endpoint, estimand, uncertainty method, and coverage gates.
+    status: supported
+    falsification_criteria:
+      - The study plan does not contain exactly 32 paired blocks and 64 planned trajectories.
+      - A paired arm differs in current state, current duties, history, event schedule, model condition, logical limits, or evaluation window.
+      - Treatment order, endpoint, conclusion rule, or attrition rule can change without a new manifest identity.
+      - A planned observation can use a different history, event schedule, model condition, or logical limit without becoming ineligible.
+    proof:
+      experiments: [E001]
+      evidence: [EV001, EV002]
+    dependencies: []
+    provenance: ai_executed
+    tags: [study-design, pairing, preregistration]
+    domain:
+      profile: AU-NSW-LH-SYN-SPS-v1
+      implementation_stage: ASW-4A
+  - id: C002
+    statement: Provider-free generated fixtures can exercise immutable publication, paired analysis, recovery, and independent reload without producing a model result or changing task reward.
+    status: supported
+    falsification_criteria:
+      - Fixture generation makes a provider call.
+      - A fixture observation is eligible as a shakedown or confirmatory outcome.
+      - The fixture path changes a task reward.
+      - Repeated publication changes an artifact identity.
+      - A changed report reloads successfully or a stored conclusion is trusted without recomputation.
+      - A shakedown report can make a confirmatory conclusion.
+      - Provider evidence can exceed its approved call, token, currency, or spend limit.
+      - Reordering the same retained evidence changes the report identity.
+    proof:
+      experiments: [E002]
+      evidence: [EV002]
+    dependencies: [C001]
+    provenance: ai_executed
+    tags: [provider-free, immutable-evidence, analysis]
+    domain:
+      profile: AU-NSW-LH-SYN-SPS-v1
+      implementation_stage: ASW-4A
+  - id: C003
+    statement: A model shakedown needs separate phase-specific approval of provider, model, adapter, call, token, currency, and spend limits before any provider call.
+    status: provisional
+    falsification_criteria:
+      - A provider call starts without a recorded approval that contains all required values.
+      - A shakedown approval is reused for a confirmatory generation.
+      - A shakedown result enters the confirmatory estimand.
+    proof:
+      experiments: []
+      evidence: [EV003]
+    dependencies: [C001, C002]
+    provenance: user
+    tags: [approval, provider, spend]
+    domain:
+      implementation_stage: ASW-4B

--- a/research/asset-stewardship/asw-4a-study-freeze/ara/logic/experiments.yaml
+++ b/research/asset-stewardship/asw-4a-study-freeze/ara/logic/experiments.yaml
@@ -1,0 +1,47 @@
+experiments:
+  - id: E001
+    verifies: [C001]
+    purpose: Prove that the provider-independent manifest expands into the exact frozen paired plan and rejects design drift.
+    setup: Use the promoted wastewater pump-station profile and the study-local ASW-4A contracts without provider credentials.
+    procedure:
+      - Build the analysis-fixture manifest from the accepted package and rule identities.
+      - Expand the manifest into all history, window, and treatment-order combinations.
+      - Validate exact counts, counterbalancing, paired identity, hidden windows, logical limits, and content identities.
+      - Bind each planned block to its history and event-schedule identities.
+      - Try invalid phase authority, changed limits, incomplete coverage, duplicate evidence, and identity drift.
+    metrics:
+      - The plan contains 32 paired blocks and 64 trials.
+      - Each history class has 16 blocks and each hidden window is balanced within its class.
+      - Treatment order is balanced within each history and window cell.
+      - Invalid or mixed-identity evidence fails closed.
+      - A model phase requires provider, model, adapter, call, token, currency, and spend approval for that phase.
+    evidence: [EV001, EV002]
+    exploratory: false
+    domain:
+      profile: AU-NSW-LH-SYN-SPS-v1
+      phase: analysis_fixture
+  - id: E002
+    verifies: [C002]
+    purpose: Prove the complete provider-free analysis, publication, reload, retry, and tamper-rejection path.
+    setup: Use generated observations with known paired differences and the real host-private immutable artifact repository.
+    procedure:
+      - Generate 64 analysis-only observations with zero provider calls, tokens, spend, and reward changes.
+      - Publish the manifest, plan, treatment-delivery records, observations, and report by content identity.
+      - Publish the same bundle again and compare every artifact identity.
+      - Independently reload all evidence and recompute the report.
+      - Change the stored report bytes and confirm that reload rejects them.
+    metrics:
+      - The report has exact coverage and 32 analyzable pairs.
+      - The known fixture risk difference is -0.5.
+      - The known fixture interval is [-0.65625, -0.34375].
+      - Provider calls, tokens, spend, study outcomes, and reward changes are all zero.
+      - The report conclusion remains analysis_fixture.
+      - A shakedown can report only shakedown and cannot contain study outcomes.
+      - Provider-call, token, currency, and spend overruns fail closed.
+      - Evidence input order does not change the report identity.
+      - Retry is identity-stable and changed evidence fails closed.
+    evidence: [EV002]
+    exploratory: false
+    domain:
+      profile: AU-NSW-LH-SYN-SPS-v1
+      phase: analysis_fixture

--- a/research/asset-stewardship/asw-4a-study-freeze/ara/staging/observations.yaml
+++ b/research/asset-stewardship/asw-4a-study-freeze/ara/staging/observations.yaml
@@ -1,0 +1,15 @@
+observations:
+  - id: O001
+    summary: ASW-4B needs a separate provider authority record before one real model shakedown.
+    status: open
+    source: OD-14
+    implications:
+      - Record provider identity.
+      - Record model identity.
+      - Record adapter identity.
+      - Record provider-call and token limits.
+      - Record spend currency.
+      - Record maximum approved spend.
+      - Keep all shakedown observations outside the confirmatory estimand.
+    domain:
+      implementation_stage: ASW-4B

--- a/research/asset-stewardship/asw-4a-study-freeze/ara/trace/exploration_tree.yaml
+++ b/research/asset-stewardship/asw-4a-study-freeze/ara/trace/exploration_tree.yaml
@@ -1,0 +1,65 @@
+nodes:
+  - id: N001
+    type: question
+    summary: Can the first continuity study be frozen and tested before any model call?
+    children: [N002]
+    also_depends_on: []
+    claims_touched: [C001, C002]
+    provenance: user
+    payload: {}
+    domain:
+      implementation_stage: ASW-4A
+  - id: N002
+    type: decision
+    summary: Keep all continuity-study contracts and analysis under the study-local experiment package.
+    children: [N003]
+    also_depends_on: []
+    claims_touched: [C001]
+    provenance: user_revised
+    payload:
+      shared_extraction: false
+      result: accepted
+    domain:
+      implementation_stage: ASW-4A
+  - id: N003
+    type: experiment
+    summary: Expand and reject drift from the fixed 32-pair provider-independent plan.
+    children: [N004]
+    also_depends_on: [N002]
+    claims_touched: [C001]
+    provenance: ai_executed
+    payload:
+      experiment_id: E001
+      result: passed
+    domain:
+      profile: AU-NSW-LH-SYN-SPS-v1
+  - id: N004
+    type: experiment
+    summary: Publish, retry, reload, recompute, and tamper-test generated analysis fixtures through the real immutable store.
+    children: [N005]
+    also_depends_on: [N003]
+    claims_touched: [C002]
+    provenance: ai_executed
+    payload:
+      experiment_id: E002
+      result: passed
+      provider_calls: 0
+      input_tokens: 0
+      output_tokens: 0
+      spend_microunits: 0
+      study_outcomes: 0
+      reward_changes: 0
+    domain:
+      profile: AU-NSW-LH-SYN-SPS-v1
+  - id: N005
+    type: decision
+    summary: Stop before ASW-4B until Theo separately approves provider, model, token, and spend limits.
+    children: []
+    also_depends_on: [N004]
+    claims_touched: [C003]
+    provenance: user
+    payload:
+      decision_id: OD-14
+      status: open
+    domain:
+      implementation_stage: ASW-4B

--- a/src/aec_bench/experiments/stewardship_continuity/__init__.py
+++ b/src/aec_bench/experiments/stewardship_continuity/__init__.py
@@ -1,0 +1,84 @@
+# ABOUTME: Exposes the versioned first-study continuity design and analysis boundary.
+# ABOUTME: Keeps all study schemas local to the stewardship experiment package.
+
+from aec_bench.experiments.stewardship_continuity.analysis import (
+    analyse_continuity_study,
+)
+from aec_bench.experiments.stewardship_continuity.artifacts import (
+    PublishedContinuityStudy,
+    publish_provider_free_fixture_study,
+    reload_and_verify_study_report,
+)
+from aec_bench.experiments.stewardship_continuity.contracts import (
+    BlockCoverage,
+    ConfidenceInterval,
+    ContinuityAnalysisSpecification,
+    ContinuityBlock,
+    ContinuityConclusion,
+    ContinuityCoverageReport,
+    ContinuityExecutionKind,
+    ContinuityFailureKind,
+    ContinuityHistoryClass,
+    ContinuityLogicalBudget,
+    ContinuityModelCondition,
+    ContinuityObservation,
+    ContinuityProviderAuthorization,
+    ContinuityStudyManifest,
+    ContinuityStudyPhase,
+    ContinuityStudyPlan,
+    ContinuityStudyReport,
+    ContinuityTreatment,
+    ContinuityTrial,
+    EvaluationWindow,
+    ObservationSource,
+    PairIneligibilityReason,
+    ProviderFreeFixtureEvidence,
+    TreatmentDeliveryRecord,
+    TreatmentDeliveryStatus,
+)
+from aec_bench.experiments.stewardship_continuity.fixtures import (
+    build_provider_free_fixture_evidence,
+)
+from aec_bench.experiments.stewardship_continuity.planning import (
+    ASW4A_STUDY_GENERATION_ID,
+    CONTINUITY_STUDY_ID,
+    build_continuity_plan,
+    build_provider_free_manifest,
+)
+
+__all__ = (
+    "ASW4A_STUDY_GENERATION_ID",
+    "CONTINUITY_STUDY_ID",
+    "BlockCoverage",
+    "ConfidenceInterval",
+    "ContinuityAnalysisSpecification",
+    "ContinuityBlock",
+    "ContinuityConclusion",
+    "ContinuityCoverageReport",
+    "ContinuityExecutionKind",
+    "ContinuityFailureKind",
+    "ContinuityHistoryClass",
+    "ContinuityLogicalBudget",
+    "ContinuityModelCondition",
+    "ContinuityObservation",
+    "ContinuityProviderAuthorization",
+    "ContinuityStudyManifest",
+    "ContinuityStudyPhase",
+    "ContinuityStudyPlan",
+    "ContinuityStudyReport",
+    "ContinuityTreatment",
+    "ContinuityTrial",
+    "EvaluationWindow",
+    "ObservationSource",
+    "PairIneligibilityReason",
+    "ProviderFreeFixtureEvidence",
+    "PublishedContinuityStudy",
+    "TreatmentDeliveryRecord",
+    "TreatmentDeliveryStatus",
+    "analyse_continuity_study",
+    "build_continuity_plan",
+    "build_provider_free_fixture_evidence",
+    "build_provider_free_manifest",
+    "publish_provider_free_fixture_study",
+    "reload_and_verify_study_report",
+)

--- a/src/aec_bench/experiments/stewardship_continuity/analysis.py
+++ b/src/aec_bench/experiments/stewardship_continuity/analysis.py
@@ -1,0 +1,410 @@
+# ABOUTME: Reduces matched continuity evidence with exact coverage and paired uncertainty.
+# ABOUTME: Prevents provider-free fixtures from becoming study conclusions.
+
+from __future__ import annotations
+
+import random
+from collections import Counter
+from collections.abc import Iterable
+from statistics import fmean
+from typing import Literal
+
+from aec_bench.experiments.stewardship_continuity.contracts import (
+    BlockCoverage,
+    ConfidenceInterval,
+    ContinuityBlock,
+    ContinuityConclusion,
+    ContinuityCoverageReport,
+    ContinuityObservation,
+    ContinuityStudyManifest,
+    ContinuityStudyPhase,
+    ContinuityStudyPlan,
+    ContinuityStudyReport,
+    ContinuityTreatment,
+    ObservationSource,
+    PairIneligibilityReason,
+    TreatmentDeliveryRecord,
+    TreatmentDeliveryStatus,
+)
+
+
+def analyse_continuity_study(
+    *,
+    manifest: ContinuityStudyManifest,
+    plan: ContinuityStudyPlan,
+    deliveries: tuple[TreatmentDeliveryRecord, ...],
+    observations: tuple[ContinuityObservation, ...],
+) -> ContinuityStudyReport:
+    """Recompute one paired report from exact retained evidence."""
+
+    selected_manifest = ContinuityStudyManifest.model_validate(
+        manifest.model_dump(mode="json"),
+    )
+    selected_plan = ContinuityStudyPlan.model_validate(
+        plan.model_dump(mode="json"),
+    )
+    if selected_plan.manifest_content_sha256 != selected_manifest.content_sha256:
+        raise ValueError("continuity plan does not belong to the supplied manifest")
+
+    planned_ids = tuple(trial.trial_id for trial in selected_plan.trials)
+    planned_id_set = set(planned_ids)
+    delivery_by_trial = _unique_delivery_map(deliveries)
+    observation_by_trial = _unique_observation_map(observations)
+    _reject_unplanned(
+        label="delivery",
+        observed_ids=set(delivery_by_trial),
+        planned_ids=planned_id_set,
+    )
+    _reject_unplanned(
+        label="observation",
+        observed_ids=set(observation_by_trial),
+        planned_ids=planned_id_set,
+    )
+    ordered_deliveries = tuple(delivery_by_trial[trial_id] for trial_id in planned_ids if trial_id in delivery_by_trial)
+    ordered_observations = tuple(
+        observation_by_trial[trial_id] for trial_id in planned_ids if trial_id in observation_by_trial
+    )
+    _validate_phase_evidence(
+        selected_manifest,
+        deliveries=ordered_deliveries,
+        observations=ordered_observations,
+    )
+
+    host_fault_counts: Counter[ContinuityTreatment] = Counter()
+    for observation in ordered_observations:
+        if observation.is_host_fault:
+            host_fault_counts[observation.treatment] += 1
+
+    block_coverage: list[BlockCoverage] = []
+    paired_differences: list[int] = []
+    complete_block_count = 0
+    for block in selected_plan.blocks:
+        block_observations = tuple(
+            observation_by_trial[trial.trial_id] for trial in block.trials if trial.trial_id in observation_by_trial
+        )
+        if len(block_observations) == 2:
+            complete_block_count += 1
+        reason = _block_ineligibility(
+            manifest=selected_manifest,
+            plan=selected_plan,
+            block=block,
+            delivery_by_trial=delivery_by_trial,
+            observation_by_trial=observation_by_trial,
+        )
+        observed_trial_ids = tuple(trial.trial_id for trial in block.trials if trial.trial_id in observation_by_trial)
+        if reason is not None:
+            block_coverage.append(
+                BlockCoverage(
+                    block_id=block.block_id,
+                    observed_trial_ids=observed_trial_ids,
+                    analyzable=False,
+                    ineligibility_reason=reason,
+                    paired_difference=None,
+                )
+            )
+            continue
+
+        by_treatment = {observation.treatment: observation for observation in block_observations}
+        current_failure = by_treatment[ContinuityTreatment.CURRENT_ACTOR_VIEW].continuity_failure
+        structured_failure = by_treatment[ContinuityTreatment.STRUCTURED_HANDOVER].continuity_failure
+        if current_failure is None or structured_failure is None:
+            raise ValueError("analyzable continuity pair lacks a binary endpoint")
+        difference: Literal[-1, 0, 1]
+        if structured_failure == current_failure:
+            difference = 0
+        elif structured_failure:
+            difference = 1
+        else:
+            difference = -1
+        paired_differences.append(difference)
+        block_coverage.append(
+            BlockCoverage(
+                block_id=block.block_id,
+                observed_trial_ids=observed_trial_ids,
+                analyzable=True,
+                ineligibility_reason=None,
+                paired_difference=difference,
+            )
+        )
+
+    missing_trial_ids = tuple(trial_id for trial_id in planned_ids if trial_id not in observation_by_trial)
+    observed_trial_count = len(observation_by_trial)
+    host_fault_count_by_treatment = {treatment: host_fault_counts[treatment] for treatment in ContinuityTreatment}
+    host_fault_arm_imbalance = abs(
+        host_fault_count_by_treatment[ContinuityTreatment.CURRENT_ACTOR_VIEW]
+        - host_fault_count_by_treatment[ContinuityTreatment.STRUCTURED_HANDOVER]
+    )
+    coverage = ContinuityCoverageReport(
+        exact=not missing_trial_ids and observed_trial_count == len(planned_ids),
+        planned_trial_count=len(planned_ids),
+        observed_trial_count=observed_trial_count,
+        missing_trial_ids=missing_trial_ids,
+        complete_block_count=complete_block_count,
+        analyzable_block_count=len(paired_differences),
+        host_fault_count_by_treatment=host_fault_count_by_treatment,
+        host_fault_arm_imbalance=host_fault_arm_imbalance,
+        blocks=tuple(block_coverage),
+    )
+    point_estimate = fmean(paired_differences) if paired_differences else None
+    confidence_interval = _paired_bootstrap_interval(
+        paired_differences,
+        replicates=selected_manifest.analysis.bootstrap_replicates,
+        seed=selected_manifest.analysis.bootstrap_seed,
+    )
+    rule_result = _classify(
+        manifest=selected_manifest,
+        coverage=coverage,
+        point_estimate=point_estimate,
+        confidence_interval=confidence_interval,
+    )
+    if selected_manifest.phase is ContinuityStudyPhase.ANALYSIS_FIXTURE:
+        conclusion = ContinuityConclusion.ANALYSIS_FIXTURE
+        fixture_rule_result: ContinuityConclusion | None = rule_result
+    elif selected_manifest.phase is ContinuityStudyPhase.SHAKEDOWN:
+        conclusion = ContinuityConclusion.SHAKEDOWN
+        fixture_rule_result = None
+    else:
+        conclusion = rule_result
+        fixture_rule_result = None
+
+    return ContinuityStudyReport(
+        manifest_content_sha256=selected_manifest.content_sha256,
+        plan_content_sha256=selected_plan.content_sha256,
+        phase=selected_manifest.phase,
+        conclusion=conclusion,
+        fixture_rule_result=fixture_rule_result,
+        coverage=coverage,
+        point_estimate=point_estimate,
+        confidence_interval=confidence_interval,
+        bootstrap_replicates=selected_manifest.analysis.bootstrap_replicates,
+        bootstrap_seed=selected_manifest.analysis.bootstrap_seed,
+        provider_call_count=sum(observation.provider_call_count for observation in ordered_observations),
+        input_token_count=sum(observation.input_token_count for observation in ordered_observations),
+        output_token_count=sum(observation.output_token_count for observation in ordered_observations),
+        maximum_input_tokens_in_one_call=max(
+            (observation.maximum_input_tokens_in_one_call for observation in ordered_observations),
+            default=0,
+        ),
+        maximum_output_tokens_in_one_call=max(
+            (observation.maximum_output_tokens_in_one_call for observation in ordered_observations),
+            default=0,
+        ),
+        spend_currency=(
+            selected_manifest.provider_authorization.spend_currency
+            if selected_manifest.provider_authorization is not None
+            else None
+        ),
+        spend_microunits=sum(observation.spend_microunits for observation in ordered_observations),
+        study_outcome_count=sum(observation.study_outcome_eligible for observation in ordered_observations),
+        fixture_observation_count=sum(
+            observation.source is ObservationSource.GENERATED_ANALYSIS_FIXTURE for observation in ordered_observations
+        ),
+        task_reward_mutation_count=sum(observation.task_reward_mutation_count for observation in ordered_observations),
+        delivery_content_sha256=tuple(delivery.content_sha256 for delivery in ordered_deliveries),
+        observation_content_sha256=tuple(observation.content_sha256 for observation in ordered_observations),
+    )
+
+
+def _unique_delivery_map(
+    deliveries: tuple[TreatmentDeliveryRecord, ...],
+) -> dict[str, TreatmentDeliveryRecord]:
+    selected: dict[str, TreatmentDeliveryRecord] = {}
+    for delivery in deliveries:
+        if delivery.trial_id in selected:
+            raise ValueError(f"duplicate delivery for trial: {delivery.trial_id}")
+        selected[delivery.trial_id] = delivery
+    return selected
+
+
+def _unique_observation_map(
+    observations: tuple[ContinuityObservation, ...],
+) -> dict[str, ContinuityObservation]:
+    selected: dict[str, ContinuityObservation] = {}
+    for observation in observations:
+        if observation.trial_id in selected:
+            raise ValueError(
+                f"duplicate observation for trial: {observation.trial_id}",
+            )
+        selected[observation.trial_id] = observation
+    return selected
+
+
+def _reject_unplanned(
+    *,
+    label: str,
+    observed_ids: set[str],
+    planned_ids: set[str],
+) -> None:
+    unexpected = tuple(sorted(observed_ids - planned_ids))
+    if unexpected:
+        raise ValueError(
+            f"unplanned {label}: {', '.join(unexpected)}",
+        )
+
+
+def _validate_phase_evidence(
+    manifest: ContinuityStudyManifest,
+    *,
+    deliveries: tuple[TreatmentDeliveryRecord, ...],
+    observations: tuple[ContinuityObservation, ...],
+) -> None:
+    expected_source = {
+        ContinuityStudyPhase.ANALYSIS_FIXTURE: ObservationSource.GENERATED_ANALYSIS_FIXTURE,
+        ContinuityStudyPhase.SHAKEDOWN: ObservationSource.SHAKEDOWN,
+        ContinuityStudyPhase.CONFIRMATORY: ObservationSource.CONFIRMATORY,
+    }[manifest.phase]
+    if any(delivery.source is not expected_source for delivery in deliveries):
+        raise ValueError(f"{manifest.phase.value} deliveries must use {expected_source.value}")
+    if any(observation.source is not expected_source for observation in observations):
+        raise ValueError(f"{manifest.phase.value} observations must use {expected_source.value}")
+    if not manifest.study_outcomes_allowed and any(observation.study_outcome_eligible for observation in observations):
+        raise ValueError(f"{manifest.phase.value} evidence cannot contain study outcomes")
+    if manifest.phase is ContinuityStudyPhase.CONFIRMATORY and any(
+        observation.study_outcome_eligible != (observation.ineligibility_reason is None) for observation in observations
+    ):
+        raise ValueError("confirmatory outcome eligibility must match the retained endpoint")
+    if any(observation.task_reward_mutation_count for observation in observations):
+        raise ValueError("continuity evidence cannot change task reward")
+    if (
+        sum(observation.provider_call_count for observation in observations) > manifest.provider_calls_allowed
+        or sum(delivery.provider_call_count for delivery in deliveries) > manifest.provider_calls_allowed
+    ):
+        raise ValueError("continuity evidence exceeds provider-call authority")
+    if manifest.provider_authorization is not None:
+        authority = manifest.provider_authorization
+        if any(
+            observation.spend_currency != authority.spend_currency
+            for observation in observations
+            if observation.provider_call_count
+        ):
+            raise ValueError("continuity evidence uses an unauthorized spend currency")
+        if (
+            any(
+                observation.maximum_input_tokens_in_one_call > authority.maximum_input_tokens_per_call
+                or observation.maximum_output_tokens_in_one_call > authority.maximum_output_tokens_per_call
+                for observation in observations
+            )
+            or sum(observation.input_token_count + observation.output_token_count for observation in observations)
+            > authority.maximum_total_tokens
+        ):
+            raise ValueError("continuity evidence exceeds token authority")
+        if sum(observation.spend_microunits for observation in observations) > authority.maximum_spend_microunits:
+            raise ValueError("continuity evidence exceeds spend authority")
+
+
+def _block_ineligibility(
+    *,
+    manifest: ContinuityStudyManifest,
+    plan: ContinuityStudyPlan,
+    block: ContinuityBlock,
+    delivery_by_trial: dict[str, TreatmentDeliveryRecord],
+    observation_by_trial: dict[str, ContinuityObservation],
+) -> PairIneligibilityReason | None:
+    if any(trial.trial_id not in observation_by_trial for trial in block.trials):
+        return PairIneligibilityReason.MISSING_ARM
+    if any(trial.trial_id not in delivery_by_trial for trial in block.trials):
+        return PairIneligibilityReason.MISSING_DELIVERY
+
+    deliveries = tuple(delivery_by_trial[trial.trial_id] for trial in block.trials)
+    observations = tuple(observation_by_trial[trial.trial_id] for trial in block.trials)
+    for trial, delivery, observation in zip(
+        block.trials,
+        deliveries,
+        observations,
+        strict=True,
+    ):
+        if (
+            delivery.manifest_content_sha256 != manifest.content_sha256
+            or observation.manifest_content_sha256 != manifest.content_sha256
+            or delivery.plan_content_sha256 != plan.content_sha256
+            or observation.plan_content_sha256 != plan.content_sha256
+            or delivery.block_id != block.block_id
+            or observation.block_id != block.block_id
+            or delivery.trial_id != trial.trial_id
+            or observation.trial_id != trial.trial_id
+            or delivery.treatment is not trial.treatment
+            or observation.treatment is not trial.treatment
+            or observation.delivery_content_sha256 != delivery.content_sha256
+            or observation.history_snapshot_sha256 != block.history_snapshot_sha256
+            or observation.event_schedule_sha256 != block.event_schedule_sha256
+            or observation.logical_budget_sha256 != trial.logical_budget_sha256
+            or observation.model_condition_sha256 != manifest.model_condition.content_sha256
+        ):
+            return PairIneligibilityReason.IDENTITY_DRIFT
+        if delivery.status is TreatmentDeliveryStatus.CORRUPT:
+            return PairIneligibilityReason.TREATMENT_DELIVERY_CORRUPTION
+        if delivery.status is not TreatmentDeliveryStatus.DELIVERED:
+            return PairIneligibilityReason.MISSING_DELIVERY
+        if observation.ineligibility_reason is not None:
+            return observation.ineligibility_reason
+
+    if not _all_equal(delivery.current_state_equivalence_sha256 for delivery in deliveries) or not _all_equal(
+        delivery.current_duties_sha256 for delivery in deliveries
+    ):
+        return PairIneligibilityReason.PAIR_IDENTITY_DRIFT
+    for field_name in (
+        "history_snapshot_sha256",
+        "event_schedule_sha256",
+        "logical_budget_sha256",
+        "model_condition_sha256",
+    ):
+        if not _all_equal(getattr(observation, field_name) for observation in observations):
+            return PairIneligibilityReason.PAIR_IDENTITY_DRIFT
+    return None
+
+
+def _all_equal(values: Iterable[object]) -> bool:
+    selected = tuple(values)
+    return bool(selected) and all(value == selected[0] for value in selected[1:])
+
+
+def _paired_bootstrap_interval(
+    differences: list[int],
+    *,
+    replicates: int,
+    seed: int,
+) -> ConfidenceInterval | None:
+    if not differences:
+        return None
+    randomizer = random.Random(seed)
+    sample_size = len(differences)
+    means = sorted(
+        fmean(differences[randomizer.randrange(sample_size)] for _ in range(sample_size)) for _ in range(replicates)
+    )
+    return ConfidenceInterval(
+        lower=_linear_quantile(means, 0.025),
+        upper=_linear_quantile(means, 0.975),
+    )
+
+
+def _linear_quantile(values: list[float], probability: float) -> float:
+    if not values:
+        raise ValueError("quantile requires at least one value")
+    position = (len(values) - 1) * probability
+    lower_index = int(position)
+    upper_index = min(lower_index + 1, len(values) - 1)
+    fraction = position - lower_index
+    return values[lower_index] + (values[upper_index] - values[lower_index]) * fraction
+
+
+def _classify(
+    *,
+    manifest: ContinuityStudyManifest,
+    coverage: ContinuityCoverageReport,
+    point_estimate: float | None,
+    confidence_interval: ConfidenceInterval | None,
+) -> ContinuityConclusion:
+    if (
+        not coverage.exact
+        or coverage.analyzable_block_count < manifest.analysis.minimum_eligible_blocks
+        or coverage.host_fault_arm_imbalance > manifest.analysis.maximum_host_fault_arm_imbalance
+        or point_estimate is None
+        or confidence_interval is None
+    ):
+        return ContinuityConclusion.COVERAGE_BLOCKED
+    threshold = manifest.analysis.minimum_meaningful_effect
+    if confidence_interval.upper < 0 and point_estimate <= -threshold:
+        return ContinuityConclusion.SUPPORTED
+    if confidence_interval.lower > 0 and point_estimate >= threshold:
+        return ContinuityConclusion.REFUTED
+    return ContinuityConclusion.INCONCLUSIVE

--- a/src/aec_bench/experiments/stewardship_continuity/artifacts.py
+++ b/src/aec_bench/experiments/stewardship_continuity/artifacts.py
@@ -1,0 +1,184 @@
+# ABOUTME: Publishes and independently reloads immutable stewardship-study evidence.
+# ABOUTME: Recomputes every report instead of trusting persisted conclusions.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from pydantic import TypeAdapter
+
+from aec_bench.experiments.stewardship_continuity.analysis import (
+    analyse_continuity_study,
+)
+from aec_bench.experiments.stewardship_continuity.contracts import (
+    ContinuityObservation,
+    ContinuityStudyManifest,
+    ContinuityStudyPlan,
+    ContinuityStudyReport,
+    TreatmentDeliveryRecord,
+)
+from aec_bench.experiments.stewardship_continuity.fixtures import (
+    build_provider_free_fixture_evidence,
+)
+from aec_bench.experiments.stewardship_continuity.planning import (
+    build_continuity_plan,
+    build_provider_free_manifest,
+)
+from aec_bench.meta_harness.immutable_artifact_store import (
+    EvidenceRepository,
+    ImmutableArtifact,
+    ImmutableArtifactIntegrityError,
+)
+
+_MANIFEST_ADAPTER = TypeAdapter(ContinuityStudyManifest)
+_PLAN_ADAPTER = TypeAdapter(ContinuityStudyPlan)
+_DELIVERY_ADAPTER = TypeAdapter(TreatmentDeliveryRecord)
+_OBSERVATION_ADAPTER = TypeAdapter(ContinuityObservation)
+_REPORT_ADAPTER = TypeAdapter(ContinuityStudyReport)
+
+
+@dataclass(frozen=True, slots=True)
+class PublishedContinuityStudy:
+    """One complete immutable ASW-4A provider-free evidence bundle."""
+
+    manifest: ContinuityStudyManifest
+    plan: ContinuityStudyPlan
+    report: ContinuityStudyReport
+    manifest_reference: ImmutableArtifact
+    plan_reference: ImmutableArtifact
+    delivery_references: tuple[ImmutableArtifact, ...]
+    observation_references: tuple[ImmutableArtifact, ...]
+    report_reference: ImmutableArtifact
+
+
+def publish_provider_free_fixture_study(
+    root: Path,
+) -> PublishedContinuityStudy:
+    """Publish, reload, and verify the complete provider-free analysis path."""
+
+    repository = EvidenceRepository(Path(root), host_private=True)
+    manifest = build_provider_free_manifest()
+    plan = build_continuity_plan(manifest)
+    evidence = build_provider_free_fixture_evidence(
+        manifest=manifest,
+        plan=plan,
+    )
+    report = analyse_continuity_study(
+        manifest=manifest,
+        plan=plan,
+        deliveries=evidence.deliveries,
+        observations=evidence.observations,
+    )
+
+    manifest_reference = repository.publish_content_addressed_model(
+        collection="manifests",
+        filename="study-manifest.json",
+        model=manifest,
+        adapter=_MANIFEST_ADAPTER,
+    ).artifact
+    plan_reference = repository.publish_content_addressed_model(
+        collection="plans",
+        filename="study-plan.json",
+        model=plan,
+        adapter=_PLAN_ADAPTER,
+    ).artifact
+    delivery_references = tuple(
+        repository.publish_content_addressed_model(
+            collection="treatment-deliveries",
+            filename="treatment-delivery.json",
+            model=delivery,
+            adapter=_DELIVERY_ADAPTER,
+        ).artifact
+        for delivery in evidence.deliveries
+    )
+    observation_references = tuple(
+        repository.publish_content_addressed_model(
+            collection="observations",
+            filename="observation.json",
+            model=observation,
+            adapter=_OBSERVATION_ADAPTER,
+        ).artifact
+        for observation in evidence.observations
+    )
+    report_reference = repository.publish_content_addressed_model(
+        collection="reports",
+        filename="study-report.json",
+        model=report,
+        adapter=_REPORT_ADAPTER,
+    ).artifact
+    reloaded = reload_and_verify_study_report(
+        root=repository.root,
+        report_content_sha256=report.content_sha256,
+    )
+    if reloaded != report:
+        raise ImmutableArtifactIntegrityError(
+            "independently reloaded continuity report differs",
+        )
+    return PublishedContinuityStudy(
+        manifest=manifest,
+        plan=plan,
+        report=report,
+        manifest_reference=manifest_reference,
+        plan_reference=plan_reference,
+        delivery_references=delivery_references,
+        observation_references=observation_references,
+        report_reference=report_reference,
+    )
+
+
+def reload_and_verify_study_report(
+    *,
+    root: Path,
+    report_content_sha256: str,
+) -> ContinuityStudyReport:
+    """Reload exact evidence and compare the stored report with recomputation."""
+
+    repository = EvidenceRepository(Path(root), host_private=True)
+    report = repository.load_content_addressed_model(
+        collection="reports",
+        content_sha256=report_content_sha256,
+        filename="study-report.json",
+        adapter=_REPORT_ADAPTER,
+    ).model
+    manifest = repository.load_content_addressed_model(
+        collection="manifests",
+        content_sha256=report.manifest_content_sha256,
+        filename="study-manifest.json",
+        adapter=_MANIFEST_ADAPTER,
+    ).model
+    plan = repository.load_content_addressed_model(
+        collection="plans",
+        content_sha256=report.plan_content_sha256,
+        filename="study-plan.json",
+        adapter=_PLAN_ADAPTER,
+    ).model
+    deliveries = tuple(
+        repository.load_content_addressed_model(
+            collection="treatment-deliveries",
+            content_sha256=content_sha256,
+            filename="treatment-delivery.json",
+            adapter=_DELIVERY_ADAPTER,
+        ).model
+        for content_sha256 in report.delivery_content_sha256
+    )
+    observations = tuple(
+        repository.load_content_addressed_model(
+            collection="observations",
+            content_sha256=content_sha256,
+            filename="observation.json",
+            adapter=_OBSERVATION_ADAPTER,
+        ).model
+        for content_sha256 in report.observation_content_sha256
+    )
+    recomputed = analyse_continuity_study(
+        manifest=manifest,
+        plan=plan,
+        deliveries=deliveries,
+        observations=observations,
+    )
+    if recomputed != report:
+        raise ImmutableArtifactIntegrityError(
+            "stored continuity report differs from independent recomputation",
+        )
+    return report

--- a/src/aec_bench/experiments/stewardship_continuity/contracts.py
+++ b/src/aec_bench/experiments/stewardship_continuity/contracts.py
@@ -1,0 +1,889 @@
+# ABOUTME: Defines versioned study-local contracts for the first stewardship continuity study.
+# ABOUTME: Separates provider-free analysis fixtures from shakedown and confirmatory outcomes.
+
+from __future__ import annotations
+
+from collections import Counter
+from enum import StrEnum
+from typing import Literal, Self
+
+from pydantic import NonNegativeInt, PositiveInt, field_validator, model_validator
+
+from aec_bench.contracts.harness_kernel import (
+    ContentAddressedModel,
+    canonical_content_sha256,
+    validate_sha256,
+)
+from aec_bench.contracts.validators import FrozenStrictModel, NonEmptyStr
+
+CONTINUITY_STUDY_MANIFEST_SCHEMA_VERSION: Literal["aecbench.stewardship-continuity-study-manifest.v1"] = (
+    "aecbench.stewardship-continuity-study-manifest.v1"
+)
+CONTINUITY_STUDY_PLAN_SCHEMA_VERSION: Literal["aecbench.stewardship-continuity-study-plan.v1"] = (
+    "aecbench.stewardship-continuity-study-plan.v1"
+)
+TREATMENT_DELIVERY_SCHEMA_VERSION: Literal["aecbench.stewardship-continuity-treatment-delivery.v1"] = (
+    "aecbench.stewardship-continuity-treatment-delivery.v1"
+)
+CONTINUITY_OBSERVATION_SCHEMA_VERSION: Literal["aecbench.stewardship-continuity-observation.v1"] = (
+    "aecbench.stewardship-continuity-observation.v1"
+)
+CONTINUITY_STUDY_REPORT_SCHEMA_VERSION: Literal["aecbench.stewardship-continuity-study-report.v1"] = (
+    "aecbench.stewardship-continuity-study-report.v1"
+)
+CONTINUITY_MODEL_CONDITION_SCHEMA_VERSION: Literal["aecbench.stewardship-continuity-model-condition.v1"] = (
+    "aecbench.stewardship-continuity-model-condition.v1"
+)
+CONTINUITY_PROVIDER_AUTHORIZATION_SCHEMA_VERSION: Literal[
+    "aecbench.stewardship-continuity-provider-authorization.v1"
+] = "aecbench.stewardship-continuity-provider-authorization.v1"
+
+DIAGNOSTIC_PERIOD_SECONDS: Literal[28_800] = 28_800
+
+
+class ContinuityStudyPhase(StrEnum):
+    """Execution class for one immutable study generation."""
+
+    ANALYSIS_FIXTURE = "analysis_fixture"
+    SHAKEDOWN = "shakedown"
+    CONFIRMATORY = "confirmatory"
+
+
+class ContinuityExecutionKind(StrEnum):
+    """Execution identity class bound into one study manifest."""
+
+    ANALYSIS_FIXTURE = "analysis_fixture"
+    PROVIDER_MODEL = "provider_model"
+
+
+class ContinuityTreatment(StrEnum):
+    """The two actor-visible continuity carriers in the first study."""
+
+    CURRENT_ACTOR_VIEW = "current_actor_view"
+    STRUCTURED_HANDOVER = "structured_handover"
+
+
+class ContinuityHistoryClass(StrEnum):
+    """The two matched history classes frozen by the research charter."""
+
+    H1_STABLE_INSPECTED = "h1_stable_inspected"
+    H2_WORSENING_VERIFICATION = "h2_worsening_verification"
+
+
+class EvaluationWindow(StrEnum):
+    """Hidden post-handover window expressed in diagnostic periods."""
+
+    THREE_DIAGNOSTIC_PERIODS = "3D"
+    FOUR_DIAGNOSTIC_PERIODS = "4D"
+
+    @property
+    def multiplier(self) -> int:
+        """Return the exact number of diagnostic periods."""
+
+        if self is EvaluationWindow.THREE_DIAGNOSTIC_PERIODS:
+            return 3
+        return 4
+
+    @property
+    def seconds(self) -> int:
+        """Return the exact simulated duration."""
+
+        return self.multiplier * DIAGNOSTIC_PERIOD_SECONDS
+
+
+class TreatmentDeliveryStatus(StrEnum):
+    """Host result for continuity-carrier delivery."""
+
+    DELIVERED = "delivered"
+    NOT_DELIVERED = "not_delivered"
+    CORRUPT = "corrupt"
+
+
+class ObservationSource(StrEnum):
+    """Authority class for one analysis input."""
+
+    GENERATED_ANALYSIS_FIXTURE = "generated_analysis_fixture"
+    SHAKEDOWN = "shakedown"
+    CONFIRMATORY = "confirmatory"
+
+
+class ContinuityFailureKind(StrEnum):
+    """Typed execution result used by attrition and endpoint rules."""
+
+    NONE = "none"
+    IDENTITY_DRIFT = "identity_drift"
+    TREATMENT_DELIVERY_CORRUPTION = "treatment_delivery_corruption"
+    HOST_FAILURE_BEFORE_DELIVERY = "host_failure_before_delivery"
+    HOST_FAILURE_AFTER_DELIVERY = "host_failure_after_delivery"
+    MODEL_EMPTY_OUTPUT = "model_empty_output"
+    MODEL_TIMEOUT = "model_timeout"
+    TOOL_FAILURE = "tool_failure"
+    CARRIER_SERIALIZATION_FAILURE = "carrier_serialization_failure"
+    OUTPUT_CONTRACT_FAILURE = "output_contract_failure"
+    INCOMPLETE = "incomplete"
+
+
+class PairIneligibilityReason(StrEnum):
+    """Reason one planned pair cannot enter the paired estimand."""
+
+    MISSING_ARM = "missing_arm"
+    MISSING_DELIVERY = "missing_delivery"
+    HOST_FAILURE = "host_failure"
+    IDENTITY_DRIFT = "identity_drift"
+    TREATMENT_DELIVERY_CORRUPTION = "treatment_delivery_corruption"
+    PAIR_IDENTITY_DRIFT = "pair_identity_drift"
+    INCOMPLETE = "incomplete"
+
+
+class ContinuityConclusion(StrEnum):
+    """Bounded interpretation of one study report."""
+
+    ANALYSIS_FIXTURE = "analysis_fixture"
+    SHAKEDOWN = "shakedown"
+    SUPPORTED = "supported"
+    REFUTED = "refuted"
+    INCONCLUSIVE = "inconclusive"
+    COVERAGE_BLOCKED = "coverage_blocked"
+
+
+class ContinuityLogicalBudget(FrozenStrictModel):
+    """Fixed logical limits applied to each planned trajectory."""
+
+    max_model_turns: Literal[16] = 16
+    max_agent_proposals: Literal[12] = 12
+    max_host_commands: Literal[32] = 32
+    fresh_agent_handovers: Literal[1] = 1
+    temporal_retrieval_allowed: Literal[False] = False
+    external_historical_search_allowed: Literal[False] = False
+    evaluation_window_visible: Literal[False] = False
+    future_events_visible: Literal[False] = False
+
+
+class ContinuityAnalysisSpecification(FrozenStrictModel):
+    """Frozen primary endpoint, estimand, uncertainty, and conclusion rules."""
+
+    endpoint: Literal["binary_obligation_continuity_failure"] = "binary_obligation_continuity_failure"
+    estimand: Literal["mean_paired_risk_difference"] = "mean_paired_risk_difference"
+    difference_order: Literal["structured_handover_minus_current_actor_view"] = (
+        "structured_handover_minus_current_actor_view"
+    )
+    minimum_meaningful_effect: float = 0.25
+    confidence_level: float = 0.95
+    uncertainty_method: Literal["paired_block_bootstrap_percentile_linear_v1"] = (
+        "paired_block_bootstrap_percentile_linear_v1"
+    )
+    bootstrap_replicates: Literal[20_000] = 20_000
+    bootstrap_seed: Literal[20_260_729] = 20_260_729
+    minimum_eligible_blocks: Literal[28] = 28
+    maximum_host_fault_arm_imbalance: Literal[2] = 2
+    missing_pairs_replaced: Literal[False] = False
+
+    @model_validator(mode="after")
+    def validate_frozen_floats(self) -> Self:
+        if self.minimum_meaningful_effect != 0.25:
+            raise ValueError("minimum meaningful effect must remain 0.25")
+        if self.confidence_level != 0.95:
+            raise ValueError("confidence level must remain 0.95")
+        return self
+
+
+class ContinuityModelCondition(ContentAddressedModel):
+    """Exact provider/model/adapter condition declared before execution."""
+
+    schema_version: Literal["aecbench.stewardship-continuity-model-condition.v1"] = (
+        CONTINUITY_MODEL_CONDITION_SCHEMA_VERSION
+    )
+    execution_kind: ContinuityExecutionKind
+    provider_id: NonEmptyStr | None
+    model_id: NonEmptyStr | None
+    adapter_id: NonEmptyStr | None
+    model_configuration_sha256: str
+
+    @field_validator("model_configuration_sha256")
+    @classmethod
+    def validate_model_configuration_hash(cls, value: str) -> str:
+        return validate_sha256(value)
+
+    @model_validator(mode="after")
+    def validate_execution_identity(self) -> Self:
+        provider_values = (
+            self.provider_id,
+            self.model_id,
+            self.adapter_id,
+        )
+        if self.execution_kind is ContinuityExecutionKind.ANALYSIS_FIXTURE:
+            if any(value is not None for value in provider_values):
+                raise ValueError("analysis fixture cannot declare provider model identity")
+        elif any(value is None for value in provider_values):
+            raise ValueError("provider model condition requires provider, model, and adapter identities")
+        return self
+
+
+class ContinuityProviderAuthorization(ContentAddressedModel):
+    """Approved provider, token, call, and spend limits for one phase."""
+
+    schema_version: Literal["aecbench.stewardship-continuity-provider-authorization.v1"] = (
+        CONTINUITY_PROVIDER_AUTHORIZATION_SCHEMA_VERSION
+    )
+    authorization_id: NonEmptyStr
+    authorized_phase: ContinuityStudyPhase
+    approved_by: NonEmptyStr
+    model_condition_sha256: str
+    maximum_provider_calls: PositiveInt
+    maximum_input_tokens_per_call: PositiveInt
+    maximum_output_tokens_per_call: PositiveInt
+    maximum_total_tokens: PositiveInt
+    spend_currency: NonEmptyStr
+    maximum_spend_microunits: PositiveInt
+
+    @field_validator("model_condition_sha256")
+    @classmethod
+    def validate_model_condition_hash(cls, value: str) -> str:
+        return validate_sha256(value)
+
+    @model_validator(mode="after")
+    def validate_provider_authority(self) -> Self:
+        if self.authorized_phase is ContinuityStudyPhase.ANALYSIS_FIXTURE:
+            raise ValueError("provider authority cannot authorize analysis fixtures")
+        if self.spend_currency != self.spend_currency.upper() or len(self.spend_currency) != 3:
+            raise ValueError("provider spend currency must be a three-letter uppercase code")
+        theoretical_maximum = self.maximum_provider_calls * (
+            self.maximum_input_tokens_per_call + self.maximum_output_tokens_per_call
+        )
+        if self.maximum_total_tokens > theoretical_maximum:
+            raise ValueError("total token authority exceeds the per-call limits")
+        return self
+
+
+class ContinuityStudyManifest(ContentAddressedModel):
+    """Immutable study design and execution authority for one generation."""
+
+    schema_version: Literal["aecbench.stewardship-continuity-study-manifest.v1"] = (
+        CONTINUITY_STUDY_MANIFEST_SCHEMA_VERSION
+    )
+    study_id: NonEmptyStr
+    study_generation_id: NonEmptyStr
+    phase: ContinuityStudyPhase
+    charter_revision: NonEmptyStr
+    task_world_id: NonEmptyStr
+    profile_id: NonEmptyStr
+    generation_id: NonEmptyStr
+    package_content_id: str
+    promotion_manifest_content_id: str
+    receipt_version: NonEmptyStr
+    authority_policy_version: NonEmptyStr
+    transition_rule_version: NonEmptyStr
+    projection_policy_id: NonEmptyStr
+    evaluation_schema_version: NonEmptyStr
+    event_schedule_revision: NonEmptyStr
+    verifier_revision: NonEmptyStr
+    harness_configuration_sha256: str
+    treatment_delivery_configuration_sha256: str
+    model_condition: ContinuityModelCondition
+    provider_authorization: ContinuityProviderAuthorization | None
+    adaptation_mode: Literal["none"] = "none"
+    diagnostic_period_seconds: Literal[28_800] = DIAGNOSTIC_PERIOD_SECONDS
+    history_classes: tuple[ContinuityHistoryClass, ...]
+    treatments: tuple[ContinuityTreatment, ...]
+    blocks_per_history: Literal[16] = 16
+    ordering_method: Literal["counterbalanced_pair_order_v1"] = "counterbalanced_pair_order_v1"
+    logical_budget: ContinuityLogicalBudget = ContinuityLogicalBudget()
+    analysis: ContinuityAnalysisSpecification = ContinuityAnalysisSpecification()
+    study_outcomes_allowed: bool
+    task_reward_mutation_allowed: Literal[False] = False
+
+    @field_validator(
+        "package_content_id",
+        "promotion_manifest_content_id",
+        "harness_configuration_sha256",
+        "treatment_delivery_configuration_sha256",
+    )
+    @classmethod
+    def validate_hashes(cls, value: str) -> str:
+        return validate_sha256(value)
+
+    @model_validator(mode="after")
+    def validate_study_authority(self) -> Self:
+        if self.history_classes != tuple(ContinuityHistoryClass):
+            raise ValueError("study manifest must contain the two canonical history classes")
+        if self.treatments != tuple(ContinuityTreatment):
+            raise ValueError("study manifest must contain the two canonical continuity treatments")
+        if self.phase is ContinuityStudyPhase.ANALYSIS_FIXTURE:
+            if (
+                self.model_condition.execution_kind is not ContinuityExecutionKind.ANALYSIS_FIXTURE
+                or self.provider_authorization is not None
+            ):
+                raise ValueError("analysis-fixture generation cannot authorize provider calls")
+            if self.study_outcomes_allowed:
+                raise ValueError("analysis-fixture generation cannot contain study outcomes")
+        else:
+            if (
+                self.model_condition.execution_kind is not ContinuityExecutionKind.PROVIDER_MODEL
+                or self.provider_authorization is None
+            ):
+                raise ValueError(f"{self.phase.value} generation requires explicit provider authority")
+            if self.provider_authorization.authorized_phase is not self.phase:
+                raise ValueError("provider authority does not authorize the selected study phase")
+            if self.provider_authorization.model_condition_sha256 != self.model_condition.content_sha256:
+                raise ValueError("provider authority does not bind the selected model condition")
+            if self.phase is ContinuityStudyPhase.SHAKEDOWN and self.study_outcomes_allowed:
+                raise ValueError("shakedown generation cannot enter the confirmatory estimand")
+            if self.phase is ContinuityStudyPhase.CONFIRMATORY and not self.study_outcomes_allowed:
+                raise ValueError("confirmatory generation must authorize outcome evidence")
+        return self
+
+    @property
+    def provider_calls_allowed(self) -> int:
+        """Return zero without authority or the exact approved call limit."""
+
+        if self.provider_authorization is None:
+            return 0
+        return self.provider_authorization.maximum_provider_calls
+
+
+class ContinuityTrial(ContentAddressedModel):
+    """One ordered continuity treatment inside a matched history block."""
+
+    schema_version: Literal["aecbench.stewardship-continuity-trial.v1"] = "aecbench.stewardship-continuity-trial.v1"
+    trial_id: NonEmptyStr
+    study_id: NonEmptyStr
+    study_generation_id: NonEmptyStr
+    block_id: NonEmptyStr
+    sequence_index: PositiveInt
+    repetition: PositiveInt
+    history_class: ContinuityHistoryClass
+    history_slot_id: NonEmptyStr
+    treatment: ContinuityTreatment
+    order_index: PositiveInt
+    evaluation_window: EvaluationWindow
+    evaluation_window_seconds: PositiveInt
+    logical_budget_sha256: str
+
+    @field_validator("logical_budget_sha256")
+    @classmethod
+    def validate_hash(cls, value: str) -> str:
+        return validate_sha256(value)
+
+    @model_validator(mode="after")
+    def validate_trial(self) -> Self:
+        if self.order_index not in {1, 2}:
+            raise ValueError("continuity trial order_index must be one or two")
+        if self.evaluation_window_seconds != self.evaluation_window.seconds:
+            raise ValueError("continuity trial window seconds differ from the frozen window")
+        expected = continuity_trial_id(
+            study_id=self.study_id,
+            study_generation_id=self.study_generation_id,
+            block_id=self.block_id,
+            sequence_index=self.sequence_index,
+            repetition=self.repetition,
+            history_class=self.history_class,
+            history_slot_id=self.history_slot_id,
+            treatment=self.treatment,
+            order_index=self.order_index,
+            evaluation_window=self.evaluation_window,
+            logical_budget_sha256=self.logical_budget_sha256,
+        )
+        if self.trial_id != expected:
+            raise ValueError("trial_id must bind the canonical continuity trial")
+        return self
+
+
+class ContinuityBlock(ContentAddressedModel):
+    """One matched history with both continuity treatments."""
+
+    schema_version: Literal["aecbench.stewardship-continuity-block.v1"] = "aecbench.stewardship-continuity-block.v1"
+    block_id: NonEmptyStr
+    study_id: NonEmptyStr
+    study_generation_id: NonEmptyStr
+    sequence_index: PositiveInt
+    repetition: PositiveInt
+    history_class: ContinuityHistoryClass
+    history_slot_id: NonEmptyStr
+    evaluation_window: EvaluationWindow
+    history_snapshot_sha256: str
+    event_schedule_sha256: str
+    trials: tuple[ContinuityTrial, ...]
+
+    @field_validator("history_snapshot_sha256", "event_schedule_sha256")
+    @classmethod
+    def validate_condition_hashes(cls, value: str) -> str:
+        return validate_sha256(value)
+
+    @model_validator(mode="after")
+    def validate_block(self) -> Self:
+        expected = continuity_block_id(
+            study_id=self.study_id,
+            study_generation_id=self.study_generation_id,
+            sequence_index=self.sequence_index,
+            repetition=self.repetition,
+            history_class=self.history_class,
+            history_slot_id=self.history_slot_id,
+            evaluation_window=self.evaluation_window,
+            history_snapshot_sha256=self.history_snapshot_sha256,
+            event_schedule_sha256=self.event_schedule_sha256,
+        )
+        if self.block_id != expected:
+            raise ValueError("block_id must bind the canonical continuity block")
+        if len(self.trials) != 2:
+            raise ValueError("continuity block must contain exactly two trials")
+        if tuple(trial.order_index for trial in self.trials) != (1, 2):
+            raise ValueError("continuity block trials must use canonical order indexes")
+        if {trial.treatment for trial in self.trials} != set(ContinuityTreatment):
+            raise ValueError("continuity block must contain both continuity treatments")
+        if any(
+            trial.block_id != self.block_id
+            or trial.study_id != self.study_id
+            or trial.study_generation_id != self.study_generation_id
+            or trial.sequence_index != self.sequence_index
+            or trial.repetition != self.repetition
+            or trial.history_class is not self.history_class
+            or trial.history_slot_id != self.history_slot_id
+            or trial.evaluation_window is not self.evaluation_window
+            for trial in self.trials
+        ):
+            raise ValueError("continuity block trials differ from their parent block")
+        return self
+
+
+class ContinuityStudyPlan(ContentAddressedModel):
+    """Complete provider-independent expansion of the first study design."""
+
+    schema_version: Literal["aecbench.stewardship-continuity-study-plan.v1"] = CONTINUITY_STUDY_PLAN_SCHEMA_VERSION
+    manifest_content_sha256: str
+    study_id: NonEmptyStr
+    study_generation_id: NonEmptyStr
+    blocks_per_history: Literal[16] = 16
+    blocks: tuple[ContinuityBlock, ...]
+    trials: tuple[ContinuityTrial, ...]
+
+    @field_validator("manifest_content_sha256")
+    @classmethod
+    def validate_hash(cls, value: str) -> str:
+        return validate_sha256(value)
+
+    @model_validator(mode="after")
+    def validate_plan(self) -> Self:
+        if len(self.blocks) != 32:
+            raise ValueError("continuity plan must contain 32 matched blocks")
+        if tuple(block.sequence_index for block in self.blocks) != tuple(range(1, 33)):
+            raise ValueError("continuity blocks must use contiguous sequence indexes")
+        flattened = tuple(trial for block in self.blocks for trial in block.trials)
+        if self.trials != flattened:
+            raise ValueError("continuity plan trials must equal the ordered block trials")
+        if len(self.trials) != 64:
+            raise ValueError("continuity plan must contain 64 planned trials")
+        trial_ids = tuple(trial.trial_id for trial in self.trials)
+        if len(trial_ids) != len(set(trial_ids)):
+            raise ValueError("continuity trial ids must be unique")
+        if Counter(block.history_class for block in self.blocks) != {
+            ContinuityHistoryClass.H1_STABLE_INSPECTED: 16,
+            ContinuityHistoryClass.H2_WORSENING_VERIFICATION: 16,
+        }:
+            raise ValueError("continuity plan must contain 16 blocks per history class")
+        self._validate_counterbalance()
+        return self
+
+    def _validate_counterbalance(self) -> None:
+        for history_class in ContinuityHistoryClass:
+            selected = tuple(block for block in self.blocks if block.history_class is history_class)
+            if Counter(block.evaluation_window for block in selected) != {
+                EvaluationWindow.THREE_DIAGNOSTIC_PERIODS: 8,
+                EvaluationWindow.FOUR_DIAGNOSTIC_PERIODS: 8,
+            }:
+                raise ValueError("continuity windows must be balanced within each history")
+            if Counter(block.trials[0].treatment for block in selected) != {
+                ContinuityTreatment.CURRENT_ACTOR_VIEW: 8,
+                ContinuityTreatment.STRUCTURED_HANDOVER: 8,
+            }:
+                raise ValueError("continuity treatment order must be balanced within each history")
+            for evaluation_window in EvaluationWindow:
+                window_blocks = tuple(block for block in selected if block.evaluation_window is evaluation_window)
+                if Counter(block.trials[0].treatment for block in window_blocks) != {
+                    ContinuityTreatment.CURRENT_ACTOR_VIEW: 4,
+                    ContinuityTreatment.STRUCTURED_HANDOVER: 4,
+                }:
+                    raise ValueError(
+                        "continuity order must be balanced within each history and window",
+                    )
+
+
+class TreatmentDeliveryRecord(ContentAddressedModel):
+    """Exact host record for one continuity-carrier delivery."""
+
+    schema_version: Literal["aecbench.stewardship-continuity-treatment-delivery.v1"] = TREATMENT_DELIVERY_SCHEMA_VERSION
+    manifest_content_sha256: str
+    plan_content_sha256: str
+    block_id: NonEmptyStr
+    trial_id: NonEmptyStr
+    treatment: ContinuityTreatment
+    source: ObservationSource
+    status: TreatmentDeliveryStatus
+    delivered_before_outcome: bool
+    current_state_equivalence_sha256: str
+    current_duties_sha256: str
+    carrier_content_sha256: str | None
+    provider_call_count: NonNegativeInt
+
+    @field_validator(
+        "manifest_content_sha256",
+        "plan_content_sha256",
+        "current_state_equivalence_sha256",
+        "current_duties_sha256",
+    )
+    @classmethod
+    def validate_required_hashes(cls, value: str) -> str:
+        return validate_sha256(value)
+
+    @field_validator("carrier_content_sha256")
+    @classmethod
+    def validate_optional_hash(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return validate_sha256(value)
+
+    @model_validator(mode="after")
+    def validate_delivery(self) -> Self:
+        if self.status is TreatmentDeliveryStatus.DELIVERED:
+            if not self.delivered_before_outcome or self.carrier_content_sha256 is None:
+                raise ValueError("delivered treatment requires a pre-outcome carrier identity")
+        elif self.delivered_before_outcome or self.carrier_content_sha256 is not None:
+            raise ValueError("undelivered treatment cannot claim a delivered carrier")
+        if self.source is ObservationSource.GENERATED_ANALYSIS_FIXTURE and self.provider_call_count != 0:
+            raise ValueError("analysis-fixture delivery cannot contain provider calls")
+        return self
+
+
+_POST_DELIVERY_FAILURES = {
+    ContinuityFailureKind.MODEL_EMPTY_OUTPUT,
+    ContinuityFailureKind.MODEL_TIMEOUT,
+    ContinuityFailureKind.TOOL_FAILURE,
+    ContinuityFailureKind.CARRIER_SERIALIZATION_FAILURE,
+    ContinuityFailureKind.OUTPUT_CONTRACT_FAILURE,
+}
+_INELIGIBLE_FAILURES = {
+    ContinuityFailureKind.IDENTITY_DRIFT,
+    ContinuityFailureKind.TREATMENT_DELIVERY_CORRUPTION,
+    ContinuityFailureKind.HOST_FAILURE_BEFORE_DELIVERY,
+    ContinuityFailureKind.HOST_FAILURE_AFTER_DELIVERY,
+    ContinuityFailureKind.INCOMPLETE,
+}
+
+
+class ContinuityObservation(ContentAddressedModel):
+    """One retained trajectory result or generated analysis fixture."""
+
+    schema_version: Literal["aecbench.stewardship-continuity-observation.v1"] = CONTINUITY_OBSERVATION_SCHEMA_VERSION
+    manifest_content_sha256: str
+    plan_content_sha256: str
+    block_id: NonEmptyStr
+    trial_id: NonEmptyStr
+    treatment: ContinuityTreatment
+    source: ObservationSource
+    delivery_content_sha256: str
+    history_snapshot_sha256: str
+    event_schedule_sha256: str
+    logical_budget_sha256: str
+    model_condition_sha256: str
+    failure_kind: ContinuityFailureKind
+    continuity_failure: bool | None
+    ineligibility_reason: PairIneligibilityReason | None
+    study_outcome_eligible: bool
+    provider_call_count: NonNegativeInt
+    input_token_count: NonNegativeInt
+    output_token_count: NonNegativeInt
+    maximum_input_tokens_in_one_call: NonNegativeInt
+    maximum_output_tokens_in_one_call: NonNegativeInt
+    spend_currency: NonEmptyStr | None
+    spend_microunits: NonNegativeInt
+    task_reward_mutation_count: NonNegativeInt
+
+    @field_validator(
+        "manifest_content_sha256",
+        "plan_content_sha256",
+        "delivery_content_sha256",
+        "history_snapshot_sha256",
+        "event_schedule_sha256",
+        "logical_budget_sha256",
+        "model_condition_sha256",
+    )
+    @classmethod
+    def validate_hashes(cls, value: str) -> str:
+        return validate_sha256(value)
+
+    @model_validator(mode="after")
+    def validate_observation(self) -> Self:
+        if self.maximum_input_tokens_in_one_call > self.input_token_count:
+            raise ValueError("maximum input tokens cannot exceed total input tokens")
+        if self.maximum_output_tokens_in_one_call > self.output_token_count:
+            raise ValueError("maximum output tokens cannot exceed total output tokens")
+        if self.spend_currency is not None and (
+            self.spend_currency != self.spend_currency.upper() or len(self.spend_currency) != 3
+        ):
+            raise ValueError("observation spend currency must be a three-letter uppercase code")
+        usage_values = (
+            self.input_token_count,
+            self.output_token_count,
+            self.maximum_input_tokens_in_one_call,
+            self.maximum_output_tokens_in_one_call,
+            self.spend_microunits,
+        )
+        if self.provider_call_count == 0:
+            if any(usage_values) or self.spend_currency is not None:
+                raise ValueError("observation without provider calls cannot contain provider usage")
+        elif self.spend_currency is None:
+            raise ValueError("observation with provider calls requires a spend currency")
+        if self.source is ObservationSource.GENERATED_ANALYSIS_FIXTURE:
+            if self.study_outcome_eligible:
+                raise ValueError("analysis fixture cannot be a study outcome")
+            if self.provider_call_count != 0:
+                raise ValueError("analysis fixture cannot contain provider calls")
+            if any(usage_values) or self.spend_currency is not None:
+                raise ValueError("analysis fixture cannot contain token or spend usage")
+            if self.task_reward_mutation_count != 0:
+                raise ValueError("analysis fixture cannot mutate task reward")
+        if self.failure_kind is ContinuityFailureKind.NONE:
+            if self.continuity_failure is None or self.ineligibility_reason is not None:
+                raise ValueError("completed observation requires one binary endpoint")
+        elif self.failure_kind in _POST_DELIVERY_FAILURES:
+            if self.continuity_failure is not True or self.ineligibility_reason is not None:
+                raise ValueError("post-delivery model or tool failure must count as continuity failure")
+        elif self.failure_kind in _INELIGIBLE_FAILURES:
+            if self.continuity_failure is not None or self.ineligibility_reason is None:
+                raise ValueError("host, identity, delivery, or incomplete failure must be ineligible")
+            if self.study_outcome_eligible:
+                raise ValueError("ineligible observation cannot enter the study outcome")
+        return self
+
+    @property
+    def is_host_fault(self) -> bool:
+        """Return whether the observation records a host-owned failure."""
+
+        return self.failure_kind in {
+            ContinuityFailureKind.HOST_FAILURE_BEFORE_DELIVERY,
+            ContinuityFailureKind.HOST_FAILURE_AFTER_DELIVERY,
+        }
+
+
+class ProviderFreeFixtureEvidence(FrozenStrictModel):
+    """Generated treatment and endpoint values used only to test analysis code."""
+
+    deliveries: tuple[TreatmentDeliveryRecord, ...]
+    observations: tuple[ContinuityObservation, ...]
+
+
+class ConfidenceInterval(FrozenStrictModel):
+    """Two-sided percentile interval over paired block differences."""
+
+    level: float = 0.95
+    lower: float
+    upper: float
+
+    @model_validator(mode="after")
+    def validate_interval(self) -> Self:
+        if self.level != 0.95:
+            raise ValueError("confidence interval level must remain 0.95")
+        if self.lower > self.upper:
+            raise ValueError("confidence interval lower bound exceeds upper bound")
+        return self
+
+
+class BlockCoverage(FrozenStrictModel):
+    """Coverage and paired endpoint result for one planned block."""
+
+    block_id: NonEmptyStr
+    observed_trial_ids: tuple[NonEmptyStr, ...]
+    analyzable: bool
+    ineligibility_reason: PairIneligibilityReason | None
+    paired_difference: Literal[-1, 0, 1] | None
+
+    @model_validator(mode="after")
+    def validate_block_coverage(self) -> Self:
+        if self.analyzable:
+            if self.ineligibility_reason is not None or self.paired_difference is None:
+                raise ValueError("analyzable block requires one paired difference")
+        elif self.ineligibility_reason is None or self.paired_difference is not None:
+            raise ValueError("ineligible block requires one typed reason and no difference")
+        return self
+
+
+class ContinuityCoverageReport(FrozenStrictModel):
+    """Exact planned, observed, paired, and ineligible coverage."""
+
+    exact: bool
+    planned_trial_count: PositiveInt
+    observed_trial_count: NonNegativeInt
+    missing_trial_ids: tuple[NonEmptyStr, ...]
+    complete_block_count: NonNegativeInt
+    analyzable_block_count: NonNegativeInt
+    host_fault_count_by_treatment: dict[ContinuityTreatment, NonNegativeInt]
+    host_fault_arm_imbalance: NonNegativeInt
+    blocks: tuple[BlockCoverage, ...]
+
+
+class ContinuityStudyReport(ContentAddressedModel):
+    """Immutable report recomputed from a manifest, plan, and retained evidence."""
+
+    schema_version: Literal["aecbench.stewardship-continuity-study-report.v1"] = CONTINUITY_STUDY_REPORT_SCHEMA_VERSION
+    manifest_content_sha256: str
+    plan_content_sha256: str
+    phase: ContinuityStudyPhase
+    conclusion: ContinuityConclusion
+    fixture_rule_result: ContinuityConclusion | None
+    coverage: ContinuityCoverageReport
+    point_estimate: float | None
+    confidence_interval: ConfidenceInterval | None
+    bootstrap_replicates: PositiveInt
+    bootstrap_seed: int
+    provider_call_count: NonNegativeInt
+    input_token_count: NonNegativeInt
+    output_token_count: NonNegativeInt
+    maximum_input_tokens_in_one_call: NonNegativeInt
+    maximum_output_tokens_in_one_call: NonNegativeInt
+    spend_currency: NonEmptyStr | None
+    spend_microunits: NonNegativeInt
+    study_outcome_count: NonNegativeInt
+    fixture_observation_count: NonNegativeInt
+    task_reward_mutation_count: NonNegativeInt
+    delivery_content_sha256: tuple[str, ...]
+    observation_content_sha256: tuple[str, ...]
+
+    @field_validator(
+        "manifest_content_sha256",
+        "plan_content_sha256",
+    )
+    @classmethod
+    def validate_hashes(cls, value: str) -> str:
+        return validate_sha256(value)
+
+    @field_validator(
+        "delivery_content_sha256",
+        "observation_content_sha256",
+    )
+    @classmethod
+    def validate_hash_sequences(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if len(value) != len(set(value)):
+            raise ValueError("study report evidence identities must be unique")
+        for digest in value:
+            validate_sha256(digest)
+        return value
+
+    @model_validator(mode="after")
+    def validate_report_authority(self) -> Self:
+        if self.maximum_input_tokens_in_one_call > self.input_token_count:
+            raise ValueError("report maximum input tokens exceed total input tokens")
+        if self.maximum_output_tokens_in_one_call > self.output_token_count:
+            raise ValueError("report maximum output tokens exceed total output tokens")
+        if self.spend_currency is not None and (
+            self.spend_currency != self.spend_currency.upper() or len(self.spend_currency) != 3
+        ):
+            raise ValueError("report spend currency must be a three-letter uppercase code")
+        usage_values = (
+            self.input_token_count,
+            self.output_token_count,
+            self.maximum_input_tokens_in_one_call,
+            self.maximum_output_tokens_in_one_call,
+            self.spend_microunits,
+        )
+        if self.provider_call_count == 0:
+            if any(usage_values):
+                raise ValueError("report without provider calls cannot contain provider usage")
+        elif self.spend_currency is None:
+            raise ValueError("report with provider calls requires a spend currency")
+        statistical_conclusions = {
+            ContinuityConclusion.SUPPORTED,
+            ContinuityConclusion.REFUTED,
+            ContinuityConclusion.INCONCLUSIVE,
+            ContinuityConclusion.COVERAGE_BLOCKED,
+        }
+        if self.phase is ContinuityStudyPhase.ANALYSIS_FIXTURE:
+            if self.conclusion is not ContinuityConclusion.ANALYSIS_FIXTURE:
+                raise ValueError("analysis fixture cannot make a study conclusion")
+            if self.fixture_rule_result not in statistical_conclusions:
+                raise ValueError("analysis fixture must expose its diagnostic rule result")
+            if self.provider_call_count != 0 or self.study_outcome_count != 0 or self.task_reward_mutation_count != 0:
+                raise ValueError("analysis fixture must contain zero calls, outcomes, and reward changes")
+            if any(usage_values) or self.spend_currency is not None:
+                raise ValueError("analysis fixture must contain zero token and spend usage")
+        elif self.phase is ContinuityStudyPhase.SHAKEDOWN:
+            if self.conclusion is not ContinuityConclusion.SHAKEDOWN:
+                raise ValueError("shakedown report cannot make a confirmatory conclusion")
+            if self.fixture_rule_result is not None:
+                raise ValueError("shakedown report cannot contain a fixture rule result")
+            if self.study_outcome_count != 0 or self.fixture_observation_count != 0:
+                raise ValueError("shakedown report cannot contain study outcomes or fixtures")
+        else:
+            if self.conclusion not in statistical_conclusions:
+                raise ValueError("confirmatory report requires a confirmatory conclusion")
+            if self.fixture_rule_result is not None or self.fixture_observation_count != 0:
+                raise ValueError("confirmatory report cannot contain fixture results")
+        if self.task_reward_mutation_count != 0:
+            raise ValueError("continuity study reports cannot contain task reward changes")
+        return self
+
+
+def continuity_block_id(
+    *,
+    study_id: str,
+    study_generation_id: str,
+    sequence_index: int,
+    repetition: int,
+    history_class: ContinuityHistoryClass,
+    history_slot_id: str,
+    evaluation_window: EvaluationWindow,
+    history_snapshot_sha256: str,
+    event_schedule_sha256: str,
+) -> str:
+    """Return one canonical matched-block identity."""
+
+    return "block-" + canonical_content_sha256(
+        {
+            "study_id": study_id,
+            "study_generation_id": study_generation_id,
+            "sequence_index": sequence_index,
+            "repetition": repetition,
+            "history_class": history_class.value,
+            "history_slot_id": history_slot_id,
+            "evaluation_window": evaluation_window.value,
+            "history_snapshot_sha256": history_snapshot_sha256,
+            "event_schedule_sha256": event_schedule_sha256,
+        }
+    )
+
+
+def continuity_trial_id(
+    *,
+    study_id: str,
+    study_generation_id: str,
+    block_id: str,
+    sequence_index: int,
+    repetition: int,
+    history_class: ContinuityHistoryClass,
+    history_slot_id: str,
+    treatment: ContinuityTreatment,
+    order_index: int,
+    evaluation_window: EvaluationWindow,
+    logical_budget_sha256: str,
+) -> str:
+    """Return one canonical treatment-trial identity."""
+
+    return "trial-" + canonical_content_sha256(
+        {
+            "study_id": study_id,
+            "study_generation_id": study_generation_id,
+            "block_id": block_id,
+            "sequence_index": sequence_index,
+            "repetition": repetition,
+            "history_class": history_class.value,
+            "history_slot_id": history_slot_id,
+            "treatment": treatment.value,
+            "order_index": order_index,
+            "evaluation_window": evaluation_window.value,
+            "logical_budget_sha256": logical_budget_sha256,
+        }
+    )
+
+
+def logical_budget_sha256(budget: ContinuityLogicalBudget) -> str:
+    """Return the canonical identity of the frozen logical budget."""
+
+    return canonical_content_sha256(budget.model_dump(mode="json"))

--- a/src/aec_bench/experiments/stewardship_continuity/fixtures.py
+++ b/src/aec_bench/experiments/stewardship_continuity/fixtures.py
@@ -1,0 +1,126 @@
+# ABOUTME: Generates deterministic provider-free evidence for the ASW-4A analysis path.
+# ABOUTME: Marks every generated value as ineligible for study-outcome claims.
+
+from __future__ import annotations
+
+from aec_bench.contracts.harness_kernel import canonical_content_sha256
+from aec_bench.experiments.stewardship_continuity.contracts import (
+    ContinuityFailureKind,
+    ContinuityHistoryClass,
+    ContinuityObservation,
+    ContinuityStudyManifest,
+    ContinuityStudyPhase,
+    ContinuityStudyPlan,
+    ContinuityTreatment,
+    ObservationSource,
+    ProviderFreeFixtureEvidence,
+    TreatmentDeliveryRecord,
+    TreatmentDeliveryStatus,
+)
+
+
+def build_provider_free_fixture_evidence(
+    *,
+    manifest: ContinuityStudyManifest,
+    plan: ContinuityStudyPlan,
+) -> ProviderFreeFixtureEvidence:
+    """Create complete synthetic analysis inputs without executing a model."""
+
+    selected_manifest = ContinuityStudyManifest.model_validate(
+        manifest.model_dump(mode="json"),
+    )
+    selected_plan = ContinuityStudyPlan.model_validate(
+        plan.model_dump(mode="json"),
+    )
+    if selected_manifest.phase is not ContinuityStudyPhase.ANALYSIS_FIXTURE:
+        raise ValueError("provider-free fixture evidence requires an analysis-fixture manifest")
+    if selected_plan.manifest_content_sha256 != selected_manifest.content_sha256:
+        raise ValueError("continuity fixture plan does not belong to its manifest")
+
+    deliveries: list[TreatmentDeliveryRecord] = []
+    observations: list[ContinuityObservation] = []
+
+    for block in selected_plan.blocks:
+        current_state_equivalence_sha256 = canonical_content_sha256(
+            {
+                "kind": "generated-current-state-equivalence",
+                "history_slot_id": block.history_slot_id,
+            }
+        )
+        current_duties_sha256 = canonical_content_sha256(
+            {
+                "kind": "generated-current-duties",
+                "history_slot_id": block.history_slot_id,
+            }
+        )
+        for trial in block.trials:
+            delivery = TreatmentDeliveryRecord(
+                manifest_content_sha256=selected_manifest.content_sha256,
+                plan_content_sha256=selected_plan.content_sha256,
+                block_id=block.block_id,
+                trial_id=trial.trial_id,
+                treatment=trial.treatment,
+                source=ObservationSource.GENERATED_ANALYSIS_FIXTURE,
+                status=TreatmentDeliveryStatus.DELIVERED,
+                delivered_before_outcome=True,
+                current_state_equivalence_sha256=current_state_equivalence_sha256,
+                current_duties_sha256=current_duties_sha256,
+                carrier_content_sha256=canonical_content_sha256(
+                    {
+                        "kind": "generated-continuity-carrier",
+                        "history_slot_id": block.history_slot_id,
+                        "treatment": trial.treatment.value,
+                    }
+                ),
+                provider_call_count=0,
+            )
+            deliveries.append(delivery)
+            observations.append(
+                ContinuityObservation(
+                    manifest_content_sha256=selected_manifest.content_sha256,
+                    plan_content_sha256=selected_plan.content_sha256,
+                    block_id=block.block_id,
+                    trial_id=trial.trial_id,
+                    treatment=trial.treatment,
+                    source=ObservationSource.GENERATED_ANALYSIS_FIXTURE,
+                    delivery_content_sha256=delivery.content_sha256,
+                    history_snapshot_sha256=block.history_snapshot_sha256,
+                    event_schedule_sha256=block.event_schedule_sha256,
+                    logical_budget_sha256=trial.logical_budget_sha256,
+                    model_condition_sha256=selected_manifest.model_condition.content_sha256,
+                    failure_kind=ContinuityFailureKind.NONE,
+                    continuity_failure=_fixture_failure(
+                        history_class=block.history_class,
+                        repetition=block.repetition,
+                        treatment=trial.treatment,
+                    ),
+                    ineligibility_reason=None,
+                    study_outcome_eligible=False,
+                    provider_call_count=0,
+                    input_token_count=0,
+                    output_token_count=0,
+                    maximum_input_tokens_in_one_call=0,
+                    maximum_output_tokens_in_one_call=0,
+                    spend_currency=None,
+                    spend_microunits=0,
+                    task_reward_mutation_count=0,
+                )
+            )
+
+    return ProviderFreeFixtureEvidence(
+        deliveries=tuple(deliveries),
+        observations=tuple(observations),
+    )
+
+
+def _fixture_failure(
+    *,
+    history_class: ContinuityHistoryClass,
+    repetition: int,
+    treatment: ContinuityTreatment,
+) -> bool:
+    if history_class is ContinuityHistoryClass.H1_STABLE_INSPECTED:
+        return treatment is ContinuityTreatment.CURRENT_ACTOR_VIEW and repetition <= 8
+    if treatment is ContinuityTreatment.CURRENT_ACTOR_VIEW:
+        return True
+    return repetition <= 8

--- a/src/aec_bench/experiments/stewardship_continuity/planning.py
+++ b/src/aec_bench/experiments/stewardship_continuity/planning.py
@@ -1,0 +1,253 @@
+# ABOUTME: Builds the frozen provider-free manifest and counterbalanced continuity plan.
+# ABOUTME: Binds the study design to the certified pump-station package and rule versions.
+
+from __future__ import annotations
+
+from aec_bench.contracts.harness_kernel import canonical_content_sha256
+from aec_bench.evaluation.stewardship import STEWARDSHIP_EVALUATION_SCHEMA_VERSION
+from aec_bench.experiments.stewardship_continuity.contracts import (
+    ContinuityBlock,
+    ContinuityExecutionKind,
+    ContinuityHistoryClass,
+    ContinuityLogicalBudget,
+    ContinuityModelCondition,
+    ContinuityStudyManifest,
+    ContinuityStudyPhase,
+    ContinuityStudyPlan,
+    ContinuityTreatment,
+    ContinuityTrial,
+    EvaluationWindow,
+    continuity_block_id,
+    continuity_trial_id,
+    logical_budget_sha256,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.reference_package_reader import (
+    EXPECTED_MANIFEST_CONTENT_ID,
+    EXPECTED_PACKAGE_CONTENT_ID,
+    load_reference_package,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_models import (
+    PUMP_STATION_AUTHORITY_POLICY_VERSION,
+    PUMP_STATION_RECEIPT_VERSION,
+    PUMP_STATION_TRANSITION_RULE_VERSION,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_session import (
+    PUMP_STATION_PROJECTION_POLICY_ID,
+    PUMP_STATION_TASK_WORLD_ID,
+    PUMP_STATION_TOOL_NAMES,
+)
+
+CONTINUITY_STUDY_ID = "asw-first-stewardship-continuity.v1"
+ASW4A_STUDY_GENERATION_ID = "asw-4a-provider-free-analysis-fixture.v1"
+CONTINUITY_EVENT_SCHEDULE_REVISION = "pump-station-continuity-event-schedule.v1"
+CONTINUITY_VERIFIER_REVISION = "pump-station-stewardship-replay-verifier.v1"
+
+
+def build_provider_free_manifest() -> ContinuityStudyManifest:
+    """Build the ASW-4A design freeze with no provider or outcome authority."""
+
+    package = load_reference_package()
+    logical_budget = ContinuityLogicalBudget()
+    model_condition = ContinuityModelCondition(
+        execution_kind=ContinuityExecutionKind.ANALYSIS_FIXTURE,
+        provider_id=None,
+        model_id=None,
+        adapter_id=None,
+        model_configuration_sha256=canonical_content_sha256(
+            {
+                "kind": "generated-provider-free-analysis-condition.v1",
+                "study_generation_id": ASW4A_STUDY_GENERATION_ID,
+            }
+        ),
+    )
+    return ContinuityStudyManifest(
+        study_id=CONTINUITY_STUDY_ID,
+        study_generation_id=ASW4A_STUDY_GENERATION_ID,
+        phase=ContinuityStudyPhase.ANALYSIS_FIXTURE,
+        charter_revision="ASW-0C-3",
+        task_world_id=PUMP_STATION_TASK_WORLD_ID,
+        profile_id=package.profile_id,
+        generation_id=package.generation_id,
+        package_content_id=EXPECTED_PACKAGE_CONTENT_ID,
+        promotion_manifest_content_id=EXPECTED_MANIFEST_CONTENT_ID,
+        receipt_version=PUMP_STATION_RECEIPT_VERSION,
+        authority_policy_version=PUMP_STATION_AUTHORITY_POLICY_VERSION,
+        transition_rule_version=PUMP_STATION_TRANSITION_RULE_VERSION,
+        projection_policy_id=PUMP_STATION_PROJECTION_POLICY_ID,
+        evaluation_schema_version=STEWARDSHIP_EVALUATION_SCHEMA_VERSION,
+        event_schedule_revision=CONTINUITY_EVENT_SCHEDULE_REVISION,
+        verifier_revision=CONTINUITY_VERIFIER_REVISION,
+        harness_configuration_sha256=canonical_content_sha256(
+            {
+                "kind": "pump-station-continuity-harness.v1",
+                "task_world_id": PUMP_STATION_TASK_WORLD_ID,
+                "projection_policy_id": PUMP_STATION_PROJECTION_POLICY_ID,
+                "tool_names": PUMP_STATION_TOOL_NAMES,
+            }
+        ),
+        treatment_delivery_configuration_sha256=canonical_content_sha256(
+            {
+                "kind": "pump-station-continuity-treatment-delivery.v1",
+                "treatments": [treatment.value for treatment in ContinuityTreatment],
+                "same_current_state_required": True,
+                "same_current_duties_required": True,
+            }
+        ),
+        model_condition=model_condition,
+        provider_authorization=None,
+        history_classes=tuple(ContinuityHistoryClass),
+        treatments=tuple(ContinuityTreatment),
+        logical_budget=logical_budget,
+        study_outcomes_allowed=False,
+    )
+
+
+def build_continuity_plan(
+    manifest: ContinuityStudyManifest,
+) -> ContinuityStudyPlan:
+    """Expand the frozen design into 32 paired, counterbalanced blocks."""
+
+    selected = ContinuityStudyManifest.model_validate(
+        manifest.model_dump(mode="json"),
+    )
+    budget_sha256 = logical_budget_sha256(selected.logical_budget)
+    blocks: list[ContinuityBlock] = []
+
+    for repetition in range(1, selected.blocks_per_history + 1):
+        evaluation_window = _evaluation_window(repetition)
+        ordered_treatments = _ordered_treatments(repetition)
+        for history_class in ContinuityHistoryClass:
+            sequence_index = len(blocks) + 1
+            history_slot_id = f"{history_class.value}-{repetition:02d}"
+            history_snapshot_sha256 = canonical_content_sha256(
+                {
+                    "kind": "planned-provider-free-continuity-history.v1",
+                    "study_generation_id": selected.study_generation_id,
+                    "history_slot_id": history_slot_id,
+                    "history_class": history_class.value,
+                }
+            )
+            event_schedule_sha256 = canonical_content_sha256(
+                {
+                    "kind": selected.event_schedule_revision,
+                    "study_generation_id": selected.study_generation_id,
+                    "history_slot_id": history_slot_id,
+                    "evaluation_window": evaluation_window.value,
+                }
+            )
+            block_id = continuity_block_id(
+                study_id=selected.study_id,
+                study_generation_id=selected.study_generation_id,
+                sequence_index=sequence_index,
+                repetition=repetition,
+                history_class=history_class,
+                history_slot_id=history_slot_id,
+                evaluation_window=evaluation_window,
+                history_snapshot_sha256=history_snapshot_sha256,
+                event_schedule_sha256=event_schedule_sha256,
+            )
+            trials = tuple(
+                _build_trial(
+                    manifest=selected,
+                    block_id=block_id,
+                    sequence_index=sequence_index,
+                    repetition=repetition,
+                    history_class=history_class,
+                    history_slot_id=history_slot_id,
+                    treatment=treatment,
+                    order_index=order_index,
+                    evaluation_window=evaluation_window,
+                    budget_sha256=budget_sha256,
+                )
+                for order_index, treatment in enumerate(
+                    ordered_treatments,
+                    start=1,
+                )
+            )
+            blocks.append(
+                ContinuityBlock(
+                    block_id=block_id,
+                    study_id=selected.study_id,
+                    study_generation_id=selected.study_generation_id,
+                    sequence_index=sequence_index,
+                    repetition=repetition,
+                    history_class=history_class,
+                    history_slot_id=history_slot_id,
+                    evaluation_window=evaluation_window,
+                    history_snapshot_sha256=history_snapshot_sha256,
+                    event_schedule_sha256=event_schedule_sha256,
+                    trials=trials,
+                )
+            )
+
+    block_tuple = tuple(blocks)
+    return ContinuityStudyPlan(
+        manifest_content_sha256=selected.content_sha256,
+        study_id=selected.study_id,
+        study_generation_id=selected.study_generation_id,
+        blocks=block_tuple,
+        trials=tuple(trial for block in block_tuple for trial in block.trials),
+    )
+
+
+def _evaluation_window(repetition: int) -> EvaluationWindow:
+    if repetition % 2:
+        return EvaluationWindow.THREE_DIAGNOSTIC_PERIODS
+    return EvaluationWindow.FOUR_DIAGNOSTIC_PERIODS
+
+
+def _ordered_treatments(
+    repetition: int,
+) -> tuple[ContinuityTreatment, ContinuityTreatment]:
+    if ((repetition - 1) // 2) % 2 == 0:
+        return (
+            ContinuityTreatment.CURRENT_ACTOR_VIEW,
+            ContinuityTreatment.STRUCTURED_HANDOVER,
+        )
+    return (
+        ContinuityTreatment.STRUCTURED_HANDOVER,
+        ContinuityTreatment.CURRENT_ACTOR_VIEW,
+    )
+
+
+def _build_trial(
+    *,
+    manifest: ContinuityStudyManifest,
+    block_id: str,
+    sequence_index: int,
+    repetition: int,
+    history_class: ContinuityHistoryClass,
+    history_slot_id: str,
+    treatment: ContinuityTreatment,
+    order_index: int,
+    evaluation_window: EvaluationWindow,
+    budget_sha256: str,
+) -> ContinuityTrial:
+    trial_id = continuity_trial_id(
+        study_id=manifest.study_id,
+        study_generation_id=manifest.study_generation_id,
+        block_id=block_id,
+        sequence_index=sequence_index,
+        repetition=repetition,
+        history_class=history_class,
+        history_slot_id=history_slot_id,
+        treatment=treatment,
+        order_index=order_index,
+        evaluation_window=evaluation_window,
+        logical_budget_sha256=budget_sha256,
+    )
+    return ContinuityTrial(
+        trial_id=trial_id,
+        study_id=manifest.study_id,
+        study_generation_id=manifest.study_generation_id,
+        block_id=block_id,
+        sequence_index=sequence_index,
+        repetition=repetition,
+        history_class=history_class,
+        history_slot_id=history_slot_id,
+        treatment=treatment,
+        order_index=order_index,
+        evaluation_window=evaluation_window,
+        evaluation_window_seconds=evaluation_window.seconds,
+        logical_budget_sha256=budget_sha256,
+    )

--- a/tests/experiments/stewardship_continuity/test_analysis.py
+++ b/tests/experiments/stewardship_continuity/test_analysis.py
@@ -1,0 +1,380 @@
+# ABOUTME: Tests paired continuity reduction, exact coverage, and uncertainty rules.
+# ABOUTME: Keeps generated analysis fixtures separate from confirmatory conclusions.
+
+from __future__ import annotations
+
+import pytest
+
+from aec_bench.experiments.stewardship_continuity import (
+    ContinuityConclusion,
+    ContinuityExecutionKind,
+    ContinuityModelCondition,
+    ContinuityObservation,
+    ContinuityProviderAuthorization,
+    ContinuityStudyManifest,
+    ContinuityStudyPhase,
+    ContinuityStudyPlan,
+    ObservationSource,
+    PairIneligibilityReason,
+    TreatmentDeliveryRecord,
+    analyse_continuity_study,
+    build_continuity_plan,
+    build_provider_free_fixture_evidence,
+    build_provider_free_manifest,
+)
+
+
+def test_provider_free_fixture_exercises_paired_bootstrap_without_study_claim() -> None:
+    manifest = build_provider_free_manifest()
+    plan = build_continuity_plan(manifest)
+    evidence = build_provider_free_fixture_evidence(manifest=manifest, plan=plan)
+
+    report = analyse_continuity_study(
+        manifest=manifest,
+        plan=plan,
+        deliveries=evidence.deliveries,
+        observations=evidence.observations,
+    )
+
+    assert report.conclusion is ContinuityConclusion.ANALYSIS_FIXTURE
+    assert report.fixture_rule_result is ContinuityConclusion.SUPPORTED
+    assert report.provider_call_count == 0
+    assert report.study_outcome_count == 0
+    assert report.fixture_observation_count == 64
+    assert report.task_reward_mutation_count == 0
+    assert report.coverage.exact
+    assert report.coverage.planned_trial_count == 64
+    assert report.coverage.observed_trial_count == 64
+    assert report.coverage.complete_block_count == 32
+    assert report.coverage.analyzable_block_count == 32
+    assert report.point_estimate == -0.5
+    assert report.confidence_interval is not None
+    assert report.confidence_interval.lower < report.point_estimate
+    assert report.confidence_interval.upper < 0
+    assert report.bootstrap_replicates == 20_000
+    assert report.bootstrap_seed == 20_260_729
+    assert (
+        analyse_continuity_study(
+            manifest=manifest,
+            plan=plan,
+            deliveries=evidence.deliveries,
+            observations=evidence.observations,
+        )
+        == report
+    )
+
+
+def test_missing_arm_stays_in_coverage_and_blocks_exact_coverage() -> None:
+    manifest = build_provider_free_manifest()
+    plan = build_continuity_plan(manifest)
+    evidence = build_provider_free_fixture_evidence(manifest=manifest, plan=plan)
+    missing = evidence.observations[0]
+
+    report = analyse_continuity_study(
+        manifest=manifest,
+        plan=plan,
+        deliveries=evidence.deliveries,
+        observations=evidence.observations[1:],
+    )
+
+    assert not report.coverage.exact
+    assert report.coverage.missing_trial_ids == (missing.trial_id,)
+    assert report.coverage.complete_block_count == 31
+    assert report.coverage.analyzable_block_count == 31
+    excluded = next(item for item in report.coverage.blocks if item.block_id == missing.block_id)
+    assert excluded.ineligibility_reason is PairIneligibilityReason.MISSING_ARM
+    assert report.conclusion is ContinuityConclusion.ANALYSIS_FIXTURE
+
+
+def test_duplicate_or_unplanned_observations_fail_closed() -> None:
+    manifest = build_provider_free_manifest()
+    plan = build_continuity_plan(manifest)
+    evidence = build_provider_free_fixture_evidence(manifest=manifest, plan=plan)
+
+    with pytest.raises(ValueError, match="duplicate observation"):
+        analyse_continuity_study(
+            manifest=manifest,
+            plan=plan,
+            deliveries=evidence.deliveries,
+            observations=(*evidence.observations, evidence.observations[0]),
+        )
+
+    payload = evidence.observations[0].model_dump(mode="json")
+    payload["content_sha256"] = ""
+    payload["trial_id"] = "unplanned-trial"
+    unplanned = ContinuityObservation.model_validate(payload)
+    with pytest.raises(ValueError, match="unplanned observation"):
+        analyse_continuity_study(
+            manifest=manifest,
+            plan=plan,
+            deliveries=evidence.deliveries,
+            observations=(*evidence.observations[1:], unplanned),
+        )
+
+
+def test_evidence_input_order_does_not_change_the_report_identity() -> None:
+    manifest = build_provider_free_manifest()
+    plan = build_continuity_plan(manifest)
+    evidence = build_provider_free_fixture_evidence(manifest=manifest, plan=plan)
+
+    ordered = analyse_continuity_study(
+        manifest=manifest,
+        plan=plan,
+        deliveries=evidence.deliveries,
+        observations=evidence.observations,
+    )
+    reversed_inputs = analyse_continuity_study(
+        manifest=manifest,
+        plan=plan,
+        deliveries=tuple(reversed(evidence.deliveries)),
+        observations=tuple(reversed(evidence.observations)),
+    )
+
+    assert reversed_inputs == ordered
+
+
+def test_pair_identity_drift_remains_visible_and_ineligible() -> None:
+    manifest = build_provider_free_manifest()
+    plan = build_continuity_plan(manifest)
+    evidence = build_provider_free_fixture_evidence(manifest=manifest, plan=plan)
+    selected = evidence.observations[0]
+    payload = selected.model_dump(mode="json")
+    payload["content_sha256"] = ""
+    payload["history_snapshot_sha256"] = "f" * 64
+    drifted = ContinuityObservation.model_validate(payload)
+    observations = (drifted, *evidence.observations[1:])
+
+    report = analyse_continuity_study(
+        manifest=manifest,
+        plan=plan,
+        deliveries=evidence.deliveries,
+        observations=observations,
+    )
+
+    block = next(item for item in report.coverage.blocks if item.block_id == selected.block_id)
+    assert block.ineligibility_reason is PairIneligibilityReason.IDENTITY_DRIFT
+    assert report.coverage.analyzable_block_count == 31
+
+
+@pytest.mark.parametrize(
+    "field_name",
+    [
+        "history_snapshot_sha256",
+        "event_schedule_sha256",
+        "logical_budget_sha256",
+        "model_condition_sha256",
+    ],
+)
+def test_matching_pair_values_still_fail_when_they_drift_from_the_plan(
+    field_name: str,
+) -> None:
+    manifest = build_provider_free_manifest()
+    plan = build_continuity_plan(manifest)
+    evidence = build_provider_free_fixture_evidence(manifest=manifest, plan=plan)
+    selected_block = plan.blocks[0]
+    replacements: list[ContinuityObservation] = []
+    for observation in evidence.observations[:2]:
+        payload = observation.model_dump(mode="json")
+        payload["content_sha256"] = ""
+        payload[field_name] = "f" * 64
+        replacements.append(ContinuityObservation.model_validate(payload))
+
+    report = analyse_continuity_study(
+        manifest=manifest,
+        plan=plan,
+        deliveries=evidence.deliveries,
+        observations=(*replacements, *evidence.observations[2:]),
+    )
+
+    coverage = next(item for item in report.coverage.blocks if item.block_id == selected_block.block_id)
+    assert coverage.ineligibility_reason is PairIneligibilityReason.IDENTITY_DRIFT
+
+
+def test_shakedown_analysis_cannot_make_a_confirmatory_conclusion() -> None:
+    manifest, plan, deliveries, observations = _build_shakedown_inputs()
+
+    report = analyse_continuity_study(
+        manifest=manifest,
+        plan=plan,
+        deliveries=deliveries,
+        observations=observations,
+    )
+
+    assert report.phase is ContinuityStudyPhase.SHAKEDOWN
+    assert report.conclusion is ContinuityConclusion.SHAKEDOWN
+    assert report.fixture_rule_result is None
+    assert report.study_outcome_count == 0
+    assert report.input_token_count == 0
+    assert report.output_token_count == 0
+    assert report.spend_currency == "USD"
+    assert report.spend_microunits == 0
+
+
+def test_analysis_enforces_shakedown_authority_and_source() -> None:
+    manifest, plan, deliveries, observations = _build_shakedown_inputs()
+
+    outcome_payload = observations[0].model_dump(mode="json")
+    outcome_payload["content_sha256"] = ""
+    outcome_payload["study_outcome_eligible"] = True
+    outcome = ContinuityObservation.model_validate(outcome_payload)
+    with pytest.raises(ValueError, match="study outcomes"):
+        analyse_continuity_study(
+            manifest=manifest,
+            plan=plan,
+            deliveries=deliveries,
+            observations=(outcome, *observations[1:]),
+        )
+
+    reward_payload = observations[0].model_dump(mode="json")
+    reward_payload["content_sha256"] = ""
+    reward_payload["task_reward_mutation_count"] = 1
+    reward_mutation = ContinuityObservation.model_validate(reward_payload)
+    with pytest.raises(ValueError, match="task reward"):
+        analyse_continuity_study(
+            manifest=manifest,
+            plan=plan,
+            deliveries=deliveries,
+            observations=(reward_mutation, *observations[1:]),
+        )
+
+    provider_payload = observations[0].model_dump(mode="json")
+    provider_payload["content_sha256"] = ""
+    provider_payload["provider_call_count"] = 2
+    provider_payload["spend_currency"] = "USD"
+    provider_overrun = ContinuityObservation.model_validate(provider_payload)
+    with pytest.raises(ValueError, match="provider-call authority"):
+        analyse_continuity_study(
+            manifest=manifest,
+            plan=plan,
+            deliveries=deliveries,
+            observations=(provider_overrun, *observations[1:]),
+        )
+
+    token_payload = observations[0].model_dump(mode="json")
+    token_payload.update(
+        {
+            "content_sha256": "",
+            "provider_call_count": 1,
+            "input_token_count": 10_001,
+            "maximum_input_tokens_in_one_call": 10_001,
+            "spend_currency": "USD",
+        }
+    )
+    token_overrun = ContinuityObservation.model_validate(token_payload)
+    with pytest.raises(ValueError, match="token authority"):
+        analyse_continuity_study(
+            manifest=manifest,
+            plan=plan,
+            deliveries=deliveries,
+            observations=(token_overrun, *observations[1:]),
+        )
+
+    spend_payload = observations[0].model_dump(mode="json")
+    spend_payload.update(
+        {
+            "content_sha256": "",
+            "provider_call_count": 1,
+            "spend_currency": "USD",
+            "spend_microunits": 1_000_001,
+        }
+    )
+    spend_overrun = ContinuityObservation.model_validate(spend_payload)
+    with pytest.raises(ValueError, match="spend authority"):
+        analyse_continuity_study(
+            manifest=manifest,
+            plan=plan,
+            deliveries=deliveries,
+            observations=(spend_overrun, *observations[1:]),
+        )
+
+    delivery_payload = deliveries[0].model_dump(mode="json")
+    delivery_payload["content_sha256"] = ""
+    delivery_payload["source"] = ObservationSource.CONFIRMATORY
+    wrong_source = TreatmentDeliveryRecord.model_validate(delivery_payload)
+    with pytest.raises(ValueError, match="shakedown deliveries"):
+        analyse_continuity_study(
+            manifest=manifest,
+            plan=plan,
+            deliveries=(wrong_source, *deliveries[1:]),
+            observations=observations,
+        )
+
+
+def _build_shakedown_inputs() -> tuple[
+    ContinuityStudyManifest,
+    ContinuityStudyPlan,
+    tuple[TreatmentDeliveryRecord, ...],
+    tuple[ContinuityObservation, ...],
+]:
+    fixture_manifest = build_provider_free_manifest()
+    fixture_plan = build_continuity_plan(fixture_manifest)
+    fixture_evidence = build_provider_free_fixture_evidence(
+        manifest=fixture_manifest,
+        plan=fixture_plan,
+    )
+    model_condition = ContinuityModelCondition(
+        execution_kind=ContinuityExecutionKind.PROVIDER_MODEL,
+        provider_id="test-provider",
+        model_id="test-model",
+        adapter_id="test-adapter",
+        model_configuration_sha256="a" * 64,
+    )
+    provider_authorization = ContinuityProviderAuthorization(
+        authorization_id="test-provider-approval",
+        authorized_phase=ContinuityStudyPhase.SHAKEDOWN,
+        approved_by="Theo",
+        model_condition_sha256=model_condition.content_sha256,
+        maximum_provider_calls=1,
+        maximum_input_tokens_per_call=10_000,
+        maximum_output_tokens_per_call=2_000,
+        maximum_total_tokens=12_000,
+        spend_currency="USD",
+        maximum_spend_microunits=1_000_000,
+    )
+    manifest_payload = fixture_manifest.model_dump(mode="json")
+    manifest_payload.update(
+        {
+            "content_sha256": "",
+            "phase": ContinuityStudyPhase.SHAKEDOWN,
+            "model_condition": model_condition.model_dump(mode="json"),
+            "provider_authorization": provider_authorization.model_dump(mode="json"),
+            "study_outcomes_allowed": False,
+        }
+    )
+    manifest = ContinuityStudyManifest.model_validate(manifest_payload)
+    plan = build_continuity_plan(manifest)
+    assert tuple(block.block_id for block in plan.blocks) == tuple(block.block_id for block in fixture_plan.blocks)
+
+    deliveries: list[TreatmentDeliveryRecord] = []
+    observations: list[ContinuityObservation] = []
+    for fixture_delivery, fixture_observation in zip(
+        fixture_evidence.deliveries,
+        fixture_evidence.observations,
+        strict=True,
+    ):
+        delivery_payload = fixture_delivery.model_dump(mode="json")
+        delivery_payload.update(
+            {
+                "content_sha256": "",
+                "manifest_content_sha256": manifest.content_sha256,
+                "plan_content_sha256": plan.content_sha256,
+                "source": ObservationSource.SHAKEDOWN,
+            }
+        )
+        delivery = TreatmentDeliveryRecord.model_validate(delivery_payload)
+        deliveries.append(delivery)
+
+        observation_payload = fixture_observation.model_dump(mode="json")
+        observation_payload.update(
+            {
+                "content_sha256": "",
+                "manifest_content_sha256": manifest.content_sha256,
+                "plan_content_sha256": plan.content_sha256,
+                "source": ObservationSource.SHAKEDOWN,
+                "delivery_content_sha256": delivery.content_sha256,
+                "model_condition_sha256": model_condition.content_sha256,
+            }
+        )
+        observations.append(ContinuityObservation.model_validate(observation_payload))
+
+    return manifest, plan, tuple(deliveries), tuple(observations)

--- a/tests/experiments/stewardship_continuity/test_artifacts.py
+++ b/tests/experiments/stewardship_continuity/test_artifacts.py
@@ -1,0 +1,73 @@
+# ABOUTME: Tests immutable stewardship-study publication and independent report reload.
+# ABOUTME: Rejects report tampering and evidence drift through the real artifact store.
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from aec_bench.experiments.stewardship_continuity import (
+    ContinuityConclusion,
+    publish_provider_free_fixture_study,
+    reload_and_verify_study_report,
+)
+from aec_bench.meta_harness.immutable_artifact_store import (
+    ImmutableArtifactIntegrityError,
+)
+
+
+def test_publishes_and_independently_reloads_complete_fixture_evidence(
+    tmp_path: Path,
+) -> None:
+    published = publish_provider_free_fixture_study(tmp_path / "study-evidence")
+
+    assert published.report.conclusion is ContinuityConclusion.ANALYSIS_FIXTURE
+    assert published.report.provider_call_count == 0
+    assert published.report.study_outcome_count == 0
+    assert published.report.task_reward_mutation_count == 0
+    assert published.report_reference.path.is_file()
+    assert published.report_reference.path.parent.name == published.report.content_sha256
+    assert len(published.delivery_references) == 64
+    assert len(published.observation_references) == 64
+
+    reloaded = reload_and_verify_study_report(
+        root=tmp_path / "study-evidence",
+        report_content_sha256=published.report.content_sha256,
+    )
+    assert reloaded == published.report
+
+
+def test_republishing_the_same_fixture_keeps_all_artifact_identities(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "study-evidence"
+
+    first = publish_provider_free_fixture_study(root)
+    second = publish_provider_free_fixture_study(root)
+
+    assert second.manifest == first.manifest
+    assert second.plan == first.plan
+    assert second.report == first.report
+    assert second.manifest_reference == first.manifest_reference
+    assert second.plan_reference == first.plan_reference
+    assert second.delivery_references == first.delivery_references
+    assert second.observation_references == first.observation_references
+    assert second.report_reference == first.report_reference
+
+
+def test_reload_rejects_tampered_report_bytes(tmp_path: Path) -> None:
+    published = publish_provider_free_fixture_study(tmp_path / "study-evidence")
+    payload = json.loads(published.report_reference.path.read_text(encoding="utf-8"))
+    payload["provider_call_count"] = 1
+    published.report_reference.path.write_text(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ImmutableArtifactIntegrityError, match="identity|invalid"):
+        reload_and_verify_study_report(
+            root=tmp_path / "study-evidence",
+            report_content_sha256=published.report.content_sha256,
+        )

--- a/tests/experiments/stewardship_continuity/test_contracts.py
+++ b/tests/experiments/stewardship_continuity/test_contracts.py
@@ -1,0 +1,266 @@
+# ABOUTME: Tests the frozen provider-free stewardship-continuity study contracts.
+# ABOUTME: Proves exact budgets, pairing, counterbalancing, and fixture ineligibility.
+
+from __future__ import annotations
+
+from collections import Counter
+
+import pytest
+from pydantic import ValidationError
+
+import aec_bench.experiments.stewardship_continuity as continuity
+from aec_bench.experiments.stewardship_continuity import (
+    ContinuityConclusion,
+    ContinuityFailureKind,
+    ContinuityHistoryClass,
+    ContinuityObservation,
+    ContinuityStudyPhase,
+    ContinuityStudyPlan,
+    ContinuityStudyReport,
+    ContinuityTreatment,
+    EvaluationWindow,
+    ObservationSource,
+    PairIneligibilityReason,
+    TreatmentDeliveryStatus,
+    analyse_continuity_study,
+    build_continuity_plan,
+    build_provider_free_fixture_evidence,
+    build_provider_free_manifest,
+)
+
+
+def test_provider_free_manifest_freezes_charter_design_and_blocks_outcomes() -> None:
+    manifest = build_provider_free_manifest()
+
+    assert manifest.phase is ContinuityStudyPhase.ANALYSIS_FIXTURE
+    assert manifest.charter_revision == "ASW-0C-3"
+    assert manifest.profile_id == "AU-NSW-LH-SYN-SPS-v1"
+    assert manifest.generation_id == "738bc2b31f40ae7ea7831a54826c10c7e1f8084e64a6c0e0883bc6290aa84c8e"
+    assert manifest.package_content_id == "642da8bdfad63d7324e0c5886f1f8f3866c9a6bd25f165fa2a5937d68e8a5e16"
+    assert manifest.adaptation_mode == "none"
+    assert manifest.event_schedule_revision == "pump-station-continuity-event-schedule.v1"
+    assert manifest.verifier_revision == "pump-station-stewardship-replay-verifier.v1"
+    assert len(manifest.harness_configuration_sha256) == 64
+    assert len(manifest.treatment_delivery_configuration_sha256) == 64
+    assert manifest.model_condition.execution_kind is continuity.ContinuityExecutionKind.ANALYSIS_FIXTURE
+    assert manifest.model_condition.provider_id is None
+    assert manifest.model_condition.model_id is None
+    assert manifest.model_condition.adapter_id is None
+    assert manifest.provider_authorization is None
+    assert manifest.provider_calls_allowed == 0
+    assert not manifest.study_outcomes_allowed
+    assert not manifest.task_reward_mutation_allowed
+    assert manifest.logical_budget.max_model_turns == 16
+    assert manifest.logical_budget.max_agent_proposals == 12
+    assert manifest.logical_budget.max_host_commands == 32
+    assert manifest.logical_budget.fresh_agent_handovers == 1
+    assert not manifest.logical_budget.temporal_retrieval_allowed
+    assert not manifest.logical_budget.evaluation_window_visible
+    assert manifest.analysis.bootstrap_replicates == 20_000
+    assert manifest.analysis.bootstrap_seed == 20_260_729
+    assert manifest.analysis.minimum_meaningful_effect == 0.25
+    assert manifest.analysis.minimum_eligible_blocks == 28
+    assert manifest.analysis.maximum_host_fault_arm_imbalance == 2
+
+
+def test_plan_has_exact_paired_coverage_and_counterbalanced_order() -> None:
+    manifest = build_provider_free_manifest()
+    plan = build_continuity_plan(manifest)
+
+    assert plan.manifest_content_sha256 == manifest.content_sha256
+    assert len(plan.blocks) == 32
+    assert len(plan.trials) == 64
+    assert len({trial.trial_id for trial in plan.trials}) == 64
+    assert tuple(trial for block in plan.blocks for trial in block.trials) == plan.trials
+
+    history_counts = Counter(block.history_class for block in plan.blocks)
+    assert history_counts == {
+        ContinuityHistoryClass.H1_STABLE_INSPECTED: 16,
+        ContinuityHistoryClass.H2_WORSENING_VERIFICATION: 16,
+    }
+    for history_class in ContinuityHistoryClass:
+        selected = [block for block in plan.blocks if block.history_class is history_class]
+        assert Counter(block.evaluation_window for block in selected) == {
+            EvaluationWindow.THREE_DIAGNOSTIC_PERIODS: 8,
+            EvaluationWindow.FOUR_DIAGNOSTIC_PERIODS: 8,
+        }
+        assert Counter(block.trials[0].treatment for block in selected) == {
+            ContinuityTreatment.CURRENT_ACTOR_VIEW: 8,
+            ContinuityTreatment.STRUCTURED_HANDOVER: 8,
+        }
+        for evaluation_window in EvaluationWindow:
+            window_blocks = [block for block in selected if block.evaluation_window is evaluation_window]
+            assert Counter(block.trials[0].treatment for block in window_blocks) == {
+                ContinuityTreatment.CURRENT_ACTOR_VIEW: 4,
+                ContinuityTreatment.STRUCTURED_HANDOVER: 4,
+            }
+
+    assert {tuple(trial.treatment for trial in block.trials) for block in plan.blocks} == {
+        (
+            ContinuityTreatment.CURRENT_ACTOR_VIEW,
+            ContinuityTreatment.STRUCTURED_HANDOVER,
+        ),
+        (
+            ContinuityTreatment.STRUCTURED_HANDOVER,
+            ContinuityTreatment.CURRENT_ACTOR_VIEW,
+        ),
+    }
+    assert {trial.evaluation_window_seconds for trial in plan.trials} == {
+        86_400,
+        115_200,
+    }
+    assert all(len(block.history_snapshot_sha256) == 64 for block in plan.blocks)
+    assert all(len(block.event_schedule_sha256) == 64 for block in plan.blocks)
+    assert build_continuity_plan(manifest) == plan
+
+
+def test_plan_rejects_a_missing_trial_even_with_a_recomputed_content_id() -> None:
+    plan = build_continuity_plan(build_provider_free_manifest())
+    payload = plan.model_dump(mode="json")
+    payload["content_sha256"] = ""
+    payload["trials"] = payload["trials"][:-1]
+
+    with pytest.raises(ValidationError, match="ordered block trials"):
+        ContinuityStudyPlan.model_validate(payload)
+
+
+def test_provider_free_evidence_is_explicitly_not_a_study_outcome() -> None:
+    manifest = build_provider_free_manifest()
+    plan = build_continuity_plan(manifest)
+    evidence = build_provider_free_fixture_evidence(manifest=manifest, plan=plan)
+
+    assert len(evidence.deliveries) == 64
+    assert len(evidence.observations) == 64
+    assert {delivery.provider_call_count for delivery in evidence.deliveries} == {0}
+    assert {delivery.status for delivery in evidence.deliveries} == {
+        TreatmentDeliveryStatus.DELIVERED,
+    }
+    assert {observation.source for observation in evidence.observations} == {
+        ObservationSource.GENERATED_ANALYSIS_FIXTURE,
+    }
+    assert {observation.input_token_count for observation in evidence.observations} == {0}
+    assert {observation.output_token_count for observation in evidence.observations} == {0}
+    assert {observation.spend_microunits for observation in evidence.observations} == {0}
+    assert {observation.spend_currency for observation in evidence.observations} == {None}
+    assert not any(observation.study_outcome_eligible for observation in evidence.observations)
+    assert all(observation.continuity_failure is not None for observation in evidence.observations)
+
+    for block in plan.blocks:
+        deliveries = [delivery for delivery in evidence.deliveries if delivery.block_id == block.block_id]
+        assert len(deliveries) == 2
+        assert len({delivery.current_state_equivalence_sha256 for delivery in deliveries}) == 1
+        assert len({delivery.carrier_content_sha256 for delivery in deliveries}) == 2
+        assert len({delivery.current_duties_sha256 for delivery in deliveries}) == 1
+
+
+def test_failure_taxonomy_separates_host_faults_from_post_delivery_failures() -> None:
+    manifest = build_provider_free_manifest()
+    plan = build_continuity_plan(manifest)
+    evidence = build_provider_free_fixture_evidence(manifest=manifest, plan=plan)
+    observation = evidence.observations[0]
+
+    timeout_payload = observation.model_dump(mode="json")
+    timeout_payload["content_sha256"] = ""
+    timeout_payload["failure_kind"] = ContinuityFailureKind.MODEL_TIMEOUT
+    timeout_payload["continuity_failure"] = True
+    timeout_payload["ineligibility_reason"] = None
+    timeout = ContinuityObservation.model_validate(timeout_payload)
+    assert timeout.continuity_failure
+    assert timeout.ineligibility_reason is None
+
+    host_payload = observation.model_dump(mode="json")
+    host_payload["content_sha256"] = ""
+    host_payload["failure_kind"] = ContinuityFailureKind.HOST_FAILURE_AFTER_DELIVERY
+    host_payload["continuity_failure"] = None
+    host_payload["ineligibility_reason"] = PairIneligibilityReason.HOST_FAILURE
+    host_fault = ContinuityObservation.model_validate(host_payload)
+    assert host_fault.continuity_failure is None
+    assert host_fault.ineligibility_reason is PairIneligibilityReason.HOST_FAILURE
+
+    invalid_payload = observation.model_dump(mode="json")
+    invalid_payload["content_sha256"] = ""
+    invalid_payload["failure_kind"] = ContinuityFailureKind.MODEL_EMPTY_OUTPUT
+    invalid_payload["continuity_failure"] = None
+    with pytest.raises(ValidationError, match="must count as continuity failure"):
+        ContinuityObservation.model_validate(invalid_payload)
+
+
+def test_model_phase_requires_exact_provider_model_token_and_spend_authority() -> None:
+    model_condition = continuity.ContinuityModelCondition(
+        execution_kind=continuity.ContinuityExecutionKind.PROVIDER_MODEL,
+        provider_id="test-provider",
+        model_id="test-model",
+        adapter_id="test-adapter",
+        model_configuration_sha256="a" * 64,
+    )
+    provider_authorization = continuity.ContinuityProviderAuthorization(
+        authorization_id="test-shakedown-approval",
+        authorized_phase=ContinuityStudyPhase.SHAKEDOWN,
+        approved_by="Theo",
+        model_condition_sha256=model_condition.content_sha256,
+        maximum_provider_calls=1,
+        maximum_input_tokens_per_call=10_000,
+        maximum_output_tokens_per_call=2_000,
+        maximum_total_tokens=12_000,
+        spend_currency="USD",
+        maximum_spend_microunits=1_000_000,
+    )
+    payload = build_provider_free_manifest().model_dump(mode="json")
+    payload.update(
+        {
+            "content_sha256": "",
+            "phase": ContinuityStudyPhase.SHAKEDOWN,
+            "model_condition": model_condition.model_dump(mode="json"),
+            "provider_authorization": provider_authorization.model_dump(mode="json"),
+            "study_outcomes_allowed": False,
+        }
+    )
+
+    manifest = continuity.ContinuityStudyManifest.model_validate(payload)
+
+    assert manifest.provider_calls_allowed == 1
+    assert manifest.provider_authorization == provider_authorization
+
+    mismatched_authorization_payload = provider_authorization.model_dump(mode="json")
+    mismatched_authorization_payload["content_sha256"] = ""
+    mismatched_authorization_payload["model_condition_sha256"] = "f" * 64
+    mismatched_payload = {
+        **payload,
+        "provider_authorization": mismatched_authorization_payload,
+    }
+    with pytest.raises(ValidationError, match="model condition"):
+        continuity.ContinuityStudyManifest.model_validate(mismatched_payload)
+
+
+@pytest.mark.parametrize(
+    ("phase", "conclusion"),
+    [
+        (ContinuityStudyPhase.SHAKEDOWN, ContinuityConclusion.SUPPORTED),
+        (ContinuityStudyPhase.CONFIRMATORY, ContinuityConclusion.ANALYSIS_FIXTURE),
+    ],
+)
+def test_report_rejects_a_conclusion_from_another_phase(
+    phase: ContinuityStudyPhase,
+    conclusion: ContinuityConclusion,
+) -> None:
+    manifest = build_provider_free_manifest()
+    plan = build_continuity_plan(manifest)
+    evidence = build_provider_free_fixture_evidence(manifest=manifest, plan=plan)
+    report = analyse_continuity_study(
+        manifest=manifest,
+        plan=plan,
+        deliveries=evidence.deliveries,
+        observations=evidence.observations,
+    )
+    payload = report.model_dump(mode="json")
+    payload.update(
+        {
+            "content_sha256": "",
+            "phase": phase,
+            "conclusion": conclusion,
+            "fixture_rule_result": None,
+        }
+    )
+
+    with pytest.raises(ValidationError, match=phase.value):
+        ContinuityStudyReport.model_validate(payload)

--- a/tests/experiments/stewardship_continuity/test_provider_free_e2e.py
+++ b/tests/experiments/stewardship_continuity/test_provider_free_e2e.py
@@ -1,0 +1,37 @@
+# ABOUTME: Runs the complete ASW-4A provider-free fixture and reload journey.
+# ABOUTME: Proves analysis readiness without provider calls, study outcomes, or reward changes.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aec_bench.experiments.stewardship_continuity import (
+    ContinuityConclusion,
+    publish_provider_free_fixture_study,
+    reload_and_verify_study_report,
+)
+
+
+def test_provider_free_study_freeze_e2e(tmp_path: Path) -> None:
+    root = tmp_path / "asw-4a"
+    result = publish_provider_free_fixture_study(root)
+    replayed = reload_and_verify_study_report(
+        root=root,
+        report_content_sha256=result.report.content_sha256,
+    )
+
+    assert replayed == result.report
+    assert replayed.conclusion is ContinuityConclusion.ANALYSIS_FIXTURE
+    assert replayed.fixture_rule_result is ContinuityConclusion.SUPPORTED
+    assert replayed.coverage.exact
+    assert replayed.coverage.analyzable_block_count == 32
+    assert replayed.provider_call_count == 0
+    assert replayed.input_token_count == 0
+    assert replayed.output_token_count == 0
+    assert replayed.spend_currency is None
+    assert replayed.spend_microunits == 0
+    assert replayed.study_outcome_count == 0
+    assert replayed.fixture_observation_count == 64
+    assert replayed.task_reward_mutation_count == 0
+    assert not result.manifest.study_outcomes_allowed
+    assert result.manifest.provider_calls_allowed == 0

--- a/tests/experiments/test_source_ownership.py
+++ b/tests/experiments/test_source_ownership.py
@@ -3,11 +3,18 @@
 
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 
 SOURCE_EXPERIMENTS = Path(__file__).parents[2] / "src" / "aec_bench" / "experiments"
 EXPECTED_LIBRARY_EXPERIMENTS = {
     "__init__.py",
+    "stewardship_continuity/__init__.py",
+    "stewardship_continuity/analysis.py",
+    "stewardship_continuity/artifacts.py",
+    "stewardship_continuity/contracts.py",
+    "stewardship_continuity/fixtures.py",
+    "stewardship_continuity/planning.py",
     "task_ecology_baseline.py",
     "task_ecology_benchmark.py",
 }
@@ -21,3 +28,24 @@ def test_library_contains_only_reusable_experiment_helpers() -> None:
     }
 
     assert actual == EXPECTED_LIBRARY_EXPERIMENTS
+
+
+def test_stewardship_continuity_helpers_do_not_import_provider_code() -> None:
+    continuity_root = SOURCE_EXPERIMENTS / "stewardship_continuity"
+    forbidden_roots = {
+        "aec_bench.adapters",
+        "aec_bench.providers",
+    }
+
+    imports = {
+        alias.name
+        for path in continuity_root.glob("*.py")
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8")))
+        if isinstance(node, ast.Import | ast.ImportFrom)
+        for alias in (node.names if isinstance(node, ast.Import) else [ast.alias(name=node.module or "")])
+    }
+
+    assert all(
+        not any(import_name == root or import_name.startswith(f"{root}.") for root in forbidden_roots)
+        for import_name in imports
+    )


### PR DESCRIPTION
## Summary

- add the versioned study-local continuity manifest, paired plan, treatment-delivery record, observation, failure taxonomy, reducer, and immutable report
- bind all 32 pairs to planned history, event schedule, model condition, logical limits, and canonical evidence order
- add phase-specific provider authority slots for provider, model, adapter, calls, tokens, currency, and spend
- prove immutable publication, retry, reload, recomputation, and tamper rejection with generated provider-free fixtures
- preserve the research decisions and evidence in an Ara-lite record

## Boundary

- zero provider calls
- zero tokens and spend
- zero study outcomes
- no task reward change
- no shared extraction
- ASW-4B still needs separate approval before one model shakedown

## Verification

- 45 focused unit, integration, and end-to-end tests passed
- Ara-lite validation passed
- Ruff lint passed
- Ruff format check passed for 11 changed Python files
- Mypy passed for 11 changed Python files