### PR TITLE
feat: register continual-world definitions

### DIFF
--- a/docs/CONTINUAL_WORLD_RUNTIME.md
+++ b/docs/CONTINUAL_WORLD_RUNTIME.md
@@ -280,6 +280,46 @@ retained offline tools receive focused maintenance tests without becoming
 runtime or agent dependencies. Otherwise, the promoted immutable package is
 the required production input.
 
+### 6.8 Step 2 definition and catalogue ownership
+
+The Step 2 correction adds only the registration boundary. It does not add or
+replace execution machinery.
+
+| Path | Owner | Compatibility and migration rule |
+| --- | --- | --- |
+| `src/aec_bench/contracts/continual_world.py` | Shared boundary contracts | Keep content-pinned world, implementation, and profile references task-neutral. Do not add task state, action names, controls, clocks, paths, or verifier fields. |
+| `src/aec_bench/task_world_templates/continual/definition.py` | Shared definition boundary | Load only an exact declared profile, pin each registered Python port, and leave its value task-owned and opaque. |
+| `src/aec_bench/task_world_templates/continual/catalogue.py` | Shared catalogue | Resolve new work by exact world ID and recovery work by exact definition content. Import no concrete task world. |
+| `src/aec_bench/task_world_templates/continual_catalogue.py` | Composition root | Register the pump and SSC-03 definitions. Concrete imports are allowed only at this boundary. |
+| `wastewater_pump_station/continual_definition.py` | Pump-station task world | Validate the exact RS1 descriptor, certified station package, opening state, and loader source. Do not start a coupled or stable run here. |
+| `lifecycles/ssc03_hydraulic_continual_definition.py` | SSC-03 task world | Register all four real variants and the existing lifecycle adapter. Pin the complete template, variant, baseline source, revised source, and adapter identity. Do not add another lifecycle run or repository. |
+
+This change is additive. It does not change a run manifest, snapshot, command,
+receipt, replay result, accepted artifact byte, CLI route, Harbor route, agent
+route, or evaluation route. Existing pump and SSC-03 execution remains on its
+current path. Later steps will store and resolve these references when the
+durable engine and dispatch paths move behind the catalogue.
+
+The pump registration includes RS1 and its v2 station package because Step 2
+validates profile content only. It does not claim that the current stable pump
+session can execute v4. That cutover belongs to Step 4. The SSC-03 registration
+proves the same definition and profile boundary through its real materializer,
+resolver, smoke environment, and verifier. It does not claim autonomous time,
+named snapshot creation, arbitrary rewind, or rollout groups.
+
+The loaded SSC-03 port exposes no mutable template, variant, or adapter object.
+Each operation rechecks the exact definition implementation, profile content,
+and supplied package variant before it delegates to the existing lifecycle
+adapter.
+
+Stable profile identity and compiled runtime-package identity are separate.
+For SSC-03, the profile reference hashes the complete runtime-independent task
+inputs. A compiled hydraulic package also records its Python runtime identity,
+so its package hash must stay with the compiled run and must not become the
+portable profile ID. The definition reference separately hashes the registered
+adapter and loader sources. Recovery must later check all three identities:
+profile, definition implementation, and compiled run package.
+
 ## 7. Implementation sequence
 
 The correction uses small pull requests against the unmerged ASW-8 branch.

--- a/src/aec_bench/contracts/__init__.py
+++ b/src/aec_bench/contracts/__init__.py
@@ -392,6 +392,13 @@ _EXPORTS_BY_MODULE: dict[str, tuple[str, ...]] = {
         "WorldSessionRequest",
         "WorldSessionResult",
     ),
