### PR TITLE
refactor: share continual-world immutable byte durability

### DIFF
--- a/docs/CONTINUAL_WORLD_RUNTIME.md
+++ b/docs/CONTINUAL_WORLD_RUNTIME.md
@@ -351,6 +351,44 @@ and reuse it rather than create a third byte store. Atomic current selection,
 transaction publication, replay, and crash recovery remain on their existing
 pump and SSC-03 paths until their shared raw-byte boundary is proved.
 
+### 6.10 Step 3B immutable byte ownership
+
+Step 3B extracts only exact immutable byte publication and reads. It proves
+that this raw contract has two real consumers without moving task or lifecycle
+policy into the lower layer.
+
+| Path | Owner | Compatibility and migration rule |
+| --- | --- | --- |
+| `src/aec_bench/ledger/immutable_artifact_store.py` | Lower filesystem durability | Own trusted-root validation, descriptor-confined traversal, atomic first-writer publication, exact-byte reads, digests, private modes, and raw collision, confinement, and integrity errors. Import no meta-harness, task, or Pydantic module. |
+| `src/aec_bench/task_world_templates/continual/durability.py` | Shared continual-world durability | Re-export the lower byte store and errors for task-world adapters. Keep the lower implementation as the single owner. |
+| `src/aec_bench/meta_harness/immutable_artifact_store.py` | Meta-harness policy facade | Keep the public import path, Pydantic encoding, canonical model bytes, logical and content-addressed evidence rules, and `EvidenceRepository`. Delegate raw byte storage to the lower owner. |
+| `wastewater_pump_station/world_run_repository.py` | Pump durability adapter | Use the continual-world byte interface and translate lower errors to the pump boundary. Keep pump codecs, state and content IDs, collection layout, `current.json` replacement, replay, and recovery in the pump adapter. |
+| `src/aec_bench/meta_harness/evidence_lifecycle.py` | Shared evidence-lifecycle kernel and second consumer | Publish exact request and result bytes through the lower store and translate lower failures to the existing lifecycle conflict message. Keep lifecycle state, transactions, checkpoints, projections, replay, and recovery unchanged. SSC-03 uses this path through its real evidence lifecycle. |
+
+The pump compatibility inventory records byte length and SHA-256 for the
+artifacts produced before extraction. The v1 and v2 inventories keep the
+`accepted-existing` status. The v3 inventory has the explicit
+`pre-extraction-compatibility-baseline` status. It proves that Step 3B does not
+change those bytes, but it does not give v3 a retroactive acceptance or
+certification claim.
+
+The raw store accepts only normalized relative paths. Each path component is
+opened relative to a trusted directory descriptor, and each final artifact
+must be a regular file. The current implementation requires a local POSIX
+filesystem that supports directory-relative descriptor operations and
+hard-link publication. This is a host-local filesystem contract. It is not an
+object-store or cross-host durability claim.
+
+The trusted root must not be changed by a malicious process that uses the same
+operating-system account. The store supports cooperative local publishers. It
+does not provide isolation from another process with the same account.
+
+This extraction does not move mutable pointers, transaction publication,
+replay, rewind, or crash recovery into the shared runtime. It also does not
+change a task codec or define task-specific artifact collections. Those
+boundaries stay with the pump and evidence-lifecycle owners until later Step 3
+work proves a shared contract for each one.
+
 ## 7. Implementation sequence
 
 The correction uses small pull requests against the unmerged ASW-8 branch.

