### PR TITLE
Correct TS1 decision boundary and resume

### DIFF
--- a/research/asset-stewardship/retrieval-state-continuity-study/ara/PAPER.md
+++ b/research/asset-stewardship/retrieval-state-continuity-study/ara/PAPER.md
@@ -86,6 +86,27 @@ conservative request before the scored window. A later study should separate
 temporal waiting from retrieval continuity and make the delayed record material
 to the action choice.
 
+## Implemented follow-ups
+
+The follow-up design now gives the incoming tenure the live world at the open
+decision point. The outgoing tenure advances the real event sequence before it
+creates the structured handover and retrieval carrier. This removes agent
+waiting from the treatment comparison.
+
+The delayed condition report now records an unresolved obstruction indicator
+that requires a current Pump A condition check. The endpoint requires that
+specific action and explicit reliance on the fetched material report. A general
+post-maintenance verification request does not satisfy the corrected endpoint.
+
+Long model-study runs can now resume from an existing output root. Resume
+reloads the exact manifest and plan, joins each completed delivery,
+observation, and trial execution, and skips only complete verified trials. It
+stops on incomplete published evidence or an interrupted trial directory so it
+cannot silently repeat a provider call.
+
+These changes have focused provider-free test evidence only. They do not amend
+the frozen 64-run result and they are not a new model-study result.
+
 ## Boundary
 
 The study code stays in
@@ -103,4 +124,4 @@ Artifact layers:
 - `logic/experiments.yaml` records provider-free and real-model checks.
 - `evidence/index.yaml` points to the frozen values and validation evidence.
 - `trace/exploration_tree.yaml` records the failures, repairs, and result.
-- `staging/observations.yaml` retains the open follow-up design questions.
+- `staging/observations.yaml` records the resolved follow-up design questions.

--- a/research/asset-stewardship/retrieval-state-continuity-study/ara/evidence/index.yaml
+++ b/research/asset-stewardship/retrieval-state-continuity-study/ara/evidence/index.yaml
@@ -32,3 +32,14 @@ evidence:
       provider_calls: 260
       study_outcomes: 64
       conclusion: refuted
+  - id: EV004
+    kind: command_output
+    path: evidence/model-study-result.md
+    description: Focused provider-free checks for decision-point handover, action-relevant delayed evidence, and verified resume.
+    source: feat/wastewater-pump-station-temporal-study-followups on 2026-08-02
+    supports: [C005]
+    produced_by: E005
+    exact_values_required: true
+    domain:
+      provider_calls: 0
+      study_outcomes: 0

--- a/research/asset-stewardship/retrieval-state-continuity-study/ara/evidence/model-study-result.md
+++ b/research/asset-stewardship/retrieval-state-continuity-study/ara/evidence/model-study-result.md
@@ -88,3 +88,27 @@ from the model's ability to wait for that event.
 - `research/asset-stewardship/retrieval-state-continuity-study/results/model-shakedown-v2`
 - `research/asset-stewardship/retrieval-state-continuity-study/results/model-shakedown-v3`
 - `research/asset-stewardship/retrieval-state-continuity-study/results/confirmatory-v2`
+
+## Provider-free follow-up evidence
+
+The follow-up implementation does not change the frozen model result above. It
+starts the incoming tenure at the open decision point, requires a fetched
+delayed report and explicit reliance for the Pump A condition-check endpoint,
+and adds verified resume from complete immutable trial evidence.
+
+Resume verifies manifest, plan, block, trial, treatment, delivery, phase,
+endpoint, retrieval, token, and spend identities before it skips a completed
+trial. It stops on an incomplete published join or an interrupted run directory
+so it cannot silently repeat a provider call.
+
+Focused provider-free validation used this command:
+
+```text
+uv run pytest -q \
+  tests/experiments/retrieval_state_continuity/test_model_execution.py \
+  tests/experiments/retrieval_state_continuity/test_contracts.py \
+  tests/experiments/retrieval_state_continuity/test_retrievability.py \
+  tests/task_world_templates/stewardship/wastewater_pump_station/test_temporal_retrieval.py
+```
+
+The result was `16 passed`. Provider calls and new study outcomes were zero.

--- a/research/asset-stewardship/retrieval-state-continuity-study/ara/logic/claims.yaml
+++ b/research/asset-stewardship/retrieval-state-continuity-study/ara/logic/claims.yaml
@@ -68,3 +68,20 @@ claims:
       in_window_proposals: 1
       material_evidence_acquired: 0
       material_evidence_used: 0
+  - id: C005
+    statement: The corrected scenario starts the incoming tenure at the open decision point, makes the delayed report material to the required station action, and resumes only from complete verified trial evidence.
+    status: supported
+    falsification_criteria:
+      - The incoming tenure starts before the material evidence availability event.
+      - A general verification request or a condition check without explicit material-report reliance satisfies the endpoint.
+      - Resume accepts an incomplete delivery, observation, and trial-execution join.
+      - Resume silently repeats an interrupted provider trial.
+    proof:
+      experiments: [E005]
+      evidence: [EV004]
+    dependencies: [C004]
+    provenance: ai_executed
+    tags: [design-correction, decision-point, verified-resume]
+    domain:
+      provider_calls: 0
+      study_outcomes: 0