+    "aec_bench.contracts.continual_world": (
+        "CONTINUAL_WORLD_DEFINITION_SCHEMA_VERSION",
+        "CONTINUAL_WORLD_PROFILE_SCHEMA_VERSION",
+        "ContinualWorldDefinitionRef",
+        "ContinualWorldDefinitionSpec",
+        "ContinualWorldProfileRef",
+    ),
     "aec_bench.contracts.world_interface": (
         "WORLD_ACTOR_INTERFACE_SCHEMA_VERSION",
         "WORLD_CONTROL_INTERFACE_SCHEMA_VERSION",

--- a/src/aec_bench/contracts/continual_world.py
+++ b/src/aec_bench/contracts/continual_world.py
@@ -1,0 +1,83 @@
+# ABOUTME: Defines content-pinned continual-world definition and profile references.
+# ABOUTME: Keeps task state, actions, controls, paths, and verifier data outside the shared boundary.
+
+from __future__ import annotations
+
+from typing import Final, Literal, Self
+
+from pydantic import field_validator, model_validator
+
+from aec_bench.contracts.harness_kernel import ContentAddressedModel, validate_sha256
+from aec_bench.contracts.validators import FrozenStrictModel, NonEmptyStr
+
+CONTINUAL_WORLD_DEFINITION_SCHEMA_VERSION: Final[Literal["aecbench.continual-world-definition.v1"]] = (
+    "aecbench.continual-world-definition.v1"
+)
+CONTINUAL_WORLD_PROFILE_SCHEMA_VERSION: Final[Literal["aecbench.continual-world-profile-ref.v1"]] = (
+    "aecbench.continual-world-profile-ref.v1"
+)
+
+
+class ContinualWorldProfileRef(FrozenStrictModel):
+    """Exact identity of one task-owned continual-world profile."""
+
+    schema_version: Literal["aecbench.continual-world-profile-ref.v1"] = CONTINUAL_WORLD_PROFILE_SCHEMA_VERSION
+    task_world_id: NonEmptyStr
+    profile_id: NonEmptyStr
+    profile_version: NonEmptyStr
+    profile_content_sha256: str
+
+    @field_validator("profile_content_sha256")
+    @classmethod
+    def validate_profile_content_sha256(cls, value: str) -> str:
+        return validate_sha256(value)
+
+
+class ContinualWorldDefinitionRef(FrozenStrictModel):
+    """Content-pinned recovery reference for one registered world definition."""
+
+    task_world_id: NonEmptyStr
+    definition_version: NonEmptyStr
+    content_sha256: str
+
+    @field_validator("content_sha256")
+    @classmethod
+    def validate_content_sha256(cls, value: str) -> str:
+        return validate_sha256(value)
+
+
+class ContinualWorldDefinitionSpec(ContentAddressedModel):
+    """Serializable identity and supported profiles for one task world."""
+
+    schema_version: Literal["aecbench.continual-world-definition.v1"] = CONTINUAL_WORLD_DEFINITION_SCHEMA_VERSION
+    task_world_id: NonEmptyStr
+    definition_version: NonEmptyStr
+    implementation_content_sha256: str
+    profiles: tuple[ContinualWorldProfileRef, ...]
+
+    @field_validator("implementation_content_sha256")
+    @classmethod
+    def validate_implementation_content_sha256(cls, value: str) -> str:
+        return validate_sha256(value)
+
+    @model_validator(mode="after")
+    def validate_profiles(self) -> Self:
+        if not self.profiles:
+            raise ValueError("continual-world definition requires at least one profile")
+        if any(profile.task_world_id != self.task_world_id for profile in self.profiles):
+            raise ValueError("continual-world profiles must belong to the same task world")
+        keys = tuple((profile.profile_id, profile.profile_version) for profile in self.profiles)
+        if len(keys) != len(set(keys)):
+            raise ValueError("continual-world profile identities must be distinct")
+        if keys != tuple(sorted(keys)):
+            raise ValueError("continual-world profiles must use stable order")
+        return self
+
+    @property
+    def ref(self) -> ContinualWorldDefinitionRef:
+        """Return the exact definition reference used by new runs and recovery."""
+        return ContinualWorldDefinitionRef(
+            task_world_id=self.task_world_id,
+            definition_version=self.definition_version,
+            content_sha256=self.content_sha256,
+        )

--- a/src/aec_bench/task_world_templates/continual/__init__.py
+++ b/src/aec_bench/task_world_templates/continual/__init__.py
@@ -1,0 +1,16 @@
+# ABOUTME: Exposes the task-neutral continual-world definition and catalogue boundary.
+# ABOUTME: Does not import any concrete task world or execution transport.
+
+from aec_bench.task_world_templates.continual.catalogue import ContinualWorldCatalogue
+from aec_bench.task_world_templates.continual.definition import (
+    ContinualWorldDefinition,
+    LoadedContinualWorldProfile,
+    python_source_sha256,
+)
+
+__all__ = [
+    "ContinualWorldCatalogue",
+    "ContinualWorldDefinition",
+    "LoadedContinualWorldProfile",
+    "python_source_sha256",
+]

--- a/src/aec_bench/task_world_templates/continual/catalogue.py
+++ b/src/aec_bench/task_world_templates/continual/catalogue.py
@@ -1,0 +1,45 @@
+# ABOUTME: Resolves continual-world definitions by stable identity and exact content reference.
+# ABOUTME: Keeps concrete task imports in the external catalogue composition root.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from aec_bench.contracts.continual_world import ContinualWorldDefinitionRef
+from aec_bench.task_world_templates.continual.definition import ContinualWorldDefinition
+
+
+@dataclass(frozen=True)
+class ContinualWorldCatalogue:
+    """Stable registry of task-owned continual-world definitions."""
+
+    definitions: tuple[ContinualWorldDefinition, ...]
+
+    def __post_init__(self) -> None:
+        task_world_ids = tuple(definition.spec.task_world_id for definition in self.definitions)
+        if len(task_world_ids) != len(set(task_world_ids)):
+            raise ValueError("continual-world catalogue task world ids must be unique")
+        object.__setattr__(
+            self,
+            "definitions",
+            tuple(sorted(self.definitions, key=lambda definition: definition.spec.task_world_id)),
+        )
+
+    def list_definition_refs(self) -> tuple[ContinualWorldDefinitionRef, ...]:
+        """Return registered references in stable task-world order."""
+        return tuple(definition.ref for definition in self.definitions)
+
+    def get(self, task_world_id: str) -> ContinualWorldDefinition:
+        """Resolve the current definition for new work by exact task-world ID."""
+        for definition in self.definitions:
+            if definition.spec.task_world_id == task_world_id:
+                return definition
+        known = ", ".join(definition.spec.task_world_id for definition in self.definitions)
+        raise KeyError(f"unknown continual task world: {task_world_id}. Known: {known}")
+
+    def resolve(self, reference: ContinualWorldDefinitionRef) -> ContinualWorldDefinition:
+        """Resolve recovery work only when version and content identity still match."""
+        definition = self.get(reference.task_world_id)
+        if definition.ref != reference:
+            raise ValueError(f"content-pinned definition does not match: {reference.task_world_id}")
+        return definition

--- a/src/aec_bench/task_world_templates/continual/definition.py
+++ b/src/aec_bench/task_world_templates/continual/definition.py
@@ -1,0 +1,68 @@
+# ABOUTME: Binds one continual-world definition to its task-owned profile loader.
+# ABOUTME: Validates exact profile identity while leaving loaded profile values opaque.
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from aec_bench.contracts.continual_world import (
+    ContinualWorldDefinitionRef,
+    ContinualWorldDefinitionSpec,
+    ContinualWorldProfileRef,
+)
+
+
+@dataclass(frozen=True)
+class LoadedContinualWorldProfile:
+    """One exact profile reference and its task-owned validated value."""
+
+    reference: ContinualWorldProfileRef
+    value: object
+
+
+@dataclass(frozen=True)
+class ContinualWorldDefinition:
+    """Registered world identity with a task-owned profile validation port."""
+
+    spec: ContinualWorldDefinitionSpec
+    profile_loader: Callable[[ContinualWorldProfileRef], LoadedContinualWorldProfile]
+
+    @property
+    def ref(self) -> ContinualWorldDefinitionRef:
+        """Return the content-pinned world-definition reference."""
+        return self.spec.ref
+
+    def profile_ref(self, profile_id: str, profile_version: str) -> ContinualWorldProfileRef:
+        """Resolve one supported profile by its exact public identity."""
+        matching_id = tuple(profile for profile in self.spec.profiles if profile.profile_id == profile_id)
+        if not matching_id:
+            raise KeyError(f"unknown continual-world profile: {profile_id}")
+        for profile in matching_id:
+            if profile.profile_version == profile_version:
+                return profile
+        raise KeyError(f"unsupported continual-world profile version: {profile_id}@{profile_version}")
+
+    def load_profile(self, reference: ContinualWorldProfileRef) -> LoadedContinualWorldProfile:
+        """Validate and load only a profile declared by this exact definition."""
+        if reference.task_world_id != self.spec.task_world_id:
+            raise ValueError("continual-world profile belongs to another task world")
+        current = self.profile_ref(reference.profile_id, reference.profile_version)
+        if reference != current:
+            raise ValueError(f"content-pinned profile does not match: {reference.profile_id}")
+        loaded = self.profile_loader(reference)
+        if loaded.reference != reference:
+            raise ValueError("task-owned profile loader returned a different profile reference")
+        return loaded
+
+
+def python_source_sha256(source_owner: type[Any] | Callable[..., Any]) -> str:
+    """Return the exact source digest for one registered Python port or value type."""
+    try:
+        source = inspect.getsource(source_owner).encode("utf-8")
+    except (OSError, TypeError) as exc:
+        raise ValueError("continual-world Python source identity is unavailable") from exc
+    return hashlib.sha256(source).hexdigest()

--- a/src/aec_bench/task_world_templates/continual_catalogue.py
+++ b/src/aec_bench/task_world_templates/continual_catalogue.py
@@ -1,0 +1,25 @@
+# ABOUTME: Composes the public continual-world catalogue from real task-owned definitions.
+# ABOUTME: Keeps concrete pump and hydraulic imports outside the task-neutral core package.
+
+from __future__ import annotations
+
+from functools import cache
+
+from aec_bench.task_world_templates.continual.catalogue import ContinualWorldCatalogue
+from aec_bench.task_world_templates.lifecycles.ssc03_hydraulic_continual_definition import (
+    ssc03_hydraulic_continual_world_definition,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.continual_definition import (
+    pump_station_continual_world_definition,
+)
+
+
+@cache
+def default_continual_world_catalogue() -> ContinualWorldCatalogue:
+    """Return the stable public catalogue with both real contract consumers."""
+    return ContinualWorldCatalogue(
+        definitions=(
+            pump_station_continual_world_definition(),
+            ssc03_hydraulic_continual_world_definition(),
+        )
+    )

--- a/src/aec_bench/task_world_templates/lifecycles/ssc03_hydraulic_continual_definition.py
+++ b/src/aec_bench/task_world_templates/lifecycles/ssc03_hydraulic_continual_definition.py
@@ -1,0 +1,200 @@
+# ABOUTME: Registers the SSC-03 hydraulic interaction world and its real public profiles.
+# ABOUTME: Reuses the existing lifecycle adapter, variant records, resolver, smoke path, and verifier.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import cache
+from pathlib import Path
+from typing import Any
+
+from aec_bench.contracts.continual_world import (
+    ContinualWorldDefinitionRef,
+    ContinualWorldDefinitionSpec,
+    ContinualWorldProfileRef,
+)
+from aec_bench.contracts.harness_kernel import canonical_content_sha256
+from aec_bench.meta_harness.evidence_lifecycle_episode import LifecycleEpisodeEnvironment
+from aec_bench.meta_harness.lifecycle_operation_protocol import LifecycleOperationResolver
+from aec_bench.task_world_templates.catalogue import get_template
+from aec_bench.task_world_templates.compiled_world import (
+    CompiledLifecycleWorld,
+    LifecycleWorldAdapter,
+    build_compiled_world_envelope,
+    validate_lifecycle_world_adapter,
+)
+from aec_bench.task_world_templates.continual.definition import (
+    ContinualWorldDefinition,
+    LoadedContinualWorldProfile,
+    python_source_sha256,
+)
+from aec_bench.task_world_templates.contracts import CompositeTaskWorldTemplate
+from aec_bench.task_world_templates.hydraulics.revisions import build_hydraulic_revision_source_state
+from aec_bench.task_world_templates.hydraulics.worlds.ssc03_detention_network import build_source_state
+from aec_bench.task_world_templates.lifecycles import registered_lifecycle_adapter
+from aec_bench.task_world_templates.lifecycles.ssc03_hydraulic_interaction_variants import (
+    TEMPLATE_ID,
+    get_ssc03_hydraulic_interaction_variant,
+)
+
+SSC03_HYDRAULIC_CONTINUAL_WORLD_ID = "aec.task_world.composite.hydraulic-interaction-lifecycle-review"
+SSC03_HYDRAULIC_CONTINUAL_DEFINITION_VERSION = "1"
+SSC03_HYDRAULIC_PROFILE_VERSION = "1"
+
+
+@dataclass(frozen=True)
+class Ssc03HydraulicContinualProfile:
+    """Immutable SSC-03 profile binding over the existing lifecycle adapter."""
+
+    reference: ContinualWorldProfileRef
+    definition_reference: ContinualWorldDefinitionRef
+
+    @property
+    def profile_id(self) -> str:
+        """Return the selected immutable hydraulic profile identity."""
+        return self.reference.profile_id
+
+    def compile(self, output_dir: Path) -> CompiledLifecycleWorld:
+        """Compile this exact profile through its existing registered adapter."""
+        template, adapter = self._validated_port()
+        template = CompositeTaskWorldTemplate.model_validate(template.model_dump(mode="json"))
+        package_dir = adapter.materialize(
+            Path(output_dir),
+            template=template,
+            variant_id=self.profile_id,
+        )
+        self._validated_package_port(package_dir)
+        envelope = build_compiled_world_envelope(
+            template=template,
+            adapter=adapter,
+            package_dir=package_dir,
+            requested_variant_id=self.profile_id,
+        )
+        return CompiledLifecycleWorld(package_dir=package_dir, envelope=envelope)
+
+    def build_operation_resolver(self, package_dir: Path, run_dir: Path) -> LifecycleOperationResolver | None:
+        """Build the existing task-owned operation resolver for this profile."""
+        adapter, _ = self._validated_package_port(package_dir)
+        return adapter.build_operation_resolver(Path(package_dir), Path(run_dir))
+
+    def build_smoke_environment(self, package_dir: Path) -> LifecycleEpisodeEnvironment | None:
+        """Build the existing deterministic smoke environment for this profile."""
+        adapter, _ = self._validated_package_port(package_dir)
+        return adapter.build_smoke_environment(Path(package_dir))
+
+    def validate_package(self, package_dir: Path) -> dict[str, Any] | None:
+        """Validate the materialized package through the existing task port."""
+        _, metadata = self._validated_package_port(package_dir)
+        return metadata
+
+    def verify(self, package_dir: Path, run_dir: Path) -> dict[str, Any]:
+        """Verify one completed lifecycle through the existing task verifier."""
+        adapter, _ = self._validated_package_port(package_dir)
+        return adapter.verify(Path(package_dir), Path(run_dir))
+
+    def _validated_port(self) -> tuple[CompositeTaskWorldTemplate, LifecycleWorldAdapter]:
+        if _ssc03_definition_spec().ref != self.definition_reference:
+            raise ValueError("SSC-03 continual-world definition implementation differs")
+        current = _profile_ref(self.profile_id)
+        if current != self.reference:
+            raise ValueError("SSC-03 continual-world profile content differs")
+        return _validated_context()
+
+    def _validated_package_port(
+        self,
+        package_dir: Path,
+    ) -> tuple[LifecycleWorldAdapter, dict[str, Any]]:
+        _, adapter = self._validated_port()
+        metadata = adapter.validate_package(Path(package_dir))
+        if metadata is None or metadata.get("variant_id") != self.profile_id:
+            raise ValueError("SSC-03 package belongs to another continual-world profile")
+        return adapter, metadata
+
+
+def _validated_context() -> tuple[CompositeTaskWorldTemplate, LifecycleWorldAdapter]:
+    template = get_template(TEMPLATE_ID)
+    lifecycle = template.evidence_lifecycle
+    if lifecycle is None or lifecycle.world_id != SSC03_HYDRAULIC_CONTINUAL_WORLD_ID:
+        raise ValueError("SSC-03 continual-world identity differs")
+    adapter = registered_lifecycle_adapter(TEMPLATE_ID)
+    validate_lifecycle_world_adapter(template, adapter)
+    identity = adapter.identity()
+    if identity.operation_resolver_factory is None or identity.smoke_environment_factory is None:
+        raise ValueError("SSC-03 continual-world adapter is missing an executable lifecycle port")
+    return template, adapter
+
+
+def _profile_ref(profile_id: str) -> ContinualWorldProfileRef:
+    template, _ = _validated_context()
+    lifecycle = template.evidence_lifecycle
+    if lifecycle is None:
+        raise ValueError("SSC-03 template is missing its evidence lifecycle")
+    variant = get_ssc03_hydraulic_interaction_variant(profile_id)
+    profile_content_sha256 = canonical_content_sha256(
+        {
+            "schema_version": "aecbench.ssc03-hydraulic-continual-profile.v1",
+            "task_world_id": lifecycle.world_id,
+            "template": template.model_dump(mode="json"),
+            "variant": variant.model_dump(mode="json"),
+            "baseline_source": build_source_state().model_dump(mode="json"),
+            "revision_source": build_hydraulic_revision_source_state(variant.revision_id).model_dump(mode="json"),
+        }
+    )
+    return ContinualWorldProfileRef(
+        task_world_id=lifecycle.world_id,
+        profile_id=profile_id,
+        profile_version=SSC03_HYDRAULIC_PROFILE_VERSION,
+        profile_content_sha256=profile_content_sha256,
+    )
+
+
+def _load_ssc03_hydraulic_profile(reference: ContinualWorldProfileRef) -> LoadedContinualWorldProfile:
+    current = _profile_ref(reference.profile_id)
+    if current != reference:
+        raise ValueError("SSC-03 continual-world profile content differs")
+    variant = get_ssc03_hydraulic_interaction_variant(reference.profile_id)
+    _, adapter = _validated_context()
+    if adapter.variant_metadata(reference.profile_id) != variant.model_dump(mode="json"):
+        raise ValueError("SSC-03 registered variant metadata differs")
+    return LoadedContinualWorldProfile(
+        reference=reference,
+        value=Ssc03HydraulicContinualProfile(
+            reference=reference,
+            definition_reference=_ssc03_definition_spec().ref,
+        ),
+    )
+
+
+def _implementation_content_sha256(adapter: LifecycleWorldAdapter) -> str:
+    return canonical_content_sha256(
+        {
+            "adapter": adapter.identity().model_dump(mode="json"),
+            "definition_spec_builder": python_source_sha256(_ssc03_definition_spec),
+            "implementation_identity_builder": python_source_sha256(_implementation_content_sha256),
+            "loaded_profile": python_source_sha256(Ssc03HydraulicContinualProfile),
+            "profile_loader": python_source_sha256(_load_ssc03_hydraulic_profile),
+            "profile_reference": python_source_sha256(_profile_ref),
+        }
+    )
+
+
+def _ssc03_definition_spec() -> ContinualWorldDefinitionSpec:
+    template, adapter = _validated_context()
+    assert template.evidence_lifecycle is not None
+    task_world_id = template.evidence_lifecycle.world_id
+    profiles = tuple(_profile_ref(profile_id) for profile_id in adapter.variant_ids())
+    return ContinualWorldDefinitionSpec(
+        task_world_id=task_world_id,
+        definition_version=SSC03_HYDRAULIC_CONTINUAL_DEFINITION_VERSION,
+        implementation_content_sha256=_implementation_content_sha256(adapter),
+        profiles=profiles,
+    )
+
+
+@cache
+def ssc03_hydraulic_continual_world_definition() -> ContinualWorldDefinition:
+    """Return the exact SSC-03 world definition over the existing lifecycle adapter."""
+    return ContinualWorldDefinition(
+        spec=_ssc03_definition_spec(),
+        profile_loader=_load_ssc03_hydraulic_profile,
+    )

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/continual_definition.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/continual_definition.py
@@ -1,0 +1,116 @@
+# ABOUTME: Registers the pump-station world and its exact ASW-8 RS1 profile.
+# ABOUTME: Reuses certified profile loaders without creating another pump execution path.
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from functools import cache
+
+from aec_bench.contracts.continual_world import ContinualWorldDefinitionSpec, ContinualWorldProfileRef
+from aec_bench.contracts.harness_kernel import canonical_content_sha256
+from aec_bench.task_world_templates.continual.definition import (
+    ContinualWorldDefinition,
+    LoadedContinualWorldProfile,
+    python_source_sha256,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.physical_models import (
+    PumpStationCoupledPhysicalState,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.reference_package_models import (
+    ReferencePackage,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.reference_package_reader import (
+    load_reference_package,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.reference_package_reader_v2 import (
+    load_v2_reference_package,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.reference_system import (
+    PUMP_STATION_REFERENCE_SYSTEM_ID,
+    PumpStationReferenceSystem,
+    create_asw_8_opening_physical_state,
+    load_reference_system,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_session import (
+    PUMP_STATION_TASK_WORLD_ID,
+)
+
+PUMP_STATION_CONTINUAL_DEFINITION_VERSION = "1"
+PUMP_STATION_RS1_PROFILE_VERSION = "1"
+
+
+@dataclass(frozen=True)
+class PumpStationContinualProfile:
+    """Validated RS1 data and opening state supplied by the registered pump port."""
+
+    reference_system: PumpStationReferenceSystem
+    station_package: ReferencePackage
+    opening_state: PumpStationCoupledPhysicalState
+
+
+def _validated_profile_data() -> tuple[PumpStationReferenceSystem, ReferencePackage]:
+    system = load_reference_system()
+    task_world_id = str(system.descriptor.get("task_world_id"))
+    if task_world_id != PUMP_STATION_TASK_WORLD_ID:
+        raise ValueError("pump reference system task-world identity differs")
+    station_binding = system.descriptor.get("station_data")
+    if not isinstance(station_binding, Mapping):
+        raise ValueError("pump reference system station-data binding is missing")
+    package = load_reference_package(profile_id=system.station_data_profile_id)
+    if package.package_content_id != station_binding.get("package_content_id"):
+        raise ValueError("pump reference system station-data binding differs")
+    return system, package
+
+
+def _load_pump_station_profile(reference: ContinualWorldProfileRef) -> LoadedContinualWorldProfile:
+    if reference.profile_id != PUMP_STATION_REFERENCE_SYSTEM_ID:
+        raise ValueError("pump continual-world profile identity differs")
+    system, package = _validated_profile_data()
+    task_world_id = str(system.descriptor.get("task_world_id"))
+    if task_world_id != reference.task_world_id or system.descriptor_content_id != reference.profile_content_sha256:
+        raise ValueError("pump continual-world profile content differs")
+    return LoadedContinualWorldProfile(
+        reference=reference,
+        value=PumpStationContinualProfile(
+            reference_system=system,
+            station_package=package,
+            opening_state=create_asw_8_opening_physical_state(),
+        ),
+    )
+
+
+def _implementation_content_sha256() -> str:
+    return canonical_content_sha256(
+        {
+            "loaded_profile": python_source_sha256(PumpStationContinualProfile),
+            "profile_loader": python_source_sha256(_load_pump_station_profile),
+            "profile_validator": python_source_sha256(_validated_profile_data),
+            "reference_system_loader": python_source_sha256(load_reference_system),
+            "reference_package_loader": python_source_sha256(load_reference_package),
+            "v2_reference_package_loader": python_source_sha256(load_v2_reference_package),
+            "opening_state_factory": python_source_sha256(create_asw_8_opening_physical_state),
+        }
+    )
+
+
+@cache
+def pump_station_continual_world_definition() -> ContinualWorldDefinition:
+    """Return the content-pinned pump definition without starting a world run."""
+    system, _ = _validated_profile_data()
+    task_world_id = str(system.descriptor.get("task_world_id"))
+    profile = ContinualWorldProfileRef(
+        task_world_id=task_world_id,
+        profile_id=PUMP_STATION_REFERENCE_SYSTEM_ID,
+        profile_version=PUMP_STATION_RS1_PROFILE_VERSION,
+        profile_content_sha256=system.descriptor_content_id,
+    )
+    return ContinualWorldDefinition(
+        spec=ContinualWorldDefinitionSpec(
+            task_world_id=task_world_id,
+            definition_version=PUMP_STATION_CONTINUAL_DEFINITION_VERSION,
+            implementation_content_sha256=_implementation_content_sha256(),
+            profiles=(profile,),
+        ),
+        profile_loader=_load_pump_station_profile,
+    )

--- a/tests/contracts/test_continual_world.py
+++ b/tests/contracts/test_continual_world.py
@@ -1,0 +1,95 @@
+# ABOUTME: Tests content-pinned continual-world definition and profile references.
+# ABOUTME: Rejects empty, mixed, duplicate, unstable, or changed registration data.
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from aec_bench.contracts.continual_world import (
+    ContinualWorldDefinitionSpec,
+    ContinualWorldProfileRef,
+)
+
+
+def _profile(
+    profile_id: str,
+    *,
+    task_world_id: str = "world-a",
+    profile_version: str = "1",
+    digest: str = "a" * 64,
+) -> ContinualWorldProfileRef:
+    return ContinualWorldProfileRef(
+        task_world_id=task_world_id,
+        profile_id=profile_id,
+        profile_version=profile_version,
+        profile_content_sha256=digest,
+    )
+
+
+def test_definition_requires_at_least_one_profile() -> None:
+    with pytest.raises(ValidationError, match="at least one profile"):
+        ContinualWorldDefinitionSpec(
+            task_world_id="world-a",
+            definition_version="1",
+            implementation_content_sha256="b" * 64,
+            profiles=(),
+        )
+
+
+def test_definition_rejects_cross_world_profile() -> None:
+    with pytest.raises(ValidationError, match="same task world"):
+        ContinualWorldDefinitionSpec(
+            task_world_id="world-a",
+            definition_version="1",
+            implementation_content_sha256="b" * 64,
+            profiles=(_profile("profile-a", task_world_id="world-b"),),
+        )
+
+
+def test_definition_rejects_duplicate_profile_version() -> None:
+    profile = _profile("profile-a")
+
+    with pytest.raises(ValidationError, match="profile identities must be distinct"):
+        ContinualWorldDefinitionSpec(
+            task_world_id="world-a",
+            definition_version="1",
+            implementation_content_sha256="b" * 64,
+            profiles=(profile, profile),
+        )
+
+
+def test_definition_requires_stable_profile_order() -> None:
+    with pytest.raises(ValidationError, match="profiles must use stable order"):
+        ContinualWorldDefinitionSpec(
+            task_world_id="world-a",
+            definition_version="1",
+            implementation_content_sha256="b" * 64,
+            profiles=(_profile("profile-b"), _profile("profile-a")),
+        )
+
+
+def test_profile_ref_rejects_invalid_content_hash() -> None:
+    with pytest.raises(ValidationError, match="64 lowercase hexadecimal"):
+        _profile("profile-a", digest="NOT-A-SHA256")
+
+
+def test_definition_rejects_invalid_implementation_hash() -> None:
+    with pytest.raises(ValidationError, match="64 lowercase hexadecimal"):
+        ContinualWorldDefinitionSpec(
+            task_world_id="world-a",
+            definition_version="1",
+            implementation_content_sha256="NOT-A-SHA256",
+            profiles=(_profile("profile-a"),),
+        )
+
+
+def test_definition_rejects_changed_content_identity() -> None:
+    with pytest.raises(ValidationError, match="does not match canonical model content"):
+        ContinualWorldDefinitionSpec(
+            task_world_id="world-a",
+            definition_version="1",
+            implementation_content_sha256="b" * 64,
+            profiles=(_profile("profile-a"),),
+            content_sha256="f" * 64,
+        )

--- a/tests/task_world_templates/continual/test_catalogue.py
+++ b/tests/task_world_templates/continual/test_catalogue.py
@@ -1,0 +1,263 @@
+# ABOUTME: Tests the task-neutral continual-world catalogue with two real task consumers.
+# ABOUTME: Proves exact pump and SSC-03 profile dispatch without adding another runtime.
+
+from __future__ import annotations
+
+import ast
+import json
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+import pytest
+
+from aec_bench.contracts.continual_world import (
+    ContinualWorldDefinitionRef,
+    ContinualWorldProfileRef,
+)
+from aec_bench.meta_harness.evidence_lifecycle import run_evidence_lifecycle
+from aec_bench.task_world_templates.continual.catalogue import ContinualWorldCatalogue
+from aec_bench.task_world_templates.continual_catalogue import default_continual_world_catalogue
+from aec_bench.task_world_templates.lifecycles.ssc03_hydraulic_continual_definition import (
+    SSC03_HYDRAULIC_CONTINUAL_WORLD_ID,
+    Ssc03HydraulicContinualProfile,
+    ssc03_hydraulic_continual_world_definition,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.continual_definition import (
+    PumpStationContinualProfile,
+    pump_station_continual_world_definition,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.physical_models import (
+    PumpStationCoupledPhysicalState,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.reference_system import (
+    PUMP_STATION_REFERENCE_SYSTEM_ID,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_session import (
+    PUMP_STATION_TASK_WORLD_ID,
+)
+
+SSC03_GOLDEN_PATH = Path(__file__).parents[1] / "fixtures" / "ssc03_hydraulic_continual_profiles.v1.json"
+
+
+def test_catalogue_rejects_duplicate_world_id() -> None:
+    definition = ssc03_hydraulic_continual_world_definition()
+
+    with pytest.raises(ValueError, match="task world ids must be unique"):
+        ContinualWorldCatalogue(definitions=(definition, definition))
+
+
+def test_catalogue_resolves_exact_content_pinned_definition() -> None:
+    catalogue = default_continual_world_catalogue()
+    definition = catalogue.get(SSC03_HYDRAULIC_CONTINUAL_WORLD_ID)
+
+    assert catalogue.resolve(definition.ref) is definition
+
+
+def test_catalogue_rejects_stale_definition_reference() -> None:
+    catalogue = default_continual_world_catalogue()
+    definition = catalogue.get(SSC03_HYDRAULIC_CONTINUAL_WORLD_ID)
+    stale = ContinualWorldDefinitionRef(
+        task_world_id=definition.ref.task_world_id,
+        definition_version=definition.ref.definition_version,
+        content_sha256="f" * 64,
+    )
+
+    with pytest.raises(ValueError, match="content-pinned definition does not match"):
+        catalogue.resolve(stale)
+
+
+def test_definition_rejects_stale_profile_reference() -> None:
+    definition = ssc03_hydraulic_continual_world_definition()
+    current = definition.profile_ref("major_idf_revision", "1")
+    stale = ContinualWorldProfileRef(
+        task_world_id=current.task_world_id,
+        profile_id=current.profile_id,
+        profile_version=current.profile_version,
+        profile_content_sha256="f" * 64,
+    )
+
+    with pytest.raises(ValueError, match="content-pinned profile does not match"):
+        definition.load_profile(stale)
+
+
+def test_definition_rejects_profile_from_another_real_world() -> None:
+    definition = ssc03_hydraulic_continual_world_definition()
+    current = definition.profile_ref("major_idf_revision", "1")
+    foreign = ContinualWorldProfileRef(
+        task_world_id=PUMP_STATION_TASK_WORLD_ID,
+        profile_id=current.profile_id,
+        profile_version=current.profile_version,
+        profile_content_sha256=current.profile_content_sha256,
+    )
+
+    with pytest.raises(ValueError, match="belongs to another task world"):
+        definition.load_profile(foreign)
+
+
+def test_catalogue_rejects_unknown_world_and_profile() -> None:
+    catalogue = default_continual_world_catalogue()
+    definition = catalogue.get(SSC03_HYDRAULIC_CONTINUAL_WORLD_ID)
+
+    with pytest.raises(KeyError, match="unknown continual task world"):
+        catalogue.get("unknown-world")
+    with pytest.raises(KeyError, match="unknown continual-world profile"):
+        definition.profile_ref("unknown-profile", "1")
+    with pytest.raises(KeyError, match="unsupported continual-world profile version"):
+        definition.profile_ref("major_idf_revision", "2")
+
+
+def test_continual_core_does_not_import_concrete_task_packages() -> None:
+    package_root = Path(__file__).parents[3] / "src" / "aec_bench" / "task_world_templates" / "continual"
+    forbidden_fragments = (
+        "stewardship",
+        "lifecycles",
+        "hydraulics",
+        "meta_harness",
+        "cli",
+        "harbor",
+    )
+
+    imported_modules: list[str] = []
+    for path in sorted(package_root.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported_modules.extend(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module is not None:
+                imported_modules.append(node.module)
+
+    assert not {
+        module for module in imported_modules if any(fragment in module.split(".") for fragment in forbidden_fragments)
+    }
+
+
+def test_default_catalogue_registers_pump_and_ssc03_worlds() -> None:
+    catalogue = default_continual_world_catalogue()
+
+    assert tuple(reference.task_world_id for reference in catalogue.list_definition_refs()) == (
+        SSC03_HYDRAULIC_CONTINUAL_WORLD_ID,
+        PUMP_STATION_TASK_WORLD_ID,
+    )
+
+
+@pytest.mark.parametrize(
+    ("task_world_id", "profile_id", "expected_type"),
+    (
+        (SSC03_HYDRAULIC_CONTINUAL_WORLD_ID, "major_idf_revision", Ssc03HydraulicContinualProfile),
+        (PUMP_STATION_TASK_WORLD_ID, PUMP_STATION_REFERENCE_SYSTEM_ID, PumpStationContinualProfile),
+    ),
+)
+def test_real_consumers_satisfy_the_same_definition_profile_contract(
+    task_world_id: str,
+    profile_id: str,
+    expected_type: type[object],
+) -> None:
+    definition = default_continual_world_catalogue().get(task_world_id)
+    reference = definition.profile_ref(profile_id, "1")
+
+    loaded = definition.load_profile(reference)
+
+    assert definition.spec.task_world_id == task_world_id
+    assert loaded.reference == reference
+    assert isinstance(loaded.value, expected_type)
+
+
+def test_pump_definition_loads_the_exact_rs1_profile() -> None:
+    definition = pump_station_continual_world_definition()
+    reference = definition.profile_ref(PUMP_STATION_REFERENCE_SYSTEM_ID, "1")
+
+    loaded = definition.load_profile(reference)
+
+    assert loaded.reference == reference
+    assert isinstance(loaded.value, PumpStationContinualProfile)
+    station_binding = loaded.value.reference_system.descriptor["station_data"]
+    assert loaded.value.station_package.package_content_id == station_binding["package_content_id"]
+    assert isinstance(loaded.value.opening_state, PumpStationCoupledPhysicalState)
+    assert (
+        loaded.value.opening_state.calendar_seconds == loaded.value.reference_system.opening_state["calendar_seconds"]
+    )
+
+
+def test_ssc03_definition_loads_every_registered_hydraulic_profile() -> None:
+    definition = ssc03_hydraulic_continual_world_definition()
+    golden = json.loads(SSC03_GOLDEN_PATH.read_text(encoding="utf-8"))
+    expected_ids = (
+        "administrative_no_op",
+        "major_idf_revision",
+        "outlet_geometry_revision",
+        "tailwater_revision",
+    )
+
+    assert tuple(profile.profile_id for profile in definition.spec.profiles) == expected_ids
+    for profile_id in expected_ids:
+        reference = definition.profile_ref(profile_id, "1")
+        loaded = definition.load_profile(reference)
+        assert loaded.reference == reference
+        assert reference.profile_content_sha256 == golden["profiles"][profile_id]
+        assert isinstance(loaded.value, Ssc03HydraulicContinualProfile)
+        assert loaded.value.reference == reference
+        assert loaded.value.profile_id == profile_id
+
+
+def test_ssc03_loaded_profile_does_not_expose_mutable_execution_inputs() -> None:
+    definition = ssc03_hydraulic_continual_world_definition()
+    loaded = definition.load_profile(definition.profile_ref("major_idf_revision", "1"))
+    assert isinstance(loaded.value, Ssc03HydraulicContinualProfile)
+
+    assert not hasattr(loaded.value, "template")
+    assert not hasattr(loaded.value, "variant")
+    assert not hasattr(loaded.value, "adapter")
+    with pytest.raises(FrozenInstanceError):
+        loaded.value.reference = definition.profile_ref("tailwater_revision", "1")  # type: ignore[misc]
+
+
+def test_ssc03_profile_rejects_package_from_another_registered_profile(tmp_path: Path) -> None:
+    definition = ssc03_hydraulic_continual_world_definition()
+    major = definition.load_profile(definition.profile_ref("major_idf_revision", "1"))
+    tailwater = definition.load_profile(definition.profile_ref("tailwater_revision", "1"))
+    assert isinstance(major.value, Ssc03HydraulicContinualProfile)
+    assert isinstance(tailwater.value, Ssc03HydraulicContinualProfile)
+    tailwater_package = tailwater.value.compile(tmp_path / "tailwater-package")
+
+    with pytest.raises(ValueError, match="package belongs to another continual-world profile"):
+        major.value.build_smoke_environment(tailwater_package.package_dir)
+
+
+def test_ssc03_profile_rejects_stale_definition_implementation(tmp_path: Path) -> None:
+    definition = ssc03_hydraulic_continual_world_definition()
+    profile_reference = definition.profile_ref("major_idf_revision", "1")
+    stale_definition_reference = ContinualWorldDefinitionRef(
+        task_world_id=definition.ref.task_world_id,
+        definition_version=definition.ref.definition_version,
+        content_sha256="f" * 64,
+    )
+    stale = Ssc03HydraulicContinualProfile(
+        reference=profile_reference,
+        definition_reference=stale_definition_reference,
+    )
+
+    with pytest.raises(ValueError, match="definition implementation differs"):
+        stale.compile(tmp_path / "package")
+
+
+def test_ssc03_catalogue_profile_executes_and_verifies_real_lifecycle(tmp_path: Path) -> None:
+    catalogue = default_continual_world_catalogue()
+    definition = catalogue.get(SSC03_HYDRAULIC_CONTINUAL_WORLD_ID)
+    loaded = definition.load_profile(definition.profile_ref("major_idf_revision", "1"))
+    assert isinstance(loaded.value, Ssc03HydraulicContinualProfile)
+    compiled = loaded.value.compile(tmp_path / "package")
+    assert compiled.envelope.world_id == loaded.reference.task_world_id
+    assert compiled.envelope.variant_id == loaded.value.profile_id
+    assert loaded.value.build_operation_resolver(compiled.package_dir, tmp_path / "run") is not None
+    environment = loaded.value.build_smoke_environment(compiled.package_dir)
+    assert environment is not None
+
+    run_evidence_lifecycle(
+        compiled.package_dir,
+        tmp_path / "run",
+        episode_environment=environment,
+    )
+    verification = loaded.value.verify(compiled.package_dir, tmp_path / "run")
+
+    assert verification["passed"] is True
+    assert verification["reward"] == 1.0

--- a/tests/task_world_templates/fixtures/ssc03_hydraulic_continual_profiles.v1.json
+++ b/tests/task_world_templates/fixtures/ssc03_hydraulic_continual_profiles.v1.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "administrative_no_op": "8904d72184baf464b6f6aa190a469b3db29cfc3e4d8001ad3235bbb9a400474e",
+    "major_idf_revision": "79a78213501cc14b023d672c0b4c6cc11d7e041210c892690b3b339c2d54a5f9",
+    "outlet_geometry_revision": "7c86a3b8936d76b3d12d3a46001dfd4a6d3a0b1bc66e68c9704e590e26bab646",
+    "tailwater_revision": "6efdce91ee91345414dff590f26647ca3493722f647f3e63472091d5d5752b26"
+  },
+  "schema_version": "1",
+  "task_world_id": "aec.task_world.composite.hydraulic-interaction-lifecycle-review"
+}


### PR DESCRIPTION
## Summary

- Add exact, content-addressed continual-world definition and profile contracts.
- Add one task-neutral catalogue and one composition root.
- Register the pump-station RS1 profile and all four real SSC-03 hydraulic profiles.
- Keep the task ports immutable and check their definition, profile, and package identities before use.

## Boundary

This change adds registration only. It does not add or replace runs, repositories, sessions, replay, recovery, branches, rollouts, transports, CLI dispatch, Harbor dispatch, evaluation dispatch, or the ASW-8 coupled runtime.

The pump adapter loads its certified reference data and opening state but does not start a run. The SSC-03 adapter delegates compile, smoke execution, and verification to the existing lifecycle implementation.

## Targeted validation

- Contract, catalogue, real-consumer, pump regression, and SSC-03 regression tests: 26 passed.
- Ruff format check on the 10 changed Python files: clean.
- Ruff check on the 10 changed Python files: clean.
- MyPy on the 10 changed source files: clean.
- Staged whitespace check: clean.
- Two independent boundary and test reviews: no remaining findings.

No full test suite was run. This follows the agreed targeted-test policy.

## Known pre-existing issue

The stale SSC-03 compiled-world golden identity fails on the unchanged PR 74 branch. It is outside this change and is tracked in #76.

## Stack

Base: feat/asw-8-reference-system-implementation, the current head branch of draft PR 74.