### PR TITLE
Step 3A: share continual-world local locking

### DIFF
--- a/docs/CONTINUAL_WORLD_RUNTIME.md
+++ b/docs/CONTINUAL_WORLD_RUNTIME.md
@@ -320,6 +320,37 @@ portable profile ID. The definition reference separately hashes the registered
 adapter and loader sources. Recovery must later check all three identities:
 profile, definition implementation, and compiled run package.
 
+### 6.9 Step 3A local lock ownership
+
+The first durable-engine extraction moves only the host-local inter-process
+lock. It is the smallest proven lifetime mechanic already used by both real
+world implementations.
+
+| Path | Owner | Compatibility and migration rule |
+| --- | --- | --- |
+| `src/aec_bench/ledger/local_lock.py` | Lower filesystem durability | Own trusted-root anchoring, confined relative-path traversal, a private regular lock file, and exclusive POSIX `flock`. Import no task or harness module. |
+| `src/aec_bench/task_world_templates/continual/durability.py` | Shared continual-world durability | Re-export the lower lock primitive as part of the continual-world runtime boundary. Import no concrete task or harness module. |
+| `wastewater_pump_station/world_run_repository.py` | Pump durability adapter | Keep `.world-run.lock`, translate shared lock failures to the existing pump error boundary, and keep every pump artifact, codec, commit, pointer, replay, and recovery rule task-local. |
+| `meta_harness/evidence_lifecycle.py` | Shared evidence-lifecycle kernel | Use the lower primitive directly to keep the dependency direction downwards. Keep `.locks/lifecycle-state.lock`, translate lock failures to `EvidenceLifecycleError`, and keep lifecycle state, transaction, ledger, and recovery rules unchanged. SSC-03 remains one real consumer of this kernel. |
+
+The shared lock is local to one POSIX host. It is not a distributed lock and
+does not provide cross-host coordination. Each caller supplies a trusted run
+root and a confined relative lock path. A relative root, including `.`, is
+anchored once as an absolute path. The root's final component must be a real
+directory, not a symbolic link. System path aliases above that root are valid.
+Callers that used a symbolic link as the run root must supply its real target or
+put the alias above the run root. Symbolic links and non-directory components
+inside the root are not valid. The lock paths and mode `0600` stay unchanged.
+Errors from work done while the lock is held keep their original type and
+identity. No task artifact path or byte changes in this extraction.
+
+Step 3 is not complete at this point. Immutable publication and confined reads
+already have a generic implementation in `meta_harness/immutable_artifact_store.py`.
+The next correction must resolve that implementation's lower-layer ownership
+and reuse it rather than create a third byte store. Atomic current selection,
+transaction publication, replay, and crash recovery remain on their existing
+pump and SSC-03 paths until their shared raw-byte boundary is proved.
+
 ## 7. Implementation sequence
 
 The correction uses small pull requests against the unmerged ASW-8 branch.

