### PR TITLE
docs: define maintained code ownership

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -175,6 +175,25 @@ These live in established locations. Use them instead of writing local copies.
 
 ---
 
+## Delivery Ownership
+
+Before completing a pull request, classify every delivered artifact and place it under its permanent owner:
+
+| Artifact | Permanent owner |
+|---|---|
+| Shared library or runtime behaviour | `src/aec_bench/` |
+| Task-template-specific behaviour or data | `src/aec_bench/task_world_templates/<family>/` |
+| Maintained repository command | `scripts/` when it is not part of the installed API; otherwise `src/aec_bench/` |
+| Permanent tests and test support | `tests/` |
+| Normative architecture and operating guidance | `docs/` |
+| Notes, experiments, generated evidence, and temporary outputs | Local ignored research or output storage |
+
+Do not deliver maintained code from a research, planning, output, or phase directory. A rarely run generator or certifier is still maintained code when the current system needs it.
+
+Final check: would the feature still build, package, test, and run if local research and phase directories were absent?
+
+---
+
 ## Adapter Rules
 
 Adapters translate protocol only. They do NOT:
@@ -271,6 +290,7 @@ environment's native skill/prompt mechanism.
 | 10 | Continuous quality | Does this reduce drift instead of adding to it? |
 | 11 | Staged evidence is host-controlled | Does the host own evidence release and immutable submissions? |
 | 12 | Continual-world runtime ownership | Are lifetime mechanics separate from task meaning and profile data? |
+| 13 | Maintained code has a permanent owner | Would this work without local research and phase directories? |
 
 ## Objective Stack
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -123,6 +123,20 @@ and merge gates are in
 
 ---
 
+## Repository Ownership Boundary
+
+A working location does not define architectural ownership. Before delivery, every maintained artifact must move to the permanent repository surface that owns its behaviour.
+
+- `src/aec_bench/` owns installed library and runtime behaviour.
+- `src/aec_bench/task_world_templates/<family>/` owns task-template-specific behaviour and data.
+- `scripts/` owns maintained repository commands that are not part of the installed API.
+- `tests/` owns permanent test coverage and support code.
+- `docs/` owns normative architecture, contracts, invariants, and operating guidance.
+
+Research, planning, output, and phase directories are work areas, not delivery surfaces. Maintained code, build steps, tests, and packaged data must not depend on them.
+
+---
+
 ## Dependency Rule
 
 Dependencies flow downward through the stack:

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -215,6 +215,22 @@ architecture defect.
 
 ---
 
+## 13. Maintained Code Has a Permanent Owner
+
+Every artifact needed to build, run, verify, generate, certify, migrate, or test the product must live in a permanent, tracked repository surface with an explicit architectural owner.
+
+The pull request is the delivery boundary. Research, planning, output, and phase directories are work areas, not delivery surfaces. Maintained code must not import, execute, package, or read required files from them.
+
+A change is incomplete if required behaviour remains in an ignored, temporary, or phase-specific location. How often code runs does not change its ownership: a generator or certifier is maintained code when it is required to reproduce or certify the current system.
+
+Python enforcement direction:
+- classify each delivered artifact as shared library code, task-template code, a maintenance command, test support, normative documentation, or local research/output;
+- place maintained artifacts in the repository surface that owns their behaviour;
+- keep the product, build, package, and permanent test dependency graphs free of research and phase paths;
+- confirm that the feature can build, package, test, and run without local research or phase directories.
+
+---
+
 ## Adapter Reserved Keys
 
 Adapter-internal extraction metadata must use explicit reserved keys and must not leak into benchmark-semantic fields.
@@ -237,6 +253,7 @@ Adapter-internal extraction metadata must use explicit reserved keys and must no
 | Continual-world ownership | Changed paths have one declared runtime, task, profile, or transport owner |
 | Shared extraction | Ownership, migration, retirement, and two-real-consumer evidence exist |
 | Test naming | Permanent test names describe stable behaviour, contracts, boundaries, or failure modes |
+| Repository ownership | Maintained artifacts have permanent owners and no research or phase dependency |
 
 ### Build Next
 


### PR DESCRIPTION
## Summary

- Define the permanent repository owners for library code, task-template code, maintenance commands, tests, and normative documentation.
- Add invariant 12: maintained code must have a permanent owner.
- Add a repository-ownership acceptance gate and a practical delivery checklist for coding agents.
- State that generators and certifiers are maintained code when the current system needs them, even when they run rarely.

## Core rule

The pull request is the delivery boundary. Research, planning, output, and phase directories are work areas, not delivery surfaces.

Before delivery, every maintained artifact must move to the repository surface that owns its behaviour. The feature must still build, package, test, and run when local research and phase directories are absent.

## Verification

No tests were run. This is a documentation-only change.
