### PR TITLE
ASW-6A-R: add hybrid closeout review contract

### DIFF
--- a/research/asset-stewardship/asset-stewardship-worlds-prd.md
+++ b/research/asset-stewardship/asset-stewardship-worlds-prd.md
@@ -7,13 +7,13 @@
 | --- | --- |
 | Status | ASW-0 through ASW-6A-R complete; all later expansions remain conditional |
 | Date | 2026-08-02 |
-| Revision | `ASW-PRD-O-2026-08-02` |
+| Revision | `ASW-PRD-P-2026-08-02` |
 | Design revision | Semantic decisions change through reviewed document revisions; this PRD does not require a self-referential or hand-authored content hash |
 | Target repository | `aec-bench` |
-| Current production basis | `main` at ASW-6A merge `56578f61d097830aa788e2d2c7848049c60dfebc` |
+| Current production basis | `main` at ASW-6A-R merge `ee72f7e6aa1713af4a41327039364e7d70e30643` |
 | Live implementation status | The certified world, production runtime, falsification stages, direct and Harbor execution, immutable evaluation, first confirmatory study, rich work processes, separate actor and host-control interfaces, local evidence health, and maintenance closeout review are complete |
 | Initial programme boundary | ASW-0 through ASW-4 |
-| Implementation status | The ASW-6A-R provider-free mechanism passed; one approved real-agent shakedown completed with an exact-verifier rejection; no later expansion is active or authorized |
+| Implementation status | The ASW-6A-R hybrid version 2 contract passed its provider-free gate; the earlier version 1 real-agent rejection remains unchanged; no later expansion is active or authorized |
 | Working programme name | Asset Stewardship Worlds |
 | First study | Obligation continuity under time and handover |
 
@@ -1774,9 +1774,10 @@ abstract dump of world state.
   that predates the work, incomplete work recorded as complete, a result that
   conflicts with physical evidence, or a missing restriction or verification
   obligation in the closeout or handover record;
-- require a source-bound review record that identifies the finding, affected
-  and unaffected records or duties, missing evidence, disposition, and required
-  follow-up; and
+- require a source-bound review record that identifies the finding, directly
+  affected and unaffected records or duties, missing evidence, disposition,
+  process-required action codes, written review rationale, related-record
+  assessment, additional recommendations, and source references; and
 - keep the planted issue, expected impact map, latent truth, and verifier target
   private from the reviewer.
 
@@ -1830,6 +1831,16 @@ agent response remains a negative result. The
 [research artifact](asw-6a-r-maintenance-closeout-review/ara/PAPER.md) retains
 the authority, trajectory, token and cost record, verifier report, and rejected
 agent claim.
+
+**Hybrid contract revision, 2026-08-02:** version 2 uses public controlled
+values where the process must route work or make a repeatable decision. It uses
+written language for the expert rationale, related-record assessment, and
+additional recommendations. Directly affected records and required action
+codes remain strict. Every decisive source reference is required, while extra
+visible source records are permitted. Version 1 submissions and verifier
+targets remain readable without migration. The 24 focused ASW-6A-R tests,
+three final affected-path checks, Ruff, and MyPy completed without a provider
+call. The earlier negative agent run and its private target remain unchanged.
 
 #### ASW-6B — Optional external historical-archive adapter
 
@@ -2193,15 +2204,15 @@ An external engine-research lane may run beside ASW-0A, but it converges only at
 | 2026-08-01 | Accept the ASW-6A provider-free gate and close the local evidence-health stage. | Version 3 compatibility, six evidence treatments, sensor and physical inspection choice, durable retry and recovery, handover privacy, installed JSON, and local Harbor parity passed. No authority is granted to ASW-6A-R or any later stage. |
 | 2026-08-02 | Approve one exact ASW-6A-R real-agent shakedown authority. | The authority fixes the Amazon Bedrock route, model, adapter, provider-call, turn, tool-call, token, and cost limits before execution. It permits one run only and does not carry into another model study. |
 | 2026-08-02 | Accept the ASW-6A-R mechanism and retain its negative real-agent result. | Provider-free execution, persistence, redaction, Harbor parity, and independent verification passed. The agent found the planted issue but failed three exact report fields. No retry or verifier change is permitted after this observed result. |
+| 2026-08-02 | Approve and accept the ASW-6A-R hybrid version 2 review contract. | Process-required work now uses public action codes, while expert rationale, related-record context, and additional recommendations remain written language. Direct impact stays strict, decisive sources are required, extra visible sources are permitted, version 1 evidence remains readable, and no provider call was made. |
 
 ## 24. Immediate next action
 
 Review the accepted **ASW-6A-R — maintenance closeout and return-to-service
 review** checkpoint and decide separately which conditional stage, if any, to
-authorize next. The negative agent result creates one bounded contract question:
-whether follow-up actions need typed public codes and whether the evaluator
-should require exact sets or permit justified additional affected records and
-source references. It does not authorize a contract change or another run.
+authorize next. The version 2 hybrid contract resolves the bounded action-code
+and set-semantics question raised by the negative agent result. It does not
+authorize another model run.
 
 ASW-6A-R does not authorize temporal retrieval, an external archive, a
 confirmatory model study, shared extraction, imperfect repair, rollout fan-out,

--- a/research/asset-stewardship/asw-6a-r-maintenance-closeout-review/ara/PAPER.md
+++ b/research/asset-stewardship/asw-6a-r-maintenance-closeout-review/ara/PAPER.md
@@ -54,6 +54,20 @@ marks affected records, follow-up, and source references as different. C005 is
 rejected for this run. No retry occurred, and the target was not changed after
 the result.
 
+Theo approved a hybrid version 2 review contract on 2026-08-02. Process work
+now uses public controlled action codes. The submitted expert record also keeps
+a written review rationale, related-record assessments, and additional written
+recommendations. Directly affected records remain an exact set. Every decisive
+source reference is required, but extra visible sources do not cause an
+automatic failure. Version 1 submissions and targets remain readable without
+migration.
+
+The version 2 provider-free gate completed with 24 focused tests and no cached
+failures. Three final affected-path checks then completed after the type-boundary
+corrections. Ruff and MyPy passed. C006 is supported by EV014. No provider call
+was made, C005 remains rejected for the original run, and no old run artifact
+was changed.
+
 ## Artifact map
 
 - `logic/claims.yaml` records falsifiable mechanism and agent claims.
@@ -62,4 +76,4 @@ the result.
 - `evidence/index.yaml` links the approved rule decision and later outputs.
 - `trace/exploration_tree.yaml` records the decision and execution sequence.
 - `staging/observations.yaml` records the negative agent result and the exposed
-  interface-to-verifier question.
+  interface-to-verifier question and its version 2 resolution.

--- a/research/asset-stewardship/asw-6a-r-maintenance-closeout-review/ara/evidence/asw-6a-r-hybrid-contract-decision.md
+++ b/research/asset-stewardship/asw-6a-r-maintenance-closeout-review/ara/evidence/asw-6a-r-hybrid-contract-decision.md
@@ -1,0 +1,20 @@
+# ASW-6A-R hybrid review contract decision
+
+Theo approved the ASW-6A-R hybrid review contract on 2026-08-02.
+
+- Keep version 1 submissions and verifier targets readable without migration.
+- Use version 2 for all new review cases and submissions.
+- Require public controlled values for the finding, disposition, direct affected
+  records, missing evidence, unaffected duties, and process-required actions.
+- Request a visible written review rationale. Do not depend on hidden model
+  analysis or provider-specific chain-of-thought fields.
+- Let the reviewer record related but not directly affected records with one
+  written rationale for each record.
+- Let the reviewer add written recommendations that do not create process work.
+- Require every decisive source reference, but allow extra visible source
+  records without an automatic failure.
+- Keep the direct affected-record set strict. Wider operating context belongs
+  in the related-record assessment.
+- Reject unknown action codes and references outside the visible review pack.
+- Make no provider call and do not retry the previous real-agent run during this
+  contract revision.

--- a/research/asset-stewardship/asw-6a-r-maintenance-closeout-review/ara/evidence/index.yaml
+++ b/research/asset-stewardship/asw-6a-r-maintenance-closeout-review/ara/evidence/index.yaml
@@ -117,3 +117,24 @@ evidence:
     exact_values_required: true
     domain:
       provider_calls: 0