--- a/src/aec_bench/ledger/immutable_artifact_store.py
+++ b/src/aec_bench/ledger/immutable_artifact_store.py
@@ -1,0 +1,1033 @@
+# ABOUTME: Publishes and reloads exact immutable bytes below one trusted filesystem root.
+# ABOUTME: Uses descriptor-confined paths, atomic first-writer links, and durable private files.
+
+from __future__ import annotations
+
+import errno
+import hashlib
+import os
+import stat
+import uuid
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+_NATIVE_DIR_FD_FUNCTIONS = (os.open, os.stat, os.mkdir, os.unlink, os.link)
+_NATIVE_NO_FOLLOW_FUNCTIONS = (os.stat, os.link)
+
+
+class ImmutableArtifactStoreError(RuntimeError):
+    """Base error for confined immutable byte storage."""
+
+
+class ImmutableArtifactConfinementError(ImmutableArtifactStoreError):
+    """Reject an unsafe root, relative path, filesystem object, or file mode."""
+
+
+class ImmutableArtifactCollisionError(ImmutableArtifactStoreError):
+    """Reject reuse of one logical path with different immutable bytes."""
+
+
+class ImmutableArtifactIntegrityError(ImmutableArtifactStoreError):
+    """Reject missing, non-regular, unreadable, or digest-mismatched content."""
+
+
+class _ImmutableArtifactMissingError(ImmutableArtifactIntegrityError):
+    """Identify a missing path for the public exists operation."""
+
+
+@dataclass(frozen=True, slots=True)
+class ImmutableArtifact:
+    """Exact physical reference returned after durable publication."""
+
+    path: Path
+    sha256: str
+    size_bytes: int
+
+
+class ImmutableByteStore:
+    """Confined first-writer store for exact task-neutral bytes."""
+
+    def __init__(
+        self,
+        root: Path,
+        *,
+        disjoint_roots: Iterable[Path] = (),
+        host_private: bool = False,
+    ) -> None:
+        _require_posix_descriptor_features()
+        protected_roots = _canonical_disjoint_roots(disjoint_roots)
+        selected, prospective = _select_prospective_root(Path(root))
+        _require_disjoint_roots(prospective, protected_roots)
+        self._host_private = host_private
+        self._root, self._root_identity = _prepare_trusted_root(
+            selected,
+            host_private=host_private,
+            protected_roots=protected_roots,
+        )
+        _require_disjoint_roots(self._root, protected_roots)
+        self._assert_root_binding()
+
+    @property
+    def root(self) -> Path:
+        """Return the canonical physical storage root."""
+
+        self._assert_root_binding()
+        return self._root
+
+    def publish_bytes(
+        self,
+        relative_path: str,
+        payload: bytes,
+    ) -> ImmutableArtifact:
+        """Publish exact bytes once, replaying equality and rejecting collisions."""
+
+        parts = _relative_parts(relative_path)
+        content = bytes(payload)
+        with self._open_parent(parts, create=True) as parent_descriptor:
+            observed = self._load_optional_at(
+                parent_descriptor,
+                parts[-1],
+                relative_path,
+            )
+            if observed is not None:
+                if observed != content:
+                    raise ImmutableArtifactCollisionError(
+                        f"immutable artifact collision at {relative_path}",
+                    )
+                self._flush_parent(parent_descriptor, relative_path)
+                return self._artifact(parts, observed)
+
+            temporary_name = f".{parts[-1]}.{uuid.uuid4().hex}.tmp"
+            temporary_created = False
+            temporary_descriptor: int | None = None
+            temporary_identity: tuple[int, int] | None = None
+            publication_error: BaseException | None = None
+            try:
+                temporary_descriptor = self._create_temporary(
+                    parent_descriptor,
+                    temporary_name,
+                )
+                temporary_created = True
+                temporary_identity = self._temporary_identity(
+                    temporary_descriptor,
+                )
+                self._write_temporary(
+                    temporary_descriptor,
+                    content,
+                )
+                self._require_entry_identity(
+                    parent_descriptor,
+                    temporary_name,
+                    temporary_identity,
+                )
+                try:
+                    os.link(
+                        temporary_name,
+                        parts[-1],
+                        src_dir_fd=parent_descriptor,
+                        dst_dir_fd=parent_descriptor,
+                        follow_symlinks=False,
+                    )
+                except FileExistsError:
+                    observed = self._load_at(
+                        parent_descriptor,
+                        parts[-1],
+                        relative_path,
+                    )
+                    if observed != content:
+                        raise ImmutableArtifactCollisionError(
+                            f"immutable artifact collision at {relative_path}",
+                        ) from None
+                except OSError as cause:
+                    raise ImmutableArtifactStoreError(
+                        f"immutable artifact cannot be linked at {relative_path}: {cause}",
+                    ) from cause
+                else:
+                    linked_identity = self._entry_identity(
+                        parent_descriptor,
+                        parts[-1],
+                        label="published artifact",
+                    )
+                    try:
+                        observed, linked_details = self._load_with_metadata_at(
+                            parent_descriptor,
+                            parts[-1],
+                            relative_path,
+                        )
+                        opened_identity = linked_details.st_dev, linked_details.st_ino
+                        if (
+                            linked_identity != temporary_identity
+                            or opened_identity != linked_identity
+                            or observed != content
+                        ):
+                            raise ImmutableArtifactIntegrityError(
+                                f"immutable artifact drifted during publication at {relative_path}",
+                            )
+                    except BaseException as validation_error:
+                        try:
+                            removed = self._unlink_if_identity(
+                                parent_descriptor,
+                                parts[-1],
+                                linked_identity,
+                                label="published artifact",
+                            )
+                            if removed:
+                                self._flush_parent(parent_descriptor, relative_path)
+                        except BaseException as rollback_error:
+                            validation_error.add_note(
+                                f"immutable artifact publication rollback failed: {rollback_error}",
+                            )
+                        raise
+                self._flush_parent(parent_descriptor, relative_path)
+            except BaseException as error:
+                publication_error = error
+                raise
+            finally:
+                cleanup_errors: list[BaseException] = []
+                if temporary_created and temporary_identity is not None:
+                    try:
+                        self._unlink_if_identity(
+                            parent_descriptor,
+                            temporary_name,
+                            temporary_identity,
+                            label="temporary file",
+                        )
+                    except BaseException as unlink_error:
+                        cleanup_errors.append(unlink_error)
+                if temporary_descriptor is not None:
+                    try:
+                        self._close_temporary_descriptor(temporary_descriptor)
+                    except BaseException as close_error:
+                        cleanup_errors.append(close_error)
+                if cleanup_errors:
+                    if publication_error is not None:
+                        for recorded_error in cleanup_errors:
+                            publication_error.add_note(str(recorded_error))
+                    else:
+                        failure = cleanup_errors[0]
+                        for recorded_error in cleanup_errors[1:]:
+                            failure.add_note(str(recorded_error))
+                        raise failure
+
+            observed = self._load_at(
+                parent_descriptor,
+                parts[-1],
+                relative_path,
+            )
+            if observed != content:
+                raise ImmutableArtifactIntegrityError(
+                    f"immutable artifact drifted during publication at {relative_path}",
+                )
+            return self._artifact(parts, observed)
+
+    def load_bytes(
+        self,
+        relative_path: str,
+        *,
+        expected_sha256: str | None = None,
+    ) -> bytes:
+        """Load exact regular-file bytes from one descriptor-confined path."""
+
+        parts = _relative_parts(relative_path)
+        with self._open_parent(parts, create=False) as parent_descriptor:
+            payload = self._load_at(parent_descriptor, parts[-1], relative_path)
+        if expected_sha256 is not None:
+            expected = _validate_sha256(expected_sha256)
+            observed = hashlib.sha256(payload).hexdigest()
+            if observed != expected:
+                raise ImmutableArtifactIntegrityError(
+                    f"immutable artifact digest mismatch at {relative_path}",
+                )
+        self._assert_root_binding()
+        return payload
+
+    def exists(self, relative_path: str) -> bool:
+        """Return whether one confined logical path has a safe filesystem entry."""
+
+        parts = _relative_parts(relative_path)
+        try:
+            with self._open_parent(parts, create=False) as parent_descriptor:
+                self._metadata_at(parent_descriptor, parts[-1], relative_path)
+                return True
+        except _ImmutableArtifactMissingError:
+            self._assert_root_binding()
+            return False
+
+    def reference(self, relative_path: str) -> ImmutableArtifact:
+        """Return a digest and size for one exact persisted artifact."""
+
+        parts = _relative_parts(relative_path)
+        payload = self.load_bytes(relative_path)
+        return self._artifact(parts, payload)
+
+    def _path(self, relative_path: str) -> Path:
+        """Return one validated logical path for compatibility-layer policies."""
+
+        parts = _relative_parts(relative_path)
+        self._assert_root_binding()
+        path = self._root.joinpath(*parts)
+        _reject_relative_symlinks(self._root, parts)
+        self._assert_root_binding()
+        return path
+
+    @contextmanager
+    def _open_parent(
+        self,
+        parts: tuple[str, ...],
+        *,
+        create: bool,
+    ) -> Iterator[int]:
+        descriptors: list[int] = []
+        active_error: BaseException | None = None
+        try:
+            root_descriptor = _open_root_directory(self._root)
+            descriptors.append(root_descriptor)
+            self._validate_root_descriptor(root_descriptor)
+            for part in parts[:-1]:
+                descriptors.append(
+                    self._open_child_directory(
+                        descriptors[-1],
+                        part,
+                        create=create,
+                    )
+                )
+            yield descriptors[-1]
+            self._assert_root_binding()
+        except BaseException as error:
+            active_error = error
+            raise
+        finally:
+            cleanup_errors: list[BaseException] = []
+            for descriptor in reversed(descriptors):
+                try:
+                    os.close(descriptor)
+                except BaseException as cleanup_error:
+                    cleanup_errors.append(cleanup_error)
+            if cleanup_errors:
+                detail = "; ".join(str(error) for error in cleanup_errors)
+                failure = ImmutableArtifactStoreError(
+                    f"immutable artifact directory cleanup failed: {detail}",
+                )
+                if active_error is not None:
+                    active_error.add_note(str(failure))
+                else:
+                    raise failure from cleanup_errors[0]
+
+    def _open_child_directory(
+        self,
+        parent_descriptor: int,
+        name: str,
+        *,
+        create: bool,
+    ) -> int:
+        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+        flags |= os.O_DIRECTORY | os.O_NOFOLLOW
+        try:
+            inspected = os.stat(name, dir_fd=parent_descriptor, follow_symlinks=False)
+        except FileNotFoundError:
+            inspected = None
+        except OSError as cause:
+            raise ImmutableArtifactConfinementError(
+                f"immutable artifact parent is unsafe: {cause}",
+            ) from cause
+        if inspected is not None and stat.S_ISLNK(inspected.st_mode):
+            raise ImmutableArtifactConfinementError(
+                f"immutable artifact parent contains a symbolic-link component: {name}",
+            )
+        created = False
+        try:
+            descriptor = os.open(name, flags, dir_fd=parent_descriptor)
+        except FileNotFoundError as cause:
+            if not create:
+                raise _ImmutableArtifactMissingError(
+                    "immutable artifact parent is missing",
+                ) from cause
+            try:
+                os.mkdir(
+                    name,
+                    mode=0o700 if self._host_private else 0o777,
+                    dir_fd=parent_descriptor,
+                )
+                created = True
+            except FileExistsError:
+                pass
+            except OSError as create_cause:
+                raise ImmutableArtifactStoreError(
+                    f"immutable artifact parent cannot be created: {create_cause}",
+                ) from create_cause
+            try:
+                descriptor = os.open(name, flags, dir_fd=parent_descriptor)
+            except OSError as open_cause:
+                raise ImmutableArtifactConfinementError(
+                    f"immutable artifact parent is unsafe: {open_cause}",
+                ) from open_cause
+        except OSError as cause:
+            raise ImmutableArtifactConfinementError(
+                f"immutable artifact parent is unsafe: {cause}",
+            ) from cause
+        active_error: BaseException | None = None
+        try:
+            details = os.fstat(descriptor)
+            if self._host_private and stat.S_IMODE(details.st_mode) & 0o077:
+                raise ImmutableArtifactConfinementError(
+                    f"immutable artifact parent permissions are not host-private: {name}",
+                )
+            if created:
+                if self._host_private:
+                    os.fchmod(descriptor, 0o700)
+                os.fsync(descriptor)
+            if create:
+                os.fsync(parent_descriptor)
+            return descriptor
+        except OSError as cause:
+            active_error = ImmutableArtifactStoreError(
+                f"immutable artifact parent cannot be made durable: {cause}",
+            )
+            raise active_error from cause
+        except BaseException as error:
+            active_error = error
+            raise
+        finally:
+            if active_error is not None:
+                try:
+                    os.close(descriptor)
+                except BaseException as cleanup_error:
+                    active_error.add_note(
+                        f"immutable artifact parent cannot be closed after failure: {cleanup_error}",
+                    )
+
+    def _create_temporary(
+        self,
+        parent_descriptor: int,
+        name: str,
+    ) -> int:
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0)
+        flags |= os.O_NOFOLLOW
+        try:
+            return os.open(name, flags, 0o600, dir_fd=parent_descriptor)
+        except OSError as cause:
+            raise ImmutableArtifactStoreError(
+                f"immutable artifact temporary file cannot be created: {cause}",
+            ) from cause
+
+    def _write_temporary(
+        self,
+        descriptor: int,
+        payload: bytes,
+    ) -> None:
+        try:
+            os.fchmod(descriptor, 0o600)
+            remaining = memoryview(payload)
+            while remaining:
+                written = os.write(descriptor, remaining)
+                if written == 0:
+                    raise ImmutableArtifactStoreError(
+                        "immutable artifact temporary write made no progress",
+                    )
+                remaining = remaining[written:]
+            os.fsync(descriptor)
+        except OSError as cause:
+            raise ImmutableArtifactStoreError(
+                f"immutable artifact temporary file cannot be written: {cause}",
+            ) from cause
+
+    def _temporary_identity(self, descriptor: int) -> tuple[int, int]:
+        try:
+            details = os.fstat(descriptor)
+        except OSError as cause:
+            raise ImmutableArtifactStoreError(
+                f"immutable artifact temporary file cannot be inspected: {cause}",
+            ) from cause
+        if not stat.S_ISREG(details.st_mode):
+            raise ImmutableArtifactIntegrityError(
+                "immutable artifact temporary file is not a regular file",
+            )
+        return details.st_dev, details.st_ino
+
+    def _require_entry_identity(
+        self,
+        parent_descriptor: int,
+        name: str,
+        expected_identity: tuple[int, int],
+    ) -> None:
+        observed_identity = self._entry_identity(
+            parent_descriptor,
+            name,
+            label="temporary file",
+        )
+        if observed_identity != expected_identity:
+            raise ImmutableArtifactIntegrityError(
+                "immutable artifact temporary file changed before publication",
+            )
+
+    @staticmethod
+    def _entry_identity(
+        parent_descriptor: int,
+        name: str,
+        *,
+        label: str,
+    ) -> tuple[int, int]:
+        try:
+            details = os.stat(name, dir_fd=parent_descriptor, follow_symlinks=False)
+        except FileNotFoundError as cause:
+            raise ImmutableArtifactIntegrityError(
+                f"immutable artifact {label} is missing",
+            ) from cause
+        except OSError as cause:
+            raise ImmutableArtifactIntegrityError(
+                f"immutable artifact {label} cannot be inspected: {cause}",
+            ) from cause
+        return details.st_dev, details.st_ino
+
+    def _unlink_if_identity(
+        self,
+        parent_descriptor: int,
+        name: str,
+        expected_identity: tuple[int, int],
+        *,
+        label: str,
+    ) -> bool:
+        try:
+            details = os.stat(name, dir_fd=parent_descriptor, follow_symlinks=False)
+        except FileNotFoundError:
+            return False
+        except OSError as cause:
+            raise ImmutableArtifactStoreError(
+                f"immutable artifact {label} cannot be inspected for removal: {cause}",
+            ) from cause
+        if (details.st_dev, details.st_ino) != expected_identity:
+            return False
+        try:
+            os.unlink(name, dir_fd=parent_descriptor)
+        except FileNotFoundError:
+            return False
+        except OSError as cause:
+            raise ImmutableArtifactStoreError(
+                f"immutable artifact {label} cannot be removed: {cause}",
+            ) from cause
+        return True
+
+    @staticmethod
+    def _close_temporary_descriptor(descriptor: int) -> None:
+        try:
+            os.close(descriptor)
+        except BaseException as cleanup_error:
+            raise ImmutableArtifactStoreError(
+                f"immutable artifact temporary file cannot be closed: {cleanup_error}",
+            ) from cleanup_error
+
+    def _flush_parent(self, descriptor: int, relative_path: str) -> None:
+        try:
+            os.fsync(descriptor)
+        except OSError as cause:
+            raise ImmutableArtifactStoreError(
+                f"immutable artifact parent cannot be flushed at {relative_path}: {cause}",
+            ) from cause
+
+    def _load_optional_at(
+        self,
+        parent_descriptor: int,
+        name: str,
+        relative_path: str,
+    ) -> bytes | None:
+        try:
+            return self._load_at(parent_descriptor, name, relative_path)
+        except _ImmutableArtifactMissingError:
+            return None
+
+    def _metadata_at(
+        self,
+        parent_descriptor: int,
+        name: str,
+        relative_path: str,
+    ) -> os.stat_result:
+        descriptor = self._open_artifact(
+            parent_descriptor,
+            name,
+            relative_path,
+        )
+        active_error: BaseException | None = None
+        try:
+            return self._validate_artifact_descriptor(descriptor, relative_path)
+        except BaseException as error:
+            active_error = error
+            raise
+        finally:
+            self._close_artifact_descriptor(descriptor, active_error=active_error)
+
+    def _load_at(
+        self,
+        parent_descriptor: int,
+        name: str,
+        relative_path: str,
+    ) -> bytes:
+        payload, _ = self._load_with_metadata_at(
+            parent_descriptor,
+            name,
+            relative_path,
+        )
+        return payload
+
+    def _load_with_metadata_at(
+        self,
+        parent_descriptor: int,
+        name: str,
+        relative_path: str,
+    ) -> tuple[bytes, os.stat_result]:
+        descriptor = self._open_artifact(
+            parent_descriptor,
+            name,
+            relative_path,
+        )
+        active_error: BaseException | None = None
+        try:
+            details = self._validate_artifact_descriptor(descriptor, relative_path)
+            chunks: list[bytes] = []
+            while chunk := os.read(descriptor, 64 * 1024):
+                chunks.append(chunk)
+            return b"".join(chunks), details
+        except OSError as cause:
+            active_error = ImmutableArtifactIntegrityError(
+                f"immutable artifact cannot be read at {relative_path}: {cause}",
+            )
+            raise active_error from cause
+        except BaseException as error:
+            active_error = error
+            raise
+        finally:
+            self._close_artifact_descriptor(descriptor, active_error=active_error)
+
+    def _open_artifact(
+        self,
+        parent_descriptor: int,
+        name: str,
+        relative_path: str,
+    ) -> int:
+        try:
+            inspected = os.stat(name, dir_fd=parent_descriptor, follow_symlinks=False)
+        except FileNotFoundError as cause:
+            raise _ImmutableArtifactMissingError(
+                f"immutable artifact is missing: {relative_path}",
+            ) from cause
+        except OSError as cause:
+            raise ImmutableArtifactIntegrityError(
+                f"immutable artifact cannot be inspected at {relative_path}: {cause}",
+            ) from cause
+        if stat.S_ISLNK(inspected.st_mode):
+            raise ImmutableArtifactConfinementError(
+                f"immutable artifact path contains a symbolic-link component: {relative_path}",
+            )
+
+        flags = os.O_RDONLY | os.O_NONBLOCK | os.O_NOFOLLOW
+        flags |= getattr(os, "O_CLOEXEC", 0)
+        try:
+            return os.open(name, flags, dir_fd=parent_descriptor)
+        except FileNotFoundError as cause:
+            raise _ImmutableArtifactMissingError(
+                f"immutable artifact is missing: {relative_path}",
+            ) from cause
+        except OSError as cause:
+            if cause.errno in {errno.ELOOP, errno.EMLINK}:
+                raise ImmutableArtifactConfinementError(
+                    f"immutable artifact path became a symbolic link at {relative_path}: {cause}",
+                ) from cause
+            raise ImmutableArtifactIntegrityError(
+                f"immutable artifact cannot be opened at {relative_path}: {cause}",
+            ) from cause
+
+    def _validate_artifact_descriptor(
+        self,
+        descriptor: int,
+        relative_path: str,
+    ) -> os.stat_result:
+        try:
+            details = os.fstat(descriptor)
+        except OSError as cause:
+            raise ImmutableArtifactIntegrityError(
+                f"immutable artifact metadata cannot be read at {relative_path}: {cause}",
+            ) from cause
+        if not stat.S_ISREG(details.st_mode):
+            raise ImmutableArtifactIntegrityError(
+                f"immutable artifact is not a regular file: {relative_path}",
+            )
+        if self._host_private and stat.S_IMODE(details.st_mode) & 0o077:
+            raise ImmutableArtifactConfinementError(
+                f"immutable artifact permissions are not host-private: {relative_path}",
+            )
+        return details
+
+    @staticmethod
+    def _close_artifact_descriptor(
+        descriptor: int,
+        *,
+        active_error: BaseException | None,
+    ) -> None:
+        try:
+            os.close(descriptor)
+        except BaseException as cleanup_error:
+            failure = ImmutableArtifactStoreError(
+                f"immutable artifact file cannot be closed: {cleanup_error}",
+            )
+            if active_error is not None:
+                active_error.add_note(str(failure))
+            else:
+                raise failure from cleanup_error
+
+    def _artifact(
+        self,
+        parts: tuple[str, ...],
+        payload: bytes,
+    ) -> ImmutableArtifact:
+        self._assert_root_binding()
+        return ImmutableArtifact(
+            path=self._root.joinpath(*parts),
+            sha256=hashlib.sha256(payload).hexdigest(),
+            size_bytes=len(payload),
+        )
+
+    def _validate_root_descriptor(self, descriptor: int) -> None:
+        details = _root_details(descriptor)
+        if (details.st_dev, details.st_ino) != self._root_identity:
+            raise ImmutableArtifactConfinementError(
+                "immutable artifact root identity changed after store creation",
+            )
+        if self._host_private and stat.S_IMODE(details.st_mode) & 0o077:
+            raise ImmutableArtifactConfinementError(
+                "host-private immutable artifact root permissions are not private",
+            )
+
+    def _assert_root_binding(self) -> None:
+        descriptor = _open_root_directory(self._root)
+        active_error: BaseException | None = None
+        try:
+            self._validate_root_descriptor(descriptor)
+        except BaseException as error:
+            active_error = error
+            raise
+        finally:
+            try:
+                os.close(descriptor)
+            except BaseException as cleanup_error:
+                failure = ImmutableArtifactStoreError(
+                    f"immutable artifact root cannot be closed: {cleanup_error}",
+                )
+                if active_error is not None:
+                    active_error.add_note(str(failure))
+                else:
+                    raise failure from cleanup_error
+
+
+def validate_immutable_artifact_root(
+    root: Path,
+    *,
+    disjoint_roots: Iterable[Path] = (),
+    must_exist: bool = False,
+) -> Path:
+    """Resolve one canonical non-symlink root disjoint from protected roots."""
+
+    selected = Path(root).expanduser()
+    if not selected.is_absolute():
+        raise ImmutableArtifactConfinementError(
+            "immutable artifact root must be absolute",
+        )
+    absolute = selected.absolute()
+    _reject_absolute_symlinks(absolute, label="immutable artifact root")
+    resolved = absolute.resolve(strict=must_exist)
+    if resolved != absolute:
+        raise ImmutableArtifactConfinementError(
+            "immutable artifact root contains a symbolic-link or non-canonical component",
+        )
+    _require_disjoint_roots(resolved, _canonical_disjoint_roots(disjoint_roots))
+    return resolved
+
+
+def _require_posix_descriptor_features() -> None:
+    missing: list[str] = []
+    if os.name != "posix":
+        missing.append("POSIX operating system")
+    for name in ("O_DIRECTORY", "O_NOFOLLOW", "O_NONBLOCK"):
+        if not hasattr(os, name):
+            missing.append(name)
+    supports_dir_fd: set[object] = set(getattr(os, "supports_dir_fd", set()))
+    for function in _NATIVE_DIR_FD_FUNCTIONS:
+        if function not in supports_dir_fd:
+            missing.append(f"{function.__name__}(dir_fd)")
+    supports_no_follow: set[object] = set(
+        getattr(os, "supports_follow_symlinks", set()),
+    )
+    for function in _NATIVE_NO_FOLLOW_FUNCTIONS:
+        if function not in supports_no_follow:
+            missing.append(f"{function.__name__}(follow_symlinks)")
+    if not hasattr(os, "fchmod"):
+        missing.append("fchmod")
+    if missing:
+        raise ImmutableArtifactConfinementError(
+            "immutable artifact store requires POSIX descriptor features: " + ", ".join(missing),
+        )
+
+
+def _select_prospective_root(root: Path) -> tuple[Path, Path]:
+    selected = Path(root).expanduser().absolute()
+    if selected.name in {"", ".", ".."}:
+        raise ImmutableArtifactConfinementError(
+            "immutable artifact root must select one directory",
+        )
+    if os.path.lexists(selected) and selected.is_symlink():
+        raise ImmutableArtifactConfinementError(
+            "immutable artifact root contains a symbolic-link component",
+        )
+    try:
+        prospective = selected.resolve(strict=False)
+    except OSError as cause:
+        raise ImmutableArtifactConfinementError(
+            f"immutable artifact root is unsafe: {cause}",
+        ) from cause
+    return selected, prospective
+
+
+def _canonical_disjoint_roots(disjoint_roots: Iterable[Path]) -> tuple[Path, ...]:
+    canonical: list[Path] = []
+    for disjoint_root in disjoint_roots:
+        protected = Path(disjoint_root).expanduser()
+        if not protected.is_absolute():
+            raise ImmutableArtifactConfinementError(
+                "immutable artifact disjoint roots must be absolute",
+            )
+        protected_absolute = protected.absolute()
+        _reject_absolute_symlinks(
+            protected_absolute,
+            label="immutable artifact disjoint root",
+        )
+        protected_resolved = protected_absolute.resolve(strict=False)
+        if protected_resolved != protected_absolute:
+            raise ImmutableArtifactConfinementError(
+                "immutable artifact disjoint root contains a symbolic-link or non-canonical component",
+            )
+        canonical.append(protected_resolved)
+    return tuple(canonical)
+
+
+def _prepare_trusted_root(
+    selected: Path,
+    *,
+    host_private: bool,
+    protected_roots: tuple[Path, ...],
+) -> tuple[Path, tuple[int, int]]:
+    missing: list[str] = []
+    cursor = selected
+    while not os.path.lexists(cursor):
+        missing.append(cursor.name)
+        cursor = cursor.parent
+    root_entries_were_missing = bool(missing)
+    if not missing:
+        missing.append(selected.name)
+        cursor = selected.parent
+
+    try:
+        canonical_parent = cursor.resolve(strict=True)
+    except OSError as cause:
+        raise ImmutableArtifactConfinementError(
+            f"immutable artifact root ancestor is unsafe: {cause}",
+        ) from cause
+    canonical_target = canonical_parent.joinpath(*reversed(missing))
+    _require_disjoint_roots(canonical_target, protected_roots)
+
+    descriptors: list[int] = []
+    active_error: BaseException | None = None
+    try:
+        descriptors.append(_open_root_directory(Path(canonical_parent.anchor)))
+        for component in canonical_parent.parts[1:]:
+            descriptors.append(
+                _open_root_child(descriptors[-1], component),
+            )
+        canonical_root = canonical_parent
+        for name in reversed(missing):
+            parent_descriptor = descriptors[-1]
+            created = False
+            try:
+                os.mkdir(
+                    name,
+                    mode=0o700 if host_private else 0o777,
+                    dir_fd=parent_descriptor,
+                )
+                created = True
+            except FileExistsError:
+                pass
+            except OSError as cause:
+                raise ImmutableArtifactStoreError(
+                    f"immutable artifact root cannot be created: {cause}",
+                ) from cause
+
+            descriptor = _open_root_child(parent_descriptor, name)
+            descriptors.append(descriptor)
+            try:
+                if created and host_private:
+                    os.fchmod(descriptor, 0o700)
+                if root_entries_were_missing or created:
+                    os.fsync(descriptor)
+                    os.fsync(parent_descriptor)
+            except OSError as cause:
+                raise ImmutableArtifactStoreError(
+                    f"immutable artifact root creation cannot be made durable: {cause}",
+                ) from cause
+            canonical_root /= name
+
+        root_descriptor = descriptors[-1]
+        details = _root_details(root_descriptor)
+        if host_private and stat.S_IMODE(details.st_mode) & 0o077:
+            raise ImmutableArtifactConfinementError(
+                "host-private immutable artifact root permissions are not private",
+            )
+        identity = details.st_dev, details.st_ino
+        try:
+            resolved_root = canonical_root.resolve(strict=True)
+            path_details = os.stat(canonical_root, follow_symlinks=False)
+        except OSError as cause:
+            raise ImmutableArtifactConfinementError(
+                f"immutable artifact root cannot be bound to its descriptor: {cause}",
+            ) from cause
+        if (
+            resolved_root != canonical_root
+            or (
+                path_details.st_dev,
+                path_details.st_ino,
+            )
+            != identity
+        ):
+            raise ImmutableArtifactConfinementError(
+                "immutable artifact root identity changed during store creation",
+            )
+        return canonical_root, identity
+    except BaseException as error:
+        active_error = error
+        raise
+    finally:
+        cleanup_errors: list[BaseException] = []
+        for descriptor in reversed(descriptors):
+            try:
+                os.close(descriptor)
+            except BaseException as cleanup_error:
+                cleanup_errors.append(cleanup_error)
+        if cleanup_errors:
+            detail = "; ".join(str(error) for error in cleanup_errors)
+            failure = ImmutableArtifactStoreError(
+                f"immutable artifact root cannot be closed: {detail}",
+            )
+            if active_error is not None:
+                active_error.add_note(str(failure))
+            else:
+                raise failure from cleanup_errors[0]
+
+
+def _open_root_directory(root: Path) -> int:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    flags |= os.O_DIRECTORY | os.O_NOFOLLOW
+    try:
+        return os.open(root, flags)
+    except OSError as cause:
+        raise ImmutableArtifactConfinementError(
+            f"immutable artifact root is unsafe: {cause}",
+        ) from cause
+
+
+def _open_root_child(parent_descriptor: int, name: str) -> int:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    flags |= os.O_DIRECTORY | os.O_NOFOLLOW
+    try:
+        inspected = os.stat(name, dir_fd=parent_descriptor, follow_symlinks=False)
+    except OSError as cause:
+        raise ImmutableArtifactConfinementError(
+            f"immutable artifact root component is unsafe: {cause}",
+        ) from cause
+    if stat.S_ISLNK(inspected.st_mode):
+        raise ImmutableArtifactConfinementError(
+            f"immutable artifact root contains a symbolic-link component: {name}",
+        )
+    try:
+        return os.open(name, flags, dir_fd=parent_descriptor)
+    except OSError as cause:
+        raise ImmutableArtifactConfinementError(
+            f"immutable artifact root component is unsafe: {cause}",
+        ) from cause
+
+
+def _root_details(descriptor: int) -> os.stat_result:
+    try:
+        details = os.fstat(descriptor)
+    except OSError as cause:
+        raise ImmutableArtifactConfinementError(
+            f"immutable artifact root identity cannot be read: {cause}",
+        ) from cause
+    if not stat.S_ISDIR(details.st_mode):
+        raise ImmutableArtifactConfinementError(
+            "immutable artifact root is not a directory",
+        )
+    return details
+
+
+def _relative_parts(relative_path: str) -> tuple[str, ...]:
+    logical = PurePosixPath(relative_path)
+    raw_parts = relative_path.split("/")
+    if (
+        not relative_path
+        or logical.is_absolute()
+        or any(part in {"", ".", ".."} for part in raw_parts)
+        or "\x00" in relative_path
+    ):
+        raise ImmutableArtifactConfinementError(
+            "immutable artifact path must be normalized, contained, and relative",
+        )
+    return tuple(raw_parts)
+
+
+def _validate_sha256(value: str) -> str:
+    if len(value) != 64 or any(character not in "0123456789abcdef" for character in value):
+        raise ValueError(
+            "SHA-256 digest must contain 64 lowercase hexadecimal characters",
+        )
+    return value
+
+
+def _reject_relative_symlinks(root: Path, parts: tuple[str, ...]) -> None:
+    current = root
+    for part in parts:
+        current /= part
+        if current.is_symlink():
+            raise ImmutableArtifactConfinementError(
+                f"immutable artifact path contains a symbolic-link component: {current}",
+            )
+
+
+def _reject_absolute_symlinks(path: Path, *, label: str) -> None:
+    current = Path(path.anchor)
+    for part in path.parts[1:]:
+        current /= part
+        if current.is_symlink():
+            raise ImmutableArtifactConfinementError(
+                f"{label} contains a symbolic-link component: {current}",
+            )
+
+
+def _require_disjoint_roots(root: Path, disjoint_roots: Iterable[Path]) -> None:
+    for protected in disjoint_roots:
+        if _paths_overlap(root, protected):
+            raise ImmutableArtifactConfinementError(
+                "immutable artifact root must not overlap a disjoint root",
+            )
+
+
+def _paths_overlap(left: Path, right: Path) -> bool:
+    return left == right or left.is_relative_to(right) or right.is_relative_to(left)
+
+
+__all__ = [
+    "ImmutableArtifact",
+    "ImmutableArtifactCollisionError",
+    "ImmutableArtifactConfinementError",
+    "ImmutableArtifactIntegrityError",
+    "ImmutableArtifactStoreError",
+    "ImmutableByteStore",
+    "validate_immutable_artifact_root",
+]

