### PR TITLE
fix: serialize pump staged publication

### DIFF
--- a/docs/CONTINUAL_WORLD_RUNTIME.md
+++ b/docs/CONTINUAL_WORLD_RUNTIME.md
@@ -429,10 +429,8 @@ same-account process. The existing `ledger/durability.py` source was already in
 the default kernel executor inventory, so this step adds no new executor source
 path or operation-specific identity.
 
-The raw function does not acquire a lock. Normal pump transitions use the
-existing run lock, but `publish_staged_transition()` does not enforce that lock
-when called directly. Closing this pre-existing adapter gap remains pointer
-policy work; it must happen before the pointer contract can move downwards.
+The raw function does not acquire a lock. The pump adapter owns its existing
+run lock and the pump-specific selection policy described in Section 6.13.
 
 An error after the descriptor-relative replacement has an unknown commit
 result: the new bytes can already be visible even when later verification,
@@ -443,9 +441,10 @@ has no scavenger. Process-death tests prove old-or-new atomic visibility. A real
 power-loss guarantee also depends on the filesystem and storage honoring
 `fsync`.
 
-Step 3 remains incomplete after Step 3C. Shared pointer policy, transaction publication,
-replay, recovery, sessions, branches, rollouts, CLI, and Harbor behavior remain
-deferred until two real consumers prove the same task-neutral contract.
+Step 3 remains incomplete after Step 3C. Shared pointer policy, transaction
+publication, replay, recovery, sessions, branches, rollouts, CLI, and Harbor
+behavior remain deferred until two real consumers prove the same task-neutral
+contract.
 
 ### 6.12 Step 3D durable directory-tree creation
 
@@ -475,6 +474,34 @@ repair its commit marker. Pump replay follows parent commit identities from the
 selected pointer, while SSC-03 replay follows state-owned actions through its
 resolver. These are different task and lifecycle policies. Combining them now
 would create a new abstraction without two proven consumers.
+
+### 6.13 Pump staged publication lock ownership
+
+Before V4 uses the existing pump repository, every path that selects a staged
+transition must own the pump run lock. This is pump pointer policy. It is not a
+shared pointer or transaction contract.
+
+| Path | Owner | Compatibility and migration rule |
+| --- | --- | --- |
+| `wastewater_pump_station/world_run_repository.py` | Pump durability adapter | Make public `publish_staged_transition()` acquire `.world-run.lock` before it reads `current.json`, checks idempotence or staleness, validates immutable evidence, and replaces the pointer. Keep one private lock-required selection helper for callers that already own that lock. |
+| `wastewater_pump_station/world_run.py` | Pump run coordinator | Keep one continuous lock across current-state read, request retry checks, transition evaluation, immutable staging, and pointer selection. Call the private lock-required helper to avoid a nested non-reentrant lock. |
+| `src/aec_bench/ledger/` and `task_world_templates/continual/` | Lower durability | Make no change. Raw immutable publication and mutable byte replacement remain lock-free caller-owned mechanics. |
+
+Two direct publishers prepared from one prior snapshot are serialized. The
+first selected transition wins; the second receives `stale-publication`. An
+exact retry is accepted only when the durable parent commit, staged commit, and
+next snapshot form one consistent chain and both commit files are present with
+their declared content identities. The receipt's pre-state and the actor or
+control input's parent binding must pass the same rule used by full chain
+replay. The returned transition is reloaded from that durable commit, not
+trusted from the caller's staged object. A valid retry creates no new commit or
+task effect. Process death before or after the pointer replacement releases the
+operating-system lock. Reload and exact retry then select or recover the same
+transition once.
+
+This correction does not promote `current.json`, commit-chain meaning, replay,
+or recovery into the shared continual-world layer. It only closes the pump
+adapter path that Step 4 will reuse.
 
 ## 7. Implementation sequence
 

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run.py
@@ -345,7 +345,7 @@ class PumpStationWorldRun:
                 information_set=information_set,
                 transition=transition,
             )
-            return self._repository.publish_staged_transition(staged)
+            return self._repository._publish_staged_transition_under_lock(staged)
 
     def stage_evidence_treatment(
         self,
@@ -393,7 +393,7 @@ class PumpStationWorldRun:
                 control_request=request,
                 transition=transition,
             )