--- a/src/aec_bench/ledger/local_lock.py
+++ b/src/aec_bench/ledger/local_lock.py
@@ -1,0 +1,223 @@
+# ABOUTME: Provides a confined local POSIX file lock for durable filesystem operations.
+# ABOUTME: Anchors lock paths below one trusted root and preserves protected-operation errors.
+
+from __future__ import annotations
+
+import fcntl
+import os
+import stat
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from pathlib import Path, PurePosixPath
+from typing import NoReturn
+
+from aec_bench.ledger.durability import mkdir_durable
+
+
+class LocalFileLockError(RuntimeError):
+    """Raised when a local file lock cannot be prepared, acquired, or released."""
+
+
+class LocalFileLockConfinementError(LocalFileLockError):
+    """Raised when a relative lock path selects an unsafe filesystem object."""
+
+
+type LocalFileLockErrorFactory = Callable[[LocalFileLockError], BaseException]
+
+
+@contextmanager
+def exclusive_local_file_lock(
+    root: Path,
+    relative_path: str,
+    *,
+    error_factory: LocalFileLockErrorFactory | None = None,
+) -> Iterator[None]:
+    """Hold one exclusive POSIX lock at a confined path below a trusted root."""
+    directory_descriptors: list[int] = []
+    lock_descriptor: int | None = None
+    try:
+        try:
+            directory_descriptors, lock_descriptor = _open_confined_lock(
+                Path(root).absolute(),
+                relative_path,
+            )
+            fcntl.flock(lock_descriptor, fcntl.LOCK_EX)
+        except LocalFileLockError as lock_error:
+            _close_after_setup_failure(lock_descriptor, directory_descriptors, lock_error)
+            _raise_lock_error(lock_error, error_factory)
+        except OSError as lock_cause:
+            acquisition_error = LocalFileLockError(f"local lock cannot be acquired: {lock_cause}")
+            _close_after_setup_failure(lock_descriptor, directory_descriptors, acquisition_error)
+            _raise_lock_error(acquisition_error, error_factory, lock_cause)
+        except BaseException as interruption:
+            _close_after_setup_failure(lock_descriptor, directory_descriptors, interruption)
+            raise
+
+        body_error: BaseException | None = None
+        try:
+            yield
+        except BaseException as protected_error:
+            body_error = protected_error
+            raise
+        finally:
+            cleanup = _release_and_close(lock_descriptor, directory_descriptors)
+            if cleanup is not None:
+                cleanup_error, cleanup_cause = cleanup
+                if body_error is not None:
+                    body_error.add_note(f"Local file lock cleanup also failed: {cleanup_error}")
+                else:
+                    _raise_lock_error(cleanup_error, error_factory, cleanup_cause)
+    finally:
+        directory_descriptors.clear()
+
+
+def _open_confined_lock(root: Path, relative_path: str) -> tuple[list[int], int]:
+    parts = _relative_lock_parts(relative_path)
+    if root.name in {"", ".", ".."}:
+        raise LocalFileLockConfinementError("local lock root must select one directory")
+    try:
+        mkdir_durable(root)
+    except OSError as cause:
+        raise LocalFileLockError(f"local lock root cannot be created: {cause}") from cause
+
+    descriptors: list[int] = []
+    try:
+        root_descriptor = _open_directory(root, "local lock root")
+        descriptors.append(root_descriptor)
+        for part in parts[:-1]:
+            descriptors.append(_open_or_create_child_directory(descriptors[-1], part))
+        lock_descriptor = _open_private_regular_file(descriptors[-1], parts[-1])
+    except BaseException as error:
+        _close_after_setup_failure(None, descriptors, error)
+        raise
+    return descriptors, lock_descriptor
+
+
+def _relative_lock_parts(relative_path: str) -> tuple[str, ...]:
+    selected = PurePosixPath(relative_path)
+    raw_parts = relative_path.split("/")
+    if (
+        not relative_path
+        or selected.is_absolute()
+        or any(part in {"", ".", ".."} for part in raw_parts)
+        or "\x00" in relative_path
+    ):
+        raise LocalFileLockConfinementError(
+            "local lock path must be a normalized confined relative file path",
+        )
+    return tuple(raw_parts)
+
+
+def _open_directory(path: Path, label: str) -> int:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        return os.open(path, flags)
+    except OSError as cause:
+        raise LocalFileLockConfinementError(f"{label} is unsafe: {cause}") from cause
+
+
+def _open_or_create_child_directory(parent_descriptor: int, name: str) -> int:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        return os.open(name, flags, dir_fd=parent_descriptor)
+    except FileNotFoundError:
+        try:
+            os.mkdir(name, mode=0o700, dir_fd=parent_descriptor)
+            os.fsync(parent_descriptor)
+        except FileExistsError:
+            pass
+        except OSError as cause:
+            raise LocalFileLockError(
+                f"local lock parent directory cannot be created: {cause}",
+            ) from cause
+        try:
+            return os.open(name, flags, dir_fd=parent_descriptor)
+        except OSError as cause:
+            raise LocalFileLockConfinementError(
+                f"local lock parent directory is unsafe: {cause}",
+            ) from cause
+    except OSError as cause:
+        raise LocalFileLockConfinementError(
+            f"local lock parent directory is unsafe: {cause}",
+        ) from cause
+
+
+def _open_private_regular_file(parent_descriptor: int, name: str) -> int:
+    flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(name, flags, 0o600, dir_fd=parent_descriptor)
+    except OSError as cause:
+        raise LocalFileLockConfinementError(f"local lock file is unsafe: {cause}") from cause
+    try:
+        details = os.fstat(descriptor)
+        if not stat.S_ISREG(details.st_mode):
+            raise LocalFileLockConfinementError("local lock target is not a regular file")
+        if stat.S_IMODE(details.st_mode) & 0o077:
+            raise LocalFileLockConfinementError("local lock file must be host-private")
+    except BaseException as error:
+        _close_after_setup_failure(descriptor, [], error)
+        raise
+    return descriptor
+
+
+def _close_after_setup_failure(
+    lock_descriptor: int | None,
+    directory_descriptors: list[int],
+    active_error: BaseException,
+) -> None:
+    close_errors = _close_descriptors(lock_descriptor, directory_descriptors)
+    if close_errors:
+        active_error.add_note(_cleanup_note(close_errors))
+
+
+def _release_and_close(
+    lock_descriptor: int | None,
+    directory_descriptors: list[int],
+) -> tuple[LocalFileLockError, BaseException] | None:
+    errors: list[tuple[str, BaseException]] = []
+    if lock_descriptor is not None:
+        try:
+            fcntl.flock(lock_descriptor, fcntl.LOCK_UN)
+        except BaseException as cause:
+            errors.append(("release", cause))
+    errors.extend(_close_descriptors(lock_descriptor, directory_descriptors))
+    if not errors:
+        return None
+    error = LocalFileLockError(_cleanup_note(errors))
+    return error, errors[0][1]
+
+
+def _close_descriptors(
+    lock_descriptor: int | None,
+    directory_descriptors: list[int],
+) -> list[tuple[str, BaseException]]:
+    errors: list[tuple[str, BaseException]] = []
+    descriptors = ([lock_descriptor] if lock_descriptor is not None else []) + list(
+        reversed(directory_descriptors),
+    )
+    directory_descriptors.clear()
+    for descriptor in descriptors:
+        try:
+            os.close(descriptor)
+        except BaseException as cause:
+            errors.append(("close", cause))
+    return errors
+
+
+def _cleanup_note(errors: list[tuple[str, BaseException]]) -> str:
+    details = "; ".join(f"{operation} failed: {cause}" for operation, cause in errors)
+    return f"local lock cleanup failed: {details}"
+
+
+def _raise_lock_error(
+    error: LocalFileLockError,
+    error_factory: LocalFileLockErrorFactory | None,
+    cause: BaseException | None = None,
+) -> NoReturn:
+    translated = error if error_factory is None else error_factory(error)
+    if translated is error:
+        raise error
+    raise translated from (cause or error)

