### PR TITLE
refactor: share durable directory creation

### DIFF
--- a/docs/CONTINUAL_WORLD_RUNTIME.md
+++ b/docs/CONTINUAL_WORLD_RUNTIME.md
@@ -443,9 +443,38 @@ has no scavenger. Process-death tests prove old-or-new atomic visibility. A real
 power-loss guarantee also depends on the filesystem and storage honoring
 `fsync`.
 
-Step 3 remains incomplete. Shared pointer policy, transaction publication,
+Step 3 remains incomplete after Step 3C. Shared pointer policy, transaction publication,
 replay, recovery, sessions, branches, rollouts, CLI, and Harbor behavior remain
 deferred until two real consumers prove the same task-neutral contract.
+
+### 6.12 Step 3D durable directory-tree creation
+
+Step 3D extracts the last proven duplicate raw filesystem mechanic. It creates
+each missing directory component, can apply an exact mode to each component
+created by that call, and flushes every parent whose child entry changed. It
+does not decide what a directory stores or how any stored record becomes
+authoritative.
+
+| Path | Owner | Compatibility and migration rule |
+| --- | --- | --- |
+| `src/aec_bench/ledger/durability.py` | Lower filesystem durability | Own missing-component discovery, optional mode application to newly created components, and parent-directory flushes. Preserve the default mode behavior for existing callers. |
+| `src/aec_bench/task_world_templates/continual/durability.py` | Shared continual-world durability | Re-export the lower directory function for task-world adapters. Keep the lower implementation as the single owner. |
+| `wastewater_pump_station/world_run_repository.py` | Pump durability adapter | Request mode `0700` for every newly created run-root component. Keep final-root validation, the existing-root mode policy, repository layout, and artifact meaning task-local. |
+| SSC-03 lifecycle stores | Existing real lower-layer consumers | Continue to call the lower function with its default mode behavior. Keep lifecycle transaction paths, state, markers, adoption, and recovery unchanged. |
+
+The optional created-directory mode does not change an existing ancestor. The
+pump repository still applies its existing `0700` policy to the selected final
+root, including when that root already exists. The extraction changes no pump
+artifact path or byte and no SSC-03 transaction record.
+
+This completes the controlled Step 3 extraction. No shared pointer,
+transaction, replay, or recovery policy is promoted. The pump run selects a
+commit through `current.json`; an unselected immutable commit has no live
+effect. SSC-03 can adopt a valid lifecycle transaction into state and then
+repair its commit marker. Pump replay follows parent commit identities from the
+selected pointer, while SSC-03 replay follows state-owned actions through its
+resolver. These are different task and lifecycle policies. Combining them now
+would create a new abstraction without two proven consumers.
 
 ## 7. Implementation sequence
 

--- a/src/aec_bench/ledger/durability.py
+++ b/src/aec_bench/ledger/durability.py
@@ -422,17 +422,29 @@ def _unlink_owned_temporary(
         ) from cause
 
 
-def mkdir_durable(path: Path) -> None:
-    """Create a directory tree and fsync every parent whose child entry changed."""
+def mkdir_durable(
+    path: Path,
+    *,
+    created_mode: int | None = None,
+) -> None:
+    """Create a directory tree, set new modes, and flush changed parent entries."""
     target = Path(path)
     missing: list[Path] = []
     cursor = target
     while not cursor.exists():
         missing.append(cursor)
         cursor = cursor.parent
-    target.mkdir(parents=True, exist_ok=True)
     for directory in reversed(missing):
+        try:
+            directory.mkdir()
+        except FileExistsError:
+            if not directory.is_dir():
+                raise
+            continue
+        if created_mode is not None:
+            directory.chmod(created_mode)
         fsync_directory(directory.parent)
+    target.mkdir(parents=True, exist_ok=True)
 
 
 def fsync_tree(root: Path) -> None:

--- a/src/aec_bench/task_world_templates/continual/__init__.py
+++ b/src/aec_bench/task_world_templates/continual/__init__.py
@@ -20,6 +20,7 @@ from aec_bench.task_world_templates.continual.durability import (
     ImmutableArtifactStoreError,
     ImmutableByteStore,
     exclusive_local_file_lock,
+    mkdir_durable,
     replace_file_bytes_durable,
 )
 
@@ -39,6 +40,7 @@ __all__ = [
     "ImmutableByteStore",
     "LoadedContinualWorldProfile",
     "exclusive_local_file_lock",
+    "mkdir_durable",
     "python_source_sha256",
     "replace_file_bytes_durable",
 ]