+  - id: EV013
+    kind: note
+    path: evidence/asw-6a-r-hybrid-contract-decision.md
+    description: Theo-approved boundary for public action codes, written expert assessment, strict direct impact, related records, required source coverage, and version 1 compatibility.
+    source: Theo decision on 2026-08-02
+    supports: []
+    produced_by: null
+    exact_values_required: true
+    domain:
+      stage: ASW-6A-R
+      review_contract_version: 2
+  - id: EV014
+    kind: command_output
+    path: evidence/logs/hybrid-contract-validation.txt
+    description: TDD, focused provider-free tests, final affected-path checks, Ruff, and MyPy evidence for the version 2 hybrid contract.
+    source: focused ASW-6A-R pytest, Ruff, and MyPy commands
+    supports: [C006]
+    produced_by: E008
+    exact_values_required: true
+    domain:
+      provider_calls: 0

--- a/research/asset-stewardship/asw-6a-r-maintenance-closeout-review/ara/evidence/logs/hybrid-contract-validation.txt
+++ b/research/asset-stewardship/asw-6a-r-maintenance-closeout-review/ara/evidence/logs/hybrid-contract-validation.txt
@@ -1,0 +1,29 @@
+ASW-6A-R hybrid contract validation
+
+TDD red phase:
+- Three selected contract tests failed during collection because the version 2
+  pack policy and hybrid review types did not exist.
+
+TDD first green phase:
+- Three selected unit, integration, and agent-contract tests passed.
+
+Final focused ASW-6A-R phase:
+- Eight ASW-6A-R test files completed with 24 collected tests and no cached
+  failures.
+- Coverage included models, derivation, reviewer session, durable repository,
+  host control, installed JSON, local Harbor, and provider-free agent contracts.
+
+Final affected-path phase after type-boundary corrections:
+- Version 1 contract reload completed with no cached failure.
+- Version 2 case derivation completed with no cached failure.
+- Local Harbor reference parity completed with no cached failure.
+
+Static checks:
+- Ruff format completed on the 11 changed code and test files.
+- Ruff check passed.
+- MyPy passed on 11 changed production and test files.
+
+Scope:
+- Provider calls: 0.
+- The 214-test pump-station folder was not repeated.
+- The full repository test suite was not run.

--- a/research/asset-stewardship/asw-6a-r-maintenance-closeout-review/ara/logic/claims.yaml
+++ b/research/asset-stewardship/asw-6a-r-maintenance-closeout-review/ara/logic/claims.yaml
@@ -29,7 +29,7 @@ claims:
       stage: ASW-6A-R
   - id: C003
     statement: A typed review can record the exact finding, affected records, unaffected duties, missing evidence, disposition, follow-up, and source references for independent evaluation.
-    status: supported
+    status: superseded
     falsification_criteria:
       - A required review field can be omitted or bound to another case.
       - The verifier accepts the wrong affected set, unaffected set, missing evidence, disposition, or source reference.
@@ -41,6 +41,7 @@ claims:
     tags: [structured-review, verification, source-binding]
     domain:
       stage: ASW-6A-R
+      superseded_by: C006
   - id: C004
     statement: Direct Python, installed JSON, handover, replay, crash recovery, and local Harbor preserve one review case and one evaluation result.
     status: supported
@@ -70,3 +71,20 @@ claims:
     tags: [agent-shakedown, model-evidence, token-accounting]
     domain:
       stage: ASW-6A-R
+  - id: C006
+    statement: Version 2 can require controlled values for process-essential work while retaining written expert assessment, strict direct impact, related-record context, and extra visible source references.
+    status: supported
+    falsification_criteria:
+      - A required action can use an unknown code, or the written review rationale can be omitted.
+      - A related record can also be declared directly affected, or a related record can come from outside the visible pack.
+      - The verifier accepts a missing decisive source reference or rejects a submission only because it adds a visible source reference.
+      - A version 1 submission or verifier target cannot be reloaded without migration.
+    proof:
+      experiments: [E008]
+      evidence: [EV014]
+    dependencies: [C001, C002, C004]
+    provenance: user_revised
+    tags: [hybrid-review, action-codes, expert-rationale, compatibility]
+    domain:
+      stage: ASW-6A-R
+      review_contract_version: 2

--- a/research/asset-stewardship/asw-6a-r-maintenance-closeout-review/ara/logic/experiments.yaml
+++ b/research/asset-stewardship/asw-6a-r-maintenance-closeout-review/ara/logic/experiments.yaml
@@ -113,3 +113,22 @@ experiments:
       provider_authority: f8cacee272560ecff04143372ec9b9da64d10aa8486248c1dc476bdfd1009a4e
       outcome: rejected
       provider_retries: 0
+  - id: E008
+    verifies: [C006]
+    purpose: Prove the version 2 hybrid review contract without another provider call.
+    setup: The accepted Pump A closeout case, version 1 compatibility models, version 2 reviewer tools, and the independent verifier.
+    procedure:
+      - Confirm that public process work accepts only declared action codes and requires a written review rationale.
+      - Submit related-record assessments and extra visible source references while keeping the direct affected set strict.
+      - Reject missing required actions, missing decisive sources, and records outside the visible pack.
+      - Reload version 1 submissions and verifier targets without migration.
+      - Exercise direct, installed JSON, durable repository, and local Harbor paths.
+    metrics:
+      - Version 2 review verification result.
+      - Version 1 reload result.
+      - Focused unit, integration, and end-to-end failures.
+    evidence: [EV014]
+    exploratory: false
+    domain:
+      test_layer: provider_free_contract_revision
+      provider_calls: 0

--- a/research/asset-stewardship/asw-6a-r-maintenance-closeout-review/ara/logic/solution/architecture.md
+++ b/research/asset-stewardship/asw-6a-r-maintenance-closeout-review/ara/logic/solution/architecture.md
@@ -13,12 +13,18 @@ target. Preparation and issue-treatment receipts bind both sides without
 changing the source world pointer or any source artifact.
 
 The reviewer session exposes only observe, handover, and typed review
-submission. Each action binds to the current case, pack, tenure, and source
-records. The review repository publishes each accepted review immutably and
-returns exact retries without duplicate records.
+submission. Version 2 uses controlled values for process-essential decisions
+and actions. It also requests a written review rationale, related-record
+assessments, and additional recommendations. Each action binds to the current
+case, pack, tenure, and source records. The review repository publishes each
+accepted review immutably and returns exact retries without duplicate records.
 
 The independent verifier reloads the source world, proves the selected history
 again, reconstructs the untreated and treated packs, checks their one declared
 difference, and evaluates every required review field against the private
-target. Direct, installed JSON, and local Harbor use these same task-owned
-contracts and repository.
+target. The verifier checks the direct affected set and required action codes
+exactly. It requires every decisive source reference but permits extra visible
+sources. Related records and recommendations remain part of the expert record
+without changing process work. Version 1 remains readable for prior evidence.
+Direct, installed JSON, and local Harbor use these same task-owned contracts
+and repository.

--- a/research/asset-stewardship/asw-6a-r-maintenance-closeout-review/ara/logic/solution/constraints.yaml
+++ b/research/asset-stewardship/asw-6a-r-maintenance-closeout-review/ara/logic/solution/constraints.yaml
@@ -8,10 +8,14 @@ constraints:
   - id: K004
     statement: Do not expose the issue class, expected impact map, unaffected control set, verifier target, latent state, or future events to the reviewer.
   - id: K005
-    statement: Require every review field and bind every source reference to the visible pack.
+    statement: Require controlled process fields and a written review rationale, and bind every source reference to the visible pack.
   - id: K006
     statement: Do not make a model-provider call before exact provider authority and limits are approved.
   - id: K007
     statement: Do not add an external archive, temporal retrieval, branch fan-out, or physical treatment.
   - id: K008
     statement: Do not run the full repository test suite for this stage.
+  - id: K009
+    statement: Keep the direct affected-record set strict, place wider context in related-record assessments, and permit extra visible source references only when all decisive references remain present.
+  - id: K010
+    statement: Preserve version 1 evidence without migration and make no provider call during the version 2 contract revision.

--- a/research/asset-stewardship/asw-6a-r-maintenance-closeout-review/ara/staging/observations.yaml
+++ b/research/asset-stewardship/asw-6a-r-maintenance-closeout-review/ara/staging/observations.yaml
@@ -46,8 +46,22 @@ observations:
       claim_status: rejected
   - id: O007
     summary: The public follow-up field accepts free text while the private verifier expects exact canonical action codes.
-    status: open
+    status: supported
     source: EV009
-    next_action: Review typed follow-up and exact-set semantics before another agent study.
+    next_action: Use the approved version 2 hybrid contract before any separately authorized later agent study.
     domain:
