### PR TITLE
ASW-5: accept programme checkpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,8 @@ research/asset-stewardship/asw-4c-confirmatory-study/**/.world-run.lock
 !research/asset-stewardship/asw-4-programme-checkpoint/**
 !research/asset-stewardship/asw-5-rich-work-processes/
 !research/asset-stewardship/asw-5-rich-work-processes/**
+!research/asset-stewardship/asw-5-programme-checkpoint/
+!research/asset-stewardship/asw-5-programme-checkpoint/**
 !research/asset-stewardship/au-nsw-lh-syn-sps-v1-parameter-family-and-mechanism-rulings.md
 !research/asset-stewardship/au-nsw-lh-syn-sps-v1-generator-protocol.md
 !research/asset-stewardship/au-nsw-lh-syn-sps-v1-independent-certification-protocol.md

--- a/research/asset-stewardship/asset-stewardship-worlds-prd.md
+++ b/research/asset-stewardship/asset-stewardship-worlds-prd.md
@@ -5,15 +5,15 @@
 
 | Field | Value |
 | --- | --- |
-| Status | ASW-0 through ASW-4 complete; the ASW-4 programme checkpoint authorizes ASW-5 only |
-| Date | 2026-07-31 |
-| Revision | `ASW-PRD-K-2026-07-31` |
+| Status | ASW-0 through ASW-5 complete; the ASW-5 programme checkpoint authorizes ASW-6A local evidence health only |
+| Date | 2026-08-01 |
+| Revision | `ASW-PRD-L-2026-08-01` |
 | Design revision | Semantic decisions change through reviewed document revisions; this PRD does not require a self-referential or hand-authored content hash |
 | Target repository | `aec-bench` |
-| Current production branch | `main` at ASW-4C merge `8ecf053e14b976e9686bb02de9da02b29781b856` |
-| Live implementation status | The certified world, production runtime, falsification stages, direct and Harbor execution, immutable evaluation, and first confirmatory study are complete |
+| Current production branch | `main` at ASW-5 merge `be24edd42dc16b01ff13f8a860c402ecde297501` |
+| Live implementation status | The certified world, production runtime, falsification stages, direct and Harbor execution, immutable evaluation, first confirmatory study, and rich work-process stage are complete |
 | Initial programme boundary | ASW-0 through ASW-4 |
-| Implementation status | The asset-local world, direct host, installed CLI, Harbor path, durable records, evaluation, falsification stages, and first study are complete; ASW-5 is the only authorized expansion |
+| Implementation status | ASW-5 rich work processes passed their provider-free gate; ASW-6A local evidence health is the only authorized expansion |
 | Working programme name | Asset Stewardship Worlds |
 | First study | Obligation continuity under time and handover |
 
@@ -882,7 +882,7 @@ Evaluation may reconstruct selected alternatives on demand in a separate private
 | FR-20 | The controller must support hidden or overlapping evaluation windows and post-window continuation without exposing the boundary. | Must |
 | FR-21 | Counterfactual branches must be replayable on demand without eager materialisation or realised-branch leakage. | Must by ASW-3 |
 | FR-22 | Composite triggers, obligation dependencies, waiver and suspension transitions, reservations, and arbitrary additional overlapping processes beyond the fixed ASW-2 inspection/intervention pair must be supported. | Conditional ASW-5 |
-| FR-23 | Sensor health, calibration, stale evidence, delayed results, and contradictory records must be supported. | Conditional ASW-6 |
+| FR-23 | Sensor health, calibration, stale evidence, delayed results, contradictory records, and a maintenance closeout review over a named asset case pack must be supported. | Conditional ASW-6 |
 | FR-24 | State-addressable rollout fan-out, imperfect restoration, recurrence, maintenance-induced defects, and rework must be supported. | Conditional ASW-7 |
 | FR-25 | Arbitrary coupled assets, generalized transferred duty beyond the fixed A/B profile rule, shared resources, constrained outages, and endogenous backlog must be supported. | Conditional ASW-8 |
 | FR-26 | Governed institutional proposals must version and selectively propagate FMECA or schedule changes. | Conditional ASW-9 |
@@ -1579,13 +1579,30 @@ unauthorized.
 
 **Exit gate:** composite obligations and overlapping processes replay and survive handover without conservation errors.
 
+**Checkpoint decision — 2026-08-01:** ASW-5 is accepted. The provider-free
+stage passed its focused and cumulative gates. Replay, version migration,
+direct and Harbor execution, fresh-agent handover, and resource conservation
+remained valid under overlapping work and a forced access interruption. The
+interruption produced one visible verification-deadline breach, as required by
+the frozen rule that suspension does not pause a required follow-up deadline.
+
+The checkpoint authorizes ASW-6A local evidence-health design, implementation,
+and falsification only. It does not authorize ASW-6A-R, temporal retrieval,
+ASW-6B, ASW-7, shared extraction, or a model study.
+
+[The ASW-5 programme checkpoint](asw-5-programme-checkpoint/ara/PAPER.md)
+records the result audit, decision, next-stage entry gate, and retained limits.
+
 ### ASW-6 — Partial observability and evidence health
 
-ASW-6 is conditional and uses two explicit parent-owned substage labels so the parent and companion roadmaps cannot silently diverge. Neither substage is part of the ASW-0 through ASW-4 critical path.
+ASW-6 uses explicit parent-owned substage labels so the parent and companion
+roadmaps cannot silently diverge. ASW-6A local evidence health is authorized by
+the ASW-5 checkpoint. ASW-6A-R, the temporal-evidence contribution, and ASW-6B
+remain conditional.
 
 #### ASW-6A — Local evidence health
 
-**Conditional scope:**
+**Authorized provider-free scope:**
 
 - inspection choice;
 - sensor state and calibration;
@@ -1595,9 +1612,55 @@ ASW-6 is conditional and uses two explicit parent-owned substage labels so the p
 - changed post-maintenance baselines; and
 - deterministic observation-quality treatments.
 
-The optional temporal-evidence companion may contribute its nested `ASW-6A-TE0` through `ASW-6A-TE4` slices only after the ASW-4 checkpoint authorizes that hypothesis. Those slices contribute to this parent-owned milestone; they do not replace or own sensor, calibration, observation-quality, contradictory-record, or post-maintenance-baseline work.
+The optional temporal-evidence companion may contribute its nested
+`ASW-6A-TE0` through `ASW-6A-TE4` slices only after a later parent checkpoint
+explicitly authorizes that hypothesis. The ASW-5 checkpoint does not authorize
+them. Those slices contribute to this parent-owned milestone; they do not
+replace or own sensor, calibration, observation-quality, contradictory-record,
+or post-maintenance-baseline work.
 
 **Exit gate:** latent truth remains concealed and every evidence item carries age, quality, provenance, and applicable operating regime.
+
+##### ASW-6A-R — Maintenance closeout and return-to-service review
+
+This review is a human asset-assurance task over one fixed, valid world history.
+The first reviewer role is an asset engineer, maintenance-assurance engineer, or
+independent verification engineer. The review object is the named Pump A
+maintenance closeout and return-to-service pack, not the simulator or an
+abstract dump of world state.
+
+**Conditional scope:**
+
+- assemble the review pack from the condition and defect history, work order
+  and approved scope, work processes and dependencies, access and resource
+  records, inspection and intervention evidence, functional checks,
+  provisional return and closeout records, post-maintenance verification,
+  active restrictions and open obligations, decision and handover lineage, and
+  the applicable FMECA and maintenance-schedule basis;
+- introduce one declared class of credible review issue in a fallible record,
+  claim, decision, or omission while keeping authoritative world state valid;
+- begin with bounded issues such as evidence for the wrong component, evidence
+  that predates the work, incomplete work recorded as complete, a result that
+  conflicts with physical evidence, or a missing restriction or verification
+  obligation in the closeout or handover record;
+- require a source-bound review record that identifies the finding, affected
+  and unaffected records or duties, missing evidence, disposition, and required
+  follow-up; and
+- keep the planted issue, expected impact map, latent truth, and verifier target
+  private from the reviewer.
+
+ASW-6A-R starts only after the local evidence-health contract can represent the
+age, quality, provenance, operating regime, and contradictions used by the
+review. Its mechanism design and provider-free falsification do not authorize a
+model study. Any agent review study requires its own frozen design, shakedown,
+provider authority, budget, and confirmatory gate. ASW-6A-R does not add a new
+physical mutation; maintenance-induced or controlled physical defects remain
+ASW-7B scope.
+
+**Exit gate:** the review pack is bound to one replay-valid history; the planted
+issue does not corrupt authoritative world state; the private verifier can
+check the exact finding, affected and unaffected set, evidence boundary, and
+disposition; and no latent or future truth leaks to the reviewer.
 
 #### ASW-6B — Optional external historical-archive adapter
 
@@ -1611,7 +1674,7 @@ ASW-6B implementation and pilot work exist only if the companion's local determi
 
 **Conditional scope:**
 
-- select a committed, verified full-world snapshot as one immutable rollout origin;
+- select a committed, verified full-world snapshot, including an eligible review checkpoint, as one immutable rollout origin;
 - create multiple isolated child continuations from that same state without moving or rewriting the parent branch;
 - hold future world conditions fixed to measure agent variation, or apply one declared and governed future-world variation as a separate treatment axis;
 - bind every child to the parent snapshot, world and rule versions, event schedule, information boundary, agent condition, rollout seed, and verification result;
@@ -1851,8 +1914,8 @@ An external engine-research lane may run beside ASW-0A, but it converges only at
 | OD-11 | Define handover projection, actor-visible contents, revision, and separately queryable authoritative history. | Resolved for the selected durable commit chain; cross-branch history remains later scope | ASW-2A3 projection and verifier boundary; ASW-2B artifact repository |
 | OD-12 | Define evaluation-window treatments and terminal-liability vector. | Resolved for the first study | [ASW-0C research charter](asw-0c-research-charter.md#12-budgets-and-evaluation-window) |
 | OD-13 | Define exact behavior for a physical terminal event, or defer the general terminal surface. | Resolved by deferral | The first charter contains no physical terminal event |
-| OD-14 | Approve model-provider identity, token limits, and financial budget. | Resolved for ASW-4 only | Phase-bound ASW-4B and ASW-4C approvals; no provider authority carries into ASW-5 |
-| OD-15 | Define the evidence threshold for each conditional expansion. | Resolved for ASW-5; later stages remain conditional | [ASW-4 programme checkpoint](asw-4-programme-checkpoint/ara/PAPER.md) |
+| OD-14 | Approve model-provider identity, token limits, and financial budget. | Resolved for ASW-4 only | Phase-bound ASW-4B and ASW-4C approvals; no provider authority carries into ASW-5 or ASW-6A |
+| OD-15 | Define the evidence threshold for each conditional expansion. | Resolved through ASW-6A local evidence health; later stages remain conditional | [ASW-5 programme checkpoint](asw-5-programme-checkpoint/ara/PAPER.md) |
 | OD-16 | Select generator/oracle and independent-certification software roles. | Resolved | ASW-0B3 through ASW-0B5 |
 | OD-17 | Define evidence/rights classification and research-to-runtime promotion shape. | Resolved | ASW-0B2 through ASW-0B5 |
 
@@ -1894,23 +1957,28 @@ An external engine-research lane may run beside ASW-0A, but it converges only at
 | 2026-07-29 | Keep the ASW-2C host boundary minimal and provider-neutral while the pump-station package owns its native tools. | The host needs strict start and resume contracts without owning task physics, action names, evaluation policy, or model-provider calls. |
 | 2026-07-31 | Accept the ASW-4 programme checkpoint and authorize ASW-5 only. | The first study produced a useful, independently reloadable research object and an exact zero-difference result; richer overlapping work provides a concrete next hypothesis without assuming that structured handover will improve it. |
 | 2026-08-01 | Place state-addressable rollout fan-out in conditional ASW-7A, before imperfect-repair and environment-variation work in ASW-7B. | Reusing one verified start for many agent continuations is a data-generation primitive distinct from changing world conditions; it needs rich durable state and lineage but must not expand provider-free ASW-5. |
+| 2026-08-01 | Add a human-grounded Pump A maintenance closeout and return-to-service review as ASW-6A-R. | A credible asset review reconciles a named case pack of condition, work, test, control, obligation, and handover records against the maintenance basis. The planted issue belongs in a fallible record, claim, decision, or omission rather than corrupting authoritative world state. |
+| 2026-08-01 | Accept the ASW-5 programme checkpoint and authorize ASW-6A local evidence health only. | ASW-5 passed its provider-free replay, handover, compatibility, and conservation gates. Evidence age, quality, provenance, operating regime, and contradictions are the next required semantics before a closeout review or temporal-retrieval study. |
 
 ## 24. Immediate next action
 
-Complete **ASW-5 — rich obligations and work processes** as one bounded,
-provider-free stage.
+Complete **ASW-6A — local evidence health** as one bounded, provider-free
+stage.
 
-Freeze its state changes and conservation checks before implementation. Then
-add composite triggers, dependencies, waiver and suspension, nested operating
-limits, reservations, spare and access processes, dependency-aware rescheduling
-and cancellation, and overlapping work orders. The exit gate must prove replay,
-resume, crash recovery, and fresh-agent handover without duplicated work, lost
-state, or resource-conservation errors.
+Freeze the evidence record, sensor, calibration, delay, staleness,
+contradiction, supersession, and operating-regime rules before implementation.
+Then add only the deterministic observation-quality paths exercised by the
+Pump A and Pump B histories. The exit gate must prove that latent truth remains
+concealed and that every actor-visible evidence item has explicit age, quality,
+provenance, component scope, and applicable operating regime through views,
+handover, replay, resume, and Harbor import.
 
-ASW-5 does not authorize a model study, temporal retrieval, shared extraction,
-imperfect repair, or coupled assets.
+ASW-6A does not authorize ASW-6A-R, temporal retrieval, an external archive,
+a model study, shared extraction, imperfect repair, rollout fan-out, or coupled
+assets.
 
-State-addressable rollout fan-out is retained as conditional ASW-7A work. It is
-not part of the ASW-5 exit gate. The programme must complete ASW-5 and pass the
-required later checkpoints before ASW-7A implementation or any rollout study is
-authorized.
+The Pump A maintenance closeout review remains conditional ASW-6A-R work. It
+can start only after the local evidence-health exit gate passes and a separate
+checkpoint authorizes it. State-addressable rollout fan-out remains conditional
+ASW-7A work and can include an eligible review checkpoint only after its own
+entry gate.

--- a/research/asset-stewardship/asw-5-programme-checkpoint/ara/PAPER.md
+++ b/research/asset-stewardship/asw-5-programme-checkpoint/ara/PAPER.md
@@ -1,0 +1,59 @@
+---
+ara_schema_version: "0.1"
+title: ASW-5 programme checkpoint
+---
+
+# Research continuation summary
+
+The ASW-5 programme checkpoint accepts the provider-free rich work-process
+stage and authorizes ASW-6A local evidence health only.
+
+ASW-5 established a useful second world-state version. Overlapping Pump A and
+Pump B work survived access loss, suspension, dependency checks, cancellation,
+resource reservation, direct and Harbor execution, durable replay, and a fresh
+agent handover. Existing version 1 histories remained reloadable and replayable.
+
+The forced access interruption also produced one real terminal liability. The
+Pump A verification deadline continued while work was suspended, so the final
+evaluation recorded one breached required follow-up and reward `0.0`. Direct
+and Harbor evaluation vectors were identical. This is an expected consequence
+of the approved rule, not an execution failure.
+
+## Checkpoint decision
+
+- Accept ASW-5 as complete.
+- Preserve its version 1 and version 2 compatibility boundary.
+- Preserve the access-interruption deadline breach as valid evidence.
+- Authorize provider-free ASW-6A local evidence-health design,
+  implementation, and falsification.
+- Keep ASW-6A-R, the temporal-evidence contribution, ASW-6B, and ASW-7
+  through ASW-10 conditional.
+- Keep all pump-station world state and rules asset-local.
+- Require a new freeze and separate provider authority before any model study.
+
+## Next hypothesis
+
+The ASW-6A hypothesis is provisional:
+
+> Evidence continuity and decision quality can become measurable when an
+> agent must distinguish current, stale, delayed, contradictory, and
+> operating-regime-mismatched records while latent world truth stays hidden.
+
+ASW-6A tests the world semantics first. It must add only the sensor,
+calibration, evidence-age, quality, provenance, component-scope,
+operating-regime, delay, staleness, contradiction, supersession, and changed
+post-maintenance-baseline behavior exercised by the fixed Pump A and Pump B
+histories.
+
+The checkpoint does not claim that these evidence conditions will improve a
+continuity treatment. It establishes the minimum local evidence-health
+contract required before the planned Pump A maintenance closeout review or an
+optional temporal-evidence study.
+
+## Artifact layers
+
+- `logic/claims.yaml` records the supported ASW-5 checkpoint claims.
+- `logic/experiments.yaml` records the provider-free result audit.
+- `evidence/index.yaml` binds the result audit, decision, and ASW-6A entry gate.
+- `trace/exploration_tree.yaml` records the evidence-led stage decision.
+- `staging/observations.yaml` keeps later review, rollout, and study work open.

--- a/research/asset-stewardship/asw-5-programme-checkpoint/ara/evidence/asw-5-result-audit.md
+++ b/research/asset-stewardship/asw-5-programme-checkpoint/ara/evidence/asw-5-result-audit.md
@@ -1,0 +1,58 @@
+# ASW-5 result audit
+
+## Frozen question
+
+Can overlapping required follow-ups, work processes, operating limits, and
+reserved resources survive interruption, cancellation, durable replay, and
+agent handover without duplicated effects, lost state, or conservation errors?
+
+## Exact result
+
+- ASW-5 merge: `be24edd42dc16b01ff13f8a860c402ecde297501`.
+- Focused ASW-5 gate: 17 passed.
+- Complete pump-station cumulative gate: 163 passed.
+- Strict MyPy: 24 changed source files and 5 changed test files passed.
+- Ruff: the complete changed source and test boundary passed.
+- Provider calls: 0.
+- Direct and Harbor final state: identical.
+- Direct and Harbor evaluation vector: identical.
+- Replay verifier: passed.
+- Independent Harbor verifier: passed.
+- Fresh-agent handover count: 1.
+- Live-process handover omissions: 0.
+- Required-follow-up breaches: 1.
+- Imported `TrialRecord` reward: `0.0`.
+
+The access interruption suspended access-dependent work. It did not pause the
+Pump A post-maintenance verification deadline. The resulting breach follows the
+approved ASW-5 rule and remains visible in the evaluation vector.
+
+## Compatibility and conservation result
+
+- Version 1 states and receipts remain byte-preserving on reload and replay.
+- Continuing a version 1 run under version 2 creates a content-addressed
+  version 2 state and an explicit migration record.
+- Unknown versions fail closed.
+- Access and the intervention slot release on suspension, cancellation, and
+  completion.
+- The repair kit stays reserved during suspension and is consumed only after
+  successful obstruction clearance.
+- Cancelled or completed work ignores stale completion events.
+- Suspended or interrupted work has no partial physical effect.
+- The parent and child operating-limit chain remains visible without latent
+  state leakage.
+
+## Wider repository result
+
+The repository-wide run recorded 7,601 passes, 21 existing skips, and 10
+failures outside ASW-5. Eight failures reproduced at unchanged `origin/main`.
+One test depends on the checkout directory name. One Azure reviewer test passes
+alone on ASW-5 and the baseline and is order-dependent in the full run. These
+existing failures remain visible but do not falsify the bounded ASW-5 claims.
+
+## Sources
+
+- `research/asset-stewardship/asw-5-rich-work-processes/ara/PAPER.md`
+- `research/asset-stewardship/asw-5-rich-work-processes/ara/evidence/current-test-status.md`
+- `research/asset-stewardship/asw-5-rich-work-processes/ara/evidence/compatibility-boundary.md`
+- `research/asset-stewardship/asw-5-rich-work-processes/ara/evidence/rule-freeze.md`

--- a/research/asset-stewardship/asw-5-programme-checkpoint/ara/evidence/asw-6a-entry-gate.md
+++ b/research/asset-stewardship/asw-5-programme-checkpoint/ara/evidence/asw-6a-entry-gate.md
@@ -1,0 +1,49 @@
+# ASW-6A local evidence-health entry gate
+
+## Provisional hypothesis
+
+Evidence continuity and decision quality can become measurable when an agent
+must distinguish current, stale, delayed, contradictory, and
+operating-regime-mismatched records while latent world truth stays hidden.
+
+This is an ASW-6A hypothesis. It is not an ASW-5 finding.
+
+## Authorized scope
+
+ASW-6A can add the minimum exercised local rules for:
+
+- inspection choice;
+- sensor state and calibration;
+- evidence age, quality, provenance, and component scope;
+- evidence applicability to an operating regime;
+- delayed evidence release;
+- stale measurements;
+- contradictory and superseded records;
+- changed post-maintenance baselines; and
+- deterministic observation-quality treatments.
+
+ASW-6A remains asset-local and provider-free. It does not add the Pump A
+maintenance closeout review, a temporal corpus, search or fetch tools,
+retrieval-state continuity, an external archive, a model study, shared
+stewardship contracts, imperfect repair, rollout fan-out, or coupled assets.
+
+## Required checks
+
+The ASW-6A exit gate must prove:
+
+- latent physical truth stays private;
+- every visible evidence item has explicit time, age, quality, provenance,
+  component scope, and applicable operating regime;
+- evidence claims cannot mutate physical truth;
+- stale, delayed, superseded, contradictory, and regime-mismatched evidence
+  remain distinguishable;
+- actor views and handovers do not hide a decision-relevant evidence-health
+  state or expose latent and future state;
+- actions remain bound to the exact visible information set;
+- snapshot, resume, retry, replay, crash recovery, direct execution, Harbor
+  import, and strict reload retain the same evidence semantics; and
+- version 1 and version 2 histories remain reloadable and replayable without
+  byte mutation.
+
+The stage must begin with an exact rule and schema freeze. No model call is part
+of the gate.

--- a/research/asset-stewardship/asw-5-programme-checkpoint/ara/evidence/checkpoint-decision.md
+++ b/research/asset-stewardship/asw-5-programme-checkpoint/ara/evidence/checkpoint-decision.md
@@ -1,0 +1,40 @@
+# ASW-5 programme checkpoint decision
+
+## Decision
+
+| Item | Decision |
+| --- | --- |
+| Programme authority | Theo |
+| Decision date | 2026-08-01 |
+| ASW-5 result | Accepted |
+| ASW-5 merge | `be24edd42dc16b01ff13f8a860c402ecde297501` |
+| Authorized next stage | ASW-6A local evidence health only |
+| ASW-6A provider calls | Not authorized |
+| ASW-6A-R | Retained but not authorized |
+| Temporal evidence contribution | Not authorized |
+| ASW-6B | Not authorized |
+| ASW-7 through ASW-10 | Remain conditional |
+| Shared extraction | Not authorized |
+| New model study | Not authorized |
+
+ASW-5 passes its programme checkpoint because the approved rich work-process
+semantics passed focused and cumulative provider-free checks. The stage
+preserved replay, version compatibility, direct and Harbor parity, fresh-agent
+handover, and resource conservation. Its forced access interruption also
+created the expected visible deadline breach instead of hiding the liability.
+
+ASW-6A is authorized because the next planned human review needs explicit
+evidence age, quality, provenance, component scope, operating regime, and
+contradiction semantics. The checkpoint does not authorize that review itself.
+
+## Retained architecture decision
+
+The wastewater pump-station package still owns its state, rules, views,
+receipts, persistence, and evaluation extensions. No second task-world consumer
+or unavoidable stable host boundary now justifies shared extraction.
+
+## Provider boundary
+
+The ASW-4B and ASW-4C provider approvals remain phase-bound. ASW-5 used no
+provider, and this checkpoint gives no provider authority to ASW-6A or a later
+review study.

--- a/research/asset-stewardship/asw-5-programme-checkpoint/ara/evidence/index.yaml
+++ b/research/asset-stewardship/asw-5-programme-checkpoint/ara/evidence/index.yaml
@@ -1,0 +1,31 @@
+evidence:
+  - id: EV001
+    kind: note
+    path: evidence/asw-5-result-audit.md
+    description: Exact ASW-5 tests, compatibility, direct and Harbor parity, handover, conservation, and terminal-liability result.
+    source: research/asset-stewardship/asw-5-rich-work-processes/ara
+    supports: [C001, C002, C003, C004]
+    produced_by: E001
+    exact_values_required: true
+    domain:
+      implementation_stage: ASW-5-checkpoint
+  - id: EV002
+    kind: note
+    path: evidence/checkpoint-decision.md
+    description: Theo-approved ASW-5 acceptance, ASW-6A authorization, and retained programme limits.
+    source: ASW-5 programme checkpoint on 2026-08-01
+    supports: [C001, C002, C003, C004]
+    produced_by: E001
+    exact_values_required: true
+    domain:
+      implementation_stage: ASW-5-checkpoint
+  - id: EV003
+    kind: note
+    path: evidence/asw-6a-entry-gate.md
+    description: Provisional next hypothesis, provider-free ASW-6A scope, evidence-health checks, and exit gate.
+    source: research/asset-stewardship/asset-stewardship-worlds-prd.md
+    supports: []
+    produced_by: E001
+    exact_values_required: false
+    domain:
+      implementation_stage: ASW-6A

--- a/research/asset-stewardship/asw-5-programme-checkpoint/ara/logic/claims.yaml
+++ b/research/asset-stewardship/asw-5-programme-checkpoint/ara/logic/claims.yaml
@@ -1,0 +1,67 @@
+claims:
+  - id: C001
+    statement: ASW-5 completed its approved provider-free rich work-process gate.
+    status: supported
+    falsification_criteria:
+      - The focused ASW-5 gate does not pass all 17 tests.
+      - The complete pump-station cumulative gate does not pass all 163 tests.
+      - ASW-5 made a model-provider call.
+    proof:
+      experiments: [E001]
+      evidence: [EV001, EV002]
+    dependencies: []
+    provenance: source
+    tags: [programme-checkpoint, provider-free, rich-work-processes]
+    domain:
+      implementation_stage: ASW-5-checkpoint
+  - id: C002
+    statement: ASW-5 preserved deterministic process state, resource conservation, direct and Harbor parity, durable replay, and complete fresh-agent handover under a forced access interruption.
+    status: supported
+    falsification_criteria:
+      - Direct and Harbor final state or evaluation vectors differ.
+      - Replay or the independent Harbor verifier fails.
+      - A resource is duplicated, lost, or consumed without successful work.
+      - The fresh-agent handover omits a live process, dependency, reservation, or nested operating limit.
+    proof:
+      experiments: [E001]
+      evidence: [EV001, EV002]
+    dependencies: [C001]
+    provenance: source
+    tags: [replay, conservation, handover, harbor]
+    domain:
+      implementation_stage: ASW-5-checkpoint
+      handover_count: 1
+      handover_omission_count: 0
+  - id: C003
+    statement: The ASW-5 access interruption produced the expected visible Pump A verification-deadline breach because suspension does not pause required follow-up deadlines.
+    status: supported
+    falsification_criteria:
+      - The interrupted history has no breached Pump A verification follow-up.
+      - The breach is hidden from the final evaluation vector.
+      - Direct and Harbor evaluation disagree about the breach.
+    proof:
+      experiments: [E001]
+      evidence: [EV001, EV002]
+    dependencies: [C001, C002]
+    provenance: source
+    tags: [deadline, suspension, terminal-liability]
+    domain:
+      implementation_stage: ASW-5-checkpoint
+      obligation_breach_count: 1
+      imported_trial_reward: 0.0
+  - id: C004
+    statement: ASW-5 added version 2 records without mutating version 1 bytes and with explicit content-addressed migration lineage.
+    status: supported
+    falsification_criteria:
+      - A version 1 run cannot reload or replay.
+      - Continuing version 1 under version 2 mutates the version 1 bytes.
+      - The version 2 continuation lacks source migration lineage.
+      - An unknown state or receipt version is accepted.
+    proof:
+      experiments: [E001]
+      evidence: [EV001, EV002]
+    dependencies: [C001]
+    provenance: source
+    tags: [compatibility, migration, lineage]
+    domain:
+      implementation_stage: ASW-5-checkpoint

--- a/research/asset-stewardship/asw-5-programme-checkpoint/ara/logic/experiments.yaml
+++ b/research/asset-stewardship/asw-5-programme-checkpoint/ara/logic/experiments.yaml
@@ -1,0 +1,29 @@
+experiments:
+  - id: E001
+    verifies: [C001, C002, C003, C004]
+    purpose: Audit the completed ASW-5 stage against its frozen provider-free programme gate.
+    setup: Use the merged ASW-5 rules, compatibility record, final focused and cumulative test evidence, installed direct and Harbor evidence, and strict evaluation result without a provider call.
+    procedure:
+      - Confirm the approved process, resource, dependency, waiver, nested-limit, and compatibility rules.
+      - Compare the final test results with the frozen unit, integration, end-to-end, and attack gate.
+      - Confirm direct and Harbor final-state and evaluation parity.
+      - Confirm replay, independent verification, strict TrialRecord reload, and complete handover.
+      - Trace the forced access interruption to the retained verification-deadline breach.
+      - Confirm version 1 byte preservation, version 2 migration lineage, and unknown-version rejection.
+      - Separate known wider repository failures from the bounded ASW-5 claims.
+      - Decide whether the result supports a local evidence-health entry gate.
+    metrics:
+      - Focused and cumulative test counts.
+      - Provider-call count.
+      - Direct and Harbor state and evaluation equality.
+      - Replay and verifier status.
+      - Handover and omission counts.
+      - Resource reservation and consumption conservation.
+      - Required-follow-up breach count and imported reward.
+      - Historical reload, migration-lineage, and unknown-version behavior.
+    evidence: [EV001, EV002, EV003]
+    exploratory: false
+    domain:
+      phase: programme_checkpoint
+      provider_calls: 0
+      result: accepted

--- a/research/asset-stewardship/asw-5-programme-checkpoint/ara/staging/observations.yaml
+++ b/research/asset-stewardship/asw-5-programme-checkpoint/ara/staging/observations.yaml
@@ -1,0 +1,30 @@
+observations:
+  - id: O001
+    summary: Explicit evidence health may make continuity and decision quality measurable in a way that the ASW-4 binary handover contrast did not.
+    status: provisional
+    source: ASW-5 programme checkpoint on 2026-08-01
+    next_action: Test local evidence-health semantics provider-free in ASW-6A before defining a review or model study.
+    domain:
+      planned_stage: ASW-6A
+  - id: O002
+    summary: The Pump A maintenance closeout and return-to-service pack is the planned first human-grounded review object.
+    status: open
+    source: Theo's roadmap decision on 2026-08-01
+    next_action: Keep ASW-6A-R blocked until the ASW-6A local evidence-health exit gate and a separate checkpoint pass.
+    domain:
+      planned_stage: ASW-6A-R
+      provider_calls_authorized: false
+  - id: O003
+    summary: An eligible review checkpoint can later become an immutable origin for state-addressable rollout fan-out.
+    status: open
+    source: Theo's roadmap decision on 2026-08-01
+    next_action: Keep implementation in conditional ASW-7A after the review mechanics and their checkpoint pass.
+    domain:
+      planned_stage: ASW-7A
+  - id: O004
+    summary: A later model study needs process-quality measures and a prospective no-meaningful-difference rule.
+    status: open
+    source: ASW-4 and ASW-5 checkpoint review
+    next_action: Freeze these measures before any later shakedown or confirmatory provider call.
+    domain:
+      planned_stage: later_model_study

--- a/research/asset-stewardship/asw-5-programme-checkpoint/ara/trace/exploration_tree.yaml
+++ b/research/asset-stewardship/asw-5-programme-checkpoint/ara/trace/exploration_tree.yaml
@@ -1,0 +1,116 @@
+nodes:
+  - id: N001
+    type: question
+    summary: Did ASW-5 pass its provider-free gate and establish a useful next research object?
+    children: [N002]
+    also_depends_on: []
+    claims_touched: [C001, C002, C003, C004]
+    provenance: user
+    payload:
+      programme_gate: after_ASW-5
+    domain:
+      implementation_stage: ASW-5-checkpoint
+  - id: N002
+    type: experiment
+    summary: Audit the frozen ASW-5 rules, compatibility boundary, tests, direct and Harbor evidence, handover, and evaluation.
+    children: [N003]
+    also_depends_on: [N001]
+    claims_touched: [C001, C002, C003, C004]
+    provenance: ai_executed
+    payload:
+      experiment_id: E001
+      result: passed
+      provider_calls: 0
+      focused_tests_passed: 17
+      cumulative_tests_passed: 163
+    domain:
+      implementation_stage: ASW-5-checkpoint
+  - id: N003
+    type: observation
+    summary: The forced access interruption preserved all state and resource invariants while creating one visible verification-deadline breach.
+    children: [N004]
+    also_depends_on: [N002]
+    claims_touched: [C002, C003]
+    provenance: source
+    payload:
+      obligation_breach_count: 1
+      imported_trial_reward: 0.0
+      handover_omission_count: 0
+    domain:
+      implementation_stage: ASW-5-checkpoint
+  - id: N004
+    type: decision
+    summary: Accept ASW-5 without hiding the deadline breach or changing its approved process rules.
+    children: [N005]
+    also_depends_on: [N003]
+    claims_touched: [C001, C002, C003, C004]
+    provenance: user
+    payload:
+      accepted_on: "2026-08-01"
+      result: accepted
+    domain:
+      implementation_stage: ASW-5-checkpoint
+  - id: N005
+    type: pivot
+    summary: Move from rich work-process semantics to provider-free local evidence-health semantics.
+    children: [N006]
+    also_depends_on: [N004]
+    claims_touched: []
+    provenance: user_revised
+    payload:
+      next_stage: ASW-6A
+      hypothesis_status: provisional
+      provider_calls_authorized: false
+    domain:
+      implementation_stage: ASW-6A
+  - id: N006
+    type: decision
+    summary: Authorize ASW-6A local evidence health only and keep all other expansion conditional.
+    children: [N007, N008, N009]
+    also_depends_on: [N005]
+    claims_touched: []
+    provenance: user
+    payload:
+      authorized_stage: ASW-6A-local
+      unauthorized_stages: [ASW-6A-R, ASW-6A-TE0, ASW-6B, ASW-7, ASW-8, ASW-9, ASW-10]
+      model_study_authorized: false
+    domain:
+      implementation_stage: ASW-5-checkpoint
+  - id: N007
+    type: decision
+    summary: Retain the Pump A maintenance closeout review as conditional ASW-6A-R after the local evidence-health gate.
+    children: []
+    also_depends_on: [N006]
+    claims_touched: []
+    provenance: user_revised
+    payload:
+      planned_stage: ASW-6A-R
+      provider_calls_authorized: false
+    domain:
+      implementation_stage: ASW-5-checkpoint
+  - id: N008
+    type: decision
+    summary: Retain review-checkpoint rollout fan-out as conditional ASW-7A.
+    children: []
+    also_depends_on: [N006]
+    claims_touched: []
+    provenance: user_revised
+    payload:
+      planned_stage: ASW-7A
+      model_rollouts_authorized: false
+    domain:
+      implementation_stage: ASW-5-checkpoint
+  - id: N009
+    type: decision
+    summary: Keep temporal retrieval, external archives, shared extraction, and model studies unauthorized.
+    children: []
+    also_depends_on: [N006]
+    claims_touched: []
+    provenance: user
+    payload:
+      temporal_evidence_authorized: false
+      external_archive_authorized: false
+      shared_extraction_authorized: false
+      model_study_authorized: false
+    domain:
+      implementation_stage: ASW-5-checkpoint

--- a/research/asset-stewardship/asw-5-rich-work-processes/ara/PAPER.md
+++ b/research/asset-stewardship/asw-5-rich-work-processes/ara/PAPER.md
@@ -90,7 +90,17 @@ failures outside ASW-5. Eight failures reproduced at the unchanged
 baseline, which identifies a full-suite order dependency. These wider
 repository defects remain visible but do not falsify the ASW-5 claims.
 
-## Retained later step
+## Retained later steps
+
+A human-grounded maintenance closeout and return-to-service review is retained
+for conditional ASW-6A-R. The first review object is the named Pump A case pack:
+condition and defect history, work order and scope, work and resource records,
+inspection and intervention evidence, functional checks, provisional return and
+closeout, post-maintenance verification, restrictions, obligations, handover
+lineage, and the applicable FMECA and maintenance-schedule basis. A controlled
+review issue belongs in a fallible record, claim, decision, or omission. It must
+not corrupt authoritative world state. This review is not part of ASW-5 and has
+no model-provider authority from this rule freeze.
 
 State-addressable rollout fan-out is retained for conditional ASW-7A. It will
 allow a later study to select one verified full-world state and create many

--- a/research/asset-stewardship/asw-5-rich-work-processes/ara/staging/observations.yaml
+++ b/research/asset-stewardship/asw-5-rich-work-processes/ara/staging/observations.yaml
@@ -46,3 +46,13 @@ observations:
       imported_trial_reward: 0.0
       obligation_breach_count: 1
       provider_calls: 0
+  - id: O007
+    summary: A later asset review should use the Pump A maintenance closeout and return-to-service pack as its human review object, with one credible issue in a fallible record, claim, decision, or omission.
+    status: open
+    source: Theo's asset-review planning decision on 2026-08-01
+    next_action: Implement this only as conditional ASW-6A-R after local evidence-health mechanics pass, and keep it outside the ASW-5 exit gate.
+    domain:
+      planned_stage: ASW-6A-R
+      review_object: pump_a_maintenance_closeout_and_return_to_service_pack
+      authoritative_state_corruption_allowed: false
+      current_stage_scope: excluded

--- a/research/asset-stewardship/asw-5-rich-work-processes/ara/trace/exploration_tree.yaml
+++ b/research/asset-stewardship/asw-5-rich-work-processes/ara/trace/exploration_tree.yaml
@@ -39,7 +39,7 @@ nodes:
   - id: N004
     type: experiment
     summary: Run red-green-refactor unit, integration, end-to-end, and attack tests without a model provider.
-    children: [N005, N006]
+    children: [N005, N006, N007]
     also_depends_on: [N003]
     claims_touched: [C001, C002, C003, C004, C005]
     provenance: ai_suggested
@@ -88,3 +88,20 @@ nodes:
     domain:
       implementation_stage: ASW-5
       gate_status: passed
+  - id: N007
+    type: decision
+    summary: Retain a human-grounded Pump A maintenance closeout and return-to-service review as conditional ASW-6A-R and keep it outside ASW-5.
+    children: []
+    also_depends_on: [N004]
+    claims_touched: []
+    provenance: user_revised
+    payload:
+      decision_status: accepted
+      reviewer_roles: [asset_engineer, maintenance_assurance_engineer, independent_verification_engineer]
+      review_object: pump_a_maintenance_closeout_and_return_to_service_pack
+      issue_location: fallible_record_claim_decision_or_omission
+      authoritative_state_corruption_allowed: false
+      provider_calls_authorized: false
+    domain:
+      current_stage: ASW-5
+      planned_stage: ASW-6A-R

--- a/research/asset-stewardship/temporal-evidence-frontier-prd.md
+++ b/research/asset-stewardship/temporal-evidence-frontier-prd.md
@@ -1,30 +1,35 @@
 # ABOUTME: Defines the optional temporal-evidence and backresearch capability for asset-stewardship worlds.
-# ABOUTME: Extends the stewardship PRD without putting any TEF contract, retrieval, or external provider on the ASW-1–ASW-4 path.
+# ABOUTME: Extends the stewardship PRD without putting any TEF contract, retrieval, or external provider on the ASW-1–ASW-5 path.
 
 # Temporal Evidence Frontier — Companion Product Requirements Document
 
 | Field | Value |
 | --- | --- |
-| Status | ASW-0A accepted; TEF remains disabled through the ASW-4 checkpoint |
-| Date | 2026-07-27 |
-| Revision | `TEF-PRD-F-2026-07-27` |
+| Status | ASW-5 accepted; TEF remains disabled while ASW-6A local evidence health is built |
+| Date | 2026-08-01 |
+| Revision | `TEF-PRD-G-2026-08-01` |
 | Companion content identity | Recorded externally in the [ASW-0A baseline and authority record](asw-0a-baseline-and-authority.md); the document does not carry a self-referential hash |
 | Target repository | `aec-bench` |
-| Target branch/worktree | `feat/asset-stewardship-asw-0a` / `.worktrees/asset-stewardship-asw-0a` |
-| Implementation baseline | Accepted ASW-0A derivative of merged PR24 commit `fdc6215c39add79d4a5549a1bfc058d9baac1b54`, tree `730594c69662369eea08f3e96274dc59778bca38`; the focused documentation-ownership gate passes |
+| Target branch/worktree | `main` at ASW-5 merge `be24edd42dc16b01ff13f8a860c402ecde297501` / a clean stage worktree |
+| Implementation baseline | Accepted ASW-5 asset-local world with versioned state, rich work processes, direct and Harbor execution, durable replay, and independent evaluation |
 | Parent product document | [Asset Stewardship Worlds PRD](asset-stewardship-worlds-prd.md) |
-| Required parent revision | `ASW-PRD-F-2026-07-27` |
-| Parent content hash | `56d6fe6a9c69796d819a1995ae63a85392ba85a4240df8baa87df99a76678335` |
+| Required parent revision | `ASW-PRD-L-2026-08-01` |
+| Parent content hash | `962c85815ba2c7c48f58a0f7b7702427bd0b536b54626afc30b74da0f8cb5bd3` |
 | Required parent world | `AU-NSW-LH-SYN-SPS-v1`, independently certified to parent validity level V3 |
 | Capability status | Design only; no temporal-evidence or BackSearch implementation exists |
-| Core programme impact | No TEF schema, field, tool, capability declaration, or implementation dependency in ASW-1 through ASW-4 |
+| Core programme impact | No TEF schema, field, tool, capability declaration, or implementation dependency in ASW-1 through ASW-5 or the authorized ASW-6A local evidence-health core |
 | Canonical implementation | ASW-6A local deterministic temporal evidence store |
 | Optional integration | ASW-6B external historical-archive adapter |
 | First confirmatory study | Retrieval-state continuity under delayed evidence |
 
 ## Executive decision
 
-After the parent ASW-4 checkpoint, add a capability-gated **Temporal Evidence Frontier** to the certified synthetic stewardship world. The capability is introduced only with its real ASW-6A producer and consumer; no TEF-specific declaration is reserved in ASW-1 through ASW-4.
+After a later parent checkpoint explicitly authorizes the temporal hypothesis,
+add a capability-gated **Temporal Evidence Frontier** to the certified
+synthetic stewardship world. The ASW-5 checkpoint does not give that authority.
+The capability is introduced only with its real ASW-6A producer and consumer;
+no TEF-specific declaration is reserved in ASW-1 through ASW-5 or the local
+evidence-health core.
 
 The capability generalises SSC-03's staged evidence precedent from host-pushed release of a fixed evidence catalogue to agent-pulled retrieval over a host-controlled, time-bounded, actor-specific corpus. It is a targeted extension to the proposed stewardship architecture, not a redesign and not a dependency of the initial obligation-continuity study.
 
@@ -204,11 +209,12 @@ This PRD does not establish that:
 
 Temporal-evidence implementation depends on the parent-certified package `AU-NSW-LH-SYN-SPS-v1`: a fictional duplex submersible wastewater pumping-station archetype in a Lower Hunter, New South Wales operating context.
 
-Before ASW-6A:
+Before ASW-6A-TE0:
 
 - the package must pass the parent V3 construct-valid benchmark gate;
 - its world, generator, independent-certifier, source, rights, derivation, assumption, engine-role, and promotion manifests must be frozen and content-addressed;
 - the parent ASW-4 obligation-continuity study and checkpoint must be accepted; and
+- a later parent checkpoint must explicitly authorize the temporal hypothesis; and
 - TEF must record the exact parent revision, package identity, lineage head, and certification report it consumes.
 
 V4 empirical or SME calibration is optional and is not a TEF prerequisite. V3 does not support claims that the package is an identified real station, a compliance design, an operational recommendation, or a digital twin.
@@ -322,7 +328,7 @@ The programme introduces no TEF seam before ASW-6:
 - Parent ASW-0A through ASW-0C freeze the baseline, certify `AU-NSW-LH-SYN-SPS-v1` to V3, and preregister the first stewardship study without a TEF deliverable.
 - Parent ASW-1 through ASW-4 own the generic world, host information-set, projection, execution, falsification, and obligation-continuity study contracts. No field, capability declaration, tool, schema, registry entry, compatibility placeholder, or import is added on TEF's behalf.
 - Temporal retrieval is behaviorally absent through ASW-4: there is no TEF object with `enabled: false`, no search/fetch surface, and no synthetic temporal field in historical records.
-- ASW-6A may begin only after the parent V3 package, ASW-4 study, and programme checkpoint are accepted. It implements and validates the local deterministic capability while consuming the parent-owned information-set boundary.
+- ASW-6A-TE0 may begin only after the parent V3 package and ASW-4 study are accepted and a later parent checkpoint explicitly authorizes the temporal hypothesis. It implements and validates the local deterministic capability while consuming the parent-owned information-set boundary.
 - Temporal Study 1 then tests retrieval-state continuity over that local deterministic capability.
 - ASW-6B0 may begin a paper-only eligibility and governance review after TS1-A; provider implementation and the external pilot remain blocked until TS1-C is accepted.
 
@@ -1175,11 +1181,17 @@ The first obligation-continuity study must not mix:
 - retrieval-state handover; or
 - search budget.
 
-Temporal work proceeds only after the ASW-4 programme checkpoint authorizes a concrete next hypothesis.
+Temporal work proceeds only after a parent programme checkpoint explicitly
+authorizes the temporal hypothesis. The ASW-5 checkpoint authorizes local
+evidence health only and keeps this companion disabled.
 
 ### ASW-6A — Temporal-evidence contribution to the parent evidence-health milestone
 
-The parent owns the overall ASW-6A evidence-health milestone, including any sensor, calibration, observation-quality, contradictory-record, or post-maintenance-baseline work. This companion contributes only the optional temporal-frontier slices below. Those slices may start only after the parent ASW-4 checkpoint explicitly authorizes the hypothesis.
+The parent owns the overall ASW-6A evidence-health milestone, including any
+sensor, calibration, observation-quality, contradictory-record, or
+post-maintenance-baseline work. This companion contributes only the optional
+temporal-frontier slices below. Those slices may start only after a later parent
+checkpoint explicitly authorizes the temporal hypothesis.
 
 Within this companion, **accepted TEF contribution** means ASW-6A-TE0 through ASW-6A-TE4 have passed and a parent checkpoint has accepted their evidence. It does not mean the broader parent ASW-6A milestone is complete.
 
@@ -1761,13 +1773,14 @@ No hook may be bypassed.
 
 Do no TEF implementation now.
 
-Execute the parent critical path in order:
+Complete the parent ASW-6A local evidence-health stage first. It must define and
+test sensor state, calibration, evidence age, quality, provenance, component
+scope, operating regime, delay, staleness, contradiction, and changed
+post-maintenance baselines without a temporal corpus, search tool, retrieval
+state, or provider.
 
-1. Begin ASW-0B1 by freezing the `AU-NSW-LH-SYN-SPS-v1` claim, fictional regional profile, two-pump boundary, intended benchmark construct, V3 target, and prohibited claims.
-2. Progress through ASW-0B2 to ASW-0B5 only after each preceding stage is separately reviewed and accepted: classify sources and rights; select and separate engine roles; freeze generator and independent-certifier protocols; and certify the package to V3 with complete derivation, assumption, and lineage evidence.
-3. ASW-0C preregisters the parent study histories, carrier treatment, complete-current-view rule, endpoint, estimand, budgets, and claim limits.
-4. ASW-1 and ASW-2 implement only the parent world and generic host-execution boundaries.
-5. ASW-3 falsifies those boundaries.
-6. ASW-4 runs the TEF-free obligation-continuity study and checkpoint with temporal retrieval absent; its separately authorized model-provider executions remain governed by the parent.
-
-Only an accepted ASW-4 checkpoint may authorize ASW-6A-TE0. The next companion action is then a bounded scenario-and-corpus design review using the already-certified parent package—not asset selection, external-provider selection, code, or a speculative shared contract.
+After that provider-free exit gate, a parent checkpoint can decide whether the
+temporal hypothesis is useful and can authorize ASW-6A-TE0 only. The first
+companion action would then be a bounded scenario-and-corpus design review using
+the certified parent package. It would not select an external provider, add
+code, or create a shared contract.


### PR DESCRIPTION
## Summary
- accept the completed provider-free ASW-5 stage
- authorize ASW-6A local evidence health only
- retain ASW-6A-R and ASW-7A as conditional later stages
- keep temporal retrieval, external providers, shared extraction, and model studies blocked
- align the parent and temporal companion roadmaps

## Validation
- focused ASW-5 gate: 17 passed
- pump-station cumulative gate: 163 passed
- Ara validation: passed for the ASW-5 result and checkpoint artifacts
- Ruff lint: passed
- MyPy: passed for 23 source files
- changed-file whitespace check: passed

## Note
A broad Ruff formatting check found one unchanged baseline test file that would be reformatted. This documentation PR does not alter that unrelated file.