--- a/src/aec_bench/task_world_templates/continual/durability.py
+++ b/src/aec_bench/task_world_templates/continual/durability.py
@@ -5,6 +5,7 @@ from aec_bench.ledger.durability import (
     DurableFileReplaceConfinementError,
     DurableFileReplaceError,
     DurableFileReplaceIntegrityError,
+    mkdir_durable,
     replace_file_bytes_durable,
 )
 from aec_bench.ledger.immutable_artifact_store import (
@@ -34,5 +35,6 @@ __all__ = [
     "ImmutableArtifactStoreError",
     "ImmutableByteStore",
     "exclusive_local_file_lock",
+    "mkdir_durable",
     "replace_file_bytes_durable",
 ]

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_repository.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_repository.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -19,6 +18,7 @@ from aec_bench.task_world_templates.continual.durability import (
     ImmutableArtifactStoreError,
     ImmutableByteStore,
     exclusive_local_file_lock,
+    mkdir_durable,
     replace_file_bytes_durable,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.evidence_health import (
@@ -116,26 +116,6 @@ def _fail(code: str, detail: str) -> NoReturn:
     raise PumpStationWorldRunError(code, detail)
 
 
-def _fsync_directory(path: Path) -> None:
-    descriptor = os.open(path, os.O_RDONLY)
-    try:
-        os.fsync(descriptor)
-    finally:
-        os.close(descriptor)
-
-
-def _mkdir_durable(path: Path) -> None:
-    missing: list[Path] = []
-    cursor = path
-    while not cursor.exists():
-        missing.append(cursor)
-        cursor = cursor.parent
-    path.mkdir(parents=True, exist_ok=True)
-    for directory in reversed(missing):
-        directory.chmod(0o700)
-        _fsync_directory(directory.parent)
-
-
 class PumpStationWorldRunRepository:
     """A confined durable repository for exactly one pump-station world run."""
 
@@ -143,7 +123,7 @@ class PumpStationWorldRunRepository:
         selected = Path(root)
         if selected.exists() and (selected.is_symlink() or not selected.is_dir()):
             _fail("artifact-confinement", "world-run root must be a plain directory")
-        _mkdir_durable(selected)
+        mkdir_durable(selected, created_mode=0o700)
         selected.chmod(0o700)
         self._root = selected.resolve(strict=True)
         self._lock_path = self._root / ".world-run.lock"

--- a/tests/ledger/test_writer.py
+++ b/tests/ledger/test_writer.py
@@ -1,6 +1,7 @@
 # ABOUTME: Tests for append-only TrialRecord persistence in the Python ledger package.
 # ABOUTME: Verifies deterministic paths, duplicate rejection, and round-trip reads.
 
+import stat
 from pathlib import Path
 
 import pytest
@@ -41,3 +42,61 @@ def test_mkdir_durable_fsyncs_each_new_parent_entry(
 
     assert target.is_dir()
     assert flushed == [tmp_path, tmp_path / "ledger", tmp_path / "ledger" / "experiment"]
+
+
+def test_mkdir_durable_applies_mode_only_to_created_directories(
+    tmp_path: Path,
+) -> None:
+    existing = tmp_path / "existing"
+    existing.mkdir(mode=0o750)
+    existing.chmod(0o750)
+    target = existing / "run" / "state"
+
+    mkdir_durable(target, created_mode=0o700)
+
+    assert stat.S_IMODE(existing.stat().st_mode) == 0o750
+    assert stat.S_IMODE((existing / "run").stat().st_mode) == 0o700
+    assert stat.S_IMODE(target.stat().st_mode) == 0o700
+
+
+def test_mkdir_durable_does_not_change_a_directory_created_concurrently(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    concurrent = tmp_path / "concurrent"
+    target = concurrent / "owned"
+    original_mkdir = Path.mkdir
+    intervened = False
+
+    def mkdir_with_concurrent_creator(
+        path: Path,
+        mode: int = 0o777,
+        parents: bool = False,
+        exist_ok: bool = False,
+    ) -> None:
+        nonlocal intervened
+        if path == concurrent and not intervened:
+            intervened = True
+            original_mkdir(path)
+            path.chmod(0o755)
+        original_mkdir(
+            path,
+            mode=mode,
+            parents=parents,
+            exist_ok=exist_ok,
+        )
+
+    monkeypatch.setattr(Path, "mkdir", mkdir_with_concurrent_creator)
+
+    mkdir_durable(target, created_mode=0o700)
+
+    assert stat.S_IMODE(concurrent.stat().st_mode) == 0o755
+    assert stat.S_IMODE(target.stat().st_mode) == 0o700
+
+
+def test_mkdir_durable_rejects_an_existing_non_directory(tmp_path: Path) -> None:
+    target = tmp_path / "not-a-directory"
+    target.write_bytes(b"file")
+
+    with pytest.raises(FileExistsError):
+        mkdir_durable(target)

--- a/tests/task_world_templates/continual/test_durability.py
+++ b/tests/task_world_templates/continual/test_durability.py
@@ -14,6 +14,7 @@ import pytest
 
 import aec_bench.ledger.durability as lower_durability
 import aec_bench.meta_harness.evidence_request_store as lifecycle_store
+import aec_bench.meta_harness.lifecycle_operation_store as lifecycle_operation_store
 import aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_repository as pump_repository
 from aec_bench.ledger.immutable_artifact_store import (
     ImmutableByteStore as LowerImmutableByteStore,
@@ -25,6 +26,7 @@ from aec_bench.task_world_templates.continual.durability import (
     ContinualWorldLockError,
     ImmutableByteStore,
     exclusive_local_file_lock,
+    mkdir_durable,
     replace_file_bytes_durable,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station import (
@@ -251,6 +253,21 @@ def test_continual_lock_is_the_lower_shared_ledger_primitive() -> None:
 
 def test_continual_immutable_byte_store_is_the_lower_shared_ledger_primitive() -> None:
     assert ImmutableByteStore is LowerImmutableByteStore
+
+
+def test_real_consumers_use_the_same_durable_directory_creation_owner() -> None:
+    assert mkdir_durable is lower_durability.mkdir_durable
+    assert vars(pump_repository)["mkdir_durable"] is mkdir_durable
+    assert vars(lifecycle_operation_store)["mkdir_durable"] is lower_durability.mkdir_durable
+
+    source_root = Path(__file__).parents[3] / "src" / "aec_bench"
+    repository_path = (
+        source_root / "task_world_templates" / "stewardship" / "wastewater_pump_station" / "world_run_repository.py"
+    )
+    source = repository_path.read_text(encoding="utf-8")
+
+    assert "def _mkdir_durable" not in source
+    assert "def _fsync_directory" not in source
 
 
 def test_real_consumers_use_the_same_durable_file_replacement_owner() -> None:

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_world_run_repository.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_world_run_repository.py
@@ -134,6 +134,37 @@ def test_repository_rejects_content_moved_under_the_wrong_identity(tmp_path) -> 
         run.steps()
 
 
+def test_repository_keeps_each_new_root_directory_private(tmp_path: Path) -> None:
+    private_parent = tmp_path / "private" / "worlds"
+
+    run = create_world_run(private_parent / "run")
+
+    assert [
+        stat.S_IMODE(path.stat().st_mode)
+        for path in (
+            tmp_path / "private",
+            private_parent,
+            run.repository.root,
+        )
+    ] == [0o700, 0o700, 0o700]
+
+
+def test_repository_keeps_existing_ancestor_mode_and_privatises_existing_root(
+    tmp_path: Path,
+) -> None:
+    existing_parent = tmp_path / "existing"
+    existing_parent.mkdir()
+    existing_parent.chmod(0o750)
+    existing_root = existing_parent / "run"
+    existing_root.mkdir()
+    existing_root.chmod(0o750)
+
+    repository = repository_runtime.PumpStationWorldRunRepository(existing_root)
+
+    assert stat.S_IMODE(existing_parent.stat().st_mode) == 0o750
+    assert stat.S_IMODE(repository.root.stat().st_mode) == 0o700
+
+
 @pytest.mark.parametrize(
     ("unsafe_kind", "expected_code"),
     (


### PR DESCRIPTION
## Scope

- extend the existing lower durable-directory helper with an optional mode for directories created by that call
- re-export the helper through the continual-world durability boundary
- remove the pump repository copy while preserving private run-root behavior
- record why pointer, transaction, replay, and recovery policy remains task-local

## Compatibility

- pump run-root components remain mode 0700
- existing pump roots still become mode 0700 while existing ancestors are unchanged
- SSC-03 keeps the previous default mode behavior
- an existing non-directory still raises FileExistsError
- V1-V3 pump artifact bytes and hashes remain unchanged

## Verification

- 48 focused tests passed
- Ruff check passed
- Ruff format check passed
- MyPy passed on the changed boundary
- three independent boundary reviews found no remaining issue

PR74 remains open and in draft. This PR targets its branch only.