-      stage_candidate: post-ASW-6A-R
+      resolved_by: EV013
+  - id: O008
+    summary: Process-required work needs public controlled action codes, while expert rationale and recommendations should remain written language.
+    status: supported
+    source: EV013
+    next_action: Keep the version 2 structured and written fields separate in all execution paths.
+    domain:
+      review_contract_version: 2
+  - id: O009
+    summary: The version 2 provider-free tests and static checks completed without another provider call.
+    status: supported
+    source: EV014
+    next_action: Preserve C005 as the unchanged negative version 1 run and require separate approval before any later model run.
+    domain:
+      provider_calls_made: 0

--- a/research/asset-stewardship/asw-6a-r-maintenance-closeout-review/ara/trace/exploration_tree.yaml
+++ b/research/asset-stewardship/asw-6a-r-maintenance-closeout-review/ara/trace/exploration_tree.yaml
@@ -68,7 +68,7 @@ nodes:
   - id: N006
     type: observation
     summary: The agent found the core issue, but extra visible-record concerns and hidden canonical follow-up codes prevented an exact pass.
-    children: []
+    children: [N007]
     also_depends_on: [N005]
     claims_touched: [C005]
     provenance: ai_executed
@@ -77,3 +77,30 @@ nodes:
       differing_fields: [affected_records, required_follow_up, source_references]
     domain:
       follow_up_question: typed_action_codes_and_set_semantics
+  - id: N007
+    type: decision
+    summary: Use controlled values for process-essential work and written language for expert assessment, with strict direct impact and a separate related-record section.
+    children: [N008]
+    also_depends_on: [N006]
+    claims_touched: [C003, C006]
+    provenance: user_revised
+    payload:
+      decision_date: 2026-08-02
+      decision_evidence: EV013
+      prior_agent_result_changed: false
+    domain:
+      provider_calls_authorized: 0
+      review_contract_version: 2
+  - id: N008
+    type: experiment
+    summary: Implement and validate the version 2 hybrid contract while retaining version 1 reload.
+    children: []
+    also_depends_on: [N007]
+    claims_touched: [C006]
+    provenance: ai_executed
+    payload:
+      experiment: E008
+      evidence: [EV014]
+      outcome: supported
+    domain:
+      provider_calls: 0

--- a/research/asset-stewardship/asw-6a-r-maintenance-closeout-review/ara/trace/sessions/session_index.yaml
+++ b/research/asset-stewardship/asw-6a-r-maintenance-closeout-review/ara/trace/sessions/session_index.yaml
@@ -4,3 +4,13 @@ sessions:
     summary: Reviewed the ASW-6A-R boundary, selected one Pump A closeout issue, required a real-agent shakedown, and received Theo approval for the complete mechanism scope.
     trace_nodes: [N001, N002, N003]
     evidence: [EV001]
+  - id: S002
+    date: 2026-08-02
+    summary: Approved and ran one authority-bound model shakedown, then retained its exact verifier rejection without retry.
+    trace_nodes: [N004, N005, N006]
+    evidence: [EV005, EV006, EV007, EV008, EV009, EV010, EV011]
+  - id: S003
+    date: 2026-08-02
+    summary: Approved and validated the hybrid version 2 contract with controlled process values, written expert assessment, and version 1 compatibility.
+    trace_nodes: [N007, N008]
+    evidence: [EV013, EV014]

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/maintenance_review.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/maintenance_review.py
@@ -7,7 +7,7 @@ import re
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
-from typing import Self
+from typing import Any, Self
 
 from pydantic import field_validator, model_validator
 
@@ -15,7 +15,7 @@ from aec_bench.contracts.harness_kernel import (
     ContentAddressedModel,
     validate_sha256,
 )
-from aec_bench.contracts.validators import NonEmptyStr
+from aec_bench.contracts.validators import FrozenStrictModel, NonEmptyStr
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_verifier import (
     PumpStationVerificationReport,
 )
@@ -24,6 +24,7 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_ru
 )
 
 PUMP_STATION_REVIEW_PACK_POLICY_V1 = "pump-a-closeout-pack.v1"
+PUMP_STATION_REVIEW_PACK_POLICY_V2 = "pump-a-closeout-pack.v2"
 PUMP_STATION_REVIEW_ISSUE_VERSION_V1 = "wrong-component-evidence-citation.v1"
 PUMP_STATION_REVIEW_VISIBILITY_POLICY_V1 = "reviewer-pack-only.v1"
 
@@ -57,6 +58,13 @@ class PumpStationReviewDisposition(StrEnum):
     ACCEPT_CLOSEOUT = "accept_closeout"
     ACCEPT_WITH_FOLLOW_UP = "accept_with_follow_up"
     REJECT_CLOSEOUT = "reject_closeout"
+
+
+class PumpStationReviewActionCode(StrEnum):
+    """Required actions that the closeout process can route."""
+
+    CORRECT_FUNCTIONAL_CHECK_CITATION = "correct-functional-check-citation"
+    REISSUE_PUMP_A_CLOSEOUT = "reissue-pump-a-closeout"
 
 
 class PumpStationReviewRecordKind(StrEnum):
@@ -97,6 +105,18 @@ def _require_distinct_non_empty(values: tuple[str, ...], field_name: str) -> tup
     return values
 
 
+class PumpStationReviewRecordAssessment(FrozenStrictModel):
+    """Written assessment of one related but not directly affected record."""
+
+    record_id: NonEmptyStr
+    rationale: NonEmptyStr
+
+    @field_validator("record_id")
+    @classmethod
+    def validate_record_id(cls, value: str) -> str:
+        return _require_safe_id(value, "record_id")
+
+
 class PumpStationReviewPreparationRequest(ContentAddressedModel):
     """Exact host-private request to derive one review case."""
 
@@ -123,7 +143,10 @@ class PumpStationReviewPreparationRequest(ContentAddressedModel):
     def validate_frozen_scope(self) -> Self:
         if self.schema_version != "pump-station.review-preparation-request.v1":
             raise ValueError("unsupported review preparation schema version")
-        if self.pack_policy != PUMP_STATION_REVIEW_PACK_POLICY_V1:
+        if self.pack_policy not in {
+            PUMP_STATION_REVIEW_PACK_POLICY_V1,
+            PUMP_STATION_REVIEW_PACK_POLICY_V2,
+        }:
             raise ValueError("unsupported pack policy")
         if self.issue_version != PUMP_STATION_REVIEW_ISSUE_VERSION_V1:
             raise ValueError("unsupported issue version")
@@ -179,8 +202,8 @@ class PumpStationReviewIssueSpecification(ContentAddressedModel):
         return self
 
 
-class PumpStationReviewVerifierTarget(ContentAddressedModel):
-    """Host-private expected answer used by the independent verifier."""
+class PumpStationReviewVerifierTargetV1(ContentAddressedModel):
+    """Version 1 host-private exact answer retained for evidence replay."""
 
     schema_version: str = "pump-station.review-verifier-target.v1"
     finding: PumpStationReviewFinding
@@ -206,8 +229,35 @@ class PumpStationReviewVerifierTarget(ContentAddressedModel):
         return self
 
 
-class PumpStationReviewSubmission(ContentAddressedModel):
-    """One immutable source-bound reviewer response."""
+class PumpStationReviewVerifierTarget(ContentAddressedModel):
+    """Host-private version 2 answer for hybrid expert review."""
+
+    schema_version: str = "pump-station.review-verifier-target.v2"
+    finding: PumpStationReviewFinding
+    affected_record_ids: tuple[NonEmptyStr, ...]
+    unaffected_duty_ids: tuple[NonEmptyStr, ...]
+    missing_evidence_ids: tuple[NonEmptyStr, ...]
+    disposition: PumpStationReviewDisposition
+    required_follow_up: tuple[PumpStationReviewActionCode, ...]
+    required_source_record_ids: tuple[NonEmptyStr, ...]
+
+    @model_validator(mode="after")
+    def validate_target(self) -> Self:
+        if self.schema_version != "pump-station.review-verifier-target.v2":
+            raise ValueError("unsupported review verifier target version")
+        for field_name in (
+            "affected_record_ids",
+            "unaffected_duty_ids",
+            "missing_evidence_ids",
+            "required_follow_up",
+            "required_source_record_ids",
+        ):
+            _require_distinct_non_empty(tuple(getattr(self, field_name)), field_name)
+        return self
+
+
+class PumpStationReviewSubmissionV1(ContentAddressedModel):
+    """Version 1 reviewer response retained for evidence replay."""
 
     schema_version: str = "pump-station.review-submission.v1"
     review_id: NonEmptyStr