--- a/research/asset-stewardship/retrieval-state-continuity-study/ara/logic/experiments.yaml
+++ b/research/asset-stewardship/retrieval-state-continuity-study/ara/logic/experiments.yaml
@@ -79,3 +79,24 @@ experiments:
     domain:
       phase: confirmatory
       study_outcomes: 64
+  - id: E005
+    verifies: [C005]
+    purpose: Verify the corrected decision boundary and safe model-study resume path without another provider study.
+    setup: Use real durable pump-station sessions, the local temporal corpus, and temporary immutable evidence repositories with no provider registry.
+    procedure:
+      - Advance the outgoing tenure through the real availability event before handover.
+      - Confirm both treatment arms give the incoming tenure the same open decision-point world state.
+      - Fetch the delayed report and prove only a report-backed Pump A condition check satisfies the endpoint.
+      - Prove a general verification request and a condition check without report reliance fail the endpoint.
+      - Publish a complete delivery, observation, and trial-execution join and reload it as resumable progress.
+      - Publish an incomplete join and confirm resume rejects it.
+    metrics:
+      - The incoming world time equals the material evidence availability time.
+      - The outgoing continue-operation event is present in structured handover history.
+      - Complete joined trial evidence is reusable and incomplete evidence is rejected.
+      - Provider calls and new study outcomes remain zero.
+    evidence: [EV004]
+    exploratory: false
+    domain:
+      provider_calls: 0
+      study_outcomes: 0

--- a/research/asset-stewardship/retrieval-state-continuity-study/ara/staging/observations.yaml
+++ b/research/asset-stewardship/retrieval-state-continuity-study/ara/staging/observations.yaml
@@ -9,9 +9,9 @@ observations:
       provider_authorization_present: true
   - id: O002
     summary: Sixty-three safe station proposals occurred before the scored window, while no run acquired or used the delayed report.
-    status: open
+    status: resolved
     source: evidence/model-study-result.md
-    next_action: In a separate follow-up, start model action at the open decision point and make the delayed record change the correct station action.
+    next_action: Keep the frozen result separate. Use the corrected boundary only in a later, separately identified study if needed.
     domain:
       interpretation_limit: true
       pre_window_proposals: 63
@@ -19,8 +19,8 @@ observations:
       material_evidence_acquired: 0
   - id: O003
     summary: The long provider study publishes every completed trial but cannot resume into an existing output directory after interruption.
-    status: open
+    status: resolved
     source: src/aec_bench/experiments/retrieval_state_continuity/execution.py
-    next_action: Add verified resume support before another long or expensive provider study.
+    next_action: Keep incomplete trial directories as explicit recovery stops so provider calls are not repeated silently.
     domain:
       engineering_follow_up: true

--- a/research/asset-stewardship/retrieval-state-continuity-study/ara/trace/exploration_tree.yaml
+++ b/research/asset-stewardship/retrieval-state-continuity-study/ara/trace/exploration_tree.yaml
@@ -122,12 +122,27 @@ nodes:
   - id: N010
     type: observation
     summary: The next study should isolate retrieval continuity from temporal waiting and remove the obvious pre-existing conservative answer.
-    children: []
+    children: [N011]
     also_depends_on: [N009]
     claims_touched: [C004]
     provenance: ai_suggested
     payload:
-      status: open
+      status: resolved_by_N011
       evidence: EV003
     domain:
       follow_up_required: true
+  - id: N011
+    type: experiment
+    summary: Correct the decision boundary and add verified resume without running another provider study.
+    children: []
+    also_depends_on: [N010]
+    claims_touched: [C005]
+    provenance: ai_executed
+    payload:
+      experiment_id: E005
+      result: passed
+      evidence: EV004
+      provider_calls: 0
+      study_outcomes: 0
+    domain:
+      model_result_changed: false

--- a/src/aec_bench/experiments/retrieval_state_continuity/contracts.py
+++ b/src/aec_bench/experiments/retrieval_state_continuity/contracts.py
@@ -113,22 +113,14 @@ class ModelExecutionSpecification(ContentAddressedModel):
     model_id: Literal["au.anthropic.claude-sonnet-4-6"] = "au.anthropic.claude-sonnet-4-6"
     adapter_id: Literal["tool_loop"] = "tool_loop"
     execution_path: Literal["direct_host_session"] = "direct_host_session"
-    prompt_id: Literal["retrieval-state-decision-window.v1"] = "retrieval-state-decision-window.v1"
-    decision_rule_id: Literal["pump-a-obstruction-evidence-decision-rule.v2"] = (
-        "pump-a-obstruction-evidence-decision-rule.v2"
+    prompt_id: Literal["retrieval-state-decision-window.v2"] = "retrieval-state-decision-window.v2"
+    decision_rule_id: Literal["pump-a-obstruction-evidence-decision-rule.v3"] = (
+        "pump-a-obstruction-evidence-decision-rule.v3"
     )
     admissible_conservative_actions: tuple[
-        Literal[
-            "request_condition_check",
-            "request_inspection",
-            "request_post_maintenance_verification",
-        ],
+        Literal["request_condition_check"],
         ...,
-    ] = (
-        "request_condition_check",
-        "request_inspection",
-        "request_post_maintenance_verification",
-    )
+    ] = ("request_condition_check",)
     authorization_id: Literal["ts1-theo-approved-2026-08-02"] = "ts1-theo-approved-2026-08-02"
     maximum_agent_turns: Literal[12] = 12
     maximum_tool_calls: Literal[24] = 24