-            return self._repository.publish_staged_transition(staged)
+            return self._repository._publish_staged_transition_under_lock(staged)
 
     def recover_evidence_treatment(
         self,
@@ -433,7 +433,7 @@ class PumpStationWorldRun:
                 control_request=request,
                 transition=transition,
             )
-            return self._repository.publish_staged_transition(staged)
+            return self._repository._publish_staged_transition_under_lock(staged)
 
     def steps(self) -> tuple[PumpStationRunStep, ...]:
         """Reload all selected run steps for independent replay."""

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_repository.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_repository.py
@@ -423,15 +423,21 @@ class PumpStationWorldRunRepository:
         self,
         staged: PumpStationStagedTransition,
     ) -> PumpStationTransition:
-        """Select a fully staged transition with one atomic pointer replacement."""
+        """Lock and select a fully staged transition with one pointer replacement."""
+        with self.locked():
+            return self._publish_staged_transition_under_lock(staged)
+
+    def _publish_staged_transition_under_lock(
+        self,
+        staged: PumpStationStagedTransition,
+    ) -> PumpStationTransition:
+        """Select one staged transition while the caller owns the run lock."""
+        transition = self._require_staged_transition_identity(staged)
         current = self.current_snapshot()
         if current == staged.snapshot:
-            return self.load_transition(staged.commit)
+            return transition
         if current != staged.prior_snapshot:
             _fail("stale-publication", "world run advanced after transition preparation")
-        if pump_station_artifact_id(staged.commit) != staged.snapshot.commit_id:
-            _fail("transition-integrity", "staged commit identity differs")
-        self.load_transition(staged.commit)
         self._replace_current(
             PumpStationCurrentRunPointer(
                 serialization_version=PUMP_STATION_SERIALIZATION_VERSION,
@@ -441,7 +447,74 @@ class PumpStationWorldRunRepository:
                 commit_id=staged.snapshot.commit_id,
             )
         )