@@ -248,6 +298,82 @@ class PumpStationReviewSubmission(ContentAddressedModel):
         ):
             _require_distinct_non_empty(tuple(getattr(self, field_name)), field_name)
         return self
+
+
+class PumpStationReviewSubmission(ContentAddressedModel):
+    """Version 2 source-bound response with codes and written assessment."""
+
+    schema_version: str = "pump-station.review-submission.v2"
+    review_id: NonEmptyStr
+    case_id: NonEmptyStr
+    public_case_content_sha256: str
+    pack_content_sha256: str
+    reviewer_tenure_id: NonEmptyStr
+    finding: PumpStationReviewFinding
+    finding_summary: NonEmptyStr
+    affected_record_ids: tuple[NonEmptyStr, ...]
+    unaffected_duty_ids: tuple[NonEmptyStr, ...]
+    missing_evidence_ids: tuple[NonEmptyStr, ...]
+    disposition: PumpStationReviewDisposition
+    required_follow_up: tuple[PumpStationReviewActionCode, ...]
+    review_rationale: NonEmptyStr
+    related_record_assessments: tuple[PumpStationReviewRecordAssessment, ...] = ()
+    additional_recommendations: tuple[NonEmptyStr, ...] = ()
+    source_record_ids: tuple[NonEmptyStr, ...]
+
+    @field_validator("review_id", "case_id")
+    @classmethod
+    def validate_stable_ids(cls, value: str, info: object) -> str:
+        field_name = getattr(info, "field_name", "identifier")
+        return _require_safe_id(value, str(field_name))
+
+    @field_validator("public_case_content_sha256", "pack_content_sha256")
+    @classmethod
+    def validate_content_hash(cls, value: str) -> str:
+        return validate_sha256(value)
+
+    @model_validator(mode="after")
+    def validate_submission(self) -> Self:
+        if self.schema_version != "pump-station.review-submission.v2":
+            raise ValueError("unsupported review submission schema version")
+        for field_name in (
+            "affected_record_ids",
+            "unaffected_duty_ids",
+            "missing_evidence_ids",
+            "required_follow_up",
+            "source_record_ids",
+        ):
+            _require_distinct_non_empty(tuple(getattr(self, field_name)), field_name)
+        related_ids = tuple(item.record_id for item in self.related_record_assessments)
+        if len(related_ids) != len(set(related_ids)):
+            raise ValueError("related_record_assessments must use distinct records")
+        if set(related_ids).intersection(self.affected_record_ids):
+            raise ValueError("related record must not be directly affected")
+        if len(self.additional_recommendations) != len(set(self.additional_recommendations)):
+            raise ValueError("additional_recommendations must be distinct")
+        return self
+
+
+PumpStationReviewSubmissionAny = PumpStationReviewSubmissionV1 | PumpStationReviewSubmission
+PumpStationReviewVerifierTargetAny = PumpStationReviewVerifierTargetV1 | PumpStationReviewVerifierTarget
+
+
+def parse_pump_station_review_submission(payload: dict[str, Any]) -> PumpStationReviewSubmissionAny:
+    """Load a review submission through its explicit schema version."""
+    if payload.get("schema_version") == "pump-station.review-submission.v1":
+        return PumpStationReviewSubmissionV1.model_validate(payload)
+    if payload.get("schema_version") == "pump-station.review-submission.v2":
+        return PumpStationReviewSubmission.model_validate(payload)
+    raise ValueError("unsupported review submission schema version")
+
+
+def parse_pump_station_review_verifier_target(payload: dict[str, Any]) -> PumpStationReviewVerifierTargetAny:
+    """Load a private verifier target through its explicit schema version."""
+    if payload.get("schema_version") == "pump-station.review-verifier-target.v1":
+        return PumpStationReviewVerifierTargetV1.model_validate(payload)
+    if payload.get("schema_version") == "pump-station.review-verifier-target.v2":
+        return PumpStationReviewVerifierTarget.model_validate(payload)
+    raise ValueError("unsupported review verifier target version")
 
 
 class PumpStationReviewSubmissionReceipt(ContentAddressedModel):
@@ -330,7 +456,10 @@ class PumpStationReviewPack(ContentAddressedModel):
     def validate_pack(self) -> Self:
         if self.schema_version != "pump-station.review-pack.v1":
             raise ValueError("unsupported review pack version")
-        if self.pack_policy != PUMP_STATION_REVIEW_PACK_POLICY_V1:
+        if self.pack_policy not in {
+            PUMP_STATION_REVIEW_PACK_POLICY_V1,
+            PUMP_STATION_REVIEW_PACK_POLICY_V2,
+        }:
             raise ValueError("unsupported pack policy")
         if self.reviewed_component_id != "pump-a":
             raise ValueError("review pack must concern pump-a")
@@ -479,7 +608,7 @@ class PreparedPumpStationReviewCase:
     untreated_pack: PumpStationReviewPack
     public_case: PumpStationReviewPublicCase
     issue: PumpStationReviewIssueSpecification
-    verifier_target: PumpStationReviewVerifierTarget
+    verifier_target: PumpStationReviewVerifierTargetAny
     preparation_receipt: PumpStationReviewPreparationReceipt
     treatment_receipt: PumpStationReviewTreatmentReceipt
     manifest: PumpStationReviewCaseManifest