--- a/src/aec_bench/experiments/retrieval_state_continuity/execution.py
+++ b/src/aec_bench/experiments/retrieval_state_continuity/execution.py
@@ -23,6 +23,7 @@ from aec_bench.experiments.retrieval_state_continuity.contracts import (
     FailureKind,
     ObservationSource,
     PairIneligibilityReason,
+    PlannedTrial,
     StudyManifest,
     StudyObservation,
     StudyPhase,
@@ -199,6 +200,16 @@ class PublishedModelStudy:
     execution_reference: ImmutableArtifact
 
 
+@dataclass(frozen=True, slots=True)
+class VerifiedModelStudyProgress:
+    """Completed trial evidence that is safe to reuse after interruption."""
+
+    deliveries: tuple[TreatmentDelivery, ...]
+    observations: tuple[StudyObservation, ...]
+    executions: tuple[ModelTrialExecution, ...]
+    completed_trial_ids: frozenset[str]
+
+
 def run_model_study(
     root: Path,
     *,
@@ -209,34 +220,45 @@ def run_model_study(
 
     if phase not in {StudyPhase.SHAKEDOWN, StudyPhase.CONFIRMATORY}:
         raise ValueError("model study must be shakedown or confirmatory")
-    destination = Path(root).resolve()
-    if destination.exists():
-        raise FileExistsError(f"model-study output already exists: {destination}")
-    destination.mkdir(parents=True, mode=0o700)
-    repository = EvidenceRepository(destination, host_private=True)
     manifest = build_model_manifest(phase)
     plan = build_study_plan(manifest)
-    manifest_reference = repository.publish_content_addressed_model(
+    destination = Path(root).resolve()
+    if not destination.exists():
+        destination.mkdir(parents=True, mode=0o700)
+    repository = EvidenceRepository(destination, host_private=True)
+    manifest_reference = _publish_or_verify_single_model(
+        repository=repository,
         collection="manifests",
         filename="study-manifest.json",
         model=manifest,
         adapter=_MANIFEST_ADAPTER,
-    ).artifact
-    plan_reference = repository.publish_content_addressed_model(
+    )
+    plan_reference = _publish_or_verify_single_model(
+        repository=repository,
         collection="plans",
         filename="study-plan.json",
         model=plan,
         adapter=_PLAN_ADAPTER,
-    ).artifact
+    )
     selected_trials = plan.blocks[0].trials if phase is StudyPhase.SHAKEDOWN else plan.trials
     block_by_id = {item.block_id: item for item in plan.blocks}
-    deliveries: list[TreatmentDelivery] = []
-    observations: list[StudyObservation] = []
-    executions: list[ModelTrialExecution] = []
-    selected_registry = registry or _local_adapter_registry()
+    progress = _load_completed_trial_evidence(
+        repository=repository,
+        manifest=manifest,
+        plan=plan,
+        selected_trials=selected_trials,
+    )
+    deliveries = {item.trial_id: item for item in progress.deliveries}
+    observations = {item.trial_id: item for item in progress.observations}
+    executions = {item.trial_id: item for item in progress.executions}
+    selected_registry: Any | None = None
     for trial in selected_trials:
+        if trial.trial_id in progress.completed_trial_ids:
+            continue
         block = block_by_id[trial.block_id]
         trial_root = destination / "runs" / f"{trial.execution_position:03d}-{trial.trial_id}"
+        if trial_root.exists():
+            raise ImmutableArtifactIntegrityError(f"interrupted trial requires explicit recovery: {trial.trial_id}")
         prepared = prepare_trial_scenario(
             trial_root / "world",
             manifest=manifest,
@@ -251,6 +273,8 @@ def run_model_study(
             execution_spec = manifest.model_execution
             if execution_spec is None:
                 raise ValueError("model study has no execution specification")
+            if selected_registry is None:
+                selected_registry = registry or _local_adapter_registry()
             adapter = selected_registry.build(
                 adapter_kind=execution_spec.adapter_id,
                 model_name=execution_spec.model_id,
@@ -300,25 +324,26 @@ def run_model_study(
             model=execution,
             adapter=TypeAdapter(ModelTrialExecution),
         )
-        deliveries.append(delivery)
-        observations.append(observation)
-        executions.append(execution)
+        deliveries[trial.trial_id] = delivery
+        observations[trial.trial_id] = observation
+        executions[trial.trial_id] = execution
 
-    delivery_tuple = tuple(deliveries)
-    observation_tuple = tuple(observations)
-    execution_tuple = tuple(executions)
+    delivery_tuple = tuple(deliveries[trial.trial_id] for trial in selected_trials)
+    observation_tuple = tuple(observations[trial.trial_id] for trial in selected_trials)
+    execution_tuple = tuple(executions[trial.trial_id] for trial in selected_trials)
     report = analyse_study(
         manifest=manifest,
         plan=plan,
         deliveries=delivery_tuple,
         observations=observation_tuple,
     )
-    report_reference = repository.publish_content_addressed_model(
+    report_reference = _publish_or_verify_single_model(
+        repository=repository,
         collection="reports",
         filename="study-report.json",
         model=report,
         adapter=_REPORT_ADAPTER,
-    ).artifact
+    )
     study_execution = ModelStudyExecution(
         manifest_content_sha256=manifest.content_sha256,
         plan_content_sha256=plan.content_sha256,
@@ -334,12 +359,13 @@ def run_model_study(
         execution_content_sha256=tuple(item.content_sha256 for item in execution_tuple),
     )
     execution_adapter = TypeAdapter(ModelStudyExecution)
-    execution_reference = repository.publish_content_addressed_model(
+    execution_reference = _publish_or_verify_single_model(
+        repository=repository,
         collection="study-executions",
         filename="study-execution.json",
         model=study_execution,
         adapter=execution_adapter,
-    ).artifact
+    )
     _assert_no_secret_material(destination)
     reloaded = reload_and_verify_model_study(
         root=destination,
@@ -360,6 +386,159 @@ def run_model_study(
         report_reference=report_reference,
         execution_reference=execution_reference,
     )
+
+
+def _load_completed_trial_evidence(
+    *,
+    repository: EvidenceRepository,
+    manifest: StudyManifest,
+    plan: StudyPlan,
+    selected_trials: tuple[PlannedTrial, ...],
+) -> VerifiedModelStudyProgress:
+    """Reload and join only complete, content-addressed trial evidence."""
+
+    deliveries = _load_content_collection(
+        repository=repository,
+        collection="treatment-deliveries",
+        filename="treatment-delivery.json",
+        adapter=_DELIVERY_ADAPTER,
+    )
+    observations = _load_content_collection(
+        repository=repository,
+        collection="observations",
+        filename="observation.json",
+        adapter=_OBSERVATION_ADAPTER,
+    )
+    executions = _load_content_collection(
+        repository=repository,
+        collection="trial-executions",
+        filename="trial-execution.json",
+        adapter=TypeAdapter(ModelTrialExecution),
+    )
+    delivery_by_id = _unique_trial_records(deliveries, label="treatment delivery")
+    observation_by_id = _unique_trial_records(observations, label="observation")
+    execution_by_id = _unique_trial_records(executions, label="trial execution")
+    published_ids = set(delivery_by_id) | set(observation_by_id) | set(execution_by_id)
+    if not (set(delivery_by_id) == set(observation_by_id) == set(execution_by_id)):
+        raise ImmutableArtifactIntegrityError("incomplete published trial evidence")
+    selected_by_id = {trial.trial_id: trial for trial in selected_trials}
+    unknown_ids = published_ids - set(selected_by_id)
+    if unknown_ids:
+        raise ImmutableArtifactIntegrityError(
+            f"published trial evidence is outside the selected schedule: {sorted(unknown_ids)}"
+        )
+    block_by_id = {block.block_id: block for block in plan.blocks}
+    expected_source = (
+        ObservationSource.GENERATED_ANALYSIS_FIXTURE
+        if manifest.phase is StudyPhase.ANALYSIS_FIXTURE
+        else ObservationSource.SHAKEDOWN
+        if manifest.phase is StudyPhase.SHAKEDOWN
+        else ObservationSource.CONFIRMATORY
+    )
+    for trial_id in published_ids:
+        trial = selected_by_id[trial_id]
+        block = block_by_id[trial.block_id]
+        delivery = delivery_by_id[trial_id]
+        observation = observation_by_id[trial_id]
+        execution = execution_by_id[trial_id]
+        common_identity = (
+            delivery.manifest_content_sha256 == manifest.content_sha256
+            and delivery.plan_content_sha256 == plan.content_sha256
+            and observation.manifest_content_sha256 == manifest.content_sha256
+            and observation.plan_content_sha256 == plan.content_sha256
+            and execution.manifest_content_sha256 == manifest.content_sha256
+            and execution.plan_content_sha256 == plan.content_sha256
+            and delivery.block_id == observation.block_id == execution.block_id == block.block_id
+            and delivery.treatment == observation.treatment == execution.treatment == trial.treatment
+            and delivery.source is observation.source is expected_source
+            and delivery.non_treatment_input_sha256 == block.non_treatment_input_sha256
+            and delivery.current_actor_view_sha256 == block.current_actor_view_sha256
+            and delivery.history_snapshot_sha256 == observation.history_snapshot_sha256 == block.history_snapshot_sha256
+            and delivery.event_schedule_sha256 == observation.event_schedule_sha256 == block.event_schedule_sha256
+            and delivery.base_carrier_sha256 == block.base_carrier_sha256
+            and observation.delivery_content_sha256 == delivery.content_sha256
+            and observation.world_history_seed == block.world_history_seed
+            and observation.sampling_replicate == block.sampling_replicate
+            and observation.budget_sha256 == trial.budget_sha256
+            and execution.phase is manifest.phase
+            and execution.delivered_carrier_sha256 == delivery.delivered_carrier_sha256
+            and execution.provider_call_count == observation.provider_call_count
+            and execution.agent_turn_count == observation.agent_turn_count
+            and execution.input_token_count == observation.input_token_count
+            and execution.output_token_count == observation.output_token_count
+            and execution.total_token_count == observation.total_token_count
+            and execution.spend_microunits == observation.spend_microunits
+            and execution.search_call_count == observation.search_call_count
+            and execution.fetch_call_count == observation.fetch_call_count
+            and execution.material_evidence_acquired == observation.material_evidence_acquired
+            and execution.material_evidence_used == observation.material_evidence_used
+            and execution.conservative_action == observation.conservative_action
+            and execution.epistemic_decision_failure == observation.epistemic_decision_failure
+            and execution.task_reward_mutation_count == observation.task_reward_mutation_count
+        )
+        if not common_identity:
+            raise ImmutableArtifactIntegrityError(f"published trial evidence identity mismatch: {trial_id}")
+    ordered = tuple(trial for trial in selected_trials if trial.trial_id in published_ids)
+    return VerifiedModelStudyProgress(
+        deliveries=tuple(delivery_by_id[trial.trial_id] for trial in ordered),
+        observations=tuple(observation_by_id[trial.trial_id] for trial in ordered),
+        executions=tuple(execution_by_id[trial.trial_id] for trial in ordered),
+        completed_trial_ids=frozenset(published_ids),
+    )
+
+
+def _load_content_collection(
+    *,
+    repository: EvidenceRepository,
+    collection: str,
+    filename: str,
+    adapter: TypeAdapter[Any],
+) -> tuple[Any, ...]:
+    models: list[Any] = []
+    for relative_path in repository.list_child_files(collection, filename=filename):
+        model = repository.load_canonical_model(relative_path, adapter)
+        expected_path = repository.content_model_path(
+            collection=collection,
+            content_sha256=model.content_sha256,
+            filename=filename,
+        )
+        if relative_path != expected_path:
+            raise ImmutableArtifactIntegrityError(f"content-addressed evidence uses the wrong path: {relative_path}")
+        models.append(model)
+    return tuple(models)
+
+
+def _unique_trial_records(records: tuple[Any, ...], *, label: str) -> dict[str, Any]:
+    indexed: dict[str, Any] = {}
+    for record in records:
+        if record.trial_id in indexed:
+            raise ImmutableArtifactIntegrityError(f"duplicate {label} for trial: {record.trial_id}")
+        indexed[record.trial_id] = record
+    return indexed
+
+
+def _publish_or_verify_single_model(
+    *,
+    repository: EvidenceRepository,
+    collection: str,
+    filename: str,
+    model: Any,
+    adapter: TypeAdapter[Any],
+) -> ImmutableArtifact:
+    existing = _load_content_collection(
+        repository=repository,
+        collection=collection,
+        filename=filename,
+        adapter=adapter,
+    )
+    if existing and (len(existing) != 1 or existing[0] != model):
+        raise ImmutableArtifactIntegrityError(f"existing {collection} do not match the requested study generation")
+    return repository.publish_content_addressed_model(
+        collection=collection,
+        filename=filename,
+        model=model,
+        adapter=adapter,
+    ).artifact
 
 
 def reload_and_verify_model_study(
@@ -595,12 +774,12 @@ def _model_system_prompt() -> str:
 
 def _model_instruction(prepared: PreparedTrialScenario) -> str:
     return (
-        "Manage the live station through the current decision window. The scored "
-        "window opens at the next declared decision point. Documentary access "
-        "can change with world time. Observe and search only when needed. Before "
-        "you finish, make one safe consequential station proposal about the "
-        "current Pump A return-to-service uncertainty. If evidence remains "
-        "unresolved, choose a conservative proposal. Do not guess a reference. "
+        "Manage the live station at the open decision point. Documentary access "
+        "can change with world time. Review current documentary access and any "
+        "unresolved retrieval work. Before you finish, resolve the Pump A "
+        "obstruction uncertainty with one safe consequential station proposal. "
+        "Use supporting evidence through the declared reliance field. Do not "
+        "guess a reference. "
         "Return a short factual summary after the proposal.\n\n"
         "STRUCTURED HANDOVER\n"
         + pump_station_artifact_bytes(prepared.handover).decode("utf-8")

--- a/src/aec_bench/experiments/retrieval_state_continuity/planning.py
+++ b/src/aec_bench/experiments/retrieval_state_continuity/planning.py
@@ -59,7 +59,7 @@ def build_provider_free_manifest() -> StudyManifest:
             "budget": budget.model_dump(mode="json"),
             "available_at_seconds": material.available_at_seconds,
             "decision_deadline_seconds": material.available_at_seconds + 3_600,
-            "decision_rule_id": "pump-a-obstruction-evidence-decision-rule.v1",
+            "decision_rule_id": "pump-a-obstruction-evidence-decision-rule.v3",
         }
     )
     base_carrier_audit_sha256 = canonical_content_sha256(
@@ -93,7 +93,7 @@ def build_provider_free_manifest() -> StudyManifest:
         material_evidence_version_id=material.version_id,
         acceptable_evidence_version_ids=(material.version_id,),
         development_query_routes=_DEVELOPMENT_QUERY_ROUTES,
-        decision_rule_id="pump-a-obstruction-evidence-decision-rule.v1",
+        decision_rule_id="pump-a-obstruction-evidence-decision-rule.v3",
         retrievability_certificate_sha256=retrievability_certificate_sha256,
         base_carrier_audit_sha256=base_carrier_audit_sha256,
         current_actor_view_policy_id="pump-station-current-state.v1",
@@ -120,9 +120,9 @@ def build_model_manifest(phase: StudyPhase) -> StudyManifest:
     payload.update(
         {
             "study_generation_id": (
-                "retrieval-state-continuity-model-shakedown.v3"
+                "retrieval-state-continuity-model-shakedown.v4"
                 if phase is StudyPhase.SHAKEDOWN
-                else "retrieval-state-continuity-confirmatory.v2"
+                else "retrieval-state-continuity-confirmatory.v3"
             ),
             "phase": phase,
             "decision_rule_id": model_execution.decision_rule_id,
@@ -131,7 +131,7 @@ def build_model_manifest(phase: StudyPhase) -> StudyManifest:
                     "prior_retrievability_certificate_sha256": (provider_free.retrievability_certificate_sha256),
                     "decision_rule_id": model_execution.decision_rule_id,
                     "admissible_conservative_actions": (model_execution.admissible_conservative_actions),
-                    "shakedown_amendment": "permitted-conservative-action-coverage.v1",
+                    "design_correction": "open-decision-point-and-material-action.v1",
                 }
             ),
             "model_execution": model_execution,

--- a/src/aec_bench/experiments/retrieval_state_continuity/scenario.py
+++ b/src/aec_bench/experiments/retrieval_state_continuity/scenario.py
@@ -271,6 +271,12 @@ def prepare_trial_scenario(
     pre_handover_status = str(pre_handover["receipt"]["public_status"])
     if pre_handover_status != "NO_ACCESSIBLE_RESULT":
         raise ValueError("pre-handover material search was not unresolved")
+    source.continue_operation(
+        proposal_id=f"outgoing-advance-{identity}",
+        reason="Advance the station to the declared handover decision point.",
+    )
+    if source.run.state.physical.calendar_seconds != manifest.evidence_available_at_seconds:
+        raise ValueError("trial handover does not occur at the open decision point")
 
     recipient_request = _session_request(
         identity=identity,
@@ -358,7 +364,7 @@ def score_trial_scenario(prepared: PreparedTrialScenario) -> ScenarioScore:
     """Apply the sealed endpoint to durable actions and retrieval receipts."""
 
     chosen_proposal_id: str | None = None
-    conservative_action = False
+    report_action = False
     for step in prepared.session.run.steps():
         proposal = step.proposal
         if proposal is None:
@@ -376,13 +382,8 @@ def score_trial_scenario(prepared: PreparedTrialScenario) -> ScenarioScore:
             item for item in prepared.session.actor_history if item.proposal_id == proposal.context.proposal_id
         )
         pump_id = getattr(proposal, "pump_id", None)
-        conservative_action = (
-            history.action_type
-            in {
-                "request_condition_check",
-                "request_inspection",
-                "request_post_maintenance_verification",
-            }
+        report_action = (
+            history.action_type == "request_condition_check"
             and history.execution in {"completed", "scheduled"}
             and pump_id == "pump-a"
         )
@@ -396,6 +397,7 @@ def score_trial_scenario(prepared: PreparedTrialScenario) -> ScenarioScore:
         except (FileNotFoundError, TemporalEvidenceIntegrityError, ValueError):
             relied_on = ()
     material_used = bool(set(relied_on) & set(prepared.tools.material_references))
+    conservative_action = report_action and material_used
     stale_source_relied_on = any(
         prepared.tools.reference_versions.get(reference) == "pump-a-maintenance-procedure.v1" for reference in relied_on
     )

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/temporal_evidence/corpus.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/temporal_evidence/corpus.py
@@ -239,8 +239,10 @@ def _versions(
             version_id="pump-a-delayed-condition-report.v1",
             title="Pump A delayed condition report",
             content_text=(
-                "The Pump A condition inspection observed an obstruction indicator. The report was created "
-                "after the inspection and became searchable only after document control ingestion."
+                "The Pump A inspection found a new obstruction indicator after the recorded functional checks. "
+                "The indicator remains unresolved and requires a current Pump A condition check before "
+                "post-maintenance verification can close. The report became searchable only after document "
+                "control ingestion."
             ),
             citation="Synthetic station condition report CR-A-17.",
             event_start_seconds=REFERENCE_WORLD_TIME_SECONDS - 1_800,

--- a/tests/experiments/retrieval_state_continuity/test_model_execution.py
+++ b/tests/experiments/retrieval_state_continuity/test_model_execution.py
@@ -6,15 +6,37 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+from pydantic import TypeAdapter
+
+from aec_bench.contracts.harness_kernel import canonical_content_sha256
 from aec_bench.experiments.retrieval_state_continuity import (
     StudyPhase,
     Treatment,
+    build_fixture_evidence,
     build_model_manifest,
+    build_provider_free_manifest,
     build_study_plan,
+)
+from aec_bench.experiments.retrieval_state_continuity.contracts import (
+    PlannedTrial,
+    StudyManifest,
+    StudyObservation,
+    StudyPlan,
+    TreatmentDelivery,
+)
+from aec_bench.experiments.retrieval_state_continuity.execution import (
+    ModelTrialExecution,
+    _load_completed_trial_evidence,
+    run_model_study,
 )
 from aec_bench.experiments.retrieval_state_continuity.scenario import (
     prepare_trial_scenario,
     score_trial_scenario,
+)
+from aec_bench.meta_harness.immutable_artifact_store import (
+    EvidenceRepository,
+    ImmutableArtifactIntegrityError,
 )
 
 
@@ -68,6 +90,10 @@ def test_paired_scenario_conserves_budget_and_only_carries_unresolved_state(
     assert len(preserved.carrier.unresolved_search_ids) == 1
     assert absent.session.result.snapshot.state_id == preserved.session.result.snapshot.state_id
     assert absent.session.event_schedule_sha256 == preserved.session.event_schedule_sha256
+    assert absent.session.run.state.physical.calendar_seconds == manifest.evidence_available_at_seconds
+    assert preserved.session.run.state.physical.calendar_seconds == manifest.evidence_available_at_seconds
+    assert absent.handover.history[-1].action_type == "continue_operation"
+    assert preserved.handover.history[-1].action_type == "continue_operation"
 
 
 def test_scenario_scores_a_post_availability_conservative_decision(
@@ -85,10 +111,6 @@ def test_scenario_scores_a_post_availability_conservative_decision(
         trial=trial,
     )
 
-    prepared.tools.continue_operation(
-        proposal_id="advance-to-window",
-        reason="Advance to the next declared decision point.",
-    )
     search_payload = json.loads(
         prepared.tools.search_evidence(
             request_id="review-current-records",
@@ -151,7 +173,7 @@ def test_model_tool_rejection_is_returned_for_agent_correction(tmp_path: Path) -
     assert payload["error_code"] == "actor-evidence-reliance-invalid"
 
 
-def test_scenario_accepts_independent_verification_as_conservative_action(
+def test_scenario_rejects_independent_verification_without_the_material_report_action(
     tmp_path: Path,
 ) -> None:
     manifest = build_model_manifest(StudyPhase.SHAKEDOWN)
@@ -164,10 +186,6 @@ def test_scenario_accepts_independent_verification_as_conservative_action(
         block=block,
         trial=block.trials[0],
     )
-    prepared.tools.continue_operation(
-        proposal_id="advance-to-window",
-        reason="Advance to the next declared decision point.",
-    )
     prepared.tools.request_post_maintenance_verification(
         proposal_id="verify-pump-a",
         reason="Keep Pump A restricted and schedule independent verification.",
@@ -176,5 +194,160 @@ def test_scenario_accepts_independent_verification_as_conservative_action(
 
     score = score_trial_scenario(prepared)
 
-    assert score.epistemic_decision_failure is False
-    assert score.conservative_action is True
+    assert score.epistemic_decision_failure is True
+    assert score.conservative_action is False
+
+
+def test_scenario_requires_material_report_reliance_for_the_condition_check(
+    tmp_path: Path,
+) -> None:
+    manifest = build_model_manifest(StudyPhase.SHAKEDOWN)
+    plan = build_study_plan(manifest)
+    block = plan.blocks[0]
+    prepared = prepare_trial_scenario(
+        tmp_path / "world",
+        manifest=manifest,
+        plan=plan,
+        block=block,
+        trial=block.trials[0],
+    )
+    prepared.tools.request_condition_check(
+        proposal_id="check-without-report",
+        reason="Check the current Pump A condition.",
+        pump_id="pump-a",
+    )
+
+    score = score_trial_scenario(prepared)
+
+    assert score.epistemic_decision_failure is True
+    assert score.material_evidence_used is False
+    assert score.conservative_action is False
+
+
+def test_verified_resume_loads_only_complete_joined_trial_evidence(tmp_path: Path) -> None:
+    manifest = build_provider_free_manifest()
+    plan = build_study_plan(manifest)
+    fixture = build_fixture_evidence(manifest=manifest, plan=plan)
+    trial = plan.trials[0]
+    delivery = fixture.deliveries[0]
+    observation = fixture.observations[0]
+    execution = _fixture_trial_execution(manifest, plan, trial, delivery, observation)
+    repository = EvidenceRepository(tmp_path / "study", host_private=True)
+    repository.publish_content_addressed_model(
+        collection="treatment-deliveries",
+        filename="treatment-delivery.json",
+        model=delivery,
+        adapter=TypeAdapter(type(delivery)),
+    )
+    repository.publish_content_addressed_model(
+        collection="observations",
+        filename="observation.json",
+        model=observation,
+        adapter=TypeAdapter(type(observation)),
+    )
+    repository.publish_content_addressed_model(
+        collection="trial-executions",
+        filename="trial-execution.json",
+        model=execution,
+        adapter=TypeAdapter(ModelTrialExecution),
+    )
+
+    progress = _load_completed_trial_evidence(
+        repository=repository,
+        manifest=manifest,
+        plan=plan,
+        selected_trials=(trial,),
+    )
+
+    assert progress.deliveries == (delivery,)
+    assert progress.observations == (observation,)
+    assert progress.executions == (execution,)
+    assert progress.completed_trial_ids == frozenset({trial.trial_id})
+
+
+def test_verified_resume_rejects_incomplete_published_trial_evidence(tmp_path: Path) -> None:
+    manifest = build_provider_free_manifest()
+    plan = build_study_plan(manifest)
+    fixture = build_fixture_evidence(manifest=manifest, plan=plan)
+    trial = plan.trials[0]
+    delivery = fixture.deliveries[0]
+    repository = EvidenceRepository(tmp_path / "study", host_private=True)
+    repository.publish_content_addressed_model(
+        collection="treatment-deliveries",
+        filename="treatment-delivery.json",
+        model=delivery,
+        adapter=TypeAdapter(type(delivery)),
+    )
+
+    with pytest.raises(ImmutableArtifactIntegrityError, match="incomplete published trial evidence"):
+        _load_completed_trial_evidence(
+            repository=repository,
+            manifest=manifest,
+            plan=plan,
+            selected_trials=(trial,),
+        )
+
+
+def test_verified_resume_stops_before_repeating_an_interrupted_trial(tmp_path: Path) -> None:
+    manifest = build_model_manifest(StudyPhase.SHAKEDOWN)
+    plan = build_study_plan(manifest)
+    trial = plan.blocks[0].trials[0]
+    destination = tmp_path / "study"
+    interrupted = destination / "runs" / f"{trial.execution_position:03d}-{trial.trial_id}"
+    interrupted.mkdir(parents=True, mode=0o700)
+    destination.chmod(0o700)
+
+    with pytest.raises(ImmutableArtifactIntegrityError, match="requires explicit recovery"):
+        run_model_study(destination, phase=StudyPhase.SHAKEDOWN)
+
+
+def _fixture_trial_execution(
+    manifest: StudyManifest,
+    plan: StudyPlan,
+    trial: PlannedTrial,
+    delivery: TreatmentDelivery,
+    observation: StudyObservation,
+) -> ModelTrialExecution:
+    digest = canonical_content_sha256({"fixture": "verified-resume"})
+    assert delivery.delivered_carrier_sha256 is not None
+    return ModelTrialExecution(
+        manifest_content_sha256=manifest.content_sha256,
+        plan_content_sha256=plan.content_sha256,
+        block_id=trial.block_id,
+        trial_id=trial.trial_id,
+        treatment=trial.treatment,
+        phase=manifest.phase,
+        provider_id="provider-free-fixture",
+        credential_profile_id="no-credentials",
+        model_id="provider-free-fixture",
+        resolved_model="provider-free-fixture",
+        adapter_id="provider-free-fixture",
+        adapter_status="completed",
+        adapter_failure_kind=None,
+        start_state_sha256=digest,
+        final_state_sha256=digest,
+        event_schedule_sha256=digest,
+        structured_handover_sha256=digest,
+        delivered_carrier_sha256=delivery.delivered_carrier_sha256,
+        shared_visible_input_sha256=digest,
+        output_sha256=digest,
+        conversation_sha256=digest,
+        trajectory_sha256=digest,
+        provider_call_count=0,
+        agent_turn_count=observation.agent_turn_count,
+        input_token_count=0,
+        output_token_count=0,
+        reported_analysis_token_count=None,
+        total_token_count=0,
+        maximum_input_tokens_in_one_call=0,
+        maximum_output_tokens_in_one_call=0,
+        spend_microunits=0,
+        search_call_count=observation.search_call_count,
+        fetch_call_count=observation.fetch_call_count,
+        material_evidence_acquired=observation.material_evidence_acquired,
+        material_evidence_used=observation.material_evidence_used,
+        conservative_action=observation.conservative_action,
+        epistemic_decision_failure=observation.epistemic_decision_failure,
+        world_verification_valid=True,
+        temporal_verification_valid=True,
+    )


### PR DESCRIPTION
## Summary
- hand the live station to the incoming tenure at the open decision point
- require the delayed Pump A report and explicit reliance for the condition-check endpoint
- resume long model-study runs only from complete, verified immutable trial evidence
- record the correction without changing the frozen 64-run result

## Validation
- 16 focused temporal-study tests passed
- focused Ruff lint and format passed
- focused Mypy passed
- Ara-lite validation passed
- no model or provider study was run