--- a/src/aec_bench/meta_harness/evidence_lifecycle.py
+++ b/src/aec_bench/meta_harness/evidence_lifecycle.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import copy
 import hashlib
 import json
-import os
 import shutil
 import tempfile
 from collections.abc import Callable, Iterator
@@ -17,6 +16,10 @@ from typing import Any
 from pydantic import ValidationError
 
 from aec_bench.ledger.durability import fsync_directory, fsync_tree, mkdir_durable
+from aec_bench.ledger.immutable_artifact_store import (
+    ImmutableArtifactStoreError,
+    ImmutableByteStore,
+)
 from aec_bench.ledger.local_lock import exclusive_local_file_lock
 from aec_bench.meta_harness.evidence_lifecycle_episode import (
     LifecycleEpisodeContext,
@@ -1392,31 +1395,11 @@ def _persist_episode_result(
 
 def _persist_host_json(path: Path, payload: str, *, conflict_message: str) -> Path:
     """Publish one deterministic host JSON artifact with conflict detection."""
-    mkdir_durable(path.parent)
-    if path.exists():
-        if not path.is_file() or path.read_text(encoding="utf-8") != payload:
-            raise EvidenceLifecycleError(conflict_message)
-        return path
-
-    temporary_path: Path | None = None
     try:
-        with tempfile.NamedTemporaryFile(
-            mode="w",
-            encoding="utf-8",
-            dir=path.parent,
-            prefix=f".{path.stem}-",
-            suffix=".tmp",
-            delete=False,
-        ) as handle:
-            temporary_path = Path(handle.name)
-            handle.write(payload)
-            handle.flush()
-            os.fsync(handle.fileno())
-        temporary_path.replace(path)
-        fsync_directory(path.parent)
-    finally:
-        if temporary_path is not None:
-            temporary_path.unlink(missing_ok=True)
+        store = ImmutableByteStore(path.parent)
+        store.publish_bytes(path.name, payload.encode("utf-8"))
+    except ImmutableArtifactStoreError as exc:
+        raise EvidenceLifecycleError(conflict_message) from exc
     return path
 
 

--- a/src/aec_bench/meta_harness/immutable_artifact_store.py
+++ b/src/aec_bench/meta_harness/immutable_artifact_store.py
@@ -7,7 +7,6 @@ import hashlib
 import json
 import os
 import stat
-import uuid
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
@@ -16,33 +15,23 @@ from typing import Generic, TypeVar
 from pydantic import JsonValue, TypeAdapter
 
 from aec_bench.contracts.harness_kernel import ContentAddressedModel, validate_sha256
-from aec_bench.ledger.durability import fsync_directory, mkdir_durable
-
-
-class ImmutableArtifactStoreError(RuntimeError):
-    """Base error for confined immutable artifact storage."""
-
-
-class ImmutableArtifactConfinementError(ImmutableArtifactStoreError):
-    """Reject an unsafe root, relative path, or symbolic-link component."""
-
-
-class ImmutableArtifactCollisionError(ImmutableArtifactStoreError):
-    """Reject reuse of one logical path with different immutable bytes."""
-
-
-class ImmutableArtifactIntegrityError(ImmutableArtifactStoreError):
-    """Reject missing, non-regular, or invalid persisted content."""
-
-
-@dataclass(frozen=True, slots=True)
-class ImmutableArtifact:
-    """Exact physical reference returned after durable publication."""
-
-    path: Path
-    sha256: str
-    size_bytes: int
-
+from aec_bench.ledger.immutable_artifact_store import ImmutableArtifact as ImmutableArtifact
+from aec_bench.ledger.immutable_artifact_store import (
+    ImmutableArtifactCollisionError as ImmutableArtifactCollisionError,
+)
+from aec_bench.ledger.immutable_artifact_store import (
+    ImmutableArtifactConfinementError as ImmutableArtifactConfinementError,
+)
+from aec_bench.ledger.immutable_artifact_store import (
+    ImmutableArtifactIntegrityError as ImmutableArtifactIntegrityError,
+)
+from aec_bench.ledger.immutable_artifact_store import (
+    ImmutableArtifactStoreError as ImmutableArtifactStoreError,
+)
+from aec_bench.ledger.immutable_artifact_store import (
+    ImmutableByteStore,
+    validate_immutable_artifact_root,
+)
 
 ModelT = TypeVar("ModelT")
 ContentModelT = TypeVar("ContentModelT", bound=ContentAddressedModel)
@@ -57,7 +46,7 @@ class StoredEvidenceModel(Generic[ModelT]):
     artifact: ImmutableArtifact
 
 
-class ImmutableArtifactStore:
+class ImmutableArtifactStore(ImmutableByteStore):
     """Narrow immutable store for canonical bytes and Pydantic-supported models."""
 
     def __init__(
@@ -67,117 +56,16 @@ class ImmutableArtifactStore:
         disjoint_roots: Iterable[Path] = (),
         host_private: bool = False,
     ) -> None:
+        protected_roots = tuple(disjoint_roots)
         selected = validate_evidence_root(
             root,
-            disjoint_roots=disjoint_roots,
+            disjoint_roots=protected_roots,
         )
-        _mkdir_storage_path(
+        super().__init__(
             selected,
+            disjoint_roots=protected_roots,
             host_private=host_private,
         )
-        self._root = selected.resolve(strict=True)
-        self._host_private = host_private
-        if self._host_private:
-            _require_private_directory(self._root)
-
-    @property
-    def root(self) -> Path:
-        """Return the exact confined storage root."""
-
-        return self._root
-
-    def publish_bytes(
-        self,
-        relative_path: str,
-        payload: bytes,
-    ) -> ImmutableArtifact:
-        """Publish exact bytes once, replaying equality and rejecting collisions."""
-
-        path = self._path(relative_path)
-        content = bytes(payload)
-        if os.path.lexists(path):
-            observed = self.load_bytes(relative_path)
-            if observed != content:
-                raise ImmutableArtifactCollisionError(
-                    f"immutable artifact collision at {relative_path}",
-                )
-            return _artifact(path, observed)
-
-        _mkdir_storage_path(
-            path.parent,
-            host_private=self._host_private,
-        )
-        _reject_symlinks(path.parent, label="immutable artifact parent")
-        temporary = path.parent / f".{path.name}.{uuid.uuid4().hex}.tmp"
-        descriptor = os.open(
-            temporary,
-            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
-            0o600,
-        )
-        try:
-            with os.fdopen(descriptor, "wb") as handle:
-                handle.write(content)
-                handle.flush()
-                os.fsync(handle.fileno())
-            try:
-                os.link(temporary, path)
-            except FileExistsError:
-                observed = self.load_bytes(relative_path)
-                if observed != content:
-                    raise ImmutableArtifactCollisionError(
-                        f"immutable artifact collision at {relative_path}",
-                    ) from None
-            fsync_directory(path.parent)
-        finally:
-            temporary.unlink(missing_ok=True)
-        observed = self.load_bytes(relative_path)
-        if observed != content:
-            raise ImmutableArtifactIntegrityError(
-                f"immutable artifact drifted during publication at {relative_path}",
-            )
-        return _artifact(path, observed)
-
-    def load_bytes(
-        self,
-        relative_path: str,
-        *,
-        expected_sha256: str | None = None,
-    ) -> bytes:
-        """Load exact regular-file bytes from one confined logical path."""
-
-        path = self._path(relative_path)
-        if path.is_symlink():
-            raise ImmutableArtifactConfinementError(
-                f"immutable artifact is a symbolic link: {relative_path}",
-            )
-        try:
-            inspected = path.stat(follow_symlinks=False)
-        except OSError as error:
-            raise ImmutableArtifactIntegrityError(
-                f"immutable artifact is missing: {relative_path}",
-            ) from error
-        if not stat.S_ISREG(inspected.st_mode):
-            raise ImmutableArtifactIntegrityError(
-                f"immutable artifact is not a regular file: {relative_path}",
-            )
-        if self._host_private and stat.S_IMODE(inspected.st_mode) & 0o077:
-            raise ImmutableArtifactConfinementError(
-                f"immutable artifact must retain host-only permissions: {relative_path}",
-            )
-        payload = path.read_bytes()
-        if expected_sha256 is not None:
-            validate_sha256(expected_sha256)
-            observed_sha256 = hashlib.sha256(payload).hexdigest()
-            if observed_sha256 != expected_sha256:
-                raise ImmutableArtifactIntegrityError(
-                    f"immutable artifact digest mismatch at {relative_path}",
-                )
-        return payload
-
-    def exists(self, relative_path: str) -> bool:
-        """Return whether a confined logical path has any filesystem entry."""
-
-        return os.path.lexists(self._path(relative_path))
 
     def publish_model(
         self,
@@ -220,26 +108,6 @@ class ImmutableArtifactStore:
         if not self.exists(relative_path):
             return None
         return self.load_model(relative_path, adapter)
-
-    def reference(self, relative_path: str) -> ImmutableArtifact:
-        """Return a digest and size for one exact persisted artifact."""
-
-        path = self._path(relative_path)
-        return _artifact(path, self.load_bytes(relative_path))
-
-    def _path(self, relative_path: str) -> Path:
-        logical = PurePosixPath(relative_path)
-        if logical.is_absolute() or not logical.parts or any(part in {"", ".", ".."} for part in logical.parts):
-            raise ImmutableArtifactConfinementError(
-                "immutable artifact path must be contained and relative",
-            )
-        path = self._root.joinpath(*logical.parts)
-        _reject_symlinks(path, label="immutable artifact path")
-        if not path.resolve(strict=False).is_relative_to(self._root):
-            raise ImmutableArtifactConfinementError(
-                "immutable artifact path escapes its root",
-            )
-        return path
 
 
 class EvidenceRepository(ImmutableArtifactStore):
@@ -480,55 +348,6 @@ def _canonical_model_bytes(
     ).encode("utf-8")
 
 
-def _artifact(path: Path, payload: bytes) -> ImmutableArtifact:
-    return ImmutableArtifact(
-        path=path.resolve(strict=True),
-        sha256=hashlib.sha256(payload).hexdigest(),
-        size_bytes=len(payload),
-    )
-
-
-def _mkdir_storage_path(
-    path: Path,
-    *,
-    host_private: bool,
-) -> None:
-    target = Path(path)
-    missing: list[Path] = []
-    cursor = target
-    while not os.path.lexists(cursor):
-        missing.append(cursor)
-        cursor = cursor.parent
-    mkdir_durable(target)
-    if not host_private:
-        return
-    for directory in reversed(missing):
-        directory.chmod(0o700)
-        fsync_directory(directory.parent)
-
-
-def _reject_symlinks(path: Path, *, label: str) -> None:
-    current = Path(path.anchor)
-    for part in path.parts[1:]:
-        current /= part
-        if current.is_symlink():
-            raise ImmutableArtifactConfinementError(
-                f"{label} contains a symbolic-link component: {current}",
-            )
-
-
-def _require_private_directory(path: Path) -> None:
-    inspected = path.stat(follow_symlinks=False)
-    if not stat.S_ISDIR(inspected.st_mode):
-        raise ImmutableArtifactConfinementError(
-            "host-private immutable artifact root must be a directory",
-        )
-    if stat.S_IMODE(inspected.st_mode) & 0o077:
-        raise ImmutableArtifactConfinementError(
-            "host-private immutable artifact root must retain host-only permissions",
-        )
-
-
 def _logical_identity_bytes(logical_identity: LogicalIdentity) -> bytes:
     if isinstance(logical_identity, str):
         if not logical_identity:
@@ -561,40 +380,8 @@ def validate_evidence_root(
 ) -> Path:
     """Resolve one canonical non-symlink root disjoint from protected roots."""
 
-    selected = Path(root).expanduser()
-    if not selected.is_absolute():
-        raise ImmutableArtifactConfinementError(
-            "immutable artifact root must be absolute",
-        )
-    absolute = selected.absolute()
-    _reject_symlinks(absolute, label="immutable artifact root")
-    resolved = absolute.resolve(strict=must_exist)
-    if resolved != absolute:
-        raise ImmutableArtifactConfinementError(
-            "immutable artifact root contains a symbolic-link or non-canonical component",
-        )
-    for disjoint_root in disjoint_roots:
-        protected = Path(disjoint_root).expanduser()
-        if not protected.is_absolute():
-            raise ImmutableArtifactConfinementError(
-                "immutable artifact disjoint roots must be absolute",
-            )
-        protected_absolute = protected.absolute()
-        _reject_symlinks(
-            protected_absolute,
-            label="immutable artifact disjoint root",
-        )
-        protected_resolved = protected_absolute.resolve(strict=False)
-        if protected_resolved != protected_absolute:
-            raise ImmutableArtifactConfinementError(
-                "immutable artifact disjoint root contains a symbolic-link or non-canonical component",
-            )
-        if _paths_overlap(resolved, protected_resolved):
-            raise ImmutableArtifactConfinementError(
-                "immutable artifact root must not overlap a disjoint root",
-            )
-    return resolved
-
-
-def _paths_overlap(left: Path, right: Path) -> bool:
-    return left == right or left.is_relative_to(right) or right.is_relative_to(left)
+    return validate_immutable_artifact_root(
+        root,
+        disjoint_roots=disjoint_roots,
+        must_exist=must_exist,
+    )

--- a/src/aec_bench/meta_harness/kernel_catalogue.py
+++ b/src/aec_bench/meta_harness/kernel_catalogue.py
@@ -352,6 +352,7 @@ DEFAULT_KERNEL_EXECUTOR_SOURCE_PATHS: tuple[str, ...] = tuple(
             "aec_bench/contracts/trajectory.py",
             "aec_bench/contracts/trial_record.py",
             "aec_bench/contracts/validators.py",
+            "aec_bench/contracts/world_session.py",
             "aec_bench/dataset/storage.py",
             "aec_bench/evaluation/task_world.py",
             "aec_bench/harness/execution_entrypoint.py",
@@ -385,6 +386,8 @@ DEFAULT_KERNEL_EXECUTOR_SOURCE_PATHS: tuple[str, ...] = tuple(
             "aec_bench/harness/trial_record_builder.py",
             "aec_bench/harness/verifier_artifacts.py",
             "aec_bench/ledger/durability.py",
+            "aec_bench/ledger/immutable_artifact_store.py",
+            "aec_bench/ledger/local_lock.py",
             "aec_bench/ledger/writer.py",
             "aec_bench/meta_harness/applicability.py",
             "aec_bench/meta_harness/authority_ledger.py",
@@ -1189,6 +1192,7 @@ def _default_operation_definitions(
             implementation=_operation_implementation_identity(
                 executor_sources,
                 paths=(
+                    "aec_bench/ledger/immutable_artifact_store.py",
                     *_COMPILATION_SOURCE_PATHS,
                     "aec_bench/meta_harness/declared_stage_runtime.py",
                     "aec_bench/meta_harness/governed_attempt_engine/__init__.py",

--- a/src/aec_bench/task_world_templates/continual/__init__.py
+++ b/src/aec_bench/task_world_templates/continual/__init__.py
@@ -10,6 +10,12 @@ from aec_bench.task_world_templates.continual.definition import (
 from aec_bench.task_world_templates.continual.durability import (
     ContinualWorldLockConfinementError,
     ContinualWorldLockError,
+    ImmutableArtifact,
+    ImmutableArtifactCollisionError,
+    ImmutableArtifactConfinementError,
+    ImmutableArtifactIntegrityError,
+    ImmutableArtifactStoreError,
+    ImmutableByteStore,
     exclusive_local_file_lock,
 )
 
@@ -18,6 +24,12 @@ __all__ = [
     "ContinualWorldDefinition",
     "ContinualWorldLockConfinementError",
     "ContinualWorldLockError",
+    "ImmutableArtifact",
+    "ImmutableArtifactCollisionError",
+    "ImmutableArtifactConfinementError",
+    "ImmutableArtifactIntegrityError",
+    "ImmutableArtifactStoreError",
+    "ImmutableByteStore",
     "LoadedContinualWorldProfile",
     "exclusive_local_file_lock",
     "python_source_sha256",

--- a/src/aec_bench/task_world_templates/continual/durability.py
+++ b/src/aec_bench/task_world_templates/continual/durability.py
@@ -1,6 +1,14 @@
-# ABOUTME: Exposes the shared local POSIX lock through the continual-world runtime boundary.
+# ABOUTME: Exposes shared local durability primitives through the continual-world runtime boundary.
 # ABOUTME: Keeps continual-world consumers independent from lower ledger implementation details.
 
+from aec_bench.ledger.immutable_artifact_store import (
+    ImmutableArtifact,
+    ImmutableArtifactCollisionError,
+    ImmutableArtifactConfinementError,
+    ImmutableArtifactIntegrityError,
+    ImmutableArtifactStoreError,
+    ImmutableByteStore,
+)
 from aec_bench.ledger.local_lock import (
     LocalFileLockConfinementError as ContinualWorldLockConfinementError,
 )
@@ -10,5 +18,11 @@ from aec_bench.ledger.local_lock import exclusive_local_file_lock as exclusive_l
 __all__ = [
     "ContinualWorldLockConfinementError",
     "ContinualWorldLockError",
+    "ImmutableArtifact",
+    "ImmutableArtifactCollisionError",
+    "ImmutableArtifactConfinementError",
+    "ImmutableArtifactIntegrityError",
+    "ImmutableArtifactStoreError",
+    "ImmutableByteStore",
     "exclusive_local_file_lock",
 ]

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_repository.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_repository.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-import stat
 import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -14,6 +13,10 @@ from pathlib import Path
 from typing import NoReturn, TypeGuard, cast
 
 from aec_bench.task_world_templates.continual.durability import (
+    ImmutableArtifactCollisionError,
+    ImmutableArtifactConfinementError,
+    ImmutableArtifactStoreError,
+    ImmutableByteStore,
     exclusive_local_file_lock,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.evidence_health import (
@@ -131,19 +134,6 @@ def _mkdir_durable(path: Path) -> None:
         _fsync_directory(directory.parent)
 
 
-def _require_regular_file(path: Path, label: str) -> None:
-    if path.is_symlink():
-        _fail("artifact-confinement", f"{label} is a symbolic link")
-    try:
-        details = path.stat(follow_symlinks=False)
-    except OSError as error:
-        _fail("artifact-integrity", f"{label} is unavailable: {error}")
-    if not stat.S_ISREG(details.st_mode):
-        _fail("artifact-integrity", f"{label} is not a regular file")
-    if stat.S_IMODE(details.st_mode) & 0o077:
-        _fail("artifact-confinement", f"{label} must be host-private")
-
-
 class PumpStationWorldRunRepository:
     """A confined durable repository for exactly one pump-station world run."""
 
@@ -155,6 +145,12 @@ class PumpStationWorldRunRepository:
         selected.chmod(0o700)
         self._root = selected.resolve(strict=True)
         self._lock_path = self._root / ".world-run.lock"
+        try:
+            self._artifacts = ImmutableByteStore(self._root, host_private=True)
+        except ImmutableArtifactConfinementError as error:
+            _fail("artifact-confinement", f"world-run root is unsafe: {error}")
+        except ImmutableArtifactStoreError as error:
+            _fail("artifact-integrity", f"world-run byte store is unavailable: {error}")
 
     @property
     def root(self) -> Path:
@@ -819,31 +815,15 @@ class PumpStationWorldRunRepository:
         self._publish_immutable(self._root / name, pump_station_artifact_bytes(value))
 
     def _publish_immutable(self, path: Path, payload: bytes) -> None:
-        if path.exists():
-            observed = self._read(path, str(path.relative_to(self._root)))
-            if observed != payload:
-                _fail("artifact-collision", str(path.relative_to(self._root)))
-            return
-        _mkdir_durable(path.parent)
-        temporary = path.parent / f".{path.name}.{uuid.uuid4().hex}.tmp"
-        descriptor = os.open(
-            temporary,
-            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
-            0o600,
-        )
+        relative_path = path.relative_to(self._root).as_posix()
         try:
-            with os.fdopen(descriptor, "wb") as handle:
-                handle.write(payload)
-                handle.flush()
-                os.fsync(handle.fileno())
-            try:
-                os.link(temporary, path)
-            except FileExistsError:
-                if self._read(path, str(path.relative_to(self._root))) != payload:
-                    _fail("artifact-collision", str(path.relative_to(self._root)))
-            _fsync_directory(path.parent)
-        finally:
-            temporary.unlink(missing_ok=True)
+            self._artifacts.publish_bytes(relative_path, payload)
+        except ImmutableArtifactCollisionError:
+            _fail("artifact-collision", relative_path)
+        except ImmutableArtifactConfinementError as error:
+            _fail("artifact-confinement", f"{relative_path} is unsafe: {error}")
+        except ImmutableArtifactStoreError as error:
+            _fail("artifact-integrity", f"{relative_path} cannot be published: {error}")
 
     def _replace_current(self, pointer: PumpStationCurrentRunPointer) -> None:
         payload = pump_station_artifact_bytes(pointer)
@@ -876,10 +856,12 @@ class PumpStationWorldRunRepository:
         )
 
     def _read(self, path: Path, label: str) -> bytes:
-        _require_regular_file(path, label)
+        relative_path = path.relative_to(self._root).as_posix()
         try:
-            return path.read_bytes()
-        except OSError as error:
+            return self._artifacts.load_bytes(relative_path)
+        except ImmutableArtifactConfinementError as error:
+            _fail("artifact-confinement", f"{label} is unsafe: {error}")
+        except ImmutableArtifactStoreError as error:
             _fail("artifact-integrity", f"{label} cannot be read: {error}")
         raise AssertionError("unreachable")
 

--- a/tests/ledger/test_immutable_byte_store.py
+++ b/tests/ledger/test_immutable_byte_store.py
@@ -1,0 +1,875 @@
+# ABOUTME: Tests the lower confined store for exact immutable byte publication and reload.
+# ABOUTME: Proves first-writer behavior, path safety, private modes, and process concurrency.
+
+from __future__ import annotations
+
+import ast
+import multiprocessing
+import os
+import stat
+import uuid
+from multiprocessing.process import BaseProcess
+from multiprocessing.queues import Queue
+from pathlib import Path
+from typing import Protocol
+
+import pytest
+
+from aec_bench.ledger.immutable_artifact_store import (
+    ImmutableArtifactCollisionError,
+    ImmutableArtifactConfinementError,
+    ImmutableArtifactIntegrityError,
+    ImmutableArtifactStoreError,
+    ImmutableByteStore,
+)
+
+
+class _ProcessSignal(Protocol):
+    def set(self) -> None: ...
+
+    def wait(self, timeout: float | None = None) -> bool: ...
+
+
+def _publish_in_child(
+    root: Path,
+    payload: bytes,
+    ready: _ProcessSignal,
+    start: _ProcessSignal,
+    results: Queue[tuple[str, str]],
+) -> None:
+    store = ImmutableByteStore(root, host_private=True)
+    ready.set()
+    if not start.wait(5):
+        raise RuntimeError("immutable publication start signal was not received")
+    try:
+        artifact = store.publish_bytes("shared/value.bin", payload)
+    except ImmutableArtifactCollisionError:
+        results.put(("collision", ""))
+    else:
+        results.put(("published", artifact.sha256))
+
+
+def _load_in_child(
+    root: Path,
+    relative_path: str,
+    results: Queue[tuple[str, str]],
+) -> None:
+    store = ImmutableByteStore(root)
+    try:
+        store.load_bytes(relative_path)
+    except ImmutableArtifactIntegrityError as error:
+        results.put(("integrity", str(error)))
+    except BaseException as error:
+        results.put((type(error).__name__, str(error)))
+    else:
+        results.put(("loaded", ""))
+
+
+def _publish_with_restrictive_umask_in_child(
+    root: Path,
+    results: Queue[tuple[str, int | str]],
+) -> None:
+    previous_umask = os.umask(0o777)
+    try:
+        store = ImmutableByteStore(root)
+        try:
+            artifact = store.publish_bytes("value.bin", b"value")
+        except BaseException as error:
+            results.put((type(error).__name__, str(error)))
+        else:
+            results.put(("published", stat.S_IMODE(artifact.path.stat().st_mode)))
+    finally:
+        os.umask(previous_umask)
+
+
+def _imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            modules.add(node.module)
+    return modules
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        b"",
+        b"\x00\xff\x10binary",
+        "asset condition: café Δ".encode(),
+        b'{"value":1}\n',
+    ),
+)
+def test_store_publishes_and_reloads_exact_arbitrary_bytes(
+    tmp_path: Path,
+    payload: bytes,
+) -> None:
+    store = ImmutableByteStore(tmp_path / "store")
+
+    first = store.publish_bytes("nested/value.bin", payload)
+    repeated = store.publish_bytes("nested/value.bin", payload)
+
+    assert repeated == first
+    assert first.size_bytes == len(payload)
+    assert store.load_bytes("nested/value.bin", expected_sha256=first.sha256) == payload
+    assert store.reference("nested/value.bin") == first
+    assert store.exists("nested/value.bin") is True
+    assert store.exists("nested/missing.bin") is False
+
+
+def test_store_rejects_collision_without_changing_first_bytes(tmp_path: Path) -> None:
+    store = ImmutableByteStore(tmp_path / "store")
+    first = store.publish_bytes("value.bin", b"first")
+
+    with pytest.raises(ImmutableArtifactCollisionError):
+        store.publish_bytes("value.bin", b"second")
+
+    assert store.load_bytes("value.bin", expected_sha256=first.sha256) == b"first"
+
+
+def test_exists_checks_safe_metadata_without_reading_content(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = ImmutableByteStore(tmp_path / "store")
+    store.publish_bytes("value.bin", b"value")
+
+    def fail_read(descriptor: int, size: int) -> bytes:
+        del descriptor, size
+        raise AssertionError("exists must not read artifact content")
+
+    monkeypatch.setattr(os, "read", fail_read)
+
+    assert store.exists("value.bin") is True
+    assert store.exists("missing.bin") is False
+
+
+def test_missing_exists_result_rechecks_root_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "store"
+    store = ImmutableByteStore(root)
+    original = tmp_path / "original-store"
+    original_stat = os.stat
+    replaced = False
+
+    def stat_and_replace(
+        path: os.PathLike[str] | str | int,
+        *,
+        dir_fd: int | None = None,
+        follow_symlinks: bool = True,
+    ) -> os.stat_result:
+        nonlocal replaced
+        if path == "missing.bin" and dir_fd is not None and not replaced:
+            root.rename(original)
+            root.mkdir()
+            replaced = True
+        return original_stat(path, dir_fd=dir_fd, follow_symlinks=follow_symlinks)
+
+    monkeypatch.setattr(os, "stat", stat_and_replace)
+
+    with pytest.raises(ImmutableArtifactConfinementError, match="identity"):
+        store.exists("missing.bin")
+
+
+@pytest.mark.parametrize(
+    ("payloads", "expected_statuses"),
+    (
+        ((b"same", b"same"), ["published", "published"]),
+        ((b"first", b"second"), ["collision", "published"]),
+    ),
+)
+def test_store_has_one_process_safe_first_writer(
+    tmp_path: Path,
+    payloads: tuple[bytes, bytes],
+    expected_statuses: list[str],
+) -> None:
+    root = tmp_path / "store"
+    root.mkdir(mode=0o700)
+    context = multiprocessing.get_context("spawn")
+    ready = (context.Event(), context.Event())
+    start = context.Event()
+    results = context.Queue()
+    processes = tuple(
+        context.Process(
+            target=_publish_in_child,
+            args=(root, payload, process_ready, start, results),
+        )
+        for payload, process_ready in zip(payloads, ready, strict=True)
+    )
+    started: list[BaseProcess] = []
+    try:
+        for process in processes:
+            process.start()
+            started.append(process)
+        assert all(signal.wait(5) for signal in ready)
+        start.set()
+        for process in processes:
+            process.join(5)
+            assert not process.is_alive()
+            assert process.exitcode == 0
+        outcomes = [results.get(timeout=5), results.get(timeout=5)]
+    finally:
+        start.set()
+        for started_process in started:
+            if started_process.is_alive():
+                started_process.kill()
+            started_process.join()
+        results.close()
+        results.join_thread()
+
+    assert sorted(status for status, _ in outcomes) == expected_statuses
+    assert ImmutableByteStore(root, host_private=True).load_bytes("shared/value.bin") in payloads
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    ("", ".", "../outside.bin", "/outside.bin", "nested//value.bin", "nested/./value.bin"),
+)
+def test_store_rejects_unconfined_relative_paths(
+    tmp_path: Path,
+    relative_path: str,
+) -> None:
+    store = ImmutableByteStore(tmp_path / "store")
+
+    with pytest.raises(ImmutableArtifactConfinementError):
+        store.publish_bytes(relative_path, b"forbidden")
+
+
+def test_store_fails_closed_before_writes_without_required_posix_features(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    selected = tmp_path / "store"
+    monkeypatch.delattr(os, "O_NOFOLLOW")
+
+    with pytest.raises(ImmutableArtifactConfinementError, match="POSIX"):
+        ImmutableByteStore(selected)
+
+    assert not selected.exists()
+
+
+def test_store_accepts_alias_above_root_but_rejects_alias_as_root(tmp_path: Path) -> None:
+    physical_parent = tmp_path / "physical"
+    physical_parent.mkdir()
+    alias = tmp_path / "alias"
+    alias.symlink_to(physical_parent, target_is_directory=True)
+
+    store = ImmutableByteStore(alias / "run")
+    store.publish_bytes("value.bin", b"value")
+
+    assert (physical_parent / "run" / "value.bin").read_bytes() == b"value"
+    with pytest.raises(ImmutableArtifactConfinementError):
+        ImmutableByteStore(alias)
+
+
+def test_store_rejects_final_root_symlink_inserted_after_prospective_check(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    selected = tmp_path / "store"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    original_resolve = Path.resolve
+    inserted = False
+
+    def resolve_and_insert(path: Path, strict: bool = False) -> Path:
+        nonlocal inserted
+        resolved = original_resolve(path, strict=strict)
+        if path == selected and not strict and not inserted:
+            selected.symlink_to(outside, target_is_directory=True)
+            inserted = True
+        return resolved
+
+    monkeypatch.setattr(Path, "resolve", resolve_and_insert)
+
+    with pytest.raises(ImmutableArtifactConfinementError, match="symbolic-link"):
+        ImmutableByteStore(selected)
+
+    assert tuple(outside.iterdir()) == ()
+
+
+def test_store_rejects_replacement_of_its_trusted_root(tmp_path: Path) -> None:
+    root = tmp_path / "store"
+    store = ImmutableByteStore(root)
+    root.rename(tmp_path / "original-store")
+    root.mkdir()
+
+    with pytest.raises(ImmutableArtifactConfinementError, match="identity"):
+        store.publish_bytes("value.bin", b"forbidden")
+
+    assert tuple(root.iterdir()) == ()
+
+
+def test_store_binds_canonical_root_and_identity_to_one_checked_descriptor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "store"
+    root.mkdir()
+    original = tmp_path / "original-store"
+    initial = root.stat()
+    initial_identity = (initial.st_dev, initial.st_ino)
+    original_close = os.close
+    replaced = False
+
+    def close_and_replace(descriptor: int) -> None:
+        nonlocal replaced
+        details = os.fstat(descriptor)
+        original_close(descriptor)
+        if not replaced and (details.st_dev, details.st_ino) == initial_identity:
+            root.rename(original)
+            root.mkdir()
+            replaced = True
+
+    monkeypatch.setattr(os, "close", close_and_replace)
+
+    with pytest.raises(ImmutableArtifactConfinementError, match="identity"):
+        ImmutableByteStore(root)
+
+
+def test_root_validation_preserves_active_error_when_close_also_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "store"
+    root.mkdir(mode=0o755)
+    original_close = os.close
+
+    def close_then_fail(descriptor: int) -> None:
+        original_close(descriptor)
+        raise OSError("forced close failure")
+
+    monkeypatch.setattr(os, "close", close_then_fail)
+
+    with pytest.raises(ImmutableArtifactConfinementError, match="permissions"):
+        ImmutableByteStore(root, host_private=True)
+
+
+def test_store_rechecks_root_identity_after_artifact_operation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "store"
+    store = ImmutableByteStore(root)
+    store.publish_bytes("value.bin", b"value")
+    original = tmp_path / "original-store"
+    original_read = os.read
+    replaced = False
+
+    def read_and_replace(descriptor: int, size: int) -> bytes:
+        nonlocal replaced
+        if not replaced:
+            root.rename(original)
+            root.mkdir()
+            replaced = True
+        return original_read(descriptor, size)
+
+    monkeypatch.setattr(os, "read", read_and_replace)
+
+    with pytest.raises(ImmutableArtifactConfinementError, match="identity"):
+        store.load_bytes("value.bin")
+
+    assert tuple(root.iterdir()) == ()
+
+
+def test_compatibility_path_rechecks_root_identity_after_symlink_scan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "store"
+    store = ImmutableByteStore(root)
+    original = tmp_path / "original-store"
+    original_is_symlink = Path.is_symlink
+    replaced = False
+
+    def inspect_and_replace(path: Path) -> bool:
+        nonlocal replaced
+        if path == root / "value.bin" and not replaced:
+            root.rename(original)
+            root.mkdir()
+            replaced = True
+        return original_is_symlink(path)
+
+    monkeypatch.setattr(Path, "is_symlink", inspect_and_replace)
+
+    with pytest.raises(ImmutableArtifactConfinementError, match="identity"):
+        store._path("value.bin")
+
+
+def test_store_rejects_disjoint_overlap_before_creating_root(tmp_path: Path) -> None:
+    protected = tmp_path / "protected"
+    protected.mkdir()
+    selected = protected / "store"
+
+    with pytest.raises(ImmutableArtifactConfinementError, match="overlap"):
+        ImmutableByteStore(selected, disjoint_roots=(protected,))
+
+    assert not selected.exists()
+
+
+def test_store_rejects_relative_disjoint_root_before_creating_root(
+    tmp_path: Path,
+) -> None:
+    selected = tmp_path / "store"
+
+    with pytest.raises(ImmutableArtifactConfinementError, match="absolute"):
+        ImmutableByteStore(selected, disjoint_roots=(Path("protected"),))
+
+    assert not selected.exists()
+
+
+def test_store_rechecks_disjoint_root_before_descriptor_bound_creation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    safe_parent = tmp_path / "safe"
+    safe_parent.mkdir()
+    original_parent = tmp_path / "original-safe"
+    protected = tmp_path / "protected"
+    protected.mkdir()
+    selected = safe_parent / "store"
+    original_resolve = Path.resolve
+    swapped = False
+
+    def resolve_and_swap(path: Path, strict: bool = False) -> Path:
+        nonlocal swapped
+        resolved = original_resolve(path, strict=strict)
+        if path == selected and not strict and not swapped:
+            safe_parent.rename(original_parent)
+            safe_parent.symlink_to(protected, target_is_directory=True)
+            swapped = True
+        return resolved
+
+    monkeypatch.setattr(Path, "resolve", resolve_and_swap)
+
+    with pytest.raises(ImmutableArtifactConfinementError, match="overlap"):
+        ImmutableByteStore(selected, disjoint_roots=(protected,))
+
+    assert not (protected / "store").exists()
+
+
+def test_store_does_not_follow_replaced_intermediate_root_ancestor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    safe_ancestor = tmp_path / "safe"
+    safe_parent = safe_ancestor / "parent"
+    safe_parent.mkdir(parents=True)
+    original_ancestor = tmp_path / "original-safe"
+    protected = tmp_path / "protected"
+    (protected / "parent").mkdir(parents=True)
+    selected = safe_parent / "store"
+    original_resolve = Path.resolve
+    swapped = False
+
+    def resolve_and_swap(path: Path, strict: bool = False) -> Path:
+        nonlocal swapped
+        resolved = original_resolve(path, strict=strict)
+        if path == safe_parent and strict and not swapped:
+            safe_ancestor.rename(original_ancestor)
+            safe_ancestor.symlink_to(protected, target_is_directory=True)
+            swapped = True
+        return resolved
+
+    monkeypatch.setattr(Path, "resolve", resolve_and_swap)
+
+    with pytest.raises(ImmutableArtifactConfinementError):
+        ImmutableByteStore(selected, disjoint_roots=(protected,))
+
+    assert not (protected / "parent" / "store").exists()
+
+
+def test_store_rejects_symbolic_link_parent_without_external_write(tmp_path: Path) -> None:
+    store = ImmutableByteStore(tmp_path / "store")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (store.root / "linked").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ImmutableArtifactConfinementError):
+        store.publish_bytes("linked/value.bin", b"forbidden")
+
+    assert tuple(outside.iterdir()) == ()
+
+
+def test_store_rejects_symbolic_link_and_non_file_targets(tmp_path: Path) -> None:
+    store = ImmutableByteStore(tmp_path / "store")
+    outside = tmp_path / "outside.bin"
+    outside.write_bytes(b"outside")
+    (store.root / "linked.bin").symlink_to(outside)
+    (store.root / "directory.bin").mkdir()
+
+    with pytest.raises(ImmutableArtifactConfinementError):
+        store.load_bytes("linked.bin")
+    with pytest.raises(ImmutableArtifactIntegrityError):
+        store.load_bytes("directory.bin")
+
+    assert outside.read_bytes() == b"outside"
+
+
+def test_store_classifies_unreadable_regular_file_as_integrity_failure(
+    tmp_path: Path,
+) -> None:
+    store = ImmutableByteStore(tmp_path / "store")
+    path = store.publish_bytes("value.bin", b"value").path
+    path.chmod(0o000)
+    try:
+        with pytest.raises(ImmutableArtifactIntegrityError, match="cannot be opened"):
+            store.load_bytes("value.bin")
+    finally:
+        path.chmod(0o600)
+
+
+def test_store_rejects_fifo_in_a_bounded_child_process(tmp_path: Path) -> None:
+    root = tmp_path / "store"
+    root.mkdir()
+    os.mkfifo(root / "value.bin")
+    context = multiprocessing.get_context("spawn")
+    results = context.Queue()
+    process = context.Process(
+        target=_load_in_child,
+        args=(root, "value.bin", results),
+    )
+    process.start()
+    try:
+        process.join(2)
+        assert not process.is_alive(), "loading a FIFO blocked the child process"
+        assert process.exitcode == 0
+        status, detail = results.get(timeout=2)
+    finally:
+        if process.is_alive():
+            process.kill()
+        process.join()
+        results.close()
+        results.join_thread()
+
+    assert status == "integrity"
+    assert "regular file" in detail
+
+
+def test_store_detects_digest_drift_and_public_file_mode(tmp_path: Path) -> None:
+    store = ImmutableByteStore(tmp_path / "store", host_private=True)
+    artifact = store.publish_bytes("value.bin", b"original")
+    artifact.path.write_bytes(b"changed")
+
+    with pytest.raises(ImmutableArtifactIntegrityError, match="digest"):
+        store.load_bytes("value.bin", expected_sha256=artifact.sha256)
+
+    artifact.path.chmod(0o644)
+    with pytest.raises(ImmutableArtifactConfinementError, match="permissions"):
+        store.load_bytes("value.bin")
+
+
+def test_host_private_store_rechecks_root_mode_during_operations(
+    tmp_path: Path,
+) -> None:
+    store = ImmutableByteStore(tmp_path / "store", host_private=True)
+    store.publish_bytes("value.bin", b"value")
+    store.root.chmod(0o755)
+
+    with pytest.raises(ImmutableArtifactConfinementError, match="permissions"):
+        store.load_bytes("value.bin")
+
+
+def test_store_preserves_sha256_validation_error_text(tmp_path: Path) -> None:
+    store = ImmutableByteStore(tmp_path / "store")
+    store.publish_bytes("value.bin", b"value")
+
+    with pytest.raises(
+        ValueError,
+        match="^SHA-256 digest must contain 64 lowercase hexadecimal characters$",
+    ):
+        store.load_bytes("value.bin", expected_sha256="not-a-digest")
+
+
+def test_host_private_store_creates_private_directories_and_files(tmp_path: Path) -> None:
+    store = ImmutableByteStore(tmp_path / "store", host_private=True)
+    artifact = store.publish_bytes("nested/deeper/value.bin", b"private")
+
+    assert stat.S_IMODE(store.root.stat().st_mode) == 0o700
+    assert stat.S_IMODE((store.root / "nested").stat().st_mode) == 0o700
+    assert stat.S_IMODE((store.root / "nested" / "deeper").stat().st_mode) == 0o700
+    assert stat.S_IMODE(artifact.path.stat().st_mode) == 0o600
+
+
+def test_host_private_store_makes_every_new_root_component_private(
+    tmp_path: Path,
+) -> None:
+    components = (
+        tmp_path / "first",
+        tmp_path / "first" / "second",
+        tmp_path / "first" / "second" / "store",
+    )
+
+    store = ImmutableByteStore(components[-1], host_private=True)
+
+    assert store.root == components[-1]
+    assert [stat.S_IMODE(path.stat().st_mode) for path in components] == [
+        0o700,
+        0o700,
+        0o700,
+    ]
+
+
+def test_host_private_root_creation_flushes_created_directories_and_parents(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    selected = tmp_path / "first" / "second" / "store"
+    flushed: set[tuple[int, int]] = set()
+    original_fsync = os.fsync
+
+    def record_fsync(descriptor: int) -> None:
+        details = os.fstat(descriptor)
+        flushed.add((details.st_dev, details.st_ino))
+        original_fsync(descriptor)
+
+    monkeypatch.setattr(os, "fsync", record_fsync)
+
+    store = ImmutableByteStore(selected, host_private=True)
+
+    expected_paths = (tmp_path, selected.parent.parent, selected.parent, store.root)
+    expected = {(path.stat().st_dev, path.stat().st_ino) for path in expected_paths}
+    assert expected <= flushed
+
+
+def test_root_creation_race_flushes_winning_directory_and_parent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    selected = tmp_path / "store"
+    flushed: set[tuple[int, int]] = set()
+    original_mkdir = os.mkdir
+    original_fsync = os.fsync
+    simulated_winner = False
+
+    def competing_mkdir(
+        path: str | bytes,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> None:
+        nonlocal simulated_winner
+        if os.fsdecode(path) == selected.name and dir_fd is not None and not simulated_winner:
+            original_mkdir(path, mode, dir_fd=dir_fd)
+            simulated_winner = True
+            raise FileExistsError(path)
+        original_mkdir(path, mode, dir_fd=dir_fd)
+
+    def record_fsync(descriptor: int) -> None:
+        details = os.fstat(descriptor)
+        flushed.add((details.st_dev, details.st_ino))
+        original_fsync(descriptor)
+
+    monkeypatch.setattr(os, "mkdir", competing_mkdir)
+    monkeypatch.setattr(os, "fsync", record_fsync)
+
+    store = ImmutableByteStore(selected)
+
+    parent_details = tmp_path.stat()
+    root_details = store.root.stat()
+    assert (parent_details.st_dev, parent_details.st_ino) in flushed
+    assert (root_details.st_dev, root_details.st_ino) in flushed
+
+
+def test_stable_existing_root_does_not_repeat_root_creation_flushes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "store"
+    root.mkdir()
+    flushed: list[int] = []
+    original_fsync = os.fsync
+
+    def record_fsync(descriptor: int) -> None:
+        flushed.append(descriptor)
+        original_fsync(descriptor)
+
+    monkeypatch.setattr(os, "fsync", record_fsync)
+
+    ImmutableByteStore(root)
+
+    assert flushed == []
+
+
+def test_child_creation_and_equal_replay_flush_the_changed_parent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = ImmutableByteStore(tmp_path / "store")
+    flushed: list[tuple[int, int]] = []
+    original_fsync = os.fsync
+
+    def record_fsync(descriptor: int) -> None:
+        details = os.fstat(descriptor)
+        flushed.append((details.st_dev, details.st_ino))
+        original_fsync(descriptor)
+
+    monkeypatch.setattr(os, "fsync", record_fsync)
+    store.publish_bytes("nested/value.bin", b"value")
+
+    root_details = store.root.stat()
+    assert (root_details.st_dev, root_details.st_ino) in flushed
+
+    flushed.clear()
+    store.publish_bytes("nested/value.bin", b"value")
+
+    assert (root_details.st_dev, root_details.st_ino) in flushed
+    parent_details = (store.root / "nested").stat()
+    assert (parent_details.st_dev, parent_details.st_ino) in flushed
+
+
+def test_orphan_temporary_file_cannot_become_published_content(tmp_path: Path) -> None:
+    store = ImmutableByteStore(tmp_path / "store")
+    orphan = store.root / ".value.bin.orphan.tmp"
+    orphan.write_bytes(b"orphan")
+
+    artifact = store.publish_bytes("value.bin", b"published")
+
+    assert artifact.path.read_bytes() == b"published"
+    assert orphan.read_bytes() == b"orphan"
+
+
+def test_published_file_mode_is_private_under_a_restrictive_umask(tmp_path: Path) -> None:
+    root = tmp_path / "store"
+    root.mkdir(mode=0o700)
+    context = multiprocessing.get_context("spawn")
+    results = context.Queue()
+    process = context.Process(
+        target=_publish_with_restrictive_umask_in_child,
+        args=(root, results),
+    )
+    process.start()
+    try:
+        process.join(5)
+        assert not process.is_alive()
+        assert process.exitcode == 0
+        outcome = results.get(timeout=2)
+    finally:
+        if process.is_alive():
+            process.kill()
+        process.join()
+        results.close()
+        results.join_thread()
+
+    assert outcome == ("published", 0o600)
+    assert (root / "value.bin").read_bytes() == b"value"
+
+
+def test_temporary_name_collision_preserves_file_not_created_by_this_call(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = ImmutableByteStore(tmp_path / "store")
+    fixed = uuid.UUID(int=0)
+    temporary = store.root / f".value.bin.{fixed.hex}.tmp"
+    temporary.write_bytes(b"pre-existing")
+    monkeypatch.setattr(uuid, "uuid4", lambda: fixed)
+
+    with pytest.raises(ImmutableArtifactStoreError, match="cannot be created"):
+        store.publish_bytes("value.bin", b"published")
+
+    assert temporary.read_bytes() == b"pre-existing"
+    assert not (store.root / "value.bin").exists()
+
+
+def test_temporary_replacement_cannot_become_published_or_be_deleted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = ImmutableByteStore(tmp_path / "store")
+    original_link = os.link
+    replacement_name: str | None = None
+
+    def link_after_replacement(
+        source: str | bytes,
+        destination: str | bytes,
+        *,
+        src_dir_fd: int | None = None,
+        dst_dir_fd: int | None = None,
+        follow_symlinks: bool = True,
+    ) -> None:
+        nonlocal replacement_name
+        replacement_name = os.fsdecode(source)
+        os.unlink(source, dir_fd=src_dir_fd)
+        descriptor = os.open(
+            source,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+            dir_fd=src_dir_fd,
+        )
+        try:
+            os.write(descriptor, b"intruder")
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        original_link(
+            source,
+            destination,
+            src_dir_fd=src_dir_fd,
+            dst_dir_fd=dst_dir_fd,
+            follow_symlinks=follow_symlinks,
+        )
+
+    monkeypatch.setattr(os, "link", link_after_replacement)
+
+    with pytest.raises(ImmutableArtifactIntegrityError):
+        store.publish_bytes("value.bin", b"expected")
+
+    assert replacement_name is not None
+    assert not (store.root / "value.bin").exists()
+    assert (store.root / replacement_name).read_bytes() == b"intruder"
+
+
+def test_unsafe_temporary_replacement_is_removed_only_from_final_name(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = ImmutableByteStore(tmp_path / "store")
+    outside = tmp_path / "outside.bin"
+    outside.write_bytes(b"outside")
+    original_link = os.link
+    replacement_name: str | None = None
+
+    def link_after_symlink_replacement(
+        source: str | bytes,
+        destination: str | bytes,
+        *,
+        src_dir_fd: int | None = None,
+        dst_dir_fd: int | None = None,
+        follow_symlinks: bool = True,
+    ) -> None:
+        nonlocal replacement_name
+        replacement_name = os.fsdecode(source)
+        os.unlink(source, dir_fd=src_dir_fd)
+        os.symlink(outside, source, dir_fd=src_dir_fd)
+        original_link(
+            source,
+            destination,
+            src_dir_fd=src_dir_fd,
+            dst_dir_fd=dst_dir_fd,
+            follow_symlinks=follow_symlinks,
+        )
+
+    monkeypatch.setattr(os, "link", link_after_symlink_replacement)
+
+    with pytest.raises(ImmutableArtifactConfinementError):
+        store.publish_bytes("value.bin", b"expected")
+
+    assert replacement_name is not None
+    assert not os.path.lexists(store.root / "value.bin")
+    replacement = store.root / replacement_name
+    assert replacement.is_symlink()
+    assert replacement.resolve() == outside
+
+
+def test_lower_store_has_no_meta_harness_or_task_dependency() -> None:
+    source = Path(__file__).parents[2] / "src" / "aec_bench" / "ledger" / "immutable_artifact_store.py"
+    imported = _imported_modules(source)
+
+    assert all(not module.startswith("aec_bench.contracts") for module in imported)
+    assert all(not module.startswith("aec_bench.meta_harness") for module in imported)
+    assert all(not module.startswith("aec_bench.task_world_templates") for module in imported)

--- a/tests/meta_harness/test_evidence_lifecycle_episode.py
+++ b/tests/meta_harness/test_evidence_lifecycle_episode.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -12,6 +13,7 @@ import pytest
 from pydantic import ValidationError
 
 import aec_bench.meta_harness.evidence_lifecycle as lifecycle_runtime
+from aec_bench.ledger.immutable_artifact_store import ImmutableByteStore
 from aec_bench.meta_harness.evidence_lifecycle import (
     EvidenceLifecycleError,
     LifecycleEpisodeExecutionError,
@@ -39,6 +41,74 @@ from aec_bench.task_world_templates.contracts import (
 from aec_bench.task_world_templates.lifecycles import materialize_lifecycle_template
 
 HYDRAULIC_TEMPLATE_ID = "hydraulic-interaction-lifecycle-review"
+
+
+def test_host_json_publication_replays_exact_bytes_and_preserves_first_writer(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "episodes" / "episode_request.json"
+    payload = '{\n  "message": "world state",\n  "revision": 3\n}\n'
+    conflict_message = "episode request conflicts with durable attempt: review.attempt-001"
+
+    assert (
+        lifecycle_runtime._persist_host_json(
+            path,
+            payload,
+            conflict_message=conflict_message,
+        )
+        == path
+    )
+    first_bytes = path.read_bytes()
+    assert first_bytes == payload.encode("utf-8")
+
+    assert (
+        lifecycle_runtime._persist_host_json(
+            path,
+            payload,
+            conflict_message=conflict_message,
+        )
+        == path
+    )
+    assert path.read_bytes() == first_bytes
+
+    with pytest.raises(EvidenceLifecycleError) as raised:
+        lifecycle_runtime._persist_host_json(
+            path,
+            '{\n  "message": "changed world state"\n}\n',
+            conflict_message=conflict_message,
+        )
+
+    assert str(raised.value) == conflict_message
+    assert path.read_bytes() == first_bytes
+
+
+def test_host_json_publication_maps_unsafe_storage_to_the_task_conflict(
+    tmp_path: Path,
+) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    alias = tmp_path / "episode-alias"
+    alias.symlink_to(outside, target_is_directory=True)
+    path = alias / "episode_result.json"
+    conflict_message = "episode result conflicts with durable attempt: review.attempt-001"
+
+    with pytest.raises(EvidenceLifecycleError) as raised:
+        lifecycle_runtime._persist_host_json(
+            path,
+            "{}\n",
+            conflict_message=conflict_message,
+        )
+
+    assert str(raised.value) == conflict_message
+    assert not (outside / path.name).exists()
+
+
+def test_host_json_publication_uses_the_shared_immutable_byte_store() -> None:
+    source = inspect.getsource(lifecycle_runtime._persist_host_json)
+
+    assert lifecycle_runtime._persist_host_json.__globals__["ImmutableByteStore"] is ImmutableByteStore
+    assert "ImmutableByteStore" in source
+    assert "NamedTemporaryFile" not in source
 
 
 def test_episode_result_rejects_verifier_owned_fields() -> None:
@@ -122,7 +192,7 @@ def test_episode_request_versions_reject_later_visibility_fields() -> None:
     assert LifecycleEpisodeRequest.model_validate(v2).schema_version == "2"
 
 
-def test_v3_episode_request_binds_public_operation_state_and_visible_artifacts(tmp_path: Path) -> None:
+def test_v3_episode_request_binds_and_persists_public_operation_state(tmp_path: Path) -> None:
     package = materialize_lifecycle_template(
         get_template(HYDRAULIC_TEMPLATE_ID),
         tmp_path / "package",
@@ -171,6 +241,20 @@ def test_v3_episode_request_binds_public_operation_state_and_visible_artifacts(t
     assert {artifact.workspace_path for artifact in request.visible_operation_artifacts} == {
         artifact["workspace_path"] for artifact in action["artifacts"] if artifact["workspace_path"] is not None
     }
+
+    request_path = lifecycle_runtime._persist_episode_request(request)
+    assert request_path.read_bytes() == lifecycle_runtime._episode_request_json(request).encode("utf-8")
+
+    result = _completed_result(request)
+    result_path = lifecycle_runtime._persist_episode_result(request, result)
+    expected_result = (json.dumps(result.model_dump(mode="json"), indent=2, sort_keys=True) + "\n").encode("utf-8")
+    assert result_path.read_bytes() == expected_result
+
+    with pytest.raises(EvidenceLifecycleError) as raised:
+        lifecycle_runtime._persist_episode_request(
+            request.model_copy(update={"requested_model": "conflicting-model"}),
+        )
+    assert str(raised.value) == f"episode request conflicts with durable attempt: {request.attempt_id}"
 
 
 def test_v3_closeout_binds_prior_operation_evidence_without_offering_operations(tmp_path: Path) -> None:

--- a/tests/meta_harness/test_immutable_artifact_store.py
+++ b/tests/meta_harness/test_immutable_artifact_store.py
@@ -13,9 +13,24 @@ from threading import Barrier
 import pytest
 from pydantic import TypeAdapter
 
+import aec_bench.meta_harness.immutable_artifact_store as store_runtime
 from aec_bench.contracts.harness_kernel import ContentAddressedModel
+from aec_bench.ledger.immutable_artifact_store import (
+    ImmutableArtifact as LowerImmutableArtifact,
+)
+from aec_bench.ledger.immutable_artifact_store import (
+    ImmutableArtifactCollisionError as LowerImmutableArtifactCollisionError,
+)
+from aec_bench.ledger.immutable_artifact_store import (
+    ImmutableArtifactConfinementError as LowerImmutableArtifactConfinementError,
+)
+from aec_bench.ledger.immutable_artifact_store import (
+    ImmutableArtifactIntegrityError as LowerImmutableArtifactIntegrityError,
+)
+from aec_bench.ledger.immutable_artifact_store import ImmutableByteStore
 from aec_bench.meta_harness.immutable_artifact_store import (
     EvidenceRepository,
+    ImmutableArtifact,
     ImmutableArtifactCollisionError,
     ImmutableArtifactConfinementError,
     ImmutableArtifactIntegrityError,
@@ -31,6 +46,14 @@ class _Artifact(ContentAddressedModel):
 class _ArtifactClaim(ContentAddressedModel):
     schema_version: str = "test.immutable-artifact-claim.v1"
     target_content_sha256: str
+
+
+def test_meta_harness_store_is_a_compatible_policy_facade_over_lower_bytes() -> None:
+    assert issubclass(ImmutableArtifactStore, ImmutableByteStore)
+    assert ImmutableArtifact is LowerImmutableArtifact
+    assert ImmutableArtifactCollisionError is LowerImmutableArtifactCollisionError
+    assert ImmutableArtifactConfinementError is LowerImmutableArtifactConfinementError
+    assert ImmutableArtifactIntegrityError is LowerImmutableArtifactIntegrityError
 
 
 def test_publishes_and_reloads_exact_model_and_bytes(tmp_path: Path) -> None:
@@ -129,6 +152,44 @@ def test_evidence_repository_publishes_content_models_and_logical_claims(
             model=_ArtifactClaim(target_content_sha256="a" * 64),
             adapter=claim_adapter,
         )
+
+
+def test_meta_facade_rechecks_disjoint_roots_during_descriptor_bound_creation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    safe_parent = tmp_path / "safe"
+    safe_parent.mkdir()
+    original_parent = tmp_path / "original-safe"
+    protected = tmp_path / "protected"
+    protected.mkdir()
+    selected = safe_parent / "evidence"
+    original_validate = store_runtime.validate_evidence_root
+
+    def validate_and_swap(
+        root: Path,
+        *,
+        disjoint_roots: tuple[Path, ...] = (),
+        must_exist: bool = False,
+    ) -> Path:
+        validated = original_validate(
+            root,
+            disjoint_roots=disjoint_roots,
+            must_exist=must_exist,
+        )
+        safe_parent.rename(original_parent)
+        safe_parent.symlink_to(protected, target_is_directory=True)
+        return validated
+
+    monkeypatch.setattr(store_runtime, "validate_evidence_root", validate_and_swap)
+
+    with pytest.raises(ImmutableArtifactConfinementError, match="overlap"):
+        ImmutableArtifactStore(
+            selected,
+            disjoint_roots=(protected,),
+        )
+
+    assert not (protected / "evidence").exists()
 
 
 def test_evidence_repository_revalidates_digests_and_disjoint_roots(

--- a/tests/meta_harness/test_kernel_catalogue.py
+++ b/tests/meta_harness/test_kernel_catalogue.py
@@ -345,6 +345,7 @@ def test_harbor_execution_operations_have_phase_neutral_kernel_definitions() -> 
             "handler_key": KernelOperationHandlerKey.RUN_STAGE,
             "effect": KernelOperationEffect.UNSCORED_EXECUTION,
             "implementation_paths": (
+                "aec_bench/ledger/immutable_artifact_store.py",
                 *_COMPILATION_SOURCE_PATHS,
                 "aec_bench/meta_harness/declared_stage_runtime.py",
                 "aec_bench/meta_harness/governed_attempt_engine/__init__.py",
@@ -821,6 +822,9 @@ def test_default_kernel_identity_owns_only_the_explicit_executor_surface() -> No
     assert "aec_bench/meta_harness/kernel_catalogue.py" in executor_paths
     assert "aec_bench/meta_harness/run_bundle_runtime.py" in executor_paths
     assert "aec_bench/harness/execution_entrypoint.py" in executor_paths
+    assert "aec_bench/contracts/world_session.py" in executor_paths
+    assert "aec_bench/ledger/immutable_artifact_store.py" in executor_paths
+    assert "aec_bench/ledger/local_lock.py" in executor_paths
     assert set(_COMPILATION_SOURCE_PATHS).issubset(executor_paths)
     assert set(_PROPOSAL_SESSION_RUNTIME_SOURCE_PATHS).issubset(executor_paths)
     assert set(_HARBOR_PROPOSAL_IMPORT_SOURCE_PATHS).issubset(executor_paths)

--- a/tests/task_world_templates/continual/test_durability.py
+++ b/tests/task_world_templates/continual/test_durability.py
@@ -12,11 +12,15 @@ from typing import Protocol
 
 import pytest
 
+from aec_bench.ledger.immutable_artifact_store import (
+    ImmutableByteStore as LowerImmutableByteStore,
+)
 from aec_bench.ledger.local_lock import exclusive_local_file_lock as lower_exclusive_local_file_lock
 from aec_bench.meta_harness.evidence_lifecycle import EvidenceLifecycleError, _lifecycle_state_lock
 from aec_bench.task_world_templates.continual.durability import (
     ContinualWorldLockConfinementError,
     ContinualWorldLockError,
+    ImmutableByteStore,
     exclusive_local_file_lock,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station import (
@@ -233,6 +237,10 @@ def test_continual_lock_is_the_lower_shared_ledger_primitive() -> None:
     assert exclusive_local_file_lock is lower_exclusive_local_file_lock
 
 
+def test_continual_immutable_byte_store_is_the_lower_shared_ledger_primitive() -> None:
+    assert ImmutableByteStore is LowerImmutableByteStore
+
+
 def test_real_consumers_do_not_own_parallel_local_lock_implementations() -> None:
     source_root = Path(__file__).parents[3] / "src" / "aec_bench"
     consumer_paths = (
@@ -248,3 +256,14 @@ def test_real_consumers_do_not_own_parallel_local_lock_implementations() -> None
         imported = _imported_modules(path)
         assert "fcntl" not in imported
         assert expected_module in imported
+
+
+def test_pump_repository_does_not_own_parallel_immutable_byte_mechanics() -> None:
+    source_root = Path(__file__).parents[3] / "src" / "aec_bench"
+    repository_path = (
+        source_root / "task_world_templates" / "stewardship" / "wastewater_pump_station" / "world_run_repository.py"
+    )
+    source = repository_path.read_text(encoding="utf-8")
+
+    assert "os.link(" not in source
+    assert "def _require_regular_file" not in source

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/fixtures/world_run_byte_inventories.v1.json
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/fixtures/world_run_byte_inventories.v1.json
@@ -1,0 +1,136 @@
+{
+  "fixture_version": "pump-station-world-run-byte-inventories.v1",
+  "baselines": {
+    "v1": {
+      "status": "accepted-existing",
+      "artifacts": {
+        "commits/1ec4d40db6cca8457e70751e55f5d006a4f94643eb6a731c7943b4010d6b0deb.json": [
+          698,
+          "1ec4d40db6cca8457e70751e55f5d006a4f94643eb6a731c7943b4010d6b0deb"
+        ],
+        "commits/c200b1c7ef76c2965128a39ac141e61e0dfb204c278bc38645aa9ee55cb9d349.json": [
+          366,
+          "c200b1c7ef76c2965128a39ac141e61e0dfb204c278bc38645aa9ee55cb9d349"
+        ],
+        "current.json": [
+          288,
+          "1e10368e0dd9d0c95ea8da3b90363732b7ac376418496f5a856a781164ed7bfd"
+        ],
+        "events/577427decaebca3e63167f390421c4a3d6481498393b2febe33974d8d79609c5.json": [
+          120,
+          "577427decaebca3e63167f390421c4a3d6481498393b2febe33974d8d79609c5"
+        ],
+        "information-sets/10effd206c74b95db611ff0980888c8911ea6eb457b5ecf85637120b0c7d80be.json": [
+          2130,
+          "10effd206c74b95db611ff0980888c8911ea6eb457b5ecf85637120b0c7d80be"
+        ],
+        "manifest.json": [
+          945,
+          "0095248686ff7c4c79fe27025d6c307aa66b8028794aab8a8b6c8cbe2fe3c10d"
+        ],
+        "proposals/6bbfad044ec2e46a2103e3b636dc12a1360bcbc98a3f52f8dc7fe97c7ca5819e.json": [
+          409,
+          "6bbfad044ec2e46a2103e3b636dc12a1360bcbc98a3f52f8dc7fe97c7ca5819e"
+        ],
+        "receipts/0b1fc0930d2dc3190e62a2a22dc23fca7815863bd135d4a70fcba3742ca9c939.json": [
+          1028,
+          "0b1fc0930d2dc3190e62a2a22dc23fca7815863bd135d4a70fcba3742ca9c939"
+        ],
+        "states/42b3d784e5dce3a37f296491835cefc90c3d80aded40ffc6cf4863dc374306ff.json": [
+          1307,
+          "02d23448e3a3dc3448ee28a27131d155b8354d09678f4311f61bb63b9902a815"
+        ],
+        "states/4eda04726fa12af73ffdebc6ecb578a51849f5b197721fd312dc18a81d3ae835.json": [
+          2668,
+          "637feca5a257868765be0d2134ce10e23999763c2ffe07aa28e0e11cc989a494"
+        ]
+      }
+    },
+    "v2": {
+      "status": "accepted-existing",
+      "artifacts": {
+        "commits/7b0c250aeb89a00cf208f732bb53b7483dbd1ec8846e03573ce4ead0014aa08d.json": [
+          692,
+          "7b0c250aeb89a00cf208f732bb53b7483dbd1ec8846e03573ce4ead0014aa08d"
+        ],
+        "commits/8d805438c317b446d0f371588dc4316aaca951cce9cbb36c0a817c1ef46f30de.json": [
+          359,
+          "8d805438c317b446d0f371588dc4316aaca951cce9cbb36c0a817c1ef46f30de"
+        ],
+        "current.json": [
+          281,
+          "e63b51fe5c4c3154d191b4524a7bdab841f19a53d60b1403bf1f4b72694a1248"
+        ],
+        "events/78e901413a4730ae0318b7a4b71b2dc1aee9b7cd261f1abb610cff7400fa20bc.json": [
+          224,
+          "78e901413a4730ae0318b7a4b71b2dc1aee9b7cd261f1abb610cff7400fa20bc"
+        ],
+        "information-sets/1fecd675ac8ccbcd463f93ba94130fe320a247ea0e3930f56c0fb35920ef6633.json": [
+          4629,
+          "1fecd675ac8ccbcd463f93ba94130fe320a247ea0e3930f56c0fb35920ef6633"
+        ],
+        "manifest.json": [
+          924,
+          "28b9157ba5c702185e4be208422ecb338a70c856fc6d3a6877b2713c30ad4198"
+        ],
+        "proposals/a978aac0b99cf85b6f56f18758df07b8cc5bf36919206e08f1ca445036fa2713.json": [
+          382,
+          "a978aac0b99cf85b6f56f18758df07b8cc5bf36919206e08f1ca445036fa2713"
+        ],
+        "receipts/68b0fef3aa23d54558103295837119334184b0a212e981a4476767366a836854.json": [
+          1088,
+          "68b0fef3aa23d54558103295837119334184b0a212e981a4476767366a836854"
+        ],
+        "states/526dd66b26a1313aacb40a12034800a8a66d3d538f8793db0aa7f3102ffeec00.json": [
+          4935,
+          "0e95b0253c48409da4ee5b7b17f83f6422780b6dbae5ab827154aff5d04d57a2"
+        ],
+        "states/b8dcbf4ec526907d87d33677cdc5995ade020e3d8fa049605d980b5674e9d97a.json": [
+          4521,
+          "1b147fb107bd4243cf0b4bcadcc6f05995c94e94aeffff3cc66c27e9772a184d"
+        ]
+      }
+    },
+    "v3": {
+      "status": "pre-extraction-compatibility-baseline",
+      "artifacts": {
+        "commits/363b6e1add6d2690e0e6c3f3e772958ee85c9b093eb0587588e1482022d3c423.json": [
+          639,
+          "363b6e1add6d2690e0e6c3f3e772958ee85c9b093eb0587588e1482022d3c423"
+        ],
+        "commits/e1e6c1e502a873a79f0b850eff3c61111ddc622e1d68bae1ba83676a10403d10.json": [
+          372,
+          "e1e6c1e502a873a79f0b850eff3c61111ddc622e1d68bae1ba83676a10403d10"
+        ],
+        "control-requests/1022776ccd8487486108a6792a90c33416214d93184cd68c90f1e7499b8fcb75.json": [
+          614,
+          "1022776ccd8487486108a6792a90c33416214d93184cd68c90f1e7499b8fcb75"
+        ],
+        "current.json": [
+          294,
+          "d2f4b85dac82fe8a1f5406a5b2e782ef580720aca1422779a5d25d13f235a4d8"
+        ],
+        "events/577427decaebca3e63167f390421c4a3d6481498393b2febe33974d8d79609c5.json": [
+          120,
+          "577427decaebca3e63167f390421c4a3d6481498393b2febe33974d8d79609c5"
+        ],
+        "manifest.json": [
+          963,
+          "631657b1d231c3efb9962aae16d0c020cc2b8b33d9aac467da603ce508e573e1"
+        ],
+        "receipts/9f5a8b9aaba19115b99dde9e118c5c281ececb4af4f9b486ae2550b9fa61e238.json": [
+          846,
+          "9f5a8b9aaba19115b99dde9e118c5c281ececb4af4f9b486ae2550b9fa61e238"
+        ],
+        "states/0761549171a5ffdc7ea914f088a6edd5762e80bddebed76b97eeabdc5f2190cf.json": [
+          6137,
+          "7ce5615f9d0a30362e2f585a918ec33b26135369b9202ff1111a7f7ef3347e2c"
+        ],
+        "states/d8f49dc33f3da9ad0e5a88abb2da2c6f1833542ea7c0fd86eacf237fb5ce1ddd.json": [
+          7199,
+          "634acfec4d05183eaa1da6a1349652ba7ed7fc05df828440cf23e2a9500c96c4"
+        ]
+      }
+    }
+  }
+}

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_world_run_byte_compatibility.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_world_run_byte_compatibility.py
@@ -130,6 +130,18 @@ def _baselines() -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))["baselines"]
 
 
+def test_compatibility_fixture_declares_exact_version_and_baseline_statuses() -> None:
+    path = Path(__file__).parent / "fixtures" / "world_run_byte_inventories.v1.json"
+    fixture = json.loads(path.read_text(encoding="utf-8"))
+
+    assert fixture["fixture_version"] == "pump-station-world-run-byte-inventories.v1"
+    assert {version: baseline["status"] for version, baseline in fixture["baselines"].items()} == {
+        "v1": "accepted-existing",
+        "v2": "accepted-existing",
+        "v3": "pre-extraction-compatibility-baseline",
+    }
+
+
 @pytest.mark.parametrize(
     ("version", "builder"),
     (

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_world_run_byte_compatibility.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_world_run_byte_compatibility.py
@@ -1,0 +1,148 @@
+# ABOUTME: Freezes the complete durable artifact inventory for supported pump record versions.
+# ABOUTME: Detects any path, size, or byte-hash drift before shared storage mechanics change.
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+from rich_work_support import rich_work_schedule
+from world_run_support import bind_proposal, create_world_run
+
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station import (
+    PUMP_STATION_EVIDENCE_TREATMENT_VERSION_V1,
+    PUMP_STATION_EVIDENCE_VISIBILITY_POLICY_V1,
+    PUMP_STATION_RECORD_VERSIONS_V2,
+    PUMP_STATION_RECORD_VERSIONS_V3,
+    ContinueOperation,
+    PumpStationEvidenceTreatmentClass,
+    PumpStationEvidenceTreatmentRequest,
+    PumpStationSchedule,
+    PumpStationWorldRun,
+    PumpStationWorldRunRepository,
+    RequestConditionalDeferral,
+    create_evidence_health_reference_state,
+    create_rich_work_reference_state,
+    load_reference_package,
+    pump_station_model_from_package,
+)
+
+type _RunBuilder = Callable[[Path], PumpStationWorldRun]
+
+
+def _durable_inventory(root: Path) -> dict[str, list[int | str]]:
+    result: dict[str, list[int | str]] = {}
+    for path in sorted(root.rglob("*.json")):
+        payload = path.read_bytes()
+        result[path.relative_to(root).as_posix()] = [
+            len(payload),
+            hashlib.sha256(payload).hexdigest(),
+        ]
+    return result
+
+
+def _build_v1_run(root: Path) -> PumpStationWorldRun:
+    run = create_world_run(root)
+    proposal, information_set = bind_proposal(
+        run,
+        RequestConditionalDeferral,
+        "proposal-resource-effect",
+        pump_id="pump-a",
+    )
+    run.apply(proposal, information_set=information_set)
+    return run
+
+
+def _build_v2_run(root: Path) -> PumpStationWorldRun:
+    package = load_reference_package()
+    model = pump_station_model_from_package(package)
+    run = PumpStationWorldRun.create(
+        repository=PumpStationWorldRunRepository(root),
+        package=package,
+        model=model,
+        initial_state=create_rich_work_reference_state(
+            model,
+            schedule=rich_work_schedule(model),
+        ),
+        run_id="run-v2",
+        episode_id="episode-v2",
+        world_branch_id="branch-v2",
+        record_versions=PUMP_STATION_RECORD_VERSIONS_V2,
+    )
+    proposal, information_set = bind_proposal(
+        run,
+        ContinueOperation,
+        "proposal-resource-arrival",
+    )
+    run.apply(proposal, information_set=information_set)
+    return run
+
+
+def _build_v3_run(root: Path) -> PumpStationWorldRun:
+    package = load_reference_package()
+    model = pump_station_model_from_package(package)
+    run = PumpStationWorldRun.create(
+        repository=PumpStationWorldRunRepository(root),
+        package=package,
+        model=model,
+        initial_state=create_evidence_health_reference_state(
+            model,
+            schedule=PumpStationSchedule(
+                access_available_after_seconds=86_400,
+                repair_kit_available_after_seconds=86_400,
+                decision_point_after_seconds=(3_600,),
+            ),
+        ),
+        run_id="run-evidence-health",
+        episode_id="episode-evidence-health",
+        world_branch_id="branch-evidence-health",
+        record_versions=PUMP_STATION_RECORD_VERSIONS_V3,
+    )
+    snapshot = run.snapshot()
+    decision_point = min(
+        event.scheduled_seconds for event in run.state.scheduled_events if event.event_type.value == "decision_point"
+    )
+    run.schedule_evidence_treatment(
+        PumpStationEvidenceTreatmentRequest(
+            request_id="treatment-control-001",
+            run_id=snapshot.run_id,
+            episode_id=snapshot.episode_id,
+            world_branch_id=snapshot.world_branch_id,
+            base_state_id=snapshot.state_id,
+            base_commit_id=snapshot.commit_id,
+            based_on_sequence=snapshot.sequence,
+            treatment_class=PumpStationEvidenceTreatmentClass.CALIBRATION_LAPSE,
+            treatment_version=PUMP_STATION_EVIDENCE_TREATMENT_VERSION_V1,
+            target_source_id="station-condition-sensor",
+            effective_decision_point_seconds=decision_point,
+            visibility_policy=PUMP_STATION_EVIDENCE_VISIBILITY_POLICY_V1,
+        )
+    )
+    return run
+
+
+def _baselines() -> dict[str, Any]:
+    path = Path(__file__).parent / "fixtures" / "world_run_byte_inventories.v1.json"
+    return json.loads(path.read_text(encoding="utf-8"))["baselines"]
+
+
+@pytest.mark.parametrize(
+    ("version", "builder"),
+    (
+        ("v1", _build_v1_run),
+        ("v2", _build_v2_run),
+        ("v3", _build_v3_run),
+    ),
+)
+def test_supported_record_versions_retain_exact_durable_artifact_inventory(
+    tmp_path: Path,
+    version: str,
+    builder: _RunBuilder,
+) -> None:
+    run = builder(tmp_path / version)
+
+    assert _durable_inventory(run.repository.root) == _baselines()[version]["artifacts"]

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_world_run_publication_recovery.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_world_run_publication_recovery.py
@@ -60,8 +60,31 @@ def _crash() -> Never:
     os._exit(_CRASH_EXIT_CODE)
 
 
-def _artifact_for_path(root: Path, path: _PathArgument) -> str | None:
-    relative = Path(os.fsdecode(path)).relative_to(root)
+def _path_from_directory_descriptor(
+    root: Path,
+    path: _PathArgument,
+    directory_descriptor: int | None,
+) -> Path:
+    selected = Path(os.fsdecode(path))
+    if selected.is_absolute() or directory_descriptor is None:
+        return selected
+
+    target = os.fstat(directory_descriptor)
+    candidates = (root, *(item for item in root.iterdir() if item.is_dir()))
+    for candidate in candidates:
+        details = candidate.stat()
+        if (details.st_dev, details.st_ino) == (target.st_dev, target.st_ino):
+            return candidate / selected
+    raise AssertionError("publication directory descriptor is outside the pump run")
+
+
+def _artifact_for_path(
+    root: Path,
+    path: _PathArgument,
+    directory_descriptor: int | None = None,
+) -> str | None:
+    absolute = _path_from_directory_descriptor(root, path, directory_descriptor)
+    relative = absolute.relative_to(root)
     key = relative.name if len(relative.parts) == 1 else relative.parts[0]
     return {
         "manifest.json": "manifest",
@@ -83,7 +106,7 @@ def _install_publication_crash(root: Path, boundary: str) -> None:
         dst_dir_fd: int | None = None,
         follow_symlinks: bool = True,
     ) -> None:
-        artifact = _artifact_for_path(root, dst)
+        artifact = _artifact_for_path(root, dst, dst_dir_fd)
         if boundary == f"{artifact}-before-link":
             _crash()
         _ORIGINAL_LINK(

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_world_run_repository.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_world_run_repository.py
@@ -107,6 +107,7 @@ def test_repository_rejects_content_moved_under_the_wrong_identity(tmp_path) -> 
         ("symbolic-link", "artifact-confinement"),
         ("directory", "artifact-integrity"),
         ("public-permissions", "artifact-confinement"),
+        ("unreadable", "artifact-integrity"),
     ),
 )
 def test_repository_rejects_unsafe_manifest_files(
@@ -124,11 +125,17 @@ def test_repository_rejects_unsafe_manifest_files(
     elif unsafe_kind == "directory":
         manifest.unlink()
         manifest.mkdir()
+    elif unsafe_kind == "unreadable":
+        manifest.chmod(0o000)
     else:
         manifest.chmod(0o644)
 
-    with pytest.raises(PumpStationWorldRunError) as raised:
-        run.repository.load_manifest()
+    try:
+        with pytest.raises(PumpStationWorldRunError) as raised:
+            run.repository.load_manifest()
+    finally:
+        if unsafe_kind == "unreadable":
+            manifest.chmod(0o600)
 
     assert raised.value.code == expected_code
 

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_world_run_repository.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_world_run_repository.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import stat
 from dataclasses import replace
+from pathlib import Path
 
 import pytest
 from world_run_support import bind_proposal, create_world_run
@@ -98,6 +99,38 @@ def test_repository_rejects_content_moved_under_the_wrong_identity(tmp_path) -> 
 
     with pytest.raises(PumpStationWorldRunError, match="artifact-integrity"):
         run.steps()
+
+
+@pytest.mark.parametrize(
+    ("unsafe_kind", "expected_code"),
+    (
+        ("symbolic-link", "artifact-confinement"),
+        ("directory", "artifact-integrity"),
+        ("public-permissions", "artifact-confinement"),
+    ),
+)
+def test_repository_rejects_unsafe_manifest_files(
+    tmp_path: Path,
+    unsafe_kind: str,
+    expected_code: str,
+) -> None:
+    run = create_world_run(tmp_path / "run")
+    manifest = run.repository.root / "manifest.json"
+    if unsafe_kind == "symbolic-link":
+        outside = tmp_path / "outside.json"
+        outside.write_bytes(manifest.read_bytes())
+        manifest.unlink()
+        manifest.symlink_to(outside)
+    elif unsafe_kind == "directory":
+        manifest.unlink()
+        manifest.mkdir()
+    else:
+        manifest.chmod(0o644)
+
+    with pytest.raises(PumpStationWorldRunError) as raised:
+        run.repository.load_manifest()
+
+    assert raised.value.code == expected_code
 
 
 def test_snapshot_preserves_elapsed_time_and_applied_event_identity(tmp_path) -> None:


### PR DESCRIPTION
## Summary

- Move exact immutable byte publication and reads to one task-neutral ledger owner.
- Keep the existing meta-harness import path as a policy facade for models and evidence.
- Use the shared byte store from the pump world-run repository and the evidence-lifecycle host JSON path.
- Preserve the exact pump v1-v3 artifact bytes and existing pump error codes.
- Rename the crash-recovery test for the behavior that it checks.

## Boundary

The lower store imports no task-world, meta-harness, contracts, or Pydantic module. Mutable current pointers, transaction publication, replay, rewind, and crash recovery stay with their current owners. The store requires local POSIX descriptor operations and supports cooperative local publishers. It does not isolate data from a malicious process that uses the same operating-system account.

This PR is stacked on draft PR #74 and targets its ASW-8 branch. It does not merge PR #74 or make it ready for main.

## Verification

- Ruff: passed on all changed Python files.
- MyPy: passed on all seven changed source files.
- Focused unit, integration, byte-compatibility, and process-kill recovery tests: 177 passed.
- Independent security review: no actionable finding.
- Independent integration review: no actionable finding.