@@ -506,7 +635,9 @@ def derive_pump_station_review_case(
 __all__ = (
     "PUMP_STATION_REVIEW_ISSUE_VERSION_V1",
     "PUMP_STATION_REVIEW_PACK_POLICY_V1",
+    "PUMP_STATION_REVIEW_PACK_POLICY_V2",
     "PUMP_STATION_REVIEW_VISIBILITY_POLICY_V1",
+    "PumpStationReviewActionCode",
     "PumpStationReviewDisposition",
     "PumpStationReviewFinding",
     "PumpStationReviewIssueClass",
@@ -517,12 +648,19 @@ __all__ = (
     "PumpStationReviewPreparationRequest",
     "PumpStationReviewPublicCase",
     "PumpStationReviewCaseManifest",
+    "PumpStationReviewRecordAssessment",
     "PumpStationReviewRecordKind",
     "PumpStationReviewerRole",
     "PumpStationReviewSubmission",
+    "PumpStationReviewSubmissionAny",
+    "PumpStationReviewSubmissionV1",
     "PumpStationReviewSubmissionReceipt",
     "PumpStationReviewTreatmentReceipt",
     "PumpStationReviewVerifierTarget",
+    "PumpStationReviewVerifierTargetAny",
+    "PumpStationReviewVerifierTargetV1",
     "PreparedPumpStationReviewCase",
     "derive_pump_station_review_case",
+    "parse_pump_station_review_submission",
+    "parse_pump_station_review_verifier_target",
 )

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/maintenance_review_agent.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/maintenance_review_agent.py
@@ -88,8 +88,13 @@ def build_pump_station_review_adapter_request(
             "First call observe_closeout_pack. Check the records against one "
             "another. Do not infer hidden state or ask for private controls. "
             "Before you finish, call submit_closeout_review with the finding, "
-            "affected records, unaffected duties, missing evidence, disposition, "
-            "required follow-up, and source references. Do not invent an identifier."
+            "directly affected records, unaffected duties, missing evidence, "
+            "disposition, public action codes, review rationale, related-record "
+            "assessments, additional recommendations, and source references. Use "
+            "the affected-record field only for records that are directly incorrect. "
+            "Use related-record assessments for wider operating context. Use action "
+            "codes for required process work and natural language for the expert "
+            "review rationale. Do not invent an identifier."
         ),
         tools=list(tool_specs),
         configuration=configuration,

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/maintenance_review_derivation.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/maintenance_review_derivation.py
@@ -8,7 +8,9 @@ from pathlib import Path
 
 from aec_bench.contracts.harness_kernel import canonical_content_sha256
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.maintenance_review import (
+    PUMP_STATION_REVIEW_PACK_POLICY_V1,
     PreparedPumpStationReviewCase,
+    PumpStationReviewActionCode,
     PumpStationReviewCaseManifest,
     PumpStationReviewDisposition,
     PumpStationReviewFinding,
@@ -21,6 +23,8 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.maintena
     PumpStationReviewRecordKind,
     PumpStationReviewTreatmentReceipt,
     PumpStationReviewVerifierTarget,
+    PumpStationReviewVerifierTargetAny,
+    PumpStationReviewVerifierTargetV1,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.physical_kernel import (
     pump_station_model_from_package,
@@ -521,22 +525,41 @@ def derive_pump_station_review_case(
             restriction.restriction_id,
         ),
     )
-    verifier_target = PumpStationReviewVerifierTarget(
-        finding=PumpStationReviewFinding.WRONG_COMPONENT_EVIDENCE_CITATION,
-        affected_record_ids=(request.target_record_id,),
-        unaffected_duty_ids=(obligation.obligation_id,),
-        missing_evidence_ids=original_closeout.evidence_ids,
-        disposition=PumpStationReviewDisposition.REJECT_CLOSEOUT,
-        required_follow_up=(
-            "correct-functional-check-citation",
-            "reissue-pump-a-closeout",
-        ),
-        required_source_record_ids=(
-            request.target_record_id,
-            original_closeout.evidence_ids[0],
-            pump_b_checks.source_record_ids[0],
-        ),
-    )
+    verifier_target: PumpStationReviewVerifierTargetAny
+    if request.pack_policy == PUMP_STATION_REVIEW_PACK_POLICY_V1:
+        verifier_target = PumpStationReviewVerifierTargetV1(
+            finding=PumpStationReviewFinding.WRONG_COMPONENT_EVIDENCE_CITATION,
+            affected_record_ids=(request.target_record_id,),
+            unaffected_duty_ids=(obligation.obligation_id,),
+            missing_evidence_ids=original_closeout.evidence_ids,
+            disposition=PumpStationReviewDisposition.REJECT_CLOSEOUT,
+            required_follow_up=(
+                "correct-functional-check-citation",
+                "reissue-pump-a-closeout",
+            ),
+            required_source_record_ids=(
+                request.target_record_id,
+                original_closeout.evidence_ids[0],
+                pump_b_checks.source_record_ids[0],
+            ),
+        )
+    else:
+        verifier_target = PumpStationReviewVerifierTarget(
+            finding=PumpStationReviewFinding.WRONG_COMPONENT_EVIDENCE_CITATION,
+            affected_record_ids=(request.target_record_id,),
+            unaffected_duty_ids=(obligation.obligation_id,),
+            missing_evidence_ids=original_closeout.evidence_ids,
+            disposition=PumpStationReviewDisposition.REJECT_CLOSEOUT,
+            required_follow_up=(
+                PumpStationReviewActionCode.CORRECT_FUNCTIONAL_CHECK_CITATION,
+                PumpStationReviewActionCode.REISSUE_PUMP_A_CLOSEOUT,
+            ),
+            required_source_record_ids=(
+                request.target_record_id,
+                original_closeout.evidence_ids[0],
+                pump_b_checks.source_record_ids[0],
+            ),
+        )
     case_id = f"review-case-{request.content_sha256[:24]}"
     public_case = PumpStationReviewPublicCase(
         case_id=case_id,

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/maintenance_review_harbor.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/maintenance_review_harbor.py
@@ -34,14 +34,16 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.harbor_s
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.maintenance_review import (
     PUMP_STATION_REVIEW_ISSUE_VERSION_V1,
-    PUMP_STATION_REVIEW_PACK_POLICY_V1,
+    PUMP_STATION_REVIEW_PACK_POLICY_V2,
     PUMP_STATION_REVIEW_VISIBILITY_POLICY_V1,
     PumpStationReviewerRole,
     PumpStationReviewIssueClass,
     PumpStationReviewPreparationRequest,
     PumpStationReviewPublicCase,
     PumpStationReviewSubmission,
+    PumpStationReviewSubmissionAny,
     PumpStationReviewSubmissionReceipt,
+    parse_pump_station_review_submission,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.maintenance_review_agent import (
     PumpStationReviewAgentAuthority,
@@ -85,7 +87,8 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_se
 )
 from aec_bench.trajectory.writer import TrajectoryWriter
 
-PUMP_STATION_REVIEW_HARBOR_RUN_SCHEMA_VERSION = "aecbench.pump-station-review-harbor-run.v1"
+PUMP_STATION_REVIEW_HARBOR_RUN_SCHEMA_VERSION_V1 = "aecbench.pump-station-review-harbor-run.v1"
+PUMP_STATION_REVIEW_HARBOR_RUN_SCHEMA_VERSION = "aecbench.pump-station-review-harbor-run.v2"
 
 
 @dataclass(frozen=True, slots=True)
@@ -202,7 +205,7 @@ def _prepare_review_session(
         asset_id=pump_station_model_from_package(bridge.package).asset_id,
         reviewed_component_id="pump-a",
         maintenance_case_id="work-order-pump-a",
-        pack_policy=PUMP_STATION_REVIEW_PACK_POLICY_V1,
+        pack_policy=PUMP_STATION_REVIEW_PACK_POLICY_V2,
         issue_class=(PumpStationReviewIssueClass.WRONG_COMPONENT_EVIDENCE_CITATION),
         issue_version=PUMP_STATION_REVIEW_ISSUE_VERSION_V1,
         target_record_id="closeout-record-pump-a",
@@ -381,7 +384,10 @@ def run_pump_station_review_model_session(
     receipt: PumpStationReviewSubmissionReceipt | None = None
     verification: PumpStationReviewVerificationReport | None = None
     if len(review_ids) == 1:
-        submission = repository.load_review(review_ids[0])
+        loaded_submission = repository.load_review(review_ids[0])
+        if not isinstance(loaded_submission, PumpStationReviewSubmission):
+            raise ValueError("new model review did not use the version 2 contract")
+        submission = loaded_submission
         receipt = repository.load_review_receipt(review_ids[0])
         verification = verify_pump_station_review(
             source_run_root=source_root,
@@ -661,7 +667,11 @@ def verify_pump_station_harbor_review_run(
         raise ValueError("pump-station Harbor review verifier runtime differs")
     inventory = _read_json(root / "artifact-inventory.json")
     if (
-        inventory.get("schema_version") != PUMP_STATION_REVIEW_HARBOR_RUN_SCHEMA_VERSION
+        inventory.get("schema_version")
+        not in {
+            PUMP_STATION_REVIEW_HARBOR_RUN_SCHEMA_VERSION_V1,
+            PUMP_STATION_REVIEW_HARBOR_RUN_SCHEMA_VERSION,
+        }
         or inventory.get("execution_kind") != PUMP_STATION_REVIEW_HARBOR_EXECUTION_KIND
         or inventory.get("task_world_id") != PUMP_STATION_REVIEW_TASK_ID
         or inventory.get("export_manifest_sha256") != file_sha256(export_manifest_path)
@@ -674,7 +684,7 @@ def verify_pump_station_harbor_review_run(
     _verify_inventory(root, inventory)
     session_request = PumpStationReviewSessionRequest.model_validate(_read_json(root / "review-session-request.json"))
     observation = PumpStationReviewObservation.model_validate(_read_json(root / "review-observation.json"))
-    submission = PumpStationReviewSubmission.model_validate(_read_json(root / "review-submission.json"))
+    submission = parse_pump_station_review_submission(_read_json(root / "review-submission.json"))
     receipt = PumpStationReviewSubmissionReceipt.model_validate(_read_json(root / "review-submission-receipt.json"))
     stored_report = PumpStationReviewVerificationReport.model_validate(
         _read_json(root / "review-verification-report.json")
@@ -718,7 +728,7 @@ def _verify_model_reviewer(
     *,
     root: Path,
     inventory: dict[str, Any],
-    submission: PumpStationReviewSubmission,
+    submission: PumpStationReviewSubmissionAny,
     report: PumpStationReviewVerificationReport,
 ) -> None:
     authority = PumpStationReviewAgentAuthority.model_validate(_read_json(root / "agent-authority.json"))

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/maintenance_review_repository.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/maintenance_review_repository.py
@@ -31,9 +31,12 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.maintena
     PumpStationReviewPreparationRequest,
     PumpStationReviewPublicCase,
     PumpStationReviewSubmission,
+    PumpStationReviewSubmissionAny,
     PumpStationReviewSubmissionReceipt,
     PumpStationReviewTreatmentReceipt,
-    PumpStationReviewVerifierTarget,
+    PumpStationReviewVerifierTargetAny,
+    parse_pump_station_review_submission,
+    parse_pump_station_review_verifier_target,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_verifier import (
     PumpStationVerificationReport,
@@ -391,10 +394,8 @@ class PumpStationReviewCaseRepository:
         with self.locked():
             existing = self._review_pointer_if_present(submission.review_id)
             if existing is not None:
-                stored = self._load_model(
-                    "review-submissions",
+                stored = self._load_review_submission(
                     existing.review_content_sha256,
-                    PumpStationReviewSubmission,
                 )
                 if stored != submission:
                     _fail(
@@ -420,6 +421,9 @@ class PumpStationReviewCaseRepository:
                 visible_source_ids.update(record.evidence_ids)
             if not set(submission.affected_record_ids).issubset(record_ids):
                 raise ValueError("affected record is outside the visible pack")
+            related_record_ids = {item.record_id for item in submission.related_record_assessments}
+            if not related_record_ids.issubset(record_ids):
+                raise ValueError("related record is outside the visible pack")
             if not set(submission.unaffected_duty_ids).issubset(record_ids):
                 raise ValueError("unaffected duty is outside the visible pack")
             if not set(submission.missing_evidence_ids).issubset(visible_source_ids):
@@ -455,14 +459,10 @@ class PumpStationReviewCaseRepository:
             )
             return receipt
 
-    def load_review(self, review_id: str) -> PumpStationReviewSubmission:
+    def load_review(self, review_id: str) -> PumpStationReviewSubmissionAny:
         """Strictly reload one immutable reviewer submission."""
         pointer = self._load_review_pointer(review_id)
-        return self._load_model(
-            "review-submissions",
-            pointer.review_content_sha256,
-            PumpStationReviewSubmission,
-        )
+        return self._load_review_submission(pointer.review_content_sha256)
 
     def load_review_receipt(
         self,
@@ -522,10 +522,8 @@ class PumpStationReviewCaseRepository:
             manifest.issue_content_sha256,
             PumpStationReviewIssueSpecification,
         )
-        target = self._load_model(
-            "verifier-targets",
+        target = self._load_review_verifier_target(
             manifest.verifier_target_content_sha256,
-            PumpStationReviewVerifierTarget,
         )
         preparation_receipt = self._load_model(
             "preparation-receipts",
@@ -752,6 +750,32 @@ class PumpStationReviewCaseRepository:
             _fail(
                 "review-artifact-integrity",
                 f"{collection} content identity differs",
+            )
+        return value
+
+    def _load_review_submission(
+        self,
+        content_id: str,
+    ) -> PumpStationReviewSubmissionAny:
+        payload = self._read_json("review-submissions", content_id)
+        value = parse_pump_station_review_submission(payload)
+        if value.content_sha256 != content_id:
+            _fail(
+                "review-artifact-integrity",
+                "review-submissions content identity differs",
+            )
+        return value
+
+    def _load_review_verifier_target(
+        self,
+        content_id: str,
+    ) -> PumpStationReviewVerifierTargetAny:
+        payload = self._read_json("verifier-targets", content_id)
+        value = parse_pump_station_review_verifier_target(payload)
+        if value.content_sha256 != content_id:
+            _fail(
+                "review-artifact-integrity",
+                "verifier-targets content identity differs",
             )
         return value
 

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/maintenance_review_session.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/maintenance_review_session.py
@@ -19,9 +19,12 @@ from aec_bench.contracts.harness_kernel import (
 from aec_bench.contracts.task_definition import ToolSpec
 from aec_bench.contracts.validators import NonEmptyStr
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.maintenance_review import (
+    PUMP_STATION_REVIEW_PACK_POLICY_V2,
+    PumpStationReviewActionCode,
     PumpStationReviewDisposition,
     PumpStationReviewFinding,
     PumpStationReviewPublicCase,
+    PumpStationReviewRecordAssessment,
     PumpStationReviewRecordKind,
     PumpStationReviewSubmission,
     PumpStationReviewSubmissionReceipt,
@@ -166,6 +169,8 @@ def build_reference_review_submission(
     reviewer_tenure_id: str,
 ) -> PumpStationReviewSubmission:
     """Derive the deterministic reference answer from visible records only."""
+    if public_case.pack.pack_policy != PUMP_STATION_REVIEW_PACK_POLICY_V2:
+        raise ValueError("reference reviewer requires the version 2 review contract")
     closeout = next(
         item
         for item in public_case.pack.records
@@ -190,6 +195,16 @@ def build_reference_review_submission(
         for item in public_case.pack.records
         if item.kind is PumpStationReviewRecordKind.DUTY_FOLLOW_UP and item.component_id == closeout.component_id
     )
+    work_order = next(
+        item
+        for item in public_case.pack.records
+        if item.kind is PumpStationReviewRecordKind.WORK_ORDER and item.component_id == closeout.component_id
+    )
+    restriction = next(
+        item
+        for item in public_case.pack.records
+        if item.kind is PumpStationReviewRecordKind.OPERATING_RESTRICTION and item.component_id == closeout.component_id
+    )
     return PumpStationReviewSubmission(
         review_id=review_id,
         case_id=public_case.case_id,
@@ -203,9 +218,30 @@ def build_reference_review_submission(
         missing_evidence_ids=correct.source_record_ids,
         disposition=PumpStationReviewDisposition.REJECT_CLOSEOUT,
         required_follow_up=(
-            "correct-functional-check-citation",
-            "reissue-pump-a-closeout",
+            PumpStationReviewActionCode.CORRECT_FUNCTIONAL_CHECK_CITATION,
+            PumpStationReviewActionCode.REISSUE_PUMP_A_CLOSEOUT,
         ),
+        review_rationale=(
+            "Pump A cannot be closed out against Pump B functional checks. "
+            "The Pump A checks remain the missing decisive evidence, while the "
+            "work order and run-in restriction remain related operating context."
+        ),
+        related_record_assessments=(
+            PumpStationReviewRecordAssessment(
+                record_id=work_order.record_id,
+                rationale=(
+                    "The work order defines the maintenance scope, but the citation error does not change that scope."
+                ),
+            ),
+            PumpStationReviewRecordAssessment(
+                record_id=restriction.record_id,
+                rationale=(
+                    "The run-in restriction remains relevant to return to service, "
+                    "but it is not made incorrect by the citation."
+                ),
+            ),
+        ),
+        additional_recommendations=("Retain the run-in restriction until the corrected closeout is reviewed.",),
         source_record_ids=(
             closeout.record_id,
             correct.source_record_ids[0],
@@ -267,6 +303,8 @@ class PumpStationReviewSession:
         submission: PumpStationReviewSubmission,
     ) -> PumpStationReviewSubmissionReceipt:
         """Publish one case-bound review without exposing its evaluation target."""
+        if self._public_case.pack.pack_policy != PUMP_STATION_REVIEW_PACK_POLICY_V2:
+            raise ValueError("review session requires the version 2 review contract")
         if (
             submission.case_id != self._public_case.case_id
             or submission.public_case_content_sha256 != self._public_case.content_sha256
@@ -294,10 +332,13 @@ class PumpStationReviewSession:
         unaffected_duty_ids: list[str],
         missing_evidence_ids: list[str],
         disposition: PumpStationReviewDisposition,
-        required_follow_up: list[str],
+        required_follow_up: list[PumpStationReviewActionCode],
+        review_rationale: str,
+        related_record_assessments: list[dict[str, str]],
+        additional_recommendations: list[str],
         source_record_ids: list[str],
     ) -> str:
-        """Submit every required review field against visible source records."""
+        """Submit direct impact, coded work, and written context from visible records."""
         receipt = self.submit_review(
             PumpStationReviewSubmission(
                 review_id=review_id,
@@ -311,7 +352,12 @@ class PumpStationReviewSession:
                 unaffected_duty_ids=tuple(unaffected_duty_ids),
                 missing_evidence_ids=tuple(missing_evidence_ids),
                 disposition=PumpStationReviewDisposition(disposition),
-                required_follow_up=tuple(required_follow_up),
+                required_follow_up=tuple(PumpStationReviewActionCode(item) for item in required_follow_up),
+                review_rationale=review_rationale,
+                related_record_assessments=tuple(
+                    PumpStationReviewRecordAssessment.model_validate(item) for item in related_record_assessments
+                ),
+                additional_recommendations=tuple(additional_recommendations),
                 source_record_ids=tuple(source_record_ids),
             )
         )

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/maintenance_review_verifier.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/maintenance_review_verifier.py
@@ -11,6 +11,8 @@ from pydantic import model_validator
 from aec_bench.contracts.harness_kernel import ContentAddressedModel
 from aec_bench.contracts.validators import NonEmptyStr
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.maintenance_review import (
+    PumpStationReviewSubmissionV1,
+    PumpStationReviewVerifierTargetV1,
     derive_pump_station_review_case,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.maintenance_review_repository import (
@@ -21,7 +23,7 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.maintena
 class PumpStationReviewVerificationReport(ContentAddressedModel):
     """Independent exact-field evaluation of one immutable review."""
 
-    schema_version: str = "pump-station.review-verification-report.v1"
+    schema_version: str = "pump-station.review-verification-report.v2"
     case_id: NonEmptyStr
     review_id: NonEmptyStr
     source_state_id: NonEmptyStr
@@ -39,7 +41,10 @@ class PumpStationReviewVerificationReport(ContentAddressedModel):
 
     @model_validator(mode="after")
     def validate_report(self) -> Self:
-        if self.schema_version != "pump-station.review-verification-report.v1":
+        if self.schema_version not in {
+            "pump-station.review-verification-report.v1",
+            "pump-station.review-verification-report.v2",
+        }:
             raise ValueError("unsupported review verification report version")
         checks = (
             self.source_valid,
@@ -83,13 +88,25 @@ def verify_pump_station_review(
         and reconstructed.source_verification.final_state_id == stored.public_case.source_snapshot.state_id
     )
     case_reconstructed = reconstructed == stored
+    uses_v1_contract = isinstance(submission, PumpStationReviewSubmissionV1)
+    if uses_v1_contract != isinstance(target, PumpStationReviewVerifierTargetV1):
+        raise ValueError("review submission and verifier target versions differ")
     finding_matches = submission.finding is target.finding
-    affected_records_match = submission.affected_record_ids == target.affected_record_ids
-    unaffected_duties_match = submission.unaffected_duty_ids == target.unaffected_duty_ids
-    missing_evidence_matches = submission.missing_evidence_ids == target.missing_evidence_ids
+    if uses_v1_contract:
+        affected_records_match = submission.affected_record_ids == target.affected_record_ids
+        unaffected_duties_match = submission.unaffected_duty_ids == target.unaffected_duty_ids
+        missing_evidence_matches = submission.missing_evidence_ids == target.missing_evidence_ids
+        follow_up_matches = submission.required_follow_up == target.required_follow_up
+        source_references_match = submission.source_record_ids == target.required_source_record_ids
+        report_schema_version = "pump-station.review-verification-report.v1"
+    else:
+        affected_records_match = set(submission.affected_record_ids) == set(target.affected_record_ids)
+        unaffected_duties_match = set(submission.unaffected_duty_ids) == set(target.unaffected_duty_ids)
+        missing_evidence_matches = set(submission.missing_evidence_ids) == set(target.missing_evidence_ids)
+        follow_up_matches = set(submission.required_follow_up) == set(target.required_follow_up)
+        source_references_match = set(target.required_source_record_ids).issubset(submission.source_record_ids)
+        report_schema_version = "pump-station.review-verification-report.v2"
     disposition_matches = submission.disposition is target.disposition
-    follow_up_matches = submission.required_follow_up == target.required_follow_up
-    source_references_match = submission.source_record_ids == target.required_source_record_ids
     receipt_matches = (
         receipt.review_content_sha256 == submission.content_sha256
         and receipt.case_id == case_id
@@ -114,9 +131,9 @@ def verify_pump_station_review(
     if not disposition_matches:
         issues.append("disposition differs")
     if not follow_up_matches:
-        issues.append("follow-up differs")
+        issues.append("required action codes differ")
     if not source_references_match:
-        issues.append("source references differ")
+        issues.append("required source references are missing")
     valid = all(
         (
             source_valid,
@@ -131,6 +148,7 @@ def verify_pump_station_review(
         )
     )
     return PumpStationReviewVerificationReport(
+        schema_version=report_schema_version,
         case_id=case_id,
         review_id=review_id,
         source_state_id=stored.public_case.source_snapshot.state_id,

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_asw_6a_r_agent_contract.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_asw_6a_r_agent_contract.py
@@ -123,6 +123,9 @@ def test_agent_request_uses_only_review_tools_and_approved_limits() -> None:
     assert request.system_prompt is not None
     assert request.instruction is not None
     assert "submit_closeout_review" in request.system_prompt
+    assert "action codes" in request.system_prompt
+    assert "review rationale" in request.system_prompt
+    assert "directly affected records" in request.system_prompt
     assert "pump-b" not in (request.system_prompt + request.instruction).lower()
     assert "wrong_component_evidence_citation" not in (request.system_prompt + request.instruction)
 

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_asw_6a_r_case_derivation.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_asw_6a_r_case_derivation.py
@@ -16,7 +16,7 @@ from aec_bench.contracts.world_session import (
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.maintenance_review import (
     PUMP_STATION_REVIEW_ISSUE_VERSION_V1,
-    PUMP_STATION_REVIEW_PACK_POLICY_V1,
+    PUMP_STATION_REVIEW_PACK_POLICY_V2,
     PUMP_STATION_REVIEW_VISIBILITY_POLICY_V1,
     PumpStationReviewDisposition,
     PumpStationReviewerRole,
@@ -45,7 +45,7 @@ def _request(snapshot: PumpStationStateSnapshotRef) -> PumpStationReviewPreparat
         asset_id="synthetic-wastewater-pump-station",
         reviewed_component_id="pump-a",
         maintenance_case_id="work-order-pump-a",
-        pack_policy=PUMP_STATION_REVIEW_PACK_POLICY_V1,
+        pack_policy=PUMP_STATION_REVIEW_PACK_POLICY_V2,
         issue_class=PumpStationReviewIssueClass.WRONG_COMPONENT_EVIDENCE_CITATION,
         issue_version=PUMP_STATION_REVIEW_ISSUE_VERSION_V1,
         target_record_id="closeout-record-pump-a",

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_asw_6a_r_review_models.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_asw_6a_r_review_models.py
@@ -11,15 +11,22 @@ from pydantic import ValidationError
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.maintenance_review import (
     PUMP_STATION_REVIEW_ISSUE_VERSION_V1,
     PUMP_STATION_REVIEW_PACK_POLICY_V1,
+    PUMP_STATION_REVIEW_PACK_POLICY_V2,
     PUMP_STATION_REVIEW_VISIBILITY_POLICY_V1,
+    PumpStationReviewActionCode,
     PumpStationReviewDisposition,
     PumpStationReviewerRole,
     PumpStationReviewFinding,
     PumpStationReviewIssueClass,
     PumpStationReviewIssueSpecification,
     PumpStationReviewPreparationRequest,
+    PumpStationReviewRecordAssessment,
     PumpStationReviewSubmission,
+    PumpStationReviewSubmissionV1,
     PumpStationReviewVerifierTarget,
+    PumpStationReviewVerifierTargetV1,
+    parse_pump_station_review_submission,
+    parse_pump_station_review_verifier_target,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_models import (
     PUMP_STATION_SNAPSHOT_VERSION_V3,
@@ -46,7 +53,7 @@ def _preparation_request(**changes: object) -> PumpStationReviewPreparationReque
         "asset_id": "synthetic-wastewater-pump-station",
         "reviewed_component_id": "pump-a",
         "maintenance_case_id": "work-order-pump-a",
-        "pack_policy": PUMP_STATION_REVIEW_PACK_POLICY_V1,
+        "pack_policy": PUMP_STATION_REVIEW_PACK_POLICY_V2,
         "issue_class": PumpStationReviewIssueClass.WRONG_COMPONENT_EVIDENCE_CITATION,
         "issue_version": PUMP_STATION_REVIEW_ISSUE_VERSION_V1,
         "target_record_id": "closeout-record-pump-a",
@@ -72,9 +79,17 @@ def _review_submission(**changes: object) -> PumpStationReviewSubmission:
         "missing_evidence_ids": ("evidence-0000-functional-checks-pump-a",),
         "disposition": PumpStationReviewDisposition.REJECT_CLOSEOUT,
         "required_follow_up": (
-            "correct-functional-check-citation",
-            "reissue-pump-a-closeout",
+            PumpStationReviewActionCode.CORRECT_FUNCTIONAL_CHECK_CITATION,
+            PumpStationReviewActionCode.REISSUE_PUMP_A_CLOSEOUT,
         ),
+        "review_rationale": ("Pump A cannot be closed out against functional checks for Pump B."),
+        "related_record_assessments": (
+            {
+                "record_id": "work-order-pump-a",
+                "rationale": "The work order is related, but its approved scope is not changed by the citation error.",
+            },
+        ),
+        "additional_recommendations": ("Confirm the corrected closeout during the next assurance review.",),
         "source_record_ids": (
             "closeout-record-pump-a",
             "evidence-0000-functional-checks-pump-a",
@@ -89,6 +104,7 @@ def test_frozen_review_values_and_preparation_binding_are_exact() -> None:
     request = _preparation_request()
 
     assert PUMP_STATION_REVIEW_PACK_POLICY_V1 == "pump-a-closeout-pack.v1"
+    assert PUMP_STATION_REVIEW_PACK_POLICY_V2 == "pump-a-closeout-pack.v2"
     assert PUMP_STATION_REVIEW_ISSUE_VERSION_V1 == "wrong-component-evidence-citation.v1"
     assert PUMP_STATION_REVIEW_VISIBILITY_POLICY_V1 == "reviewer-pack-only.v1"
     assert tuple(PumpStationReviewIssueClass) == (PumpStationReviewIssueClass.WRONG_COMPONENT_EVIDENCE_CITATION,)
@@ -135,6 +151,7 @@ def test_review_submission_requires_every_frozen_field_and_distinct_ids() -> Non
         "missing_evidence_ids",
         "disposition",
         "required_follow_up",
+        "review_rationale",
         "source_record_ids",
     ):
         incomplete = dict(payload)
@@ -149,6 +166,81 @@ def test_review_submission_requires_every_frozen_field_and_distinct_ids() -> Non
                 "closeout-record-pump-a",
             )
         )
+
+
+def test_hybrid_review_uses_public_action_codes_and_keeps_written_assessment() -> None:
+    submission = _review_submission()
+
+    assert submission.required_follow_up == (
+        PumpStationReviewActionCode.CORRECT_FUNCTIONAL_CHECK_CITATION,
+        PumpStationReviewActionCode.REISSUE_PUMP_A_CLOSEOUT,
+    )
+    assert submission.review_rationale.startswith("Pump A cannot be closed out")
+    assert submission.related_record_assessments == (
+        PumpStationReviewRecordAssessment(
+            record_id="work-order-pump-a",
+            rationale=("The work order is related, but its approved scope is not changed by the citation error."),
+        ),
+    )
+    assert submission.additional_recommendations == (
+        "Confirm the corrected closeout during the next assurance review.",
+    )
+
+    with pytest.raises(ValidationError, match="Input should be"):
+        _review_submission(required_follow_up=("write-a-good-report",))
+    with pytest.raises(ValidationError, match="related record must not be directly affected"):
+        _review_submission(
+            related_record_assessments=(
+                {
+                    "record_id": "closeout-record-pump-a",
+                    "rationale": "This record is already in the direct affected set.",
+                },
+            )
+        )
+
+
+def test_version_1_review_contract_still_reloads_without_migration() -> None:
+    submission = PumpStationReviewSubmissionV1(
+        review_id="review-v1",
+        case_id="case-review-v1",
+        public_case_content_sha256="a" * 64,
+        pack_content_sha256="b" * 64,
+        reviewer_tenure_id="tenure-review-v1",
+        finding=PumpStationReviewFinding.WRONG_COMPONENT_EVIDENCE_CITATION,
+        finding_summary="The Pump A closeout cites Pump B functional checks.",
+        affected_record_ids=("closeout-record-pump-a",),
+        unaffected_duty_ids=("obligation-0000-pump-a-verification",),
+        missing_evidence_ids=("evidence-0000-functional-checks-pump-a",),
+        disposition=PumpStationReviewDisposition.REJECT_CLOSEOUT,
+        required_follow_up=(
+            "correct-functional-check-citation",
+            "reissue-pump-a-closeout",
+        ),
+        source_record_ids=(
+            "closeout-record-pump-a",
+            "evidence-0000-functional-checks-pump-a",
+            "evidence-functional-checks-pump-b",
+        ),
+    )
+    target = PumpStationReviewVerifierTargetV1(
+        finding=PumpStationReviewFinding.WRONG_COMPONENT_EVIDENCE_CITATION,
+        affected_record_ids=("closeout-record-pump-a",),
+        unaffected_duty_ids=("obligation-0000-pump-a-verification",),
+        missing_evidence_ids=("evidence-0000-functional-checks-pump-a",),
+        disposition=PumpStationReviewDisposition.REJECT_CLOSEOUT,
+        required_follow_up=(
+            "correct-functional-check-citation",
+            "reissue-pump-a-closeout",
+        ),
+        required_source_record_ids=(
+            "closeout-record-pump-a",
+            "evidence-0000-functional-checks-pump-a",
+            "evidence-functional-checks-pump-b",
+        ),
+    )
+
+    assert parse_pump_station_review_submission(submission.model_dump(mode="json")) == submission
+    assert parse_pump_station_review_verifier_target(target.model_dump(mode="json")) == target
     with pytest.raises(ValidationError, match="source_record_ids must be distinct"):
         _review_submission(
             source_record_ids=(
@@ -180,8 +272,8 @@ def test_private_issue_and_verifier_target_do_not_fit_the_public_request() -> No
         missing_evidence_ids=("evidence-0000-functional-checks-pump-a",),
         disposition=PumpStationReviewDisposition.REJECT_CLOSEOUT,
         required_follow_up=(
-            "correct-functional-check-citation",
-            "reissue-pump-a-closeout",
+            PumpStationReviewActionCode.CORRECT_FUNCTIONAL_CHECK_CITATION,
+            PumpStationReviewActionCode.REISSUE_PUMP_A_CLOSEOUT,
         ),
         required_source_record_ids=(
             "closeout-record-pump-a",

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_asw_6a_r_reviewer_session.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_asw_6a_r_reviewer_session.py
@@ -12,6 +12,7 @@ from test_asw_6a_r_case_derivation import _request
 
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.maintenance_review import (
     PreparedPumpStationReviewCase,
+    PumpStationReviewActionCode,
     PumpStationReviewDisposition,
     PumpStationReviewFinding,
     PumpStationReviewSubmission,
@@ -110,6 +111,16 @@ def test_fresh_tenure_receives_same_redacted_pack_and_submits_exact_review(
         review_id="review-001",
         reviewer_tenure_id="review-tenure-002",
     )
+    submission = PumpStationReviewSubmission.model_validate(
+        {
+            **submission.model_dump(mode="json", exclude={"content_sha256"}),
+            "source_record_ids": [
+                *submission.source_record_ids,
+                "work-order-pump-a",
+                "restriction-0000-pump-a-run-in",
+            ],
+        }
+    )
 
     receipt = second.submit_review(submission)
     repeated = second.submit_review(submission)
@@ -137,6 +148,11 @@ def test_fresh_tenure_receives_same_redacted_pack_and_submits_exact_review(
     assert verified.disposition_matches is True
     assert verified.follow_up_matches is True
     assert verified.source_references_match is True
+    assert submission.review_rationale
+    assert {item.record_id for item in submission.related_record_assessments} == {
+        "work-order-pump-a",
+        "restriction-0000-pump-a-run-in",
+    }
     assert "issue_class" not in public_text
     assert "verifier_target" not in public_text
     assert "unaffected_control_ids" not in public_text
@@ -170,7 +186,10 @@ def test_wrong_review_is_persisted_but_independent_verifier_rejects_it(
         unaffected_duty_ids=("obligation-0000-pump-a-verification",),
         missing_evidence_ids=("evidence-0000-functional-checks-pump-a",),
         disposition=PumpStationReviewDisposition.ACCEPT_CLOSEOUT,
-        required_follow_up=("archive-closeout",),
+        required_follow_up=(PumpStationReviewActionCode.CORRECT_FUNCTIONAL_CHECK_CITATION,),
+        review_rationale="The visible records were read, but the closeout decision is wrong.",
+        related_record_assessments=(),
+        additional_recommendations=("Archive the closeout after correction.",),
         source_record_ids=("work-order-pump-a",),
     )
 


### PR DESCRIPTION
## Summary

- add the ASW-6A-R version 2 review contract
- use public controlled values for process-required actions
- keep written review rationale, related-record assessments, and additional recommendations
- keep the directly affected-record set strict
- require all decisive sources while permitting extra visible source references
- keep version 1 submissions and verifier targets readable without migration
- tell later agents to separate direct record errors from wider operating context

## Prior agent result

The earlier real-agent run remains an unchanged negative version 1 result. This change does not rewrite its submission, target, verification report, token record, or cost record. No provider call or retry occurred.

## Validation

- 24 focused ASW-6A-R tests completed with no failures
- 3 final affected-path checks completed after the type-boundary corrections
- Ruff format and lint passed
- MyPy passed for 11 changed production and test files
- research-artifact validation passed with no diagnostics
- whitespace check passed

The 214-test pump-station folder and the full repository suite were not repeated.