--- a/src/aec_bench/meta_harness/evidence_lifecycle.py
+++ b/src/aec_bench/meta_harness/evidence_lifecycle.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import copy
-import fcntl
 import hashlib
 import json
 import os
@@ -18,6 +17,7 @@ from typing import Any
 from pydantic import ValidationError
 
 from aec_bench.ledger.durability import fsync_directory, fsync_tree, mkdir_durable
+from aec_bench.ledger.local_lock import exclusive_local_file_lock
 from aec_bench.meta_harness.evidence_lifecycle_episode import (
     LifecycleEpisodeContext,
     LifecycleEpisodeEnvironment,
@@ -2175,16 +2175,14 @@ def _migrate_legacy_state(
 
 @contextmanager
 def _lifecycle_state_lock(run_dir: Path) -> Iterator[None]:
-    lock_dir = run_dir / ".locks"
-    mkdir_durable(lock_dir)
-    lock_path = lock_dir / "lifecycle-state.lock"
-    descriptor = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
-    try:
-        fcntl.flock(descriptor, fcntl.LOCK_EX)
+    with exclusive_local_file_lock(
+        run_dir,
+        ".locks/lifecycle-state.lock",
+        error_factory=lambda error: EvidenceLifecycleError(
+            f"lifecycle state lock is unsafe: {error}",
+        ),
+    ):
         yield
-    finally:
-        fcntl.flock(descriptor, fcntl.LOCK_UN)
-        os.close(descriptor)
 
 
 def _spec_sha256(spec: EvidenceLifecycleSpec) -> str:

--- a/src/aec_bench/task_world_templates/continual/__init__.py
+++ b/src/aec_bench/task_world_templates/continual/__init__.py
@@ -1,5 +1,5 @@
-# ABOUTME: Exposes the task-neutral continual-world definition and catalogue boundary.
-# ABOUTME: Does not import any concrete task world or execution transport.
+# ABOUTME: Exposes task-neutral continual-world definition, catalogue, and local durability boundaries.
+# ABOUTME: Imports no concrete task world or execution transport.
 
 from aec_bench.task_world_templates.continual.catalogue import ContinualWorldCatalogue
 from aec_bench.task_world_templates.continual.definition import (
@@ -7,10 +7,18 @@ from aec_bench.task_world_templates.continual.definition import (
     LoadedContinualWorldProfile,
     python_source_sha256,
 )
+from aec_bench.task_world_templates.continual.durability import (
+    ContinualWorldLockConfinementError,
+    ContinualWorldLockError,
+    exclusive_local_file_lock,
+)
 
 __all__ = [
     "ContinualWorldCatalogue",
     "ContinualWorldDefinition",
+    "ContinualWorldLockConfinementError",
+    "ContinualWorldLockError",
     "LoadedContinualWorldProfile",
+    "exclusive_local_file_lock",
     "python_source_sha256",
 ]

--- a/src/aec_bench/task_world_templates/continual/durability.py
+++ b/src/aec_bench/task_world_templates/continual/durability.py
@@ -1,0 +1,14 @@
+# ABOUTME: Exposes the shared local POSIX lock through the continual-world runtime boundary.
+# ABOUTME: Keeps continual-world consumers independent from lower ledger implementation details.
+
+from aec_bench.ledger.local_lock import (
+    LocalFileLockConfinementError as ContinualWorldLockConfinementError,
+)
+from aec_bench.ledger.local_lock import LocalFileLockError as ContinualWorldLockError
+from aec_bench.ledger.local_lock import exclusive_local_file_lock as exclusive_local_file_lock
+
+__all__ = [
+    "ContinualWorldLockConfinementError",
+    "ContinualWorldLockError",
+    "exclusive_local_file_lock",
+]

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_repository.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_repository.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import fcntl
 import hashlib
 import json
 import os
@@ -14,6 +13,9 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import NoReturn, TypeGuard, cast
 
+from aec_bench.task_world_templates.continual.durability import (
+    exclusive_local_file_lock,
+)
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.evidence_health import (
     PumpStationEvidenceTreatmentRequest,
 )
@@ -162,20 +164,15 @@ class PumpStationWorldRunRepository:
     @contextmanager
     def locked(self) -> Iterator[None]:
         """Serialize state selection across local processes."""
-        flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_CLOEXEC", 0)
-        flags |= getattr(os, "O_NOFOLLOW", 0)
-        descriptor = os.open(self._lock_path, flags, 0o600)
-        try:
-            details = os.fstat(descriptor)
-            if not stat.S_ISREG(details.st_mode):
-                _fail("artifact-confinement", "world-run lock is not a regular file")
-            fcntl.flock(descriptor, fcntl.LOCK_EX)
-            try:
-                yield
-            finally:
-                fcntl.flock(descriptor, fcntl.LOCK_UN)
-        finally:
-            os.close(descriptor)
+        with exclusive_local_file_lock(
+            self._root,
+            ".world-run.lock",
+            error_factory=lambda error: PumpStationWorldRunError(
+                "artifact-confinement",
+                f"world-run lock is unsafe: {error}",
+            ),
+        ):
+            yield
 
     def initialize(
         self,

--- a/tests/task_world_templates/continual/test_durability.py
+++ b/tests/task_world_templates/continual/test_durability.py
@@ -1,0 +1,250 @@
+# ABOUTME: Tests the shared local lock used by real continual-world durability consumers.
+# ABOUTME: Proves process exclusion, confinement, and task-owned error translation without fake worlds.
+
+from __future__ import annotations
+
+import ast
+import multiprocessing
+import stat
+from contextlib import chdir
+from pathlib import Path
+from typing import Protocol
+
+import pytest
+
+from aec_bench.ledger.local_lock import exclusive_local_file_lock as lower_exclusive_local_file_lock
+from aec_bench.meta_harness.evidence_lifecycle import EvidenceLifecycleError, _lifecycle_state_lock
+from aec_bench.task_world_templates.continual.durability import (
+    ContinualWorldLockConfinementError,
+    ContinualWorldLockError,
+    exclusive_local_file_lock,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station import (
+    PumpStationWorldRunError,
+    PumpStationWorldRunRepository,
+)
+
+
+class _ProcessSignal(Protocol):
+    def set(self) -> None: ...
+
+    def wait(self, timeout: float | None = None) -> bool: ...
+
+
+def _acquire_in_child(
+    root: Path,
+    ready: _ProcessSignal,
+    start: _ProcessSignal,
+    attempting: _ProcessSignal,
+    acquired: _ProcessSignal,
+) -> None:
+    ready.set()
+    if not start.wait(5):
+        raise RuntimeError("lock test start signal was not received")
+    attempting.set()
+    with exclusive_local_file_lock(root, "world.lock"):
+        acquired.set()
+
+
+def _imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            modules.add(node.module)
+    return modules
+
+
+def test_exclusive_local_file_lock_serializes_real_processes(tmp_path: Path) -> None:
+    root = tmp_path / "nested"
+    lock_path = root / "world.lock"
+    context = multiprocessing.get_context("spawn")
+    ready = context.Event()
+    start = context.Event()
+    attempting = context.Event()
+    acquired = context.Event()
+    process = context.Process(
+        target=_acquire_in_child,
+        args=(root, ready, start, attempting, acquired),
+    )
+
+    started = False
+    try:
+        process.start()
+        started = True
+        assert ready.wait(5)
+        with exclusive_local_file_lock(root, "world.lock"):
+            start.set()
+            assert attempting.wait(5)
+            assert not acquired.wait(0.5)
+            assert process.is_alive()
+
+        assert acquired.wait(5)
+        process.join(5)
+        assert not process.is_alive()
+        assert process.exitcode == 0
+    finally:
+        start.set()
+        if started:
+            if process.is_alive():
+                process.kill()
+            process.join()
+
+    assert stat.S_IMODE(lock_path.stat().st_mode) == 0o600
+
+
+@pytest.mark.parametrize("unsafe_kind", ("symbolic-link", "directory"))
+def test_exclusive_local_file_lock_rejects_unsafe_targets(
+    tmp_path: Path,
+    unsafe_kind: str,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    lock_path = root / "world.lock"
+    if unsafe_kind == "symbolic-link":
+        outside = tmp_path / "outside.lock"
+        outside.write_bytes(b"")
+        lock_path.symlink_to(outside)
+    else:
+        lock_path.mkdir()
+
+    with pytest.raises(ContinualWorldLockConfinementError):
+        with exclusive_local_file_lock(root, "world.lock"):
+            raise AssertionError("unsafe lock target must not be entered")
+
+
+def test_exclusive_local_file_lock_accepts_external_path_alias(tmp_path: Path) -> None:
+    physical_parent = tmp_path / "physical"
+    physical_parent.mkdir()
+    alias = tmp_path / "alias"
+    alias.symlink_to(physical_parent, target_is_directory=True)
+
+    with exclusive_local_file_lock(alias / "run", "world.lock"):
+        assert (physical_parent / "run" / "world.lock").is_file()
+
+
+def test_exclusive_local_file_lock_rejects_internal_parent_alias(tmp_path: Path) -> None:
+    root = tmp_path / "run"
+    root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (root / ".locks").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ContinualWorldLockConfinementError):
+        with exclusive_local_file_lock(root, ".locks/world.lock"):
+            raise AssertionError("internal lock parent alias must not be entered")
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    ("../outside.lock", "/outside.lock", "locks//world.lock", "locks/./world.lock"),
+)
+def test_exclusive_local_file_lock_rejects_unconfined_relative_paths(
+    tmp_path: Path,
+    relative_path: str,
+) -> None:
+    with pytest.raises(ContinualWorldLockConfinementError):
+        with exclusive_local_file_lock(tmp_path / "run", relative_path):
+            raise AssertionError("unconfined lock path must not be entered")
+
+
+def test_exclusive_local_file_lock_rejects_insecure_regular_file(tmp_path: Path) -> None:
+    root = tmp_path / "run"
+    root.mkdir()
+    lock_path = root / "world.lock"
+    lock_path.write_bytes(b"")
+    lock_path.chmod(0o644)
+
+    with pytest.raises(ContinualWorldLockConfinementError):
+        with exclusive_local_file_lock(root, "world.lock"):
+            raise AssertionError("insecure lock file must not be entered")
+
+
+def test_exclusive_local_file_lock_accepts_dot_as_trusted_root(tmp_path: Path) -> None:
+    with chdir(tmp_path):
+        with exclusive_local_file_lock(Path("."), "world.lock"):
+            assert (tmp_path / "world.lock").is_file()
+
+
+def test_exclusive_local_file_lock_rejects_symbolic_link_root(tmp_path: Path) -> None:
+    physical_root = tmp_path / "physical"
+    physical_root.mkdir()
+    alias_root = tmp_path / "alias"
+    alias_root.symlink_to(physical_root, target_is_directory=True)
+
+    with pytest.raises(ContinualWorldLockConfinementError):
+        with exclusive_local_file_lock(alias_root, "world.lock"):
+            raise AssertionError("symbolic-link root must not be entered")
+
+
+def test_pump_repository_translates_unsafe_shared_lock_target(tmp_path: Path) -> None:
+    repository = PumpStationWorldRunRepository(tmp_path / "run")
+    outside = tmp_path / "outside.lock"
+    outside.write_bytes(b"")
+    (repository.root / ".world-run.lock").symlink_to(outside)
+
+    with pytest.raises(PumpStationWorldRunError, match="artifact-confinement"):
+        with repository.locked():
+            raise AssertionError("unsafe pump lock target must not be entered")
+
+
+def test_lifecycle_translates_unsafe_shared_lock_target(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    lock_dir = run_dir / ".locks"
+    lock_dir.mkdir(parents=True)
+    outside = tmp_path / "outside.lock"
+    outside.write_bytes(b"")
+    (lock_dir / "lifecycle-state.lock").symlink_to(outside)
+
+    with pytest.raises(EvidenceLifecycleError, match="lifecycle state lock"):
+        with _lifecycle_state_lock(run_dir):
+            raise AssertionError("unsafe lifecycle lock target must not be entered")
+
+
+def test_lifecycle_translates_lock_parent_file(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / ".locks").write_bytes(b"not a directory")
+
+    with pytest.raises(EvidenceLifecycleError, match="lifecycle state lock"):
+        with _lifecycle_state_lock(run_dir):
+            raise AssertionError("invalid lifecycle lock parent must not be entered")
+
+
+def test_consumer_body_lock_errors_are_not_reclassified(tmp_path: Path) -> None:
+    repository = PumpStationWorldRunRepository(tmp_path / "pump-run")
+    pump_body_error = ContinualWorldLockError("pump body failed")
+
+    with pytest.raises(ContinualWorldLockError) as pump_raised:
+        with repository.locked():
+            raise pump_body_error
+    assert pump_raised.value is pump_body_error
+
+    lifecycle_body_error = ContinualWorldLockError("lifecycle body failed")
+    with pytest.raises(ContinualWorldLockError) as lifecycle_raised:
+        with _lifecycle_state_lock(tmp_path / "lifecycle-run"):
+            raise lifecycle_body_error
+    assert lifecycle_raised.value is lifecycle_body_error
+
+
+def test_continual_lock_is_the_lower_shared_ledger_primitive() -> None:
+    assert exclusive_local_file_lock is lower_exclusive_local_file_lock
+
+
+def test_real_consumers_do_not_own_parallel_local_lock_implementations() -> None:
+    source_root = Path(__file__).parents[3] / "src" / "aec_bench"
+    consumer_paths = (
+        source_root / "task_world_templates" / "stewardship" / "wastewater_pump_station" / "world_run_repository.py",
+        source_root / "meta_harness" / "evidence_lifecycle.py",
+    )
+
+    expected_modules = (
+        "aec_bench.task_world_templates.continual.durability",
+        "aec_bench.ledger.local_lock",
+    )
+    for path, expected_module in zip(consumer_paths, expected_modules, strict=True):
+        imported = _imported_modules(path)
+        assert "fcntl" not in imported
+        assert expected_module in imported


### PR DESCRIPTION
## Summary

- Add one lower host-local inter-process lock primitive under the ledger filesystem boundary.
- Re-export it through the continual-world boundary for the pump adapter, while the shared evidence-lifecycle kernel imports the lower layer directly.
- Confine relative lock paths below one trusted root, preserve protected-operation errors, and close all descriptors after setup or cleanup interruption.
- Record the Step 3A ownership and symbolic-link root migration rule.

## Scope

This is only Step 3A of the durable-engine extraction. Pump codecs, commits, replay, recovery, and SSC-03 lifecycle transactions remain task-owned. No accepted pump artifact bytes or lock paths change. PR 74 remains draft and is not merged by this pull request.

## Targeted verification

- 18 shared-lock regression tests passed.
- 13 named compatibility tests passed for legacy pump bytes, replay, repository reload, crash recovery, SSC-03 concurrency, compiled-world execution, and catalogue execution.
- Ruff format and lint passed for changed Python files.
- MyPy passed for all changed source files.
- Three independent focused reviews reported no remaining findings.