-        return staged.transition
+        return transition
+
+    def _require_staged_transition_identity(
+        self,
+        staged: PumpStationStagedTransition,
+    ) -> PumpStationTransition:
+        """Require one durable parent, commit, and next-snapshot identity chain."""
+        prior = staged.prior_snapshot
+        snapshot = staged.snapshot
+        commit = staged.commit
+        if (
+            pump_station_artifact_id(commit) != snapshot.commit_id
+            or commit.run_id != snapshot.run_id
+            or commit.sequence != snapshot.sequence
+            or commit.parent_commit_id != prior.commit_id
+            or commit.state_id != snapshot.state_id
+            or snapshot.snapshot_version != prior.snapshot_version
+            or snapshot.run_id != prior.run_id
+            or snapshot.episode_id != prior.episode_id
+            or snapshot.world_branch_id != prior.world_branch_id
+            or snapshot.sequence != prior.sequence + 1
+        ):
+            _fail("transition-integrity", "staged snapshot and commit chain differ")
+        if self.load_commit(snapshot.commit_id) != commit:
+            _fail("transition-integrity", "stored staged commit differs")
+        parent = self.load_commit(prior.commit_id)
+        if parent.run_id != prior.run_id or parent.sequence != prior.sequence or parent.state_id != prior.state_id:
+            _fail("transition-integrity", "staged prior snapshot and commit differ")
+        durable_input, information_set, transition = self._load_step(commit)
+        if not self._step_extends_parent(
+            parent,
+            commit,
+            durable_input,
+            information_set,
+            transition,
+        ):
+            _fail("transition-integrity", "staged transition does not extend its parent")
+        return transition
+
+    @staticmethod
+    def _step_extends_parent(
+        parent: PumpStationWorldRunCommit,
+        commit: PumpStationWorldRunCommit,
+        durable_input: PumpStationDurableInput,
+        information_set: PumpStationInformationSet | None,
+        transition: PumpStationTransition,
+    ) -> bool:
+        """Return whether one durable step is bound to its exact parent commit."""
+        parent_content_id = pump_station_artifact_id(parent)
+        if (
+            commit.sequence != parent.sequence + 1
+            or commit.parent_commit_id != parent_content_id
+            or transition.receipt.pre_state_id != parent.state_id
+        ):
+            return False
+        if _is_control_input(durable_input):
+            return (
+                information_set is None
+                and durable_input.based_on_sequence == parent.sequence
+                and durable_input.base_state_id == parent.state_id
+                and durable_input.base_commit_id == parent_content_id
+            )
+        proposal = cast(PumpStationProposal, durable_input)
+        return (
+            information_set is not None
+            and proposal.context.based_on_sequence == parent.sequence
+            and information_set.base_view.current_state.state_sequence == parent.sequence
+        )
 
     def find_committed_proposal(
         self,
@@ -750,28 +823,14 @@ class PumpStationWorldRunRepository:
             _fail("artifact-integrity", "initial commit differs from manifest")
         previous = chain[0]
         for commit in chain[1:]:
-            if commit.sequence != previous.sequence + 1:
-                _fail("artifact-integrity", "commit sequence is not contiguous")
             durable_input, information_set, transition = self._load_step(commit)
-            extends_parent = (
-                commit.parent_commit_id == pump_station_artifact_id(previous)
-                and transition.receipt.pre_state_id == previous.state_id
-            )
-            if _is_control_input(durable_input):
-                input_matches_parent = (
-                    information_set is None
-                    and durable_input.based_on_sequence == previous.sequence
-                    and durable_input.base_state_id == previous.state_id
-                    and durable_input.base_commit_id == pump_station_artifact_id(previous)
-                )
-            else:
-                proposal = cast(PumpStationProposal, durable_input)
-                input_matches_parent = (
-                    information_set is not None
-                    and proposal.context.based_on_sequence == previous.sequence
-                    and information_set.base_view.current_state.state_sequence == previous.sequence
-                )
-            if not extends_parent or not input_matches_parent:
+            if not self._step_extends_parent(
+                previous,
+                commit,
+                durable_input,
+                information_set,
+                transition,
+            ):
                 _fail("artifact-integrity", "commit does not extend its parent")
             previous = commit
         if (

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_world_run_publication_recovery.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_world_run_publication_recovery.py
@@ -5,23 +5,47 @@ from __future__ import annotations
 
 import multiprocessing
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import replace
 from pathlib import Path
-from typing import Never
+from typing import Never, Protocol
 
 import pytest
 
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station import (
+    PUMP_STATION_EVIDENCE_TREATMENT_VERSION_V1,
+    PUMP_STATION_EVIDENCE_VISIBILITY_POLICY_V1,
+    PUMP_STATION_PHYSICAL_TREATMENT_DECISION_RIGHT,
+    PUMP_STATION_PHYSICAL_TREATMENT_VERSION,
+    PUMP_STATION_PHYSICAL_TREATMENT_VISIBILITY,
+    PUMP_STATION_RECORD_VERSIONS_V3,
+    PumpStationEvidenceTreatmentClass,
+    PumpStationEvidenceTreatmentRequest,
     PumpStationInformationSet,
+    PumpStationPhysicalTreatmentActivationRequest,
+    PumpStationPhysicalTreatmentClass,
+    PumpStationSchedule,
+    PumpStationStagedTransition,
+    PumpStationTreatmentSeverity,
     PumpStationWorldRun,
+    PumpStationWorldRunError,
     PumpStationWorldRunRepository,
     RequestConditionalDeferral,
     TransferDuty,
+    apply_stewardship_proposal,
+    create_evidence_health_reference_state,
     load_reference_package,
     pump_station_model_from_package,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_models import (
     PumpStationProposal,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_state_machine import (
+    apply_physical_treatment_activation,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_serialization import (
+    pump_station_artifact_id,
 )
 from tests.task_world_templates.stewardship.wastewater_pump_station.world_run_support import (
     bind_proposal,
@@ -54,6 +78,29 @@ _TRANSITION_BOUNDARIES = tuple(
 type _PathArgument = str | bytes | os.PathLike[str] | os.PathLike[bytes]
 _ORIGINAL_LINK = os.link
 _ORIGINAL_REPLACE = os.replace
+
+
+class _ProcessSignal(Protocol):
+    def set(self) -> None: ...
+
+    def wait(self, timeout: float | None = None) -> bool: ...
+
+
+class _ProcessResults(Protocol):
+    def get(self, timeout: float | None = None) -> object: ...
+
+    def put(self, value: object) -> None: ...
+
+
+class _ChildProcess(Protocol):
+    @property
+    def exitcode(self) -> int | None: ...
+
+    def is_alive(self) -> bool: ...
+
+    def join(self, timeout: float | None = None) -> None: ...
+
+    def kill(self) -> None: ...
 
 
 def _crash() -> Never:
@@ -173,6 +220,38 @@ def _crash_during_transition(
     run.apply(proposal, information_set=information_set)
 
 
+def _publish_staged_in_child(
+    root: Path,
+    staged: PumpStationStagedTransition,
+    ready: _ProcessSignal,
+    start: _ProcessSignal,
+    finished: _ProcessSignal,
+    results: _ProcessResults,
+) -> None:
+    repository = PumpStationWorldRunRepository(root)
+    ready.set()
+    if not start.wait(5):
+        raise RuntimeError("staged publication start signal was not received")
+    try:
+        repository.publish_staged_transition(staged)
+    except PumpStationWorldRunError as error:
+        results.put(("error", error.code))
+    else:
+        results.put(("published", staged.snapshot.commit_id))
+    finally:
+        finished.set()
+
+
+def _crash_during_staged_publication(
+    root: Path,
+    boundary: str,
+    staged: PumpStationStagedTransition,
+) -> None:
+    repository = PumpStationWorldRunRepository(root)
+    _install_publication_crash(root, boundary)
+    repository.publish_staged_transition(staged)
+
+
 def _assert_expected_crash(target: Callable[..., object], *args: object) -> None:
     context = multiprocessing.get_context("spawn")
     process = context.Process(target=target, args=args)
@@ -183,6 +262,505 @@ def _assert_expected_crash(target: Callable[..., object], *args: object) -> None
         process.join()
         pytest.fail("fault-injection process did not stop")
     assert process.exitcode == _CRASH_EXIT_CODE
+
+
+def _join_process(process: _ChildProcess) -> None:
+    process.join(10)
+    if process.is_alive():
+        process.kill()
+        process.join()
+        pytest.fail("staged publication process did not stop")
+    assert process.exitcode == 0
+
+
+def test_direct_staged_publication_waits_for_the_run_lock(tmp_path: Path) -> None:
+    run = create_world_run(tmp_path / "run")
+    proposal, information_set = bind_proposal(
+        run,
+        RequestConditionalDeferral,
+        "proposal-lock-owner",
+        pump_id="pump-a",
+    )
+    staged = run.stage(proposal, information_set=information_set)
+    context = multiprocessing.get_context("spawn")
+    ready = context.Event()
+    start = context.Event()
+    finished = context.Event()
+    results = context.Queue()
+    process = context.Process(
+        target=_publish_staged_in_child,
+        args=(run.repository.root, staged, ready, start, finished, results),
+    )
+
+    process.start()
+    try:
+        assert ready.wait(5)
+        with run.repository.locked():
+            start.set()
+            assert not finished.wait(0.5)
+        assert finished.wait(5)
+        _join_process(process)
+    finally:
+        start.set()
+        if process.is_alive():
+            process.kill()
+            process.join()
+
+    assert results.get(timeout=5) == ("published", staged.snapshot.commit_id)
+    assert run.snapshot() == staged.snapshot
+
+
+def test_combined_transition_paths_enter_the_run_lock_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    actor_run = create_world_run(tmp_path / "actor-run")
+    actor_proposal, actor_information = bind_proposal(
+        actor_run,
+        RequestConditionalDeferral,
+        "proposal-single-lock",
+        pump_id="pump-a",
+    )
+    physical_run = create_world_run(tmp_path / "physical-run")
+    physical_snapshot = physical_run.snapshot()
+    physical_request = PumpStationPhysicalTreatmentActivationRequest(
+        request_id="treatment-single-lock.activation",
+        schedule_request_id="treatment-single-lock",
+        run_id=physical_snapshot.run_id,
+        episode_id=physical_snapshot.episode_id,
+        world_branch_id=physical_snapshot.world_branch_id,
+        base_state_id=physical_snapshot.state_id,
+        base_commit_id=physical_snapshot.commit_id,
+        based_on_sequence=physical_snapshot.sequence,
+        parent_state_id=physical_snapshot.state_id,
+        treatment_class=PumpStationPhysicalTreatmentClass.RECURRENT_OBSTRUCTION,
+        treatment_version=PUMP_STATION_PHYSICAL_TREATMENT_VERSION,
+        affected_pump_ids=("pump-a",),
+        activation_calendar_seconds=physical_run.state.physical.calendar_seconds,
+        severity=PumpStationTreatmentSeverity.LOW,
+        random_stream_id="treatment-single-lock-stream",
+        random_seed=17,
+        visibility_policy=PUMP_STATION_PHYSICAL_TREATMENT_VISIBILITY,
+        decision_right_id=PUMP_STATION_PHYSICAL_TREATMENT_DECISION_RIGHT,
+    )
+    package = load_reference_package()
+    model = pump_station_model_from_package(package)
+    schedule = PumpStationSchedule(
+        access_available_after_seconds=86_400,
+        repair_kit_available_after_seconds=86_400,
+        decision_point_after_seconds=(3_600,),
+    )
+    evidence_run = PumpStationWorldRun.create(
+        repository=PumpStationWorldRunRepository(tmp_path / "evidence-run"),
+        package=package,
+        model=model,
+        initial_state=create_evidence_health_reference_state(
+            model,
+            schedule=schedule,
+        ),
+        run_id="run-single-lock-evidence",
+        episode_id="episode-single-lock-evidence",
+        world_branch_id="branch-single-lock-evidence",
+        record_versions=PUMP_STATION_RECORD_VERSIONS_V3,
+    )
+    evidence_snapshot = evidence_run.snapshot()
+    decision_point = min(
+        event.scheduled_seconds
+        for event in evidence_run.state.scheduled_events
+        if event.event_type.value == "decision_point"
+    )
+    evidence_request = PumpStationEvidenceTreatmentRequest(
+        request_id="treatment-single-lock-evidence",
+        run_id=evidence_snapshot.run_id,
+        episode_id=evidence_snapshot.episode_id,
+        world_branch_id=evidence_snapshot.world_branch_id,
+        base_state_id=evidence_snapshot.state_id,
+        base_commit_id=evidence_snapshot.commit_id,
+        based_on_sequence=evidence_snapshot.sequence,
+        treatment_class=PumpStationEvidenceTreatmentClass.CALIBRATION_LAPSE,
+        treatment_version=PUMP_STATION_EVIDENCE_TREATMENT_VERSION_V1,
+        target_source_id="station-condition-sensor",
+        effective_decision_point_seconds=decision_point,
+        visibility_policy=PUMP_STATION_EVIDENCE_VISIBILITY_POLICY_V1,
+    )
+    original_locked = PumpStationWorldRunRepository.locked
+    lock_depth = 0
+    lock_entries = 0
+
+    @contextmanager
+    def single_entry_lock(
+        repository: PumpStationWorldRunRepository,
+    ) -> Iterator[None]:
+        nonlocal lock_depth, lock_entries
+        if lock_depth:
+            raise AssertionError("combined transition entered the run lock twice")
+        lock_depth += 1
+        lock_entries += 1
+        try:
+            with original_locked(repository):
+                yield
+        finally:
+            lock_depth -= 1
+
+    monkeypatch.setattr(
+        PumpStationWorldRunRepository,
+        "locked",
+        single_entry_lock,
+    )
+
+    actor_run.apply(actor_proposal, information_set=actor_information)
+    evidence_run.schedule_evidence_treatment(evidence_request)
+    physical_run.apply_physical_treatment(physical_request)
+
+    assert lock_entries == 3
+    assert lock_depth == 0
+
+
+def test_concurrent_staged_publications_select_exactly_one_transition(
+    tmp_path: Path,
+) -> None:
+    run = create_world_run(tmp_path / "run")
+    first_proposal, first_information = bind_proposal(
+        run,
+        RequestConditionalDeferral,
+        "proposal-concurrent-first",
+        pump_id="pump-a",
+    )
+    second_proposal, second_information = bind_proposal(
+        run,
+        TransferDuty,
+        "proposal-concurrent-second",
+    )
+    staged = (
+        run.stage(first_proposal, information_set=first_information),
+        run.stage(second_proposal, information_set=second_information),
+    )
+    context = multiprocessing.get_context("spawn")
+    ready = (context.Event(), context.Event())
+    start = context.Event()
+    finished = (context.Event(), context.Event())
+    results = context.Queue()
+    processes = tuple(
+        context.Process(
+            target=_publish_staged_in_child,
+            args=(run.repository.root, item, ready[index], start, finished[index], results),
+        )
+        for index, item in enumerate(staged)
+    )
+
+    for process in processes:
+        process.start()
+    try:
+        assert all(signal.wait(5) for signal in ready)
+        start.set()
+        assert all(signal.wait(5) for signal in finished)
+        for process in processes:
+            _join_process(process)
+    finally:
+        start.set()
+        for process in processes:
+            if process.is_alive():
+                process.kill()
+                process.join()
+
+    outcomes = {results.get(timeout=5) for _ in processes}
+    assert {outcome[0] for outcome in outcomes} == {"error", "published"}
+    assert ("error", "stale-publication") in outcomes
+    selected = run.snapshot()
+    assert selected in tuple(item.snapshot for item in staged)
+    assert len(run.steps()) == 1
+
+
+def test_selected_staged_publication_retries_without_another_effect(
+    tmp_path: Path,
+) -> None:
+    run = create_world_run(tmp_path / "run")
+    proposal, information_set = bind_proposal(
+        run,
+        RequestConditionalDeferral,
+        "proposal-direct-retry",
+        pump_id="pump-a",
+    )
+    staged = run.stage(proposal, information_set=information_set)
+
+    first = run.repository.publish_staged_transition(staged)
+    repeated = run.repository.publish_staged_transition(staged)
+
+    assert repeated == first
+    assert run.snapshot() == staged.snapshot
+    assert len(run.repository.commits()) == 2
+    assert len(run.steps()) == 1
+
+
+def test_selected_staged_retry_rejects_a_mismatched_commit(tmp_path: Path) -> None:
+    run = create_world_run(tmp_path / "run")
+    first_proposal, information_set = bind_proposal(
+        run,
+        RequestConditionalDeferral,
+        "proposal-selected-retry",
+        pump_id="pump-a",
+    )
+    second_proposal, second_information = bind_proposal(
+        run,
+        TransferDuty,
+        "proposal-unselected-retry",
+    )
+    selected = run.stage(first_proposal, information_set=information_set)
+    unselected = run.stage(second_proposal, information_set=second_information)
+    run.repository.publish_staged_transition(selected)
+
+    with pytest.raises(PumpStationWorldRunError) as raised:
+        run.repository.publish_staged_transition(
+            replace(selected, commit=unselected.commit),
+        )
+
+    assert raised.value.code == "transition-integrity"
+    assert run.snapshot() == selected.snapshot
+    assert len(run.steps()) == 1
+
+
+def test_staged_publication_returns_the_durable_transition(tmp_path: Path) -> None:
+    run = create_world_run(tmp_path / "run")
+    selected_proposal, information_set = bind_proposal(
+        run,
+        RequestConditionalDeferral,
+        "proposal-durable-return",
+        pump_id="pump-a",
+    )
+    other_proposal, other_information = bind_proposal(
+        run,
+        TransferDuty,
+        "proposal-caller-transition",
+    )
+    selected = run.stage(selected_proposal, information_set=information_set)
+    other = run.stage(other_proposal, information_set=other_information)
+
+    returned = run.repository.publish_staged_transition(
+        replace(selected, transition=other.transition),
+    )
+
+    assert returned == selected.transition
+    assert run.snapshot() == selected.snapshot
+    assert run.steps()[0].transition == selected.transition
+
+
+def test_staged_publication_rejects_a_snapshot_that_differs_from_its_commit(
+    tmp_path: Path,
+) -> None:
+    run = create_world_run(tmp_path / "run")
+    proposal, information_set = bind_proposal(
+        run,
+        RequestConditionalDeferral,
+        "proposal-snapshot-integrity",
+        pump_id="pump-a",
+    )
+    staged = run.stage(proposal, information_set=information_set)
+    corrupted = replace(
+        staged,
+        snapshot=replace(
+            staged.snapshot,
+            state_id=staged.prior_snapshot.state_id,
+        ),
+    )
+
+    with pytest.raises(PumpStationWorldRunError) as raised:
+        run.repository.publish_staged_transition(corrupted)
+
+    assert raised.value.code == "transition-integrity"
+    assert run.snapshot() == staged.prior_snapshot
+    assert run.steps() == ()
+
+
+def test_staged_publication_rejects_a_missing_immutable_commit(tmp_path: Path) -> None:
+    run = create_world_run(tmp_path / "run")
+    proposal, information_set = bind_proposal(
+        run,
+        RequestConditionalDeferral,
+        "proposal-missing-commit",
+        pump_id="pump-a",
+    )
+    staged = run.stage(proposal, information_set=information_set)
+    (run.repository.root / "commits" / f"{staged.snapshot.commit_id}.json").unlink()
+
+    with pytest.raises(PumpStationWorldRunError) as raised:
+        run.repository.publish_staged_transition(staged)
+
+    assert raised.value.code == "artifact-integrity"
+    assert run.snapshot() == staged.prior_snapshot
+    assert run.steps() == ()
+
+
+def test_staged_publication_rejects_a_receipt_from_another_parent_state(
+    tmp_path: Path,
+) -> None:
+    run = create_world_run(tmp_path / "run")
+    proposal, information_set = bind_proposal(
+        run,
+        RequestConditionalDeferral,
+        "proposal-receipt-parent",
+        pump_id="pump-a",
+    )
+    staged = run.stage(proposal, information_set=information_set)
+    receipt = replace(
+        staged.transition.receipt,
+        pre_state_id="state-from-another-parent",
+    )
+    receipt_content_id = pump_station_artifact_id(receipt)
+    run.repository._publish_content("receipts", receipt_content_id, receipt)
+    commit = replace(
+        staged.commit,
+        receipt_content_id=receipt_content_id,
+    )
+    commit_id = pump_station_artifact_id(commit)
+    run.repository._publish_content("commits", commit_id, commit)
+    corrupted = replace(
+        staged,
+        snapshot=replace(staged.snapshot, commit_id=commit_id),
+        transition=replace(staged.transition, receipt=receipt),
+        commit=commit,
+    )
+
+    with pytest.raises(PumpStationWorldRunError) as raised:
+        run.repository.publish_staged_transition(corrupted)
+
+    assert raised.value.code == "transition-integrity"
+    assert run.snapshot() == staged.prior_snapshot
+    assert run.steps() == ()
+
+
+def test_staged_publication_rejects_an_actor_input_from_another_sequence(
+    tmp_path: Path,
+) -> None:
+    run = create_world_run(tmp_path / "run")
+    proposal, information_set = bind_proposal(
+        run,
+        RequestConditionalDeferral,
+        "proposal-actor-parent",
+        pump_id="pump-a",
+    )
+    prior = run.snapshot()
+    transition = apply_stewardship_proposal(
+        run.model,
+        run.state,
+        proposal,
+        information_set=information_set,
+    )
+    mismatched = replace(
+        proposal,
+        context=replace(
+            proposal.context,
+            based_on_sequence=prior.sequence + 9,
+        ),
+    )
+    staged = run.repository.stage_transition(
+        manifest=run.manifest,
+        prior_snapshot=prior,
+        proposal=mismatched,
+        information_set=information_set,
+        transition=transition,
+    )
+
+    with pytest.raises(PumpStationWorldRunError) as raised:
+        run.repository.publish_staged_transition(staged)
+
+    assert raised.value.code == "transition-integrity"
+    assert run.snapshot() == prior
+    assert run.steps() == ()
+
+
+def test_staged_publication_rejects_a_control_input_from_another_commit(
+    tmp_path: Path,
+) -> None:
+    run = create_world_run(tmp_path / "run")
+    prior = run.snapshot()
+    request = PumpStationPhysicalTreatmentActivationRequest(
+        request_id="treatment-parent-binding.activation",
+        schedule_request_id="treatment-parent-binding",
+        run_id=prior.run_id,
+        episode_id=prior.episode_id,
+        world_branch_id=prior.world_branch_id,
+        base_state_id=prior.state_id,
+        base_commit_id=prior.commit_id,
+        based_on_sequence=prior.sequence,
+        parent_state_id=prior.state_id,
+        treatment_class=PumpStationPhysicalTreatmentClass.RECURRENT_OBSTRUCTION,
+        treatment_version=PUMP_STATION_PHYSICAL_TREATMENT_VERSION,
+        affected_pump_ids=("pump-a",),
+        activation_calendar_seconds=run.state.physical.calendar_seconds,
+        severity=PumpStationTreatmentSeverity.LOW,
+        random_stream_id="treatment-parent-binding-stream",
+        random_seed=11,
+        visibility_policy=PUMP_STATION_PHYSICAL_TREATMENT_VISIBILITY,
+        decision_right_id=PUMP_STATION_PHYSICAL_TREATMENT_DECISION_RIGHT,
+    )
+    transition = apply_physical_treatment_activation(run.state, request)
+    staged = run.repository.stage_control_transition(
+        manifest=run.manifest,
+        prior_snapshot=prior,
+        control_request=request,
+        transition=transition,
+    )
+    mismatched = replace(
+        request,
+        base_commit_id="commit-from-another-parent",
+    )
+    request_content_id = pump_station_artifact_id(mismatched)
+    run.repository._publish_content(
+        "control-requests",
+        request_content_id,
+        mismatched,
+    )
+    commit = replace(
+        staged.commit,
+        proposal_content_id=request_content_id,
+    )
+    commit_id = pump_station_artifact_id(commit)
+    run.repository._publish_content("commits", commit_id, commit)
+    corrupted = replace(
+        staged,
+        snapshot=replace(staged.snapshot, commit_id=commit_id),
+        commit=commit,
+        control_request=mismatched,
+    )
+
+    with pytest.raises(PumpStationWorldRunError) as raised:
+        run.repository.publish_staged_transition(corrupted)
+
+    assert raised.value.code == "transition-integrity"
+    assert run.snapshot() == prior
+    assert run.steps() == ()
+
+
+@pytest.mark.parametrize(
+    "boundary",
+    ("current-before-replace", "current-after-replace"),
+)
+def test_direct_staged_publication_recovers_once_after_process_death(
+    tmp_path: Path,
+    boundary: str,
+) -> None:
+    run = create_world_run(tmp_path / "run")
+    proposal, information_set = bind_proposal(
+        run,
+        RequestConditionalDeferral,
+        "proposal-direct-crash",
+        pump_id="pump-a",
+    )
+    staged = run.stage(proposal, information_set=information_set)
+
+    _assert_expected_crash(
+        _crash_during_staged_publication,
+        run.repository.root,
+        boundary,
+        staged,
+    )
+    recovered = run.repository.publish_staged_transition(staged)
+    repeated = run.repository.publish_staged_transition(staged)
+
+    assert repeated == recovered == staged.transition
+    assert run.snapshot() == staged.snapshot
+    assert len(run.repository.commits()) == 2
+    assert len(run.steps()) == 1
 
 
 @pytest.mark.parametrize("boundary", _INITIALIZATION_BOUNDARIES)


### PR DESCRIPTION
## Summary

- make direct staged publication own the pump run lock
- preserve one continuous lock for actor and control transitions without nested flock entry
- validate durable parent, input, receipt, commit, snapshot, and transition identity before pointer selection
- use the same parent-extension rule for publication and replay

## Focused verification

- 49 publication and recovery tests
- 27 nearby repository, crash, control, physical-treatment, and byte-compatibility tests
- Ruff check and format check
- MyPy on both changed source files
- git diff check

## Scope

This is pump-specific pointer policy required before V4 uses the existing run repository. It does not move pointer, transaction, replay, or recovery policy into the shared continual-world layer.