### PR TITLE
ASW-8 Step 5: route V4 transitions through registered world run

### DIFF
--- a/docs/CONTINUAL_WORLD_RUNTIME.md
+++ b/docs/CONTINUAL_WORLD_RUNTIME.md
@@ -555,6 +555,67 @@ and hashes remain unchanged. The parallel coupled run remains only as a
 behaviour oracle until V4 transitions, replay, sessions, and verification have
 parity on the existing path.
 
+### 6.15 V4 transitions and replay on the existing pump run
+
+Step 5 moves the V4 actor actions and the three root host controls onto the
+existing pump commit chain. It does not add a second live pointer, a `HEAD`
+file, or a generation store. The selected state remains the commit named by
+`current.json`.
+
+| Path | Owner | Compatibility and migration rule |
+| --- | --- | --- |
+| `wastewater_pump_station/world_run.py` | Pump run coordinator | Accept the shared actor request or the pump-bound root-control request. Bind each change to the selected run, episode, branch, sequence, state, and commit. Evaluate it with the model pinned in the run manifest. |
+| `wastewater_pump_station/world_run_repository.py` | Pump durability adapter | Stage and select the V4 command, actor evidence when present, receipt, state, and commit under the existing run lock. Use the existing immutable stores, commit chain, and `current.json` pointer. |
+| `wastewater_pump_station/world_run_models.py` | Pump durable records | Add separate V4 command and commit-v2 records. Do not change the V1-V3 command, commit, state, receipt, or inventory bytes. |
+| `wastewater_pump_station/world_run_commands.py` | Pump command codec | Rebuild the shared actor request or typed root control from one strict command. Verify its content identity before selection and replay. |
+| `wastewater_pump_station/stewardship_state_machine.py` | Pump task semantics | Convert a validated actor action to a typed proposal before mutation. Apply the operations review, process outcome, and common boundary as typed root controls. |
+| `wastewater_pump_station/stewardship_verifier.py` | Pump replay verifier | Reload every selected V4 step and replay it from the registered opening state with the exact manifest-bound model. Compare the complete transition and final state. |
+
+An actor action uses `WorldActorActionRequest`. Its binding names the exact
+public view and information set for the selected commit. The run validates the
+task, run, episode, branch, sequence, state, commit, actor, and view identities
+before it applies the typed proposal. A root control uses
+`PumpStationBoundControlRequest`. This separate envelope binds the control to
+the same selected world identities without giving the actor access to the
+host-control surface. The repository reloads the stored manifest and rejects a
+caller manifest or command scope that differs from it. It also rebuilds the
+command input and checks its content identity before it can select a state.
+
+The V4 actor view identity covers every public view field. Staging and replay
+rebuild the complete view and information set from the parent state, manifest
+scope, actor tenure, and manifest-bound source artifacts. A command and a view
+cannot define their own matching but foreign episode, branch, or evidence
+scope.
+
+Request identity is global across the legacy and V4 pump transition records.
+An exact retry is found before the run checks whether the old base snapshot is
+still current. The retry is accepted only when its complete command and parent
+binding match the selected committed evidence. Reuse of the same request ID
+with changed action, control, arguments, authority, or parent identity is a
+conflict. Two real processes use the same run lock, so only one task effect can
+be selected. If a complete immutable commit exists after a process stops
+before pointer selection, an exact retry selects that stored transition. It
+does not evaluate a new outcome for the same command.
+
+Replay does not trust the live Python objects used during the first
+transition. It reloads the durable command, proposal and information set when
+present, receipt, state, and commit. It then rebuilds the transition from the
+registered opening state. The replay uses the coupled model named by the
+manifest. It does not load a default model that can drift from the run.
+Replay captures the selected steps and final pointer under one run lock, then
+performs the deterministic calculation after it releases the lock.
+
+The V4 backlog bindings on inspection, obstruction clearance, and verification
+do not enter V1-V3 storage. A legacy run rejects these fields before retry
+lookup or transition evaluation. Accepted legacy proposals keep their exact
+bytes and exact-retry meaning.
+
+This slice keeps the existing coupled run only as a behaviour oracle. It is
+not the live source of V4 state or selection. Session ownership and handover
+remain for Step 6. Child physical treatment and rollout branches remain for
+Step 7. Temporal search and fetch remain read-only evidence operations; they
+do not create world-transition commits.
+
 ## 7. Implementation sequence
 
 The correction uses small pull requests against the unmerged ASW-8 branch.

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/actor_interface.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/actor_interface.py
@@ -35,6 +35,7 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewards
 
 PUMP_STATION_ACTOR_INTERFACE_VERSION = "pump-station.actor.v1"
 PUMP_STATION_ACTOR_INTERFACE_VERSION_V2 = "pump-station.actor.v2"
+PUMP_STATION_ACTOR_WORKSPACE_TOOL_ID_V2 = "pump-station-actor-interface.v2"
 PUMP_STATION_ACTOR_ACTION_NAMES = (
     "continue_operation",
     "transfer_duty",
@@ -276,9 +277,11 @@ def pump_station_proposal_from_validated_arguments_v2(
             source_backlog_item_id=duty.source_backlog_item_id,
         )
     if action_name == "request_inspection":
+        inspection = cast(_BacklogPumpArguments, validated)
         return RequestInspection(
             context=context,
-            pump_id=cast(_BacklogPumpArguments, validated).pump_id,
+            pump_id=inspection.pump_id,
+            backlog_item_id=inspection.backlog_item_id,
         )
     if action_name == "request_obstruction_clearance":
         clearance = cast(_BacklogClearanceArguments, validated)
@@ -286,6 +289,7 @@ def pump_station_proposal_from_validated_arguments_v2(
             context=context,
             pump_id=clearance.pump_id,
             inspection_evidence_id=clearance.inspection_evidence_id,
+            backlog_item_id=clearance.backlog_item_id,
         )
     if action_name == "request_functional_check":
         functional = cast(_BacklogPumpArguments, validated)
@@ -307,9 +311,11 @@ def pump_station_proposal_from_validated_arguments_v2(
             work_order_id=cast(_WorkOrderArguments, validated).work_order_id,
         )
     if action_name == "request_post_maintenance_verification":
+        verification = cast(_BacklogPumpArguments, validated)
         return RequestVerification(
             context=context,
-            pump_id=cast(_BacklogPumpArguments, validated).pump_id,
+            pump_id=verification.pump_id,
+            backlog_item_id=verification.backlog_item_id,
         )
     if action_name == "resume_process":
         return ResumeProcess(

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/coupled_runtime.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/coupled_runtime.py
@@ -52,7 +52,6 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.physical
     PumpStationOperatingDelta,
     PumpStationOutageEpisode,
     PumpStationPumpAvailability,
-    PumpStationPumpBoundary,
     PumpStationPumpMode,
     PumpStationServiceRequirement,
 )
@@ -70,18 +69,38 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewards
     stewardship_content_id,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_models import (
+    PUMP_STATION_AUTHORITY_POLICY_VERSION_V4,
+    PUMP_STATION_COMMON_BOUNDARY_CONTROL_VERSION,
+    PUMP_STATION_OPERATIONS_REVIEW_VERSION,
+    PUMP_STATION_PROCESS_OUTCOME_VERSION,
+    PUMP_STATION_RECEIPT_VERSION_V4,
+    PUMP_STATION_STATE_VERSION_V4,
+    PUMP_STATION_TRANSITION_RULE_VERSION_V4,
     PumpStationAuthority,
+    PumpStationCommonBoundaryRequest,
     PumpStationEvidence,
     PumpStationEvidenceKind,
     PumpStationObligation,
     PumpStationObligationKind,
     PumpStationObligationStatus,
+    PumpStationOperationsBoundaryReviewRequest,
+    PumpStationProcessOutcomeRequest,
     PumpStationRestriction,
     PumpStationRestrictionKind,
     PumpStationRestrictionStatus,
     PumpStationStewardshipState,
+    PumpStationTransitionReceiptV4,
+    PumpStationTransitionV4,
     PumpStationWorkOrder,
     PumpStationWorkOrderStatus,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_views import (
+    PumpStationContinuityCarrier,
+    PumpStationCoupledActorView,
+    PumpStationCurrentContext,
+    PumpStationInformationSet,
+    PumpStationObservationHistory,
+    bind_information_set,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.time_presentation import (
     PUMP_STATION_TIME_ZONE,
@@ -92,18 +111,11 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_ru
     PUMP_STATION_WORLD_MANIFEST_VERSION_V2 as PUMP_STATION_WORLD_MANIFEST_VERSION_V2,
 )
 
-PUMP_STATION_STATE_VERSION_V4 = "pump-station-stewardship-state.v4"
 PUMP_STATION_SNAPSHOT_VERSION_V4 = "pump-station-state-snapshot.v4"
-PUMP_STATION_RECEIPT_VERSION_V4 = "pump-station-transition-receipt.v4"
-PUMP_STATION_AUTHORITY_POLICY_VERSION_V4 = "pump-station-authority-policy.v4"
-PUMP_STATION_TRANSITION_RULE_VERSION_V4 = "pump-station-transition-rules.v4"
 PUMP_STATION_ACTOR_PROJECTION_VERSION_V5 = "pump-station-current-state.v5"
 PUMP_STATION_ACTOR_VIEW_SCHEMA_V4 = "pump-station.actor-view.v4"
 PUMP_STATION_INFORMATION_BOUNDARY_V4 = "pump-station-actor-view.v4"
-PUMP_STATION_OPERATIONS_REVIEW_VERSION = "pump-station.operations-boundary-review.v1"
 PUMP_STATION_COUPLED_TREATMENT_VERSION = "pump-station.coupled-treatment.v1"
-PUMP_STATION_PROCESS_OUTCOME_VERSION = "pump-station.process-outcome.v1"
-PUMP_STATION_COMMON_BOUNDARY_CONTROL_VERSION = "pump-station.common-boundary-control.v1"
 if TYPE_CHECKING:
     type PumpStationCoupledWorldState = PumpStationStewardshipState[
         PumpStationCoupledPhysicalState,
@@ -130,58 +142,6 @@ def _fail(code: str, detail: str) -> NoReturn:
 
 
 @dataclass(frozen=True, slots=True)
-class PumpStationCoupledTransitionReceipt:
-    """Complete v4 receipt for one actor action or host-control transition."""
-
-    receipt_version: str
-    sequence: int
-    transition_id: str
-    request_id: str
-    action_or_control_kind: str
-    actor_action: bool
-    authority_outcome: str
-    required_authorities: tuple[str, ...]
-    authority_decision_detail: str
-    permit_ids: tuple[str, ...]
-    execution_status: str
-    before_state_id: str
-    after_state_id: str
-    start_calendar_seconds: int
-    end_calendar_seconds: int
-    target_id: str | None
-    backlog_item_id: str | None
-    reason: str
-    changed_record_ids: tuple[str, ...]
-    changed_pool_ids: tuple[str, ...]
-    changed_reservation_ids: tuple[str, ...]
-    changed_backlog_item_ids: tuple[str, ...]
-    generation_record_ids: tuple[str, ...]
-    changed_liability_owner_ids: tuple[str, ...]
-    operating_interval_id: str | None
-
-
-@dataclass(frozen=True, slots=True)
-class PumpStationOperationsBoundaryReviewRequest:
-    """Host-only content-addressed review that can release one v4 pump boundary."""
-
-    version: str
-    review_id: str
-    review_kind: str
-    pump_id: str
-    restriction_or_isolation_permit_id: str
-    accepted_evidence_id: str
-    requested_outcome: str
-    base_state_id: str
-    operations_authority_id: str
-    reason: str
-
-    @property
-    def content_id(self) -> str:
-        """Return the exact review-input identity."""
-        return stewardship_content_id(self, record_profile="v4")
-
-
-@dataclass(frozen=True, slots=True)
 class PumpStationCoupledTreatmentRequest:
     """Host-private common-cause treatment for one isolated v4 child."""
 
@@ -200,87 +160,8 @@ class PumpStationCoupledTreatmentRequest:
         return stewardship_content_id(self, record_profile="v4")
 
 
-@dataclass(frozen=True, slots=True)
-class PumpStationProcessOutcomeRequest:
-    """Host-owned evidence for one failed active v4 process attempt."""
-
-    version: str
-    request_id: str
-    authority_id: str
-    process_id: str
-    outcome: str
-    evidence_id: str
-    base_state_id: str
-
-    @property
-    def content_id(self) -> str:
-        """Return the exact process-outcome input identity."""
-        return stewardship_content_id(self, record_profile="v4")
-
-
-@dataclass(frozen=True, slots=True)
-class PumpStationCommonBoundaryRequest:
-    """Host-owned change to one declared station-wide operating boundary."""
-
-    version: str
-    request_id: str
-    authority_id: str
-    boundary_kind: str
-    available: bool
-    base_state_id: str
-
-    @property
-    def content_id(self) -> str:
-        """Return the exact common-boundary input identity."""
-        return stewardship_content_id(self, record_profile="v4")
-
-
-@dataclass(frozen=True, slots=True)
-class PumpStationCoupledActorView:
-    """Projection v5 with planning data and no latent condition."""
-
-    projection_policy_id: str
-    observation_schema_id: str
-    information_boundary_id: str
-    state_id: str
-    sequence: int
-    time_zone: str
-    current_datetime: str
-    calendar_seconds: int
-    service_schedule: tuple[PumpStationServiceRequirement, ...]
-    disclosed_through_calendar_seconds: int
-    service_schedule_disclosed_through_datetime: str
-    resource_schedule_disclosed_through_datetime: str
-    service_schedule_local: tuple[tuple[str, str, int], ...]
-    resource_availability_local: tuple[tuple[str, tuple[tuple[str, str], ...]], ...]
-    assignment_pump_ids: tuple[str, ...]
-    service_running_pump_ids: tuple[str, ...]
-    test_running_pump_ids: tuple[str, ...]
-    required_service_scu: int
-    available_assured_scu: int
-    assigned_operating_scu: int
-    served_scu: int
-    unserved_scu: int
-    surplus_scu: int
-    pump_clocks: tuple[tuple[str, int, int], ...]
-    pump_runtime_display: tuple[tuple[str, str], ...]
-    pump_boundaries: tuple[PumpStationPumpBoundary, ...]
-    pump_availability: tuple[PumpStationPumpAvailability, ...]
-    resource_quantities: tuple[tuple[str, int, int], ...]
-    ranked_backlog: tuple[PumpStationBacklogItem, ...]
-    processes: tuple[PumpStationCoupledProcess, ...]
-    active_restriction_ids: tuple[str, ...]
-    active_liability_ids: tuple[str, ...]
-    accepted_evidence_ids: tuple[str, ...]
-    evidence_health: tuple[tuple[str, str, str, bool], ...]
-
-
-@dataclass(frozen=True, slots=True)
-class PumpStationCoupledTransition:
-    """One applied transition with immutable before, after, and receipt evidence."""
-
-    state: PumpStationCoupledWorldState
-    receipt: PumpStationCoupledTransitionReceipt
+PumpStationCoupledTransitionReceipt = PumpStationTransitionReceiptV4
+PumpStationCoupledTransition = PumpStationTransitionV4
 
 
 def _opening_backlog() -> tuple[PumpStationBacklogItem, PumpStationBacklogItem]:
@@ -1001,6 +882,7 @@ def _runtime_boundary_effect_ids(
 
 
 def _advance_physical(
+    model: PumpStationCoupledModel,
     state: PumpStationCoupledWorldState,
     end_seconds: int,
     transition_id: str,
@@ -1045,7 +927,7 @@ def _advance_physical(
             tuple(deltas),
         ),
     )
-    result = advance_coupled_pump_station(_model(), state.physical, interval)
+    result = advance_coupled_pump_station(model, state.physical, interval)
     collateral = list(state.collateral_runtime)
     for delta in result.operating_interval.pump_deltas:
         if delta.attributed_outage_episode_id is None:
@@ -1431,13 +1313,16 @@ def _finish_transition(
     reason: str,
     changed_record_ids: tuple[str, ...],
     operating_interval_id: str | None = None,
+    authority_requirements: tuple[str, ...] | None = None,
 ) -> PumpStationCoupledTransition:
     sequenced = replace(after, sequence=before.sequence + 1)
     transition_id = f"transition-{sequenced.sequence}-{request_id}"
-    required_authorities = _required_authorities(action_kind)
+    required_authorities = authority_requirements or _required_authorities(action_kind)
     permit_ids = (f"controlled-test-permit-{request_id}",) if action_kind == "request_functional_check" else ()
     receipt = PumpStationCoupledTransitionReceipt(
         receipt_version=PUMP_STATION_RECEIPT_VERSION_V4,
+        authority_policy_version=PUMP_STATION_AUTHORITY_POLICY_VERSION_V4,
+        transition_rule_version=PUMP_STATION_TRANSITION_RULE_VERSION_V4,
         sequence=sequenced.sequence,
         transition_id=transition_id,
         request_id=request_id,
@@ -1513,6 +1398,7 @@ def _required_authorities(action_kind: str) -> tuple[str, ...]:
 
 
 def _continue_operation(
+    model: PumpStationCoupledModel,
     state: PumpStationCoupledWorldState,
     *,
     request_id: str,
@@ -1520,7 +1406,7 @@ def _continue_operation(
 ) -> PumpStationCoupledTransition:
     event_time = _next_event_time(state)
     transition_id = f"transition-{state.sequence + 1}-{request_id}"
-    advanced = _advance_physical(state, event_time, transition_id)
+    advanced = _advance_physical(model, state, event_time, transition_id)
     interval = advanced.operating_intervals[-1]
     updated = _apply_event_effects(
         advanced,
@@ -1547,6 +1433,7 @@ def apply_coupled_actor_action(
     request_id: str,
     action_name: str,
     arguments: dict[str, Any],
+    model: PumpStationCoupledModel | None = None,
 ) -> PumpStationCoupledTransition:
     """Apply one exact actor-interface-v2 action without accepting private overrides."""
     reason_value = arguments.get("reason")
@@ -1554,7 +1441,12 @@ def apply_coupled_actor_action(
         _fail("actor-action-arguments", "a non-empty natural-language reason is required")
     reason = reason_value.strip()
     if action_name == "continue_operation":
-        return _continue_operation(state, request_id=request_id, reason=reason)
+        return _continue_operation(
+            model or _model(),
+            state,
+            request_id=request_id,
+            reason=reason,
+        )
     if action_name in {"search_evidence", "fetch_evidence"}:
         _fail("temporal-action-route", "search and fetch use the verified temporal gateway")
 
@@ -2268,6 +2160,7 @@ def apply_process_outcome(
         backlog_item_id=process.backlog_item_id,
         reason="Record the authority-owned failed process evidence.",
         changed_record_ids=tuple(changed),
+        authority_requirements=(("maintenance",) if process.kind == "functional_check" else ("verification",)),
     )
 
 
@@ -2380,7 +2273,15 @@ def _project_pump_availability(
     )
 
 
-def project_coupled_actor_view(state: PumpStationCoupledWorldState) -> PumpStationCoupledActorView:
+def project_coupled_actor_view(
+    state: PumpStationCoupledWorldState,
+    *,
+    episode_id: str = "oracle-episode",
+    world_branch_id: str = "oracle-branch",
+    actor_id: str = "reference-controller",
+    agent_tenure_id: str = "reference-controller",
+    source_artifact_ids: tuple[str, ...] = (),
+) -> PumpStationCoupledActorView:
     """Project current v5 planning state without latent conditions or private events."""
     quantities: list[tuple[str, int, int]] = []
     for pool in state.resources.pools:
@@ -2399,7 +2300,13 @@ def project_coupled_actor_view(state: PumpStationCoupledWorldState) -> PumpStati
     )
     assigned_operating_scu = len(state.physical.service_running_pump_ids)
     served_scu = min(required_service_scu, assigned_operating_scu)
-    return PumpStationCoupledActorView(
+    view = PumpStationCoupledActorView(
+        view_id="pending",
+        episode_id=episode_id,
+        world_branch_id=world_branch_id,
+        actor_id=actor_id,
+        agent_tenure_id=agent_tenure_id,
+        source_artifact_ids=source_artifact_ids,
         projection_policy_id=PUMP_STATION_ACTOR_PROJECTION_VERSION_V5,
         observation_schema_id=PUMP_STATION_ACTOR_VIEW_SCHEMA_V4,
         information_boundary_id=PUMP_STATION_INFORMATION_BOUNDARY_V4,
@@ -2484,5 +2391,40 @@ def project_coupled_actor_view(state: PumpStationCoupledWorldState) -> PumpStati
             )
             for item in state.evidence
             if item.health is not None
+        ),
+    )
+    return view
+
+
+def project_coupled_information_set(
+    state: PumpStationCoupledWorldState,
+    *,
+    episode_id: str,
+    world_branch_id: str,
+    actor_id: str,
+    agent_tenure_id: str,
+    source_artifact_ids: tuple[str, ...],
+    workspace_tool_ids: tuple[str, ...],
+) -> PumpStationInformationSet:
+    """Project the complete V4 actor view and its exact visible context."""
+    view = project_coupled_actor_view(
+        state,
+        episode_id=episode_id,
+        world_branch_id=world_branch_id,
+        actor_id=actor_id,
+        agent_tenure_id=agent_tenure_id,
+        source_artifact_ids=source_artifact_ids,
+    )
+    return bind_information_set(
+        view,
+        PumpStationObservationHistory(
+            agent_tenure_id=agent_tenure_id,
+            view_ids=(view.view_id,),
+        ),
+        PumpStationCurrentContext(
+            continuity_carrier=PumpStationContinuityCarrier.CURRENT_ACTOR_VIEW,
+            conversation_prefix_id=None,
+            workspace_tool_ids=workspace_tool_ids,
+            visible_material_ids=source_artifact_ids,
         ),
     )

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/stewardship_identity.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/stewardship_identity.py
@@ -69,6 +69,9 @@ _V4_FIELD_EXCLUSIONS = {
         "pending_start_pump_ids",
         "event_effect_ids",
     },
+    "RequestInspection": {"backlog_item_id"},
+    "RequestObstructionClearance": {"backlog_item_id"},
+    "RequestVerification": {"backlog_item_id"},
 }
 
 
@@ -83,6 +86,14 @@ def _field_exclusions(type_name: str, profile: str) -> set[str]:
 
 def _record_profile(value: object) -> str:
     type_name = type(value).__name__
+    if type_name in {
+        "PumpStationCommandV4",
+        "PumpStationTransitionReceiptV4",
+        "PumpStationTransitionV4",
+        "PumpStationWorldRunCommitV2",
+        "PumpStationStagedTransitionV4",
+    }:
+        return "v4"
     if type_name in {"PumpStationStewardshipState", "PumpStationCurrentStateView"}:
         version = str(getattr(value, "state_version", ""))
         if version.endswith(".v4"):
@@ -92,6 +103,8 @@ def _record_profile(value: object) -> str:
         return "v2" if version.endswith(".v2") else "v1"
     if type_name == "PumpStationActorView":
         return _record_profile(cast(Any, value).current_state)
+    if type_name == "PumpStationCoupledActorView":
+        return "v4"
     if type_name == "PumpStationStructuredHandover":
         return _record_profile(cast(Any, value).current_actor_view)
     if type_name == "PumpStationInformationSet":

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/stewardship_models.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/stewardship_models.py
@@ -50,6 +50,10 @@ PUMP_STATION_TRANSITION_RULE_VERSION_V1 = "pump-station-transition-rules.v1"
 PUMP_STATION_TRANSITION_RULE_VERSION_V2 = "pump-station-transition-rules.v2"
 PUMP_STATION_TRANSITION_RULE_VERSION_V3 = "pump-station-transition-rules.v3"
 PUMP_STATION_TRANSITION_RULE_VERSION_V4 = "pump-station-transition-rules.v4"
+PUMP_STATION_OPERATIONS_REVIEW_VERSION = "pump-station.operations-boundary-review.v1"
+PUMP_STATION_PROCESS_OUTCOME_VERSION = "pump-station.process-outcome.v1"
+PUMP_STATION_COMMON_BOUNDARY_CONTROL_VERSION = "pump-station.common-boundary-control.v1"
+PUMP_STATION_BOUND_CONTROL_VERSION = "pump-station.bound-control.v1"
 
 PUMP_STATION_RECEIPT_VERSION = PUMP_STATION_RECEIPT_VERSION_V1
 PUMP_STATION_AUTHORITY_POLICY_VERSION = PUMP_STATION_AUTHORITY_POLICY_VERSION_V1
@@ -305,9 +309,12 @@ class RequestInspection:
 
     context: ProposalContext
     pump_id: str
+    backlog_item_id: str | None = None
 
     def __post_init__(self) -> None:
         _require_text(self.pump_id, "pump_id")
+        if self.backlog_item_id is not None:
+            _require_text(self.backlog_item_id, "backlog_item_id")
 
 
 @dataclass(frozen=True, slots=True)
@@ -339,10 +346,13 @@ class RequestObstructionClearance:
     context: ProposalContext
     pump_id: str
     inspection_evidence_id: str
+    backlog_item_id: str | None = None
 
     def __post_init__(self) -> None:
         _require_text(self.pump_id, "pump_id")
         _require_text(self.inspection_evidence_id, "inspection_evidence_id")
+        if self.backlog_item_id is not None:
+            _require_text(self.backlog_item_id, "backlog_item_id")
 
 
 @dataclass(frozen=True, slots=True)
@@ -394,9 +404,12 @@ class RequestVerification:
 
     context: ProposalContext
     pump_id: str
+    backlog_item_id: str | None = None
 
     def __post_init__(self) -> None:
         _require_text(self.pump_id, "pump_id")
+        if self.backlog_item_id is not None:
+            _require_text(self.backlog_item_id, "backlog_item_id")
 
 
 @dataclass(frozen=True, slots=True)
@@ -969,6 +982,194 @@ type PumpStationCoupledStewardshipState = PumpStationStewardshipState[
     PumpStationPoolReservation,
 ]
 type PumpStationStewardshipStateRecord = PumpStationLegacyStewardshipState | PumpStationCoupledStewardshipState
+
+
+@dataclass(frozen=True, slots=True)
+class PumpStationOperationsBoundaryReviewRequest:
+    """Host-only review that can release one exact V4 pump boundary."""
+
+    version: str
+    review_id: str
+    review_kind: str
+    pump_id: str
+    restriction_or_isolation_permit_id: str
+    accepted_evidence_id: str
+    requested_outcome: str
+    base_state_id: str
+    operations_authority_id: str
+    reason: str
+
+    @property
+    def content_id(self) -> str:
+        """Return the exact task-semantic review identity."""
+        from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_identity import (
+            stewardship_content_id,
+        )
+
+        return stewardship_content_id(self, record_profile="v4")
+
+
+@dataclass(frozen=True, slots=True)
+class PumpStationProcessOutcomeRequest:
+    """Host-owned evidence for one failed active V4 process attempt."""
+
+    version: str
+    request_id: str
+    authority_id: str
+    process_id: str
+    outcome: str
+    evidence_id: str
+    base_state_id: str
+
+    @property
+    def content_id(self) -> str:
+        """Return the exact task-semantic process-outcome identity."""
+        from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_identity import (
+            stewardship_content_id,
+        )
+
+        return stewardship_content_id(self, record_profile="v4")
+
+
+@dataclass(frozen=True, slots=True)
+class PumpStationCommonBoundaryRequest:
+    """Host-owned change to one declared station-wide operating boundary."""
+
+    version: str
+    request_id: str
+    authority_id: str
+    boundary_kind: str
+    available: bool
+    base_state_id: str
+
+    @property
+    def content_id(self) -> str:
+        """Return the exact task-semantic common-boundary identity."""
+        from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_identity import (
+            stewardship_content_id,
+        )
+
+        return stewardship_content_id(self, record_profile="v4")
+
+
+type PumpStationRootControl = (
+    PumpStationOperationsBoundaryReviewRequest | PumpStationProcessOutcomeRequest | PumpStationCommonBoundaryRequest
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PumpStationBoundControlRequest:
+    """One root host control bound to an exact durable V4 parent snapshot."""
+
+    control_envelope_version: str
+    request_id: str
+    run_id: str
+    episode_id: str
+    world_branch_id: str
+    base_state_id: str
+    base_commit_id: str
+    based_on_sequence: int
+    control: PumpStationRootControl
+
+    def __post_init__(self) -> None:
+        if self.control_envelope_version != PUMP_STATION_BOUND_CONTROL_VERSION:
+            _fail("control-envelope-version", self.control_envelope_version)
+        for field_name in (
+            "request_id",
+            "run_id",
+            "episode_id",
+            "world_branch_id",
+            "base_state_id",
+            "base_commit_id",
+        ):
+            _require_text(cast(str, getattr(self, field_name)), field_name)
+        if self.based_on_sequence < 0:
+            _fail("control-envelope-shape", "based_on_sequence must be non-negative")
+        inner_request_id = (
+            self.control.review_id
+            if isinstance(self.control, PumpStationOperationsBoundaryReviewRequest)
+            else self.control.request_id
+        )
+        if self.request_id != inner_request_id:
+            _fail("control-envelope-shape", "outer and inner request identities differ")
+        if self.base_state_id != self.control.base_state_id:
+            _fail("control-envelope-shape", "outer and inner state bindings differ")
+
+    @property
+    def authority_id(self) -> str:
+        """Return the task authority carried by the semantic control."""
+        if isinstance(self.control, PumpStationOperationsBoundaryReviewRequest):
+            return self.control.operations_authority_id
+        return self.control.authority_id
+
+
+@dataclass(frozen=True, slots=True)
+class PumpStationTransitionReceiptV4:
+    """Complete V4 receipt for one actor action or host-control transition."""
+
+    receipt_version: str
+    authority_policy_version: str
+    transition_rule_version: str
+    sequence: int
+    transition_id: str
+    request_id: str
+    action_or_control_kind: str
+    actor_action: bool
+    authority_outcome: str
+    required_authorities: tuple[str, ...]
+    authority_decision_detail: str
+    permit_ids: tuple[str, ...]
+    execution_status: str
+    before_state_id: str
+    after_state_id: str
+    start_calendar_seconds: int
+    end_calendar_seconds: int
+    target_id: str | None
+    backlog_item_id: str | None
+    reason: str
+    changed_record_ids: tuple[str, ...]
+    changed_pool_ids: tuple[str, ...]
+    changed_reservation_ids: tuple[str, ...]
+    changed_backlog_item_ids: tuple[str, ...]
+    generation_record_ids: tuple[str, ...]
+    changed_liability_owner_ids: tuple[str, ...]
+    operating_interval_id: str | None
+
+    def __post_init__(self) -> None:
+        if self.receipt_version != PUMP_STATION_RECEIPT_VERSION_V4:
+            _fail("receipt-version", self.receipt_version)
+        if self.authority_policy_version != PUMP_STATION_AUTHORITY_POLICY_VERSION_V4:
+            _fail("authority-policy-version", self.authority_policy_version)
+        if self.transition_rule_version != PUMP_STATION_TRANSITION_RULE_VERSION_V4:
+            _fail("transition-rule-version", self.transition_rule_version)
+        if self.sequence < 1:
+            _fail("receipt-shape", "V4 receipt sequence must be positive")
+        if self.start_calendar_seconds < 0 or self.end_calendar_seconds < self.start_calendar_seconds:
+            _fail("receipt-shape", "V4 receipt time range is invalid")
+        for field_name in (
+            "transition_id",
+            "request_id",
+            "action_or_control_kind",
+            "authority_outcome",
+            "authority_decision_detail",
+            "execution_status",
+            "before_state_id",
+            "after_state_id",
+            "reason",
+        ):
+            _require_text(cast(str, getattr(self, field_name)), field_name)
+
+
+@dataclass(frozen=True, slots=True)
+class PumpStationTransitionV4:
+    """One complete V4 state transition and its exact durable receipt."""
+
+    state: PumpStationCoupledStewardshipState
+    receipt: PumpStationTransitionReceiptV4
+
+    def __post_init__(self) -> None:
+        if self.state.sequence != self.receipt.sequence or self.state.state_id != self.receipt.after_state_id:
+            _fail("transition-integrity", "V4 state and receipt differ")
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/stewardship_state_machine.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/stewardship_state_machine.py
@@ -25,6 +25,7 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.physical
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.physical_models import (
     OperatingInterval,
     PumpStationChangeKind,
+    PumpStationCoupledModel,
     PumpStationEnvironment,
     PumpStationModel,
     PumpStationState,
@@ -81,6 +82,8 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewards
     PumpStationAuthority,
     PumpStationAuthorityDecision,
     PumpStationAuthorityOutcome,
+    PumpStationCommonBoundaryRequest,
+    PumpStationCoupledStewardshipState,
     PumpStationEventType,
     PumpStationEvidence,
     PumpStationEvidenceKind,
@@ -88,25 +91,32 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewards
     PumpStationObligation,
     PumpStationObligationKind,
     PumpStationObligationStatus,
+    PumpStationOperationsBoundaryReviewRequest,
     PumpStationPendingEvidence,
     PumpStationProcess,
     PumpStationProcessKind,
+    PumpStationProcessOutcomeRequest,
     PumpStationProcessStatus,
+    PumpStationProposal,
     PumpStationProposalError,
     PumpStationRestriction,
     PumpStationRestrictionKind,
     PumpStationRestrictionStatus,
+    PumpStationRootControl,
     PumpStationSchedule,
     PumpStationScheduledEvent,
     PumpStationStewardshipState,
     PumpStationTransition,
     PumpStationTransitionReceipt,
+    PumpStationTransitionV4,
     PumpStationWorkOrder,
     PumpStationWorkOrderStatus,
     PumpStationWorkResources,
     RequestConditionalDeferral,
     RequestConditionCheck,
     RequestDependencyWaiver,
+    RequestDutyAssignment,
+    RequestFunctionalCheck,
     RequestInspection,
     RequestObstructionClearance,
     RequestProvisionalClosure,
@@ -131,7 +141,10 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewards
     work_order_for_pump as _work_order_for_pump,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_views import (
+    PumpStationCoupledActorView,
     PumpStationInformationSet,
+    bind_information_set,
+    coupled_actor_view_id,
     proposal_binding_error,
 )
 
@@ -1450,6 +1463,181 @@ def apply_stewardship_proposal(
         state,
         typed_proposal,
         authority,
+    )
+
+
+def apply_stewardship_proposal_v4(
+    model: PumpStationCoupledModel,
+    state: PumpStationCoupledStewardshipState,
+    proposal: object,
+    *,
+    information_set: PumpStationInformationSet,
+) -> PumpStationTransitionV4:
+    """Apply one typed V4 proposal through the task-owned transition rules."""
+    view = information_set.base_view
+    context = getattr(proposal, "context", None)
+    if not isinstance(view, PumpStationCoupledActorView) or context is None:
+        raise PumpStationProposalError(
+            "proposal-type",
+            "V4 proposal requires a V4 actor view and typed context",
+        )
+    if view.view_id != coupled_actor_view_id(view):
+        raise PumpStationProposalError(
+            "proposal-binding",
+            "V4 actor view identity differs from its complete content",
+        )
+    if (
+        bind_information_set(
+            view,
+            information_set.observation_history,
+            information_set.current_context,
+        )
+        != information_set
+    ):
+        raise PumpStationProposalError(
+            "proposal-binding",
+            "V4 information set identity differs from its content",
+        )
+    expected = (
+        context.agent_tenure_id,
+        context.based_on_sequence,
+        context.base_view_id,
+        context.information_set_id,
+    )
+    observed = (
+        view.agent_tenure_id,
+        state.sequence,
+        view.view_id,
+        information_set.information_set_id,
+    )
+    if expected != observed or view.state_id != state.state_id or view.sequence != state.sequence:
+        raise PumpStationProposalError(
+            "proposal-binding",
+            "V4 proposal does not bind the selected state and information set",
+        )
+    action_name, arguments = _v4_proposal_arguments(proposal)
+    from aec_bench.task_world_templates.stewardship.wastewater_pump_station.coupled_runtime import (
+        apply_coupled_actor_action,
+    )
+
+    return apply_coupled_actor_action(
+        state,
+        request_id=context.proposal_id,
+        action_name=action_name,
+        arguments={"reason": context.reason, **arguments},
+        model=model,
+    )
+
+
+def validate_legacy_proposal_profile(proposal: PumpStationProposal) -> None:
+    """Reject V4-only proposal bindings before legacy serialization can lose them."""
+    if (
+        isinstance(
+            proposal,
+            RequestInspection | RequestObstructionClearance | RequestVerification,
+        )
+        and proposal.backlog_item_id is not None
+    ):
+        raise PumpStationProposalError(
+            "proposal-profile",
+            "V4 backlog binding cannot enter a V1-V3 proposal record",
+        )
+
+
+def _v4_proposal_arguments(proposal: object) -> tuple[str, dict[str, object]]:
+    """Return the closed V2 actor operation and exact typed proposal fields."""
+    if isinstance(proposal, ContinueOperation):
+        return "continue_operation", {}
+    if isinstance(proposal, RequestDutyAssignment):
+        return (
+            "request_duty_assignment",
+            {
+                "ordered_pump_ids": proposal.ordered_pump_ids,
+                "source_outage_id": proposal.source_outage_id,
+                "source_backlog_item_id": proposal.source_backlog_item_id,
+            },
+        )
+    if isinstance(proposal, RequestInspection):
+        if proposal.backlog_item_id is None:
+            raise PumpStationProposalError("proposal-binding", "inspection lacks backlog binding")
+        return (
+            "request_inspection",
+            {"pump_id": proposal.pump_id, "backlog_item_id": proposal.backlog_item_id},
+        )
+    if isinstance(proposal, RequestObstructionClearance):
+        if proposal.backlog_item_id is None:
+            raise PumpStationProposalError("proposal-binding", "clearance lacks backlog binding")
+        return (
+            "request_obstruction_clearance",
+            {
+                "pump_id": proposal.pump_id,
+                "backlog_item_id": proposal.backlog_item_id,
+                "inspection_evidence_id": proposal.inspection_evidence_id,
+            },
+        )
+    if isinstance(proposal, RequestFunctionalCheck):
+        return (
+            "request_functional_check",
+            {"pump_id": proposal.pump_id, "backlog_item_id": proposal.backlog_item_id},
+        )
+    if isinstance(proposal, RequestProvisionalReturn):
+        return (
+            "request_provisional_return",
+            {
+                "pump_id": proposal.pump_id,
+                "functional_check_evidence_id": proposal.functional_check_evidence_id,
+            },
+        )
+    if isinstance(proposal, RequestProvisionalClosure):
+        return "request_provisional_closure", {"work_order_id": proposal.work_order_id}
+    if isinstance(proposal, RequestVerification):
+        if proposal.backlog_item_id is None:
+            raise PumpStationProposalError("proposal-binding", "verification lacks backlog binding")
+        return (
+            "request_post_maintenance_verification",
+            {"pump_id": proposal.pump_id, "backlog_item_id": proposal.backlog_item_id},
+        )
+    if isinstance(proposal, ResumeProcess):
+        return "resume_process", {"process_id": proposal.process_id}
+    if isinstance(proposal, CancelProcess):
+        return "cancel_process", {"process_id": proposal.process_id}
+    if isinstance(proposal, RequestConditionCheck):
+        return "request_condition_check", {"pump_id": proposal.pump_id}
+    if isinstance(proposal, RequestDependencyWaiver):
+        return (
+            "request_dependency_waiver",
+            {
+                "process_id": proposal.process_id,
+                "dependency_id": proposal.dependency_id,
+                "evidence_id": proposal.evidence_id,
+            },
+        )
+    raise PumpStationProposalError(
+        "proposal-type",
+        f"unsupported V4 proposal type {type(proposal).__name__}",
+    )
+
+
+def apply_stewardship_control_v4(
+    state: PumpStationCoupledStewardshipState,
+    control: PumpStationRootControl,
+) -> PumpStationTransitionV4:
+    """Apply one closed root host control through the task-owned V4 rules."""
+    from aec_bench.task_world_templates.stewardship.wastewater_pump_station.coupled_runtime import (
+        apply_common_boundary_control,
+        apply_operations_boundary_review,
+        apply_process_outcome,
+    )
+
+    if isinstance(control, PumpStationOperationsBoundaryReviewRequest):
+        return apply_operations_boundary_review(state, control)
+    if isinstance(control, PumpStationProcessOutcomeRequest):
+        return apply_process_outcome(state, control)
+    if isinstance(control, PumpStationCommonBoundaryRequest):
+        return apply_common_boundary_control(state, control)
+    raise PumpStationProposalError(
+        "control-type",
+        f"unsupported V4 control type {type(control).__name__}",
     )
 
 

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/stewardship_verifier.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/stewardship_verifier.py
@@ -4,11 +4,25 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import cast
 
+from aec_bench.contracts.world_interface import (
+    WorldActorActionRequest,
+    WorldInterfaceError,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.actor_interface import (
+    PUMP_STATION_ACTOR_WORKSPACE_TOOL_ID_V2,
+    pump_station_proposal_from_validated_arguments_v2,
+    validate_pump_station_actor_arguments_v2,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.coupled_runtime import (
+    project_coupled_information_set,
+)
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.evidence_health import (
     PumpStationEvidenceTreatmentRequest,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.physical_models import (
+    PumpStationCoupledModel,
     PumpStationModel,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.physical_treatments import (
@@ -18,26 +32,36 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewards
     stewardship_state_id,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_models import (
+    ProposalContext,
+    PumpStationCoupledStewardshipState,
     PumpStationObligationStatus,
     PumpStationProposal,
     PumpStationProposalError,
     PumpStationRestrictionStatus,
     PumpStationStewardshipState,
     PumpStationTransition,
+    PumpStationTransitionV4,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_state_machine import (
     apply_evidence_treatment_schedule,
     apply_physical_treatment_activation,
+    apply_stewardship_control_v4,
     apply_stewardship_proposal,
+    apply_stewardship_proposal_v4,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_views import (
     PumpStationInformationSet,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_commands import (
+    decode_pump_station_v4_command,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_models import (
     PUMP_STATION_RECORD_VERSIONS_V1,
     PUMP_STATION_RECORD_VERSIONS_V2,
     PUMP_STATION_RECORD_VERSIONS_V3,
+    PumpStationCommandV4,
     PumpStationRecordVersions,
+    PumpStationWorldRunError,
 )
 
 
@@ -69,6 +93,31 @@ class PumpStationVerificationReport:
     final_state_id: str
     active_restriction_ids: tuple[str, ...]
     open_obligation_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class PumpStationRunStepV4:
+    """One recorded V4 command and its complete replay evidence."""
+
+    command: PumpStationCommandV4
+    proposal: PumpStationProposal | None
+    information_set: PumpStationInformationSet | None
+    transition: PumpStationTransitionV4
+
+    def __post_init__(self) -> None:
+        actor_step = self.command.kind == "actor"
+        if actor_step != (self.proposal is not None and self.information_set is not None):
+            raise ValueError("V4 actor step requires one proposal and information set")
+
+
+@dataclass(frozen=True, slots=True)
+class PumpStationVerificationReportV4:
+    """Private result of independent V4 command and transition replay."""
+
+    valid: bool
+    issues: tuple[str, ...]
+    replayed_transition_ids: tuple[str, ...]
+    final_state_id: str
 
 
 def verify_stewardship_run(
@@ -147,4 +196,114 @@ def verify_stewardship_run(
             for obligation in state.obligations
             if obligation.status is not PumpStationObligationStatus.FULFILLED
         ),
+    )
+
+
+def verify_stewardship_run_v4(
+    model: PumpStationCoupledModel,
+    initial_state: PumpStationCoupledStewardshipState,
+    steps: tuple[PumpStationRunStepV4, ...],
+    *,
+    expected_final_state_id: str,
+    expected_task_world_id: str,
+    expected_run_id: str,
+    expected_episode_id: str,
+    expected_world_branch_id: str,
+    expected_actor_id: str,
+    expected_source_artifact_ids: tuple[str, ...],
+) -> PumpStationVerificationReportV4:
+    """Replay each V4 command from the persisted opening state and exact model."""
+    state = initial_state
+    issues: list[str] = []
+    replayed_transition_ids: list[str] = []
+    for step in steps:
+        command = step.command
+        try:
+            observed_scope = (
+                command.task_world_id,
+                command.run_id,
+                command.episode_id,
+                command.world_branch_id,
+            )
+            expected_scope = (
+                expected_task_world_id,
+                expected_run_id,
+                expected_episode_id,
+                expected_world_branch_id,
+            )
+            if observed_scope != expected_scope:
+                raise ValueError("command-scope differs from the verified run")
+            if command.based_on_sequence != state.sequence or command.base_state_id != state.state_id:
+                raise ValueError("command-parent differs from the replayed state")
+            decoded_command = decode_pump_station_v4_command(command)
+            if command.kind == "actor":
+                if step.proposal is None or step.information_set is None:
+                    raise ValueError("actor step lacks proposal evidence")
+                if not isinstance(decoded_command, WorldActorActionRequest):
+                    raise ValueError("actor command decoded as a root control")
+                request = decoded_command
+                expected_information_set = project_coupled_information_set(
+                    state,
+                    episode_id=expected_episode_id,
+                    world_branch_id=expected_world_branch_id,
+                    actor_id=expected_actor_id,
+                    agent_tenure_id=request.binding.agent_tenure_id,
+                    source_artifact_ids=expected_source_artifact_ids,
+                    workspace_tool_ids=(PUMP_STATION_ACTOR_WORKSPACE_TOOL_ID_V2,),
+                )
+                if step.information_set != expected_information_set:
+                    raise ValueError("actor-view or information-set content differs")
+                arguments = validate_pump_station_actor_arguments_v2(
+                    command.action_name,
+                    cast(dict[str, object], request.arguments),
+                )
+                reason = arguments.get("reason")
+                if not isinstance(reason, str):
+                    raise ValueError("actor reason is missing")
+                expected_proposal = pump_station_proposal_from_validated_arguments_v2(
+                    action_name=command.action_name,
+                    arguments=arguments,
+                    context=ProposalContext(
+                        proposal_id=command.request_id,
+                        agent_tenure_id=request.binding.agent_tenure_id,
+                        based_on_sequence=command.based_on_sequence,
+                        base_view_id=request.binding.actor_view_id,
+                        information_set_id=request.binding.information_set_id,
+                        reason=reason,
+                    ),
+                )
+                if expected_proposal != step.proposal:
+                    raise ValueError("stored actor proposal differs from its command")
+                replayed = apply_stewardship_proposal_v4(
+                    model,
+                    state,
+                    step.proposal,
+                    information_set=step.information_set,
+                )
+            else:
+                if isinstance(decoded_command, WorldActorActionRequest):
+                    raise ValueError("root-control command decoded as an actor request")
+                replayed = apply_stewardship_control_v4(state, decoded_command)
+        except (
+            PumpStationProposalError,
+            PumpStationWorldRunError,
+            WorldInterfaceError,
+            TypeError,
+            ValueError,
+        ) as error:
+            issues.append(f"transition-replay-error:{step.transition.receipt.transition_id}:{error}")
+            break
+        replayed_transition_ids.append(replayed.receipt.transition_id)
+        if replayed != step.transition:
+            issues.append(f"transition-replay-mismatch:{step.transition.receipt.transition_id}")
+            break
+        state = replayed.state
+    final_state_id = stewardship_state_id(state)
+    if not issues and final_state_id != expected_final_state_id:
+        issues.append("terminal-state-mismatch")
+    return PumpStationVerificationReportV4(
+        valid=not issues and len(replayed_transition_ids) == len(steps),
+        issues=tuple(issues),
+        replayed_transition_ids=tuple(replayed_transition_ids),
+        final_state_id=final_state_id,
     )

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/stewardship_views.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/stewardship_views.py
@@ -3,9 +3,13 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from enum import StrEnum
 
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.coupled_work import (
+    PumpStationBacklogItem,
+    PumpStationCoupledProcess,
+)
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.evidence_health import (
     PumpStationEvidenceQuality,
     evidence_quality_at,
@@ -18,6 +22,9 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.physical
     PumpStationEnvironment,
     PumpStationModel,
     PumpStationObservation,
+    PumpStationPumpAvailability,
+    PumpStationPumpBoundary,
+    PumpStationServiceRequirement,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_identity import (
     stewardship_content_id,
@@ -206,6 +213,65 @@ class PumpStationActorView:
 
 
 @dataclass(frozen=True, slots=True)
+class PumpStationCoupledActorView:
+    """V4 actor view with exact world, tenure, and public planning identity."""
+
+    view_id: str
+    episode_id: str
+    world_branch_id: str
+    actor_id: str
+    agent_tenure_id: str
+    source_artifact_ids: tuple[str, ...]
+    projection_policy_id: str
+    observation_schema_id: str
+    information_boundary_id: str
+    state_id: str
+    sequence: int
+    time_zone: str
+    current_datetime: str
+    calendar_seconds: int
+    service_schedule: tuple[PumpStationServiceRequirement, ...]
+    disclosed_through_calendar_seconds: int
+    service_schedule_disclosed_through_datetime: str
+    resource_schedule_disclosed_through_datetime: str
+    service_schedule_local: tuple[tuple[str, str, int], ...]
+    resource_availability_local: tuple[tuple[str, tuple[tuple[str, str], ...]], ...]
+    assignment_pump_ids: tuple[str, ...]
+    service_running_pump_ids: tuple[str, ...]
+    test_running_pump_ids: tuple[str, ...]
+    required_service_scu: int
+    available_assured_scu: int
+    assigned_operating_scu: int
+    served_scu: int
+    unserved_scu: int
+    surplus_scu: int
+    pump_clocks: tuple[tuple[str, int, int], ...]
+    pump_runtime_display: tuple[tuple[str, str], ...]
+    pump_boundaries: tuple[PumpStationPumpBoundary, ...]
+    pump_availability: tuple[PumpStationPumpAvailability, ...]
+    resource_quantities: tuple[tuple[str, int, int], ...]
+    ranked_backlog: tuple[PumpStationBacklogItem, ...]
+    processes: tuple[PumpStationCoupledProcess, ...]
+    active_restriction_ids: tuple[str, ...]
+    active_liability_ids: tuple[str, ...]
+    accepted_evidence_ids: tuple[str, ...]
+    evidence_health: tuple[tuple[str, str, str, bool], ...]
+
+    def __post_init__(self) -> None:
+        expected_view_id = coupled_actor_view_id(self)
+        if self.view_id == "pending":
+            object.__setattr__(self, "view_id", expected_view_id)
+        elif self.view_id != expected_view_id:
+            raise ValueError("V4 actor view identity differs from its complete content")
+
+
+def coupled_actor_view_id(view: PumpStationCoupledActorView) -> str:
+    """Return the V4 identity of every actor-visible view field."""
+    identity_payload = {field.name: getattr(view, field.name) for field in fields(view) if field.name != "view_id"}
+    return stewardship_content_id(identity_payload, record_profile="v4")
+
+
+@dataclass(frozen=True, slots=True)
 class PumpStationActorHistoryEntry:
     """Bounded actor-visible account of one realised transition."""
 
@@ -281,7 +347,7 @@ class PumpStationInformationSet:
     """Content identity of a base view and exact actor-visible commitment context."""
 
     information_set_id: str
-    base_view: PumpStationActorView
+    base_view: PumpStationActorView | PumpStationCoupledActorView
     observation_history: PumpStationObservationHistory
     current_context: PumpStationCurrentContext
 
@@ -609,7 +675,7 @@ def create_structured_handover(
 
 
 def _information_set_id(
-    base_view: PumpStationActorView,
+    base_view: PumpStationActorView | PumpStationCoupledActorView,
     observation_history: PumpStationObservationHistory,
     current_context: PumpStationCurrentContext,
 ) -> str:
@@ -620,7 +686,9 @@ def _information_set_id(
             "current_context": current_context,
         },
         record_profile=(
-            "v3"
+            "v4"
+            if isinstance(base_view, PumpStationCoupledActorView)
+            else "v3"
             if base_view.current_state.state_version.endswith(".v3")
             else "v2"
             if base_view.current_state.state_version.endswith(".v2")
@@ -630,7 +698,7 @@ def _information_set_id(
 
 
 def bind_information_set(
-    base_view: PumpStationActorView,
+    base_view: PumpStationActorView | PumpStationCoupledActorView,
     observation_history: PumpStationObservationHistory,
     current_context: PumpStationCurrentContext,
 ) -> PumpStationInformationSet:
@@ -659,6 +727,8 @@ def proposal_binding_error(
 ) -> str | None:
     """Return the first fail-closed proposal binding error, if present."""
     view = information_set.base_view
+    if isinstance(view, PumpStationCoupledActorView):
+        return "legacy proposal cannot use a V4 actor view"
     if context.agent_tenure_id != view.agent_tenure_id:
         return "proposal and base view use different actor tenures"
     if context.base_view_id != view.view_id:

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run.py
@@ -3,13 +3,31 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping
 from dataclasses import replace
 from typing import TYPE_CHECKING, Generic, NoReturn, TypeVar, cast
 
+from pydantic import JsonValue
+
 from aec_bench.contracts.continual_world import (
     ContinualWorldDefinitionRef,
     ContinualWorldProfileRef,
+)
+from aec_bench.contracts.world_interface import (
+    WorldActorActionRequest,
+    WorldActorBinding,
+    WorldActorObservation,
+    WorldInterfaceError,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.actor_interface import (
+    PUMP_STATION_ACTOR_WORKSPACE_TOOL_ID_V2,
+    pump_station_proposal_from_validated_arguments_v2,
+    validate_pump_station_actor_arguments_v2,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.coupled_runtime import (
+    PumpStationCoupledWorldError,
+    project_coupled_information_set,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.evidence_health import (
     PumpStationEvidenceTreatmentRequest,
@@ -25,6 +43,7 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.referenc
     ReferencePackage,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_identity import (
+    canonical_stewardship_value,
     stewardship_content_id,
     stewardship_state_id,
 )
@@ -32,24 +51,37 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewards
     PUMP_STATION_STATE_VERSION_V1,
     PUMP_STATION_STATE_VERSION_V2,
     PUMP_STATION_STATE_VERSION_V3,
+    ProposalContext,
+    PumpStationBoundControlRequest,
+    PumpStationCommonBoundaryRequest,
     PumpStationCoupledStewardshipState,
     PumpStationLegacyStewardshipState,
+    PumpStationOperationsBoundaryReviewRequest,
+    PumpStationProcessOutcomeRequest,
     PumpStationProposal,
+    PumpStationProposalError,
     PumpStationTransition,
+    PumpStationTransitionV4,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_state_machine import (
     apply_evidence_treatment_schedule,
     apply_physical_treatment_activation,
+    apply_stewardship_control_v4,
     apply_stewardship_proposal,
+    apply_stewardship_proposal_v4,
     materialize_evidence_health_state,
+    validate_legacy_proposal_profile,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_verifier import (
     PumpStationRunStep,
+    PumpStationVerificationReportV4,
+    verify_stewardship_run_v4,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_views import (
     PumpStationInformationSet,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_models import (
+    PUMP_STATION_COMMAND_VERSION_V4,
     PUMP_STATION_MIGRATION_VERSION,
     PUMP_STATION_RECORD_VERSIONS_V1,
     PUMP_STATION_RECORD_VERSIONS_V2,
@@ -57,6 +89,7 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_ru
     PUMP_STATION_RECORD_VERSIONS_V4,
     PUMP_STATION_SERIALIZATION_VERSION,
     PUMP_STATION_WORLD_MANIFEST_VERSION_V2,
+    PumpStationCommandV4,
     PumpStationInitialStateSource,
     PumpStationRecordVersions,
     PumpStationStagedTransition,
@@ -457,6 +490,185 @@ class PumpStationWorldRun(Generic[_RunModelT, _RunStateT]):
         """Return the exact currently selected dynamic state."""
         return self._repository.current_snapshot()
 
+    def observe_v4_actor(
+        self,
+        *,
+        session_id: str,
+        agent_tenure_id: str,
+    ) -> WorldActorObservation:
+        """Return one V4 actor view bound to the exact selected commit."""
+        manifest = self._reference_manifest()
+        with self._repository.locked():
+            snapshot = self._repository.current_snapshot()
+            information_set = self._v4_information_set(
+                snapshot,
+                agent_tenure_id=agent_tenure_id,
+            )
+            view = information_set.base_view
+            binding = WorldActorBinding(
+                task_world_id=manifest.task_world_id,
+                session_id=session_id,
+                run_id=manifest.run_id,
+                episode_id=manifest.episode_id,
+                world_branch_id=manifest.world_branch_id,
+                sequence=snapshot.sequence,
+                state_id=snapshot.state_id,
+                commit_id=snapshot.commit_id,
+                agent_tenure_id=agent_tenure_id,
+                actor_view_id=view.view_id,
+                information_set_id=information_set.information_set_id,
+            )
+            return WorldActorObservation(
+                binding=binding,
+                view=cast(
+                    dict[str, JsonValue],
+                    canonical_stewardship_value(view, record_profile="v4"),
+                ),
+            )
+
+    def apply_v4_actor_action(
+        self,
+        request: WorldActorActionRequest,
+    ) -> PumpStationTransitionV4:
+        """Apply or exactly recover one shared actor request on the V4 run."""
+        manifest = self._reference_manifest()
+        if not isinstance(self._model, PumpStationCoupledModel):
+            _fail("world-run-identity", "V4 actor action requires the coupled model")
+        command = self._v4_actor_command(request)
+        with self._repository.locked():
+            committed = self._repository.find_committed_v4_command(request.request_id)
+            if committed is not None:
+                return self._repository.validate_repeated_v4_command(
+                    committed,
+                    command,
+                )
+            recovered = self._repository._recover_staged_v4_command_under_lock(
+                command,
+            )
+            if recovered is not None:
+                return recovered
+            prior = self._repository.current_snapshot()
+            self._validate_v4_actor_scope(request.binding, prior)
+            information_set = self._v4_information_set(
+                prior,
+                agent_tenure_id=request.binding.agent_tenure_id,
+            )
+            if (
+                information_set.base_view.view_id != request.binding.actor_view_id
+                or information_set.information_set_id != request.binding.information_set_id
+            ):
+                _fail(
+                    "actor-request-binding",
+                    "actor view or information set differs from the selected state",
+                )
+            try:
+                arguments = validate_pump_station_actor_arguments_v2(
+                    request.action_name,
+                    cast(dict[str, object], request.arguments),
+                )
+            except WorldInterfaceError as error:
+                _fail(error.code, error.detail)
+            reason = arguments.get("reason")
+            if not isinstance(reason, str) or reason != reason.strip():
+                _fail(
+                    "actor-action-arguments",
+                    "reason must be non-empty and must not have surrounding whitespace",
+                )
+            proposal = pump_station_proposal_from_validated_arguments_v2(
+                action_name=request.action_name,
+                arguments=arguments,
+                context=ProposalContext(
+                    proposal_id=request.request_id,
+                    agent_tenure_id=request.binding.agent_tenure_id,
+                    based_on_sequence=request.binding.sequence,
+                    base_view_id=request.binding.actor_view_id,
+                    information_set_id=request.binding.information_set_id,
+                    reason=reason,
+                ),
+            )
+            state = cast(
+                PumpStationCoupledStewardshipState,
+                self._repository.load_state(prior.state_id),
+            )
+            try:
+                transition = apply_stewardship_proposal_v4(
+                    self._model,
+                    state,
+                    proposal,
+                    information_set=information_set,
+                )
+            except (PumpStationProposalError, PumpStationCoupledWorldError) as error:
+                _fail(error.code, str(error))
+            staged = self._repository.stage_v4_transition(
+                manifest=manifest,
+                prior_snapshot=prior,
+                command=command,
+                proposal=proposal,
+                information_set=information_set,
+                transition=transition,
+            )
+            return self._repository._publish_staged_v4_transition_under_lock(staged)
+
+    def apply_v4_control(
+        self,
+        request: PumpStationBoundControlRequest,
+    ) -> PumpStationTransitionV4:
+        """Apply or exactly recover one bound root host-control request."""
+        manifest = self._reference_manifest()
+        command = self._v4_control_command(request)
+        with self._repository.locked():
+            committed = self._repository.find_committed_v4_command(request.request_id)
+            if committed is not None:
+                return self._repository.validate_repeated_v4_command(
+                    committed,
+                    command,
+                )
+            recovered = self._repository._recover_staged_v4_command_under_lock(
+                command,
+            )
+            if recovered is not None:
+                return recovered
+            prior = self._repository.current_snapshot()
+            observed = (
+                request.run_id,
+                request.episode_id,
+                request.world_branch_id,
+                request.based_on_sequence,
+                request.base_state_id,
+                request.base_commit_id,
+            )
+            expected = (
+                manifest.run_id,
+                manifest.episode_id,
+                manifest.world_branch_id,
+                prior.sequence,
+                prior.state_id,
+                prior.commit_id,
+            )
+            if observed != expected:
+                _fail(
+                    "control-request-scope",
+                    "V4 control does not bind the selected world snapshot",
+                )
+            state = cast(
+                PumpStationCoupledStewardshipState,
+                self._repository.load_state(prior.state_id),
+            )
+            try:
+                transition = apply_stewardship_control_v4(
+                    state,
+                    request.control,
+                )
+            except PumpStationCoupledWorldError as error:
+                _fail(error.code, str(error))
+            staged = self._repository.stage_v4_transition(
+                manifest=manifest,
+                prior_snapshot=prior,
+                command=command,
+                transition=transition,
+            )
+            return self._repository._publish_staged_v4_transition_under_lock(staged)
+
     def stage(
         self,
         proposal: PumpStationProposal,
@@ -465,6 +677,7 @@ class PumpStationWorldRun(Generic[_RunModelT, _RunStateT]):
     ) -> PumpStationStagedTransition:
         """Write immutable transition evidence without selecting its state."""
         model = self._legacy_model()
+        self._require_legacy_proposal_profile(proposal)
         with self._repository.locked():
             prior = self._repository.current_snapshot()
             committed = self._repository.find_committed_proposal(
@@ -498,6 +711,7 @@ class PumpStationWorldRun(Generic[_RunModelT, _RunStateT]):
     ) -> PumpStationTransition:
         """Apply or idempotently replay one exact bound proposal."""
         model = self._legacy_model()
+        self._require_legacy_proposal_profile(proposal)
         with self._repository.locked():
             prior = self._repository.current_snapshot()
             committed = self._repository.find_committed_proposal(
@@ -618,6 +832,35 @@ class PumpStationWorldRun(Generic[_RunModelT, _RunStateT]):
     def steps(self) -> tuple[PumpStationRunStep, ...]:
         """Reload all selected run steps for independent replay."""
         return self._repository.steps()
+
+    def verify_v4(self) -> PumpStationVerificationReportV4:
+        """Independently replay the selected V4 command chain."""
+        manifest = self._reference_manifest()
+        if not isinstance(self._model, PumpStationCoupledModel):
+            _fail("world-run-identity", "V4 verification requires the coupled model")
+        initial_state = cast(
+            PumpStationCoupledStewardshipState,
+            self._repository.load_state(manifest.initial_state_id),
+        )
+        with self._repository.locked():
+            steps = self._repository.v4_steps()
+            expected_final_state_id = self._repository.current_snapshot().state_id
+        return verify_stewardship_run_v4(
+            self._model,
+            initial_state,
+            steps,
+            expected_final_state_id=expected_final_state_id,
+            expected_task_world_id=manifest.task_world_id,
+            expected_run_id=manifest.run_id,
+            expected_episode_id=manifest.episode_id,
+            expected_world_branch_id=manifest.world_branch_id,
+            expected_actor_id="pump-station-actor",
+            expected_source_artifact_ids=(
+                manifest.reference_system_content_id,
+                manifest.package_content_id,
+                manifest.temporal_bundle_content_id,
+            ),
+        )
 
     @staticmethod
     def _load_registered_reference_profile() -> tuple[
@@ -872,6 +1115,135 @@ class PumpStationWorldRun(Generic[_RunModelT, _RunStateT]):
             _fail("reference-system-manifest-required", "run uses the legacy manifest")
         return self._manifest
 
+    def _v4_information_set(
+        self,
+        snapshot: PumpStationStateSnapshotRef,
+        *,
+        agent_tenure_id: str,
+    ) -> PumpStationInformationSet:
+        """Build the exact V4 view, history, and visible commitment context."""
+        manifest = self._reference_manifest()
+        state = cast(
+            PumpStationCoupledStewardshipState,
+            self._repository.load_state(snapshot.state_id),
+        )
+        source_artifact_ids = (
+            manifest.reference_system_content_id,
+            manifest.package_content_id,
+            manifest.temporal_bundle_content_id,
+        )
+        return project_coupled_information_set(
+            state,
+            episode_id=manifest.episode_id,
+            world_branch_id=manifest.world_branch_id,
+            actor_id="pump-station-actor",
+            agent_tenure_id=agent_tenure_id,
+            source_artifact_ids=source_artifact_ids,
+            workspace_tool_ids=(PUMP_STATION_ACTOR_WORKSPACE_TOOL_ID_V2,),
+        )
+
+    @staticmethod
+    def _v4_actor_command(request: WorldActorActionRequest) -> PumpStationCommandV4:
+        """Convert one shared actor request to the strict durable V4 command."""
+        binding = request.binding
+        return PumpStationCommandV4(
+            command_version=PUMP_STATION_COMMAND_VERSION_V4,
+            kind="actor",
+            request_id=request.request_id,
+            request_content_id=request.content_sha256,
+            action_name=request.action_name,
+            arguments_json=json.dumps(
+                request.arguments,
+                allow_nan=False,
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            ),
+            task_world_id=binding.task_world_id,
+            run_id=binding.run_id,
+            episode_id=binding.episode_id,
+            world_branch_id=binding.world_branch_id,
+            based_on_sequence=binding.sequence,
+            base_state_id=binding.state_id,
+            base_commit_id=binding.commit_id,
+            session_id=binding.session_id,
+            agent_tenure_id=binding.agent_tenure_id,
+            actor_view_id=binding.actor_view_id,
+            information_set_id=binding.information_set_id,
+        )
+
+    def _v4_control_command(
+        self,
+        request: PumpStationBoundControlRequest,
+    ) -> PumpStationCommandV4:
+        """Convert one bound root control to the strict durable V4 command."""
+        control = request.control
+        if isinstance(control, PumpStationOperationsBoundaryReviewRequest):
+            kind = "operations_review"
+            action_name = "operations_boundary_review"
+        elif isinstance(control, PumpStationProcessOutcomeRequest):
+            kind = "process_outcome"
+            action_name = "process_outcome"
+        elif isinstance(control, PumpStationCommonBoundaryRequest):
+            kind = "common_boundary"
+            action_name = "common_boundary_control"
+        else:
+            _fail("control-type", f"unsupported V4 control {type(control).__name__}")
+        manifest = self._reference_manifest()
+        return PumpStationCommandV4(
+            command_version=PUMP_STATION_COMMAND_VERSION_V4,
+            kind=kind,
+            request_id=request.request_id,
+            request_content_id=control.content_id,
+            action_name=action_name,
+            arguments_json=json.dumps(
+                canonical_stewardship_value(control, record_profile="v4"),
+                allow_nan=False,
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            ),
+            task_world_id=manifest.task_world_id,
+            run_id=request.run_id,
+            episode_id=request.episode_id,
+            world_branch_id=request.world_branch_id,
+            based_on_sequence=request.based_on_sequence,
+            base_state_id=request.base_state_id,
+            base_commit_id=request.base_commit_id,
+            authority_id=request.authority_id,
+        )
+
+    def _validate_v4_actor_scope(
+        self,
+        binding: WorldActorBinding,
+        snapshot: PumpStationStateSnapshotRef,
+    ) -> None:
+        """Require one actor request to name the selected run and parent commit."""
+        manifest = self._reference_manifest()
+        observed = (
+            binding.task_world_id,
+            binding.run_id,
+            binding.episode_id,
+            binding.world_branch_id,
+            binding.sequence,
+            binding.state_id,
+            binding.commit_id,
+        )
+        expected = (
+            manifest.task_world_id,
+            manifest.run_id,
+            manifest.episode_id,
+            manifest.world_branch_id,
+            snapshot.sequence,
+            snapshot.state_id,
+            snapshot.commit_id,
+        )
+        if observed != expected:
+            _fail(
+                "actor-request-binding",
+                "actor request does not bind the selected world snapshot",
+            )
+
     def _require_legacy_transitions(self) -> None:
         """Keep V4 closed until its task-owned transition port uses this run."""
         if self._manifest.record_versions == PUMP_STATION_RECORD_VERSIONS_V4:
@@ -879,6 +1251,14 @@ class PumpStationWorldRun(Generic[_RunModelT, _RunStateT]):
                 "v4-transition-not-routed",
                 "registered V4 transitions are not yet integrated",
             )
+
+    @staticmethod
+    def _require_legacy_proposal_profile(proposal: PumpStationProposal) -> None:
+        """Reject V4-only fields before a legacy request can be retried or stored."""
+        try:
+            validate_legacy_proposal_profile(proposal)
+        except PumpStationProposalError as error:
+            _fail(error.code, str(error))
 
     def _legacy_model(self) -> PumpStationModel:
         """Return the two-pump model selected by legacy transition paths."""

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_commands.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_commands.py
@@ -1,0 +1,199 @@
+# ABOUTME: Rebuilds strict pump actor and root-control inputs from durable V4 commands.
+# ABOUTME: Verifies command content identity before repository selection or replay.
+
+from __future__ import annotations
+
+import json
+from typing import NoReturn, cast
+
+from pydantic import JsonValue
+
+from aec_bench.contracts.world_interface import (
+    WorldActorActionRequest,
+    WorldActorBinding,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_models import (
+    PumpStationCommonBoundaryRequest,
+    PumpStationOperationsBoundaryReviewRequest,
+    PumpStationProcessOutcomeRequest,
+    PumpStationRootControl,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_models import (
+    PumpStationCommandV4,
+    PumpStationWorldRunError,
+)
+
+type PumpStationDecodedCommand = WorldActorActionRequest | PumpStationRootControl
+
+_ROOT_CONTROL_ARGUMENT_FIELDS = {
+    "operations_review": frozenset(
+        {
+            "version",
+            "review_id",
+            "review_kind",
+            "pump_id",
+            "restriction_or_isolation_permit_id",
+            "accepted_evidence_id",
+            "requested_outcome",
+            "base_state_id",
+            "operations_authority_id",
+            "reason",
+        }
+    ),
+    "process_outcome": frozenset(
+        {
+            "version",
+            "request_id",
+            "authority_id",
+            "process_id",
+            "outcome",
+            "evidence_id",
+            "base_state_id",
+        }
+    ),
+    "common_boundary": frozenset(
+        {
+            "version",
+            "request_id",
+            "authority_id",
+            "boundary_kind",
+            "available",
+            "base_state_id",
+        }
+    ),
+}
+
+
+def _fail(code: str, detail: str) -> NoReturn:
+    raise PumpStationWorldRunError(code, detail)
+
+
+def decode_pump_station_v4_command(
+    command: PumpStationCommandV4,
+) -> PumpStationDecodedCommand:
+    """Rebuild and verify the exact public or task-semantic command input."""
+    arguments = json.loads(command.arguments_json)
+    if not isinstance(arguments, dict):
+        _fail("command-content", "command arguments are not an object")
+    if command.kind == "actor":
+        request = _actor_request_from_command(
+            command,
+            cast(dict[str, JsonValue], arguments),
+        )
+        if request.content_sha256 != command.request_content_id:
+            _fail("command-content", "actor request content identity differs")
+        return request
+    control = _root_control_from_command(command, arguments)
+    if control.content_id != command.request_content_id:
+        _fail("command-content", "root-control content identity differs")
+    authority_id = (
+        control.operations_authority_id
+        if isinstance(control, PumpStationOperationsBoundaryReviewRequest)
+        else control.authority_id
+    )
+    if authority_id != command.authority_id:
+        _fail("command-content", "root-control authority differs")
+    return control
+
+
+def _actor_request_from_command(
+    command: PumpStationCommandV4,
+    arguments: dict[str, JsonValue],
+) -> WorldActorActionRequest:
+    actor_fields = (
+        command.session_id,
+        command.agent_tenure_id,
+        command.actor_view_id,
+        command.information_set_id,
+    )
+    if any(value is None for value in actor_fields):
+        _fail("command-content", "actor command lacks its binding")
+    binding = WorldActorBinding(
+        task_world_id=command.task_world_id,
+        session_id=cast(str, command.session_id),
+        run_id=command.run_id,
+        episode_id=command.episode_id,
+        world_branch_id=command.world_branch_id,
+        sequence=command.based_on_sequence,
+        state_id=command.base_state_id,
+        commit_id=command.base_commit_id,
+        agent_tenure_id=cast(str, command.agent_tenure_id),
+        actor_view_id=cast(str, command.actor_view_id),
+        information_set_id=cast(str, command.information_set_id),
+    )
+    return WorldActorActionRequest(
+        request_id=command.request_id,
+        action_name=command.action_name,
+        binding=binding,
+        arguments=arguments,
+    )
+
+
+def _root_control_from_command(
+    command: PumpStationCommandV4,
+    arguments: dict[str, object],
+) -> PumpStationRootControl:
+    expected_fields = _ROOT_CONTROL_ARGUMENT_FIELDS.get(command.kind)
+    if expected_fields is None:
+        _fail("command-content", f"unsupported V4 control kind {command.kind}")
+    observed_fields = frozenset(arguments)
+    if observed_fields != expected_fields:
+        missing = sorted(expected_fields - observed_fields)
+        extra = sorted(observed_fields - expected_fields)
+        _fail(
+            "command-content",
+            f"{command.kind} control fields differ: missing={missing}, extra={extra}",
+        )
+    if command.kind == "operations_review":
+        return PumpStationOperationsBoundaryReviewRequest(
+            version=_text_argument(arguments, "version"),
+            review_id=_text_argument(arguments, "review_id"),
+            review_kind=_text_argument(arguments, "review_kind"),
+            pump_id=_text_argument(arguments, "pump_id"),
+            restriction_or_isolation_permit_id=_text_argument(
+                arguments,
+                "restriction_or_isolation_permit_id",
+            ),
+            accepted_evidence_id=_text_argument(arguments, "accepted_evidence_id"),
+            requested_outcome=_text_argument(arguments, "requested_outcome"),
+            base_state_id=_text_argument(arguments, "base_state_id"),
+            operations_authority_id=_text_argument(
+                arguments,
+                "operations_authority_id",
+            ),
+            reason=_text_argument(arguments, "reason"),
+        )
+    if command.kind == "process_outcome":
+        return PumpStationProcessOutcomeRequest(
+            version=_text_argument(arguments, "version"),
+            request_id=_text_argument(arguments, "request_id"),
+            authority_id=_text_argument(arguments, "authority_id"),
+            process_id=_text_argument(arguments, "process_id"),
+            outcome=_text_argument(arguments, "outcome"),
+            evidence_id=_text_argument(arguments, "evidence_id"),
+            base_state_id=_text_argument(arguments, "base_state_id"),
+        )
+    if command.kind == "common_boundary":
+        return PumpStationCommonBoundaryRequest(
+            version=_text_argument(arguments, "version"),
+            request_id=_text_argument(arguments, "request_id"),
+            authority_id=_text_argument(arguments, "authority_id"),
+            boundary_kind=_text_argument(arguments, "boundary_kind"),
+            available=_bool_argument(arguments, "available"),
+            base_state_id=_text_argument(arguments, "base_state_id"),
+        )
+    _fail("command-content", f"unsupported V4 control kind {command.kind}")
+
+
+def _text_argument(arguments: dict[str, object], field_name: str) -> str:
+    value = arguments.get(field_name)
+    if not isinstance(value, str) or not value.strip():
+        _fail("command-content", f"control field {field_name} must be non-empty text")
+    return value
+
+
+def _bool_argument(arguments: dict[str, object], field_name: str) -> bool:
+    value = arguments.get(field_name)
+    if not isinstance(value, bool):
+        _fail("command-content", f"control field {field_name} must be Boolean")
+    return value

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_models.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_models.py
@@ -3,7 +3,9 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
+from typing import NoReturn
 
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.evidence_health import (
     PumpStationEvidenceTreatmentRequest,
@@ -27,6 +29,7 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewards
     PumpStationEventType,
     PumpStationProposal,
     PumpStationTransition,
+    PumpStationTransitionV4,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_views import (
     PumpStationInformationSet,
@@ -40,6 +43,7 @@ PUMP_STATION_SNAPSHOT_VERSION_V3 = "pump-station-state-snapshot.v3"
 PUMP_STATION_SNAPSHOT_VERSION_V4 = "pump-station-state-snapshot.v4"
 PUMP_STATION_SNAPSHOT_VERSION = PUMP_STATION_SNAPSHOT_VERSION_V1
 PUMP_STATION_MIGRATION_VERSION = "pump-station-world-run-migration.v1"
+PUMP_STATION_COMMAND_VERSION_V4 = "pump-station-world-command.v4"
 
 
 @dataclass(frozen=True, slots=True)
@@ -452,6 +456,121 @@ class PumpStationAppliedEventBatch:
     event_types: tuple[PumpStationEventType, ...]
 
 
+def _unique_json_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for key, child in pairs:
+        if key in value:
+            raise PumpStationWorldRunError("canonical-json", f"duplicate field {key}")
+        value[key] = child
+    return value
+
+
+def _reject_nonstandard_json_constant(value: str) -> NoReturn:
+    raise PumpStationWorldRunError(
+        "canonical-json",
+        f"non-standard JSON constant {value}",
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class PumpStationCommandV4:
+    """Exact actor or host-control command bound to one selected V4 parent."""
+
+    command_version: str
+    kind: str
+    request_id: str
+    request_content_id: str
+    action_name: str
+    arguments_json: str
+    task_world_id: str
+    run_id: str
+    episode_id: str
+    world_branch_id: str
+    based_on_sequence: int
+    base_state_id: str
+    base_commit_id: str
+    session_id: str | None = None
+    agent_tenure_id: str | None = None
+    actor_view_id: str | None = None
+    information_set_id: str | None = None
+    authority_id: str | None = None
+
+    def __post_init__(self) -> None:
+        require_world_run_version(
+            self.command_version,
+            PUMP_STATION_COMMAND_VERSION_V4,
+            "command-version",
+        )
+        expected_actions = {
+            "operations_review": "operations_boundary_review",
+            "process_outcome": "process_outcome",
+            "common_boundary": "common_boundary_control",
+        }
+        if self.kind != "actor" and self.kind not in expected_actions:
+            raise PumpStationWorldRunError("command-kind", self.kind)
+        if self.kind in expected_actions and self.action_name != expected_actions[self.kind]:
+            raise PumpStationWorldRunError("command-kind", self.action_name)
+        for field_name in (
+            "request_id",
+            "request_content_id",
+            "action_name",
+            "task_world_id",
+            "run_id",
+            "episode_id",
+            "world_branch_id",
+            "base_state_id",
+            "base_commit_id",
+        ):
+            require_world_run_text(getattr(self, field_name), field_name)
+        if self.based_on_sequence < 0:
+            raise PumpStationWorldRunError(
+                "command-shape",
+                "based_on_sequence must be non-negative",
+            )
+        actor_fields = (
+            ("session_id", self.session_id),
+            ("agent_tenure_id", self.agent_tenure_id),
+            ("actor_view_id", self.actor_view_id),
+            ("information_set_id", self.information_set_id),
+        )
+        if self.kind == "actor":
+            if any(value is None for _, value in actor_fields) or self.authority_id is not None:
+                raise PumpStationWorldRunError(
+                    "command-shape",
+                    "actor command lacks its actor binding",
+                )
+            for field_name, value in actor_fields:
+                require_world_run_text(value, field_name)
+        else:
+            if any(value is not None for _, value in actor_fields) or self.authority_id is None:
+                raise PumpStationWorldRunError(
+                    "command-shape",
+                    "host-control command has an actor binding or lacks authority",
+                )
+            require_world_run_text(self.authority_id, "authority_id")
+        try:
+            arguments = json.loads(
+                self.arguments_json,
+                object_pairs_hook=_unique_json_object,
+                parse_constant=_reject_nonstandard_json_constant,
+            )
+        except (json.JSONDecodeError, UnicodeDecodeError) as error:
+            raise PumpStationWorldRunError("canonical-json", str(error)) from error
+        if not isinstance(arguments, dict):
+            raise PumpStationWorldRunError("command-shape", "arguments must be an object")
+        canonical = json.dumps(
+            arguments,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        if canonical != self.arguments_json:
+            raise PumpStationWorldRunError(
+                "canonical-json",
+                "command arguments are not canonical",
+            )
+
+
 @dataclass(frozen=True, slots=True)
 class PumpStationWorldRunCommit:
     """Immutable link from one committed state to its complete transition evidence."""
@@ -473,6 +592,57 @@ class PumpStationWorldRunCommit:
             PUMP_STATION_SERIALIZATION_VERSION,
             "serialization-version",
         )
+
+
+@dataclass(frozen=True, slots=True)
+class PumpStationWorldRunCommitV2:
+    """Immutable V4 link from one parent commit to complete command evidence."""
+
+    serialization_version: str
+    run_id: str
+    sequence: int
+    parent_commit_id: str
+    state_id: str
+    request_id: str
+    command_content_id: str
+    proposal_content_id: str | None
+    information_set_content_id: str | None
+    receipt_content_id: str
+
+    def __post_init__(self) -> None:
+        require_world_run_version(
+            self.serialization_version,
+            PUMP_STATION_WORLD_MANIFEST_VERSION_V2,
+            "serialization-version",
+        )
+        for field_name in (
+            "run_id",
+            "parent_commit_id",
+            "state_id",
+            "request_id",
+            "command_content_id",
+            "receipt_content_id",
+        ):
+            require_world_run_text(getattr(self, field_name), field_name)
+        if self.sequence < 1:
+            raise PumpStationWorldRunError(
+                "world-run-shape",
+                "V4 transition commit sequence must be positive",
+            )
+        if (self.proposal_content_id is None) != (self.information_set_content_id is None):
+            raise PumpStationWorldRunError(
+                "world-run-shape",
+                "V4 actor proposal and information set must appear together",
+            )
+        if self.proposal_content_id is not None:
+            require_world_run_text(self.proposal_content_id, "proposal_content_id")
+            require_world_run_text(
+                self.information_set_content_id,
+                "information_set_content_id",
+            )
+
+
+type PumpStationWorldRunCommitRecord = PumpStationWorldRunCommit | PumpStationWorldRunCommitV2
 
 
 @dataclass(frozen=True, slots=True)
@@ -504,3 +674,24 @@ class PumpStationStagedTransition:
     transition: PumpStationTransition
     commit: PumpStationWorldRunCommit
     control_request: PumpStationEvidenceTreatmentRequest | PumpStationPhysicalTreatmentActivationRequest | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PumpStationStagedTransitionV4:
+    """Immutable V4 evidence prepared before current-state selection."""
+
+    prior_snapshot: PumpStationStateSnapshotRef
+    snapshot: PumpStationStateSnapshotRef
+    command: PumpStationCommandV4
+    transition: PumpStationTransitionV4
+    commit: PumpStationWorldRunCommitV2
+    proposal: PumpStationProposal | None = None
+    information_set: PumpStationInformationSet | None = None
+
+    def __post_init__(self) -> None:
+        actor_step = self.command.kind == "actor"
+        if actor_step != (self.proposal is not None and self.information_set is not None):
+            raise PumpStationWorldRunError(
+                "transition-integrity",
+                "V4 actor evidence requires one proposal and information set",
+            )

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_repository.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_repository.py
@@ -21,6 +21,12 @@ from aec_bench.task_world_templates.continual.durability import (
     mkdir_durable,
     replace_file_bytes_durable,
 )
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.actor_interface import (
+    PUMP_STATION_ACTOR_WORKSPACE_TOOL_ID_V2,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.coupled_runtime import (
+    project_coupled_information_set,
+)
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.evidence_health import (
     PumpStationEvidenceTreatmentRequest,
 )
@@ -34,12 +40,15 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewards
     PUMP_STATION_STATE_VERSION_V4,
     CancelProcess,
     ContinueOperation,
+    PumpStationCoupledStewardshipState,
     PumpStationLegacyStewardshipState,
     PumpStationProposal,
     PumpStationStewardshipState,
     PumpStationStewardshipStateRecord,
     PumpStationTransition,
     PumpStationTransitionReceipt,
+    PumpStationTransitionReceiptV4,
+    PumpStationTransitionV4,
     RequestConditionalDeferral,
     RequestConditionCheck,
     RequestDependencyWaiver,
@@ -55,17 +64,26 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewards
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_verifier import (
     PumpStationRunStep,
+    PumpStationRunStepV4,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_views import (
+    PumpStationActorView,
     PumpStationInformationSet,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_commands import (
+    decode_pump_station_v4_command,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_models import (
     PUMP_STATION_SERIALIZATION_VERSION,
     PumpStationAppliedEventBatch,
+    PumpStationCommandV4,
     PumpStationCurrentRunPointer,
     PumpStationStagedTransition,
+    PumpStationStagedTransitionV4,
     PumpStationStateSnapshotRef,
     PumpStationWorldRunCommit,
+    PumpStationWorldRunCommitRecord,
+    PumpStationWorldRunCommitV2,
     PumpStationWorldRunError,
     PumpStationWorldRunManifest,
     PumpStationWorldRunManifestRecord,
@@ -256,11 +274,14 @@ class PumpStationWorldRunRepository:
             _fail("record-versions", "legacy state access selected a V4 state")
         return cast(PumpStationLegacyStewardshipState, state)
 
-    def load_commit(self, commit_id: str) -> PumpStationWorldRunCommit:
+    def load_commit(self, commit_id: str) -> PumpStationWorldRunCommitRecord:
         """Reload one immutable commit by content identity."""
-        commit = load_pump_station_artifact(
-            self._read_content("commits", commit_id),
-            PumpStationWorldRunCommit,
+        commit = cast(
+            PumpStationWorldRunCommitRecord,
+            load_pump_station_artifact(
+                self._read_content("commits", commit_id),
+                PumpStationWorldRunCommit | PumpStationWorldRunCommitV2,
+            ),
         )
         if pump_station_artifact_id(commit) != commit_id:
             _fail("artifact-integrity", f"commit identity differs for {commit_id}")
@@ -268,7 +289,7 @@ class PumpStationWorldRunRepository:
 
     def snapshot_for_commit(
         self,
-        commit: PumpStationWorldRunCommit,
+        commit: PumpStationWorldRunCommitRecord,
     ) -> PumpStationStateSnapshotRef:
         """Return the exact snapshot selected by one commit on the live chain."""
         commit_id = pump_station_artifact_id(commit)
@@ -439,6 +460,143 @@ class PumpStationWorldRunRepository:
             control_request=control_request,
         )
 
+    def stage_v4_transition(
+        self,
+        *,
+        manifest: PumpStationWorldRunManifestV2,
+        prior_snapshot: PumpStationStateSnapshotRef,
+        command: PumpStationCommandV4,
+        transition: PumpStationTransitionV4,
+        proposal: PumpStationProposal | None = None,
+        information_set: PumpStationInformationSet | None = None,
+    ) -> PumpStationStagedTransitionV4:
+        """Publish complete V4 command evidence without selecting its state."""
+        stored_manifest = self.load_manifest()
+        if not isinstance(stored_manifest, PumpStationWorldRunManifestV2) or stored_manifest != manifest:
+            _fail("world-run-identity", "V4 caller manifest differs from the stored run")
+        self._require_v4_command_scope(command, stored_manifest)
+        decode_pump_station_v4_command(command)
+        receipt = transition.receipt
+        actor_step = command.kind == "actor"
+        if (
+            command.task_world_id != manifest.task_world_id
+            or command.run_id != manifest.run_id
+            or command.episode_id != manifest.episode_id
+            or command.world_branch_id != manifest.world_branch_id
+            or command.based_on_sequence != prior_snapshot.sequence
+            or command.base_state_id != prior_snapshot.state_id
+            or command.base_commit_id != prior_snapshot.commit_id
+            or receipt.sequence != prior_snapshot.sequence + 1
+            or receipt.before_state_id != prior_snapshot.state_id
+            or receipt.after_state_id != stewardship_state_id(transition.state)
+            or receipt.request_id != command.request_id
+            or receipt.action_or_control_kind != command.action_name
+            or receipt.actor_action != actor_step
+            or receipt.receipt_version != manifest.receipt_version
+            or receipt.authority_policy_version != manifest.authority_policy_version
+            or receipt.transition_rule_version != manifest.transition_rule_version
+            or actor_step != (proposal is not None and information_set is not None)
+        ):
+            _fail("transition-integrity", "V4 transition does not extend the selected state")
+        if actor_step:
+            assert proposal is not None
+            assert information_set is not None
+            parent_state = self._load_v4_state(prior_snapshot.state_id)
+            expected_information_set = self._project_v4_information_set(
+                stored_manifest,
+                parent_state,
+                command,
+            )
+            if (
+                proposal.context.proposal_id != command.request_id
+                or proposal.context.agent_tenure_id != command.agent_tenure_id
+                or proposal.context.based_on_sequence != command.based_on_sequence
+                or proposal.context.base_view_id != command.actor_view_id
+                or proposal.context.information_set_id != command.information_set_id
+                or information_set.information_set_id != command.information_set_id
+                or information_set != expected_information_set
+            ):
+                _fail("transition-integrity", "V4 actor evidence bindings differ")
+        self._reject_v4_command_collision(
+            command,
+            parent_commit_id=prior_snapshot.commit_id,
+        )
+        state_id = self._publish_state(transition.state)
+        command_content_id = pump_station_artifact_id(command, record_profile="v4")
+        receipt_content_id = pump_station_artifact_id(receipt, record_profile="v4")
+        proposal_content_id: str | None = None
+        information_set_content_id: str | None = None
+        self._publish_content(
+            "commands",
+            command_content_id,
+            command,
+            record_profile="v4",
+        )
+        if proposal is not None and information_set is not None:
+            proposal_content_id = pump_station_artifact_id(
+                proposal,
+                record_profile="v4",
+            )
+            information_set_content_id = pump_station_artifact_id(
+                information_set,
+                record_profile="v4",
+            )
+            self._publish_content(
+                "proposals",
+                proposal_content_id,
+                proposal,
+                record_profile="v4",
+            )
+            self._publish_content(
+                "information-sets",
+                information_set_content_id,
+                information_set,
+                record_profile="v4",
+            )
+        self._publish_content(
+            "receipts",
+            receipt_content_id,
+            receipt,
+            record_profile="v4",
+        )
+        commit = PumpStationWorldRunCommitV2(
+            serialization_version=manifest.serialization_version,
+            run_id=manifest.run_id,
+            sequence=receipt.sequence,
+            parent_commit_id=prior_snapshot.commit_id,
+            state_id=state_id,
+            request_id=command.request_id,
+            command_content_id=command_content_id,
+            proposal_content_id=proposal_content_id,
+            information_set_content_id=information_set_content_id,
+            receipt_content_id=receipt_content_id,
+        )
+        commit_id = pump_station_artifact_id(commit, record_profile="v4")
+        self._publish_content(
+            "commits",
+            commit_id,
+            commit,
+            record_profile="v4",
+        )
+        snapshot = PumpStationStateSnapshotRef(
+            snapshot_version=manifest.snapshot_version,
+            run_id=manifest.run_id,
+            episode_id=manifest.episode_id,
+            world_branch_id=manifest.world_branch_id,
+            sequence=receipt.sequence,
+            state_id=state_id,
+            commit_id=commit_id,
+        )
+        return PumpStationStagedTransitionV4(
+            prior_snapshot=prior_snapshot,
+            snapshot=snapshot,
+            command=command,
+            transition=transition,
+            commit=commit,
+            proposal=proposal,
+            information_set=information_set,
+        )
+
     def publish_staged_transition(
         self,
         staged: PumpStationStagedTransition,
@@ -446,6 +604,36 @@ class PumpStationWorldRunRepository:
         """Lock and select a fully staged transition with one pointer replacement."""
         with self.locked():
             return self._publish_staged_transition_under_lock(staged)
+
+    def publish_staged_v4_transition(
+        self,
+        staged: PumpStationStagedTransitionV4,
+    ) -> PumpStationTransitionV4:
+        """Lock and select one fully staged V4 transition."""
+        with self.locked():
+            return self._publish_staged_v4_transition_under_lock(staged)
+
+    def _publish_staged_v4_transition_under_lock(
+        self,
+        staged: PumpStationStagedTransitionV4,
+    ) -> PumpStationTransitionV4:
+        """Select one staged V4 transition while the caller owns the run lock."""
+        transition = self._require_staged_v4_identity(staged)
+        current = self.current_snapshot()
+        if current == staged.snapshot:
+            return transition
+        if current != staged.prior_snapshot:
+            _fail("stale-publication", "world run advanced after V4 transition preparation")
+        self._replace_current(
+            PumpStationCurrentRunPointer(
+                serialization_version=PUMP_STATION_SERIALIZATION_VERSION,
+                run_id=staged.snapshot.run_id,
+                sequence=staged.snapshot.sequence,
+                state_id=staged.snapshot.state_id,
+                commit_id=staged.snapshot.commit_id,
+            )
+        )
+        return transition
 
     def _publish_staged_transition_under_lock(
         self,
@@ -490,9 +678,12 @@ class PumpStationWorldRunRepository:
             or snapshot.sequence != prior.sequence + 1
         ):
             _fail("transition-integrity", "staged snapshot and commit chain differ")
-        if self.load_commit(snapshot.commit_id) != commit:
+        stored_commit = self.load_commit(snapshot.commit_id)
+        if not isinstance(stored_commit, PumpStationWorldRunCommit) or stored_commit != commit:
             _fail("transition-integrity", "stored staged commit differs")
         parent = self.load_commit(prior.commit_id)
+        if not isinstance(parent, PumpStationWorldRunCommit):
+            _fail("transition-integrity", "legacy transition has a V4 parent")
         if parent.run_id != prior.run_id or parent.sequence != prior.sequence or parent.state_id != prior.state_id:
             _fail("transition-integrity", "staged prior snapshot and commit differ")
         durable_input, information_set, transition = self._load_step(commit)
@@ -505,6 +696,65 @@ class PumpStationWorldRunRepository:
         ):
             _fail("transition-integrity", "staged transition does not extend its parent")
         return transition
+
+    def _require_staged_v4_identity(
+        self,
+        staged: PumpStationStagedTransitionV4,
+    ) -> PumpStationTransitionV4:
+        """Require one durable V4 parent, commit, command, and next snapshot."""
+        prior = staged.prior_snapshot
+        snapshot = staged.snapshot
+        commit = staged.commit
+        if (
+            pump_station_artifact_id(commit, record_profile="v4") != snapshot.commit_id
+            or commit.run_id != snapshot.run_id
+            or commit.sequence != snapshot.sequence
+            or commit.parent_commit_id != prior.commit_id
+            or commit.state_id != snapshot.state_id
+            or snapshot.snapshot_version != prior.snapshot_version
+            or snapshot.run_id != prior.run_id
+            or snapshot.episode_id != prior.episode_id
+            or snapshot.world_branch_id != prior.world_branch_id
+            or snapshot.sequence != prior.sequence + 1
+        ):
+            _fail("transition-integrity", "staged V4 snapshot and commit chain differ")
+        if self.load_commit(snapshot.commit_id) != commit:
+            _fail("transition-integrity", "stored staged V4 commit differs")
+        parent = self.load_commit(prior.commit_id)
+        if parent.run_id != prior.run_id or parent.sequence != prior.sequence or parent.state_id != prior.state_id:
+            _fail("transition-integrity", "staged V4 prior snapshot and commit differ")
+        command, proposal, information_set, transition = self._load_v4_step(commit)
+        if (
+            command != staged.command
+            or proposal != staged.proposal
+            or information_set != staged.information_set
+            or transition != staged.transition
+            or not self._v4_step_extends_parent(parent, commit, command, transition)
+        ):
+            _fail("transition-integrity", "staged V4 evidence does not extend its parent")
+        return transition
+
+    @staticmethod
+    def _v4_step_extends_parent(
+        parent: PumpStationWorldRunCommitRecord,
+        commit: PumpStationWorldRunCommitV2,
+        command: PumpStationCommandV4,
+        transition: PumpStationTransitionV4,
+    ) -> bool:
+        """Return whether one V4 command and receipt bind their exact parent."""
+        parent_content_id = pump_station_artifact_id(parent)
+        return (
+            commit.sequence == parent.sequence + 1
+            and commit.parent_commit_id == parent_content_id
+            and command.based_on_sequence == parent.sequence
+            and command.base_state_id == parent.state_id
+            and command.base_commit_id == parent_content_id
+            and transition.receipt.sequence == commit.sequence
+            and transition.receipt.before_state_id == parent.state_id
+            and transition.receipt.after_state_id == commit.state_id
+            and transition.receipt.request_id == command.request_id
+            and transition.receipt.action_or_control_kind == command.action_name
+        )
 
     @staticmethod
     def _step_extends_parent(
@@ -532,6 +782,7 @@ class PumpStationWorldRunRepository:
         proposal = cast(PumpStationProposal, durable_input)
         return (
             information_set is not None
+            and isinstance(information_set.base_view, PumpStationActorView)
             and proposal.context.based_on_sequence == parent.sequence
             and information_set.base_view.current_state.state_sequence == parent.sequence
         )
@@ -542,7 +793,11 @@ class PumpStationWorldRunRepository:
     ) -> PumpStationWorldRunCommit | None:
         """Return a proposal commit only when it is on the selected chain."""
         for commit in reversed(self.commits()):
-            if commit.proposal_id == proposal_id and commit.information_set_content_id is not None:
+            if (
+                isinstance(commit, PumpStationWorldRunCommit)
+                and commit.proposal_id == proposal_id
+                and commit.information_set_content_id is not None
+            ):
                 return commit
         return None
 
@@ -553,17 +808,135 @@ class PumpStationWorldRunRepository:
         """Return one selected host-control commit by idempotent request identity."""
         for commit in reversed(self.commits()):
             if (
-                commit.proposal_id == request_id
+                isinstance(commit, PumpStationWorldRunCommit)
+                and commit.proposal_id == request_id
                 and commit.information_set_content_id is None
                 and commit.proposal_content_id is not None
             ):
                 return commit
         return None
 
-    def commits(self) -> tuple[PumpStationWorldRunCommit, ...]:
+    def find_committed_v4_command(
+        self,
+        request_id: str,
+    ) -> PumpStationWorldRunCommitV2 | None:
+        """Return one selected V4 commit by its cross-surface request identity."""
+        for commit in reversed(self.commits()):
+            if isinstance(commit, PumpStationWorldRunCommitV2) and commit.request_id == request_id:
+                return commit
+        return None
+
+    def recover_staged_v4_command(
+        self,
+        command: PumpStationCommandV4,
+    ) -> PumpStationTransitionV4 | None:
+        """Select one exact complete V4 command left durable before selection."""
+        with self.locked():
+            return self._recover_staged_v4_command_under_lock(command)
+
+    def _recover_staged_v4_command_under_lock(
+        self,
+        command: PumpStationCommandV4,
+    ) -> PumpStationTransitionV4 | None:
+        """Recover one unselected V4 commit while the caller owns the run lock."""
+        manifest = self.load_manifest()
+        if not isinstance(manifest, PumpStationWorldRunManifestV2):
+            _fail("record-versions", "legacy manifest cannot recover a V4 command")
+        self._require_v4_command_scope(command, manifest)
+        decode_pump_station_v4_command(command)
+        matches: list[
+            tuple[
+                PumpStationWorldRunCommitV2,
+                PumpStationProposal | None,
+                PumpStationInformationSet | None,
+                PumpStationTransitionV4,
+            ]
+        ] = []
+        commits_root = self._root / "commits"
+        if not commits_root.exists():
+            return None
+        for path in sorted(commits_root.glob("*.json")):
+            commit = self.load_commit(path.stem)
+            if isinstance(commit, PumpStationWorldRunCommit):
+                if commit.proposal_id == command.request_id:
+                    _fail(
+                        "v4-command-id-conflict",
+                        f"{command.request_id} is already used by a legacy transition",
+                    )
+                continue
+            if commit.request_id != command.request_id:
+                continue
+            stored_command, proposal, information_set, transition = self._load_v4_step(commit)
+            if stored_command != command or commit.parent_commit_id != command.base_commit_id:
+                _fail(
+                    "v4-command-id-conflict",
+                    f"{command.request_id} has different staged content",
+                )
+            matches.append((commit, proposal, information_set, transition))
+        if not matches:
+            return None
+        if len(matches) != 1:
+            _fail(
+                "v4-command-id-conflict",
+                f"{command.request_id} has more than one durable outcome",
+            )
+        commit, proposal, information_set, transition = matches[0]
+        parent = self.load_commit(commit.parent_commit_id)
+        if not self._v4_step_extends_parent(
+            parent,
+            commit,
+            command,
+            transition,
+        ):
+            _fail("transition-integrity", "staged V4 recovery does not extend its parent")
+        prior_snapshot = PumpStationStateSnapshotRef(
+            snapshot_version=manifest.snapshot_version,
+            run_id=manifest.run_id,
+            episode_id=manifest.episode_id,
+            world_branch_id=manifest.world_branch_id,
+            sequence=parent.sequence,
+            state_id=parent.state_id,
+            commit_id=commit.parent_commit_id,
+        )
+        commit_id = pump_station_artifact_id(commit, record_profile="v4")
+        snapshot = PumpStationStateSnapshotRef(
+            snapshot_version=manifest.snapshot_version,
+            run_id=manifest.run_id,
+            episode_id=manifest.episode_id,
+            world_branch_id=manifest.world_branch_id,
+            sequence=commit.sequence,
+            state_id=commit.state_id,
+            commit_id=commit_id,
+        )
+        staged = PumpStationStagedTransitionV4(
+            prior_snapshot=prior_snapshot,
+            snapshot=snapshot,
+            command=command,
+            transition=transition,
+            commit=commit,
+            proposal=proposal,
+            information_set=information_set,
+        )
+        return self._publish_staged_v4_transition_under_lock(staged)
+
+    def validate_repeated_v4_command(
+        self,
+        commit: PumpStationWorldRunCommitV2,
+        command: PumpStationCommandV4,
+    ) -> PumpStationTransitionV4:
+        """Return a selected V4 retry only when the complete command is identical."""
+        stored_command, _, _, transition = self._load_v4_step(commit)
+        if stored_command != command:
+            _fail(
+                "v4-command-id-conflict",
+                f"{command.request_id} is already bound to different content",
+            )
+        return transition
+
+    def commits(self) -> tuple[PumpStationWorldRunCommitRecord, ...]:
         """Reload the exact selected commit chain from initial state to current."""
         pointer = self._load_current()
-        chain: list[PumpStationWorldRunCommit] = []
+        chain: list[PumpStationWorldRunCommitRecord] = []
         seen: set[str] = set()
         commit_id: str | None = pointer.commit_id
         while commit_id is not None:
@@ -581,6 +954,8 @@ class PumpStationWorldRunRepository:
         """Reload every committed proposal, information set, receipt, event batch, and state."""
         steps: list[PumpStationRunStep] = []
         for commit in self.commits()[1:]:
+            if not isinstance(commit, PumpStationWorldRunCommit):
+                _fail("record-versions", "legacy step access selected a V4 commit")
             durable_input, information_set, transition = self._load_step(commit)
             if _is_control_input(durable_input):
                 steps.append(
@@ -605,6 +980,25 @@ class PumpStationWorldRunRepository:
                         transition=transition,
                     )
                 )
+        return tuple(steps)
+
+    def v4_steps(
+        self,
+    ) -> tuple[PumpStationRunStepV4, ...]:
+        """Reload every selected V4 command and its complete transition evidence."""
+        steps: list[PumpStationRunStepV4] = []
+        for commit in self.commits()[1:]:
+            if not isinstance(commit, PumpStationWorldRunCommitV2):
+                _fail("record-versions", "V4 step access selected a legacy commit")
+            command, proposal, information_set, transition = self._load_v4_step(commit)
+            steps.append(
+                PumpStationRunStepV4(
+                    command=command,
+                    proposal=proposal,
+                    information_set=information_set,
+                    transition=transition,
+                )
+            )
         return tuple(steps)
 
     def load_transition(
@@ -770,7 +1164,148 @@ class PumpStationWorldRunRepository:
             ),
         )
 
-    def _load_proposal(self, content_id: str) -> PumpStationProposal:
+    def _load_v4_step(
+        self,
+        commit: PumpStationWorldRunCommitV2,
+    ) -> tuple[
+        PumpStationCommandV4,
+        PumpStationProposal | None,
+        PumpStationInformationSet | None,
+        PumpStationTransitionV4,
+    ]:
+        """Reload and reconcile one strict V4 command, state, and receipt."""
+        command = load_pump_station_artifact(
+            self._read_content("commands", commit.command_content_id),
+            PumpStationCommandV4,
+            record_profile="v4",
+        )
+        manifest = self.load_manifest()
+        if not isinstance(manifest, PumpStationWorldRunManifestV2):
+            _fail("record-versions", "legacy manifest selected a V4 command")
+        self._require_v4_command_scope(command, manifest)
+        decode_pump_station_v4_command(command)
+        proposal: PumpStationProposal | None = None
+        information_set: PumpStationInformationSet | None = None
+        if commit.proposal_content_id is not None:
+            if commit.information_set_content_id is None:
+                _fail("artifact-integrity", "V4 actor commit lacks an information set")
+            proposal = self._load_proposal(
+                commit.proposal_content_id,
+                record_profile="v4",
+            )
+            information_set = load_pump_station_artifact(
+                self._read_content(
+                    "information-sets",
+                    commit.information_set_content_id,
+                ),
+                PumpStationInformationSet,
+                record_profile="v4",
+            )
+        receipt = load_pump_station_artifact(
+            self._read_content("receipts", commit.receipt_content_id),
+            PumpStationTransitionReceiptV4,
+            record_profile="v4",
+        )
+        state = self.load_state(commit.state_id)
+        if state.state_version != PUMP_STATION_STATE_VERSION_V4:
+            _fail("record-versions", "V4 transition evidence selects a legacy state")
+        coupled_state = cast(PumpStationCoupledStewardshipState, state)
+        transition = PumpStationTransitionV4(
+            state=coupled_state,
+            receipt=receipt,
+        )
+        if (
+            pump_station_artifact_id(command, record_profile="v4") != commit.command_content_id
+            or pump_station_artifact_id(receipt, record_profile="v4") != commit.receipt_content_id
+            or command.request_id != commit.request_id
+            or receipt.request_id != commit.request_id
+            or receipt.sequence != commit.sequence
+            or receipt.after_state_id != commit.state_id
+            or receipt.actor_action != (command.kind == "actor")
+        ):
+            _fail("artifact-integrity", "V4 commit evidence does not reconcile")
+        if command.kind == "actor":
+            if proposal is None or information_set is None:
+                _fail("artifact-integrity", "V4 actor command lacks bound proposal evidence")
+            parent = self.load_commit(commit.parent_commit_id)
+            parent_state = self._load_v4_state(parent.state_id)
+            expected_information_set = self._project_v4_information_set(
+                manifest,
+                parent_state,
+                command,
+            )
+            if (
+                pump_station_artifact_id(proposal, record_profile="v4") != commit.proposal_content_id
+                or pump_station_artifact_id(information_set, record_profile="v4") != commit.information_set_content_id
+                or proposal.context.proposal_id != command.request_id
+                or proposal.context.information_set_id != information_set.information_set_id
+                or information_set != expected_information_set
+            ):
+                _fail("artifact-integrity", "V4 actor evidence does not reconcile")
+        elif proposal is not None or information_set is not None:
+            _fail("artifact-integrity", "V4 host control contains actor evidence")
+        return command, proposal, information_set, transition
+
+    @staticmethod
+    def _require_v4_command_scope(
+        command: PumpStationCommandV4,
+        manifest: PumpStationWorldRunManifestV2,
+    ) -> None:
+        """Require one V4 command to use the immutable stored world scope."""
+        observed = (
+            command.task_world_id,
+            command.run_id,
+            command.episode_id,
+            command.world_branch_id,
+        )
+        expected = (
+            manifest.task_world_id,
+            manifest.run_id,
+            manifest.episode_id,
+            manifest.world_branch_id,
+        )
+        if observed != expected:
+            _fail("world-run-identity", "V4 command scope differs from the stored run")
+
+    def _load_v4_state(
+        self,
+        state_id: str,
+    ) -> PumpStationCoupledStewardshipState:
+        """Reload one state only when it uses the registered V4 profile."""
+        state = self.load_state(state_id)
+        if state.state_version != PUMP_STATION_STATE_VERSION_V4:
+            _fail("record-versions", "V4 command selected a legacy state")
+        return cast(PumpStationCoupledStewardshipState, state)
+
+    @staticmethod
+    def _project_v4_information_set(
+        manifest: PumpStationWorldRunManifestV2,
+        state: PumpStationCoupledStewardshipState,
+        command: PumpStationCommandV4,
+    ) -> PumpStationInformationSet:
+        """Rebuild the only actor information set valid for one V4 parent."""
+        if command.agent_tenure_id is None:
+            _fail("command-content", "V4 actor command lacks its tenure")
+        return project_coupled_information_set(
+            state,
+            episode_id=manifest.episode_id,
+            world_branch_id=manifest.world_branch_id,
+            actor_id="pump-station-actor",
+            agent_tenure_id=command.agent_tenure_id,
+            source_artifact_ids=(
+                manifest.reference_system_content_id,
+                manifest.package_content_id,
+                manifest.temporal_bundle_content_id,
+            ),
+            workspace_tool_ids=(PUMP_STATION_ACTOR_WORKSPACE_TOOL_ID_V2,),
+        )
+
+    def _load_proposal(
+        self,
+        content_id: str,
+        *,
+        record_profile: str | None = None,
+    ) -> PumpStationProposal:
         payload = self._read_content("proposals", content_id)
         try:
             document = json.loads(payload)
@@ -782,7 +1317,11 @@ class PumpStationWorldRunRepository:
             _fail("artifact-type", f"unknown stored proposal type {type_name!r}")
         return cast(
             PumpStationProposal,
-            load_pump_station_artifact(payload, proposal_type),
+            load_pump_station_artifact(
+                payload,
+                proposal_type,
+                record_profile=record_profile,
+            ),
         )
 
     def _reject_proposal_collision(
@@ -797,6 +1336,13 @@ class PumpStationWorldRunRepository:
             return
         for path in commits_root.glob("*.json"):
             commit = self.load_commit(path.stem)
+            if isinstance(commit, PumpStationWorldRunCommitV2):
+                if commit.request_id == proposal.context.proposal_id:
+                    _fail(
+                        "proposal-id-conflict",
+                        f"{proposal.context.proposal_id} is already used by a V4 transition",
+                    )
+                continue
             if commit.proposal_id != proposal.context.proposal_id:
                 continue
             stored_input, stored_information_set, _ = self._load_step(commit)
@@ -821,6 +1367,13 @@ class PumpStationWorldRunRepository:
             return
         for path in commits_root.glob("*.json"):
             commit = self.load_commit(path.stem)
+            if isinstance(commit, PumpStationWorldRunCommitV2):
+                if commit.request_id == request.request_id:
+                    _fail(
+                        "control-request-id-conflict",
+                        f"{request.request_id} is already used by a V4 transition",
+                    )
+                continue
             if commit.proposal_id != request.request_id:
                 continue
             stored_input, information_set, _ = self._load_step(commit)
@@ -830,9 +1383,42 @@ class PumpStationWorldRunRepository:
                     f"{request.request_id} has different staged content",
                 )
 
+    def _reject_v4_command_collision(
+        self,
+        command: PumpStationCommandV4,
+        *,
+        parent_commit_id: str,
+    ) -> None:
+        """Reject reuse of one V4 request identity for changed staged content."""
+        commits_root = self._root / "commits"
+        if not commits_root.exists():
+            return
+        for path in commits_root.glob("*.json"):
+            commit = self.load_commit(path.stem)
+            if isinstance(commit, PumpStationWorldRunCommit):
+                if commit.proposal_id == command.request_id:
+                    _fail(
+                        "v4-command-id-conflict",
+                        f"{command.request_id} is already used by a legacy transition",
+                    )
+                continue
+            if commit.request_id != command.request_id:
+                continue
+            stored, _, _, _ = self._load_v4_step(commit)
+            if stored == command and commit.parent_commit_id == parent_commit_id:
+                _fail(
+                    "v4-command-already-staged",
+                    f"{command.request_id} already has one durable staged outcome",
+                )
+            else:
+                _fail(
+                    "v4-command-id-conflict",
+                    f"{command.request_id} has different staged content",
+                )
+
     def _validate_chain(
         self,
-        chain: tuple[PumpStationWorldRunCommit, ...],
+        chain: tuple[PumpStationWorldRunCommitRecord, ...],
         pointer: PumpStationCurrentRunPointer,
     ) -> None:
         if (
@@ -844,16 +1430,29 @@ class PumpStationWorldRunRepository:
         manifest = self.load_manifest()
         if chain[0].state_id != manifest.initial_state_id:
             _fail("artifact-integrity", "initial commit differs from manifest")
-        previous = chain[0]
+        previous: PumpStationWorldRunCommitRecord = chain[0]
         for commit in chain[1:]:
-            durable_input, information_set, transition = self._load_step(commit)
-            if not self._step_extends_parent(
-                previous,
-                commit,
-                durable_input,
-                information_set,
-                transition,
-            ):
+            valid = False
+            if isinstance(commit, PumpStationWorldRunCommitV2):
+                if not isinstance(manifest, PumpStationWorldRunManifestV2):
+                    _fail("record-versions", "legacy manifest selected a V4 commit")
+                command, _, _, transition_v4 = self._load_v4_step(commit)
+                valid = self._v4_step_extends_parent(
+                    previous,
+                    commit,
+                    command,
+                    transition_v4,
+                )
+            elif isinstance(previous, PumpStationWorldRunCommit):
+                durable_input, information_set, transition = self._load_step(commit)
+                valid = self._step_extends_parent(
+                    previous,
+                    commit,
+                    durable_input,
+                    information_set,
+                    transition,
+                )
+            if not valid:
                 _fail("artifact-integrity", "commit does not extend its parent")
             previous = commit
         if (
@@ -868,8 +1467,18 @@ class PumpStationWorldRunRepository:
         self._publish_content("states", state_id, state)
         return state_id
 
-    def _publish_content(self, collection: str, content_id: str, value: object) -> None:
-        payload = pump_station_artifact_bytes(value)
+    def _publish_content(
+        self,
+        collection: str,
+        content_id: str,
+        value: object,
+        *,
+        record_profile: str | None = None,
+    ) -> None:
+        payload = pump_station_artifact_bytes(
+            value,
+            record_profile=record_profile,
+        )
         if collection != "states" and hashlib.sha256(payload).hexdigest() != content_id:
             _fail("artifact-integrity", f"{collection} content identity differs")
         path = self._root / collection / f"{content_id}.json"

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_serialization.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_serialization.py
@@ -86,6 +86,9 @@ _V4_FIELD_EXCLUSIONS = {
         "event_effect_ids",
     },
     "PumpStationActorView": {"time_context"},
+    "RequestInspection": {"backlog_item_id"},
+    "RequestObstructionClearance": {"backlog_item_id"},
+    "RequestVerification": {"backlog_item_id"},
 }
 
 
@@ -104,6 +107,14 @@ def _fail(code: str, detail: str) -> NoReturn:
 
 def _record_profile(value: object) -> str:
     type_name = type(value).__name__
+    if type_name in {
+        "PumpStationCommandV4",
+        "PumpStationTransitionReceiptV4",
+        "PumpStationTransitionV4",
+        "PumpStationWorldRunCommitV2",
+        "PumpStationStagedTransitionV4",
+    }:
+        return _V4
     if type_name == "PumpStationWorldRunManifest":
         return _MANIFEST_V1
     if type_name == "PumpStationWorldRunManifestV2":
@@ -120,6 +131,8 @@ def _record_profile(value: object) -> str:
         if version.endswith(".v3"):
             return _V3
         return _V2 if version.endswith(".v2") else _V1
+    if type_name == "PumpStationCoupledActorView":
+        return _V4
     if type_name in {"PumpStationActorView", "PumpStationStructuredHandover"}:
         actor_view = value if type_name == "PumpStationActorView" else getattr(value, "current_actor_view", None)
         if str(getattr(actor_view, "projection_policy_id", "")).endswith(".v4"):
@@ -142,11 +155,21 @@ def _record_profile(value: object) -> str:
 def _document_profile(value: object) -> str:
     if isinstance(value, dict):
         type_name = value.get("$type")
+        if type_name in {
+            "PumpStationCommandV4",
+            "PumpStationTransitionReceiptV4",
+            "PumpStationTransitionV4",
+            "PumpStationWorldRunCommitV2",
+            "PumpStationStagedTransitionV4",
+        }:
+            return _V4
         if type_name == "PumpStationWorldRunManifest":
             return _MANIFEST_V1
         if type_name == "PumpStationWorldRunManifestV2":
             return _MANIFEST_V2
         if type_name == "PumpStationActorView" and str(value.get("projection_policy_id", "")).endswith(".v4"):
+            return _V4
+        if type_name == "PumpStationCoupledActorView":
             return _V4
         if type_name in {"PumpStationStewardshipState", "PumpStationCurrentStateView"}:
             version = str(value.get("state_version", ""))

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_asw_8_operational_boundaries.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_asw_8_operational_boundaries.py
@@ -15,11 +15,7 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.coupled_
     create_coupled_run,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.coupled_runtime import (
-    PUMP_STATION_COMMON_BOUNDARY_CONTROL_VERSION,
-    PUMP_STATION_PROCESS_OUTCOME_VERSION,
-    PumpStationCommonBoundaryRequest,
     PumpStationCoupledWorldError,
-    PumpStationProcessOutcomeRequest,
     project_coupled_actor_view,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.coupled_work import (
@@ -32,6 +28,12 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.coupled_
     PumpStationReusablePool,
     PumpStationWorkGenerationRecord,
     apply_declared_work_generation,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_models import (
+    PUMP_STATION_COMMON_BOUNDARY_CONTROL_VERSION,
+    PUMP_STATION_PROCESS_OUTCOME_VERSION,
+    PumpStationCommonBoundaryRequest,
+    PumpStationProcessOutcomeRequest,
 )
 
 
@@ -352,6 +354,7 @@ def test_failed_functional_check_retains_wg03_and_failed_verification_creates_on
         )
     )
     retained = functional.state.backlog_item(wg03.item_id)
+    assert functional.receipts[-1].required_authorities == ("maintenance",)
     assert retained.status is PumpStationBacklogStatus.PLANNED
     assert retained.closure_evidence_ids == ("evidence-b-functional-failed-001",)
     assert len([item for item in functional.state.backlog if item.generation_rule_id == "WG-03"]) == 1

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_registered_world_run_parity.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_registered_world_run_parity.py
@@ -1,0 +1,283 @@
+# ABOUTME: Compares registered V4 world-run transitions with the retained coupled behaviour oracle.
+# ABOUTME: Runs the reference journey without treating a tenure handover as a world-state mutation.
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from aec_bench.contracts.world_interface import WorldActorActionRequest
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.coupled_execution import (
+    execute_asw_8_reference_controller,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.coupled_run import (
+    create_coupled_run,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_models import (
+    PUMP_STATION_BOUND_CONTROL_VERSION,
+    PUMP_STATION_COMMON_BOUNDARY_CONTROL_VERSION,
+    PumpStationBoundControlRequest,
+    PumpStationCommonBoundaryRequest,
+    PumpStationOperationsBoundaryReviewRequest,
+    PumpStationProposalError,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_state_machine import (
+    apply_stewardship_control_v4,
+    apply_stewardship_proposal_v4,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_verifier import (
+    verify_stewardship_run_v4,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_views import (
+    bind_information_set,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run import (
+    PumpStationWorldRun,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_models import (
+    PumpStationWorldRunError,
+    PumpStationWorldRunManifestV2,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_repository import (
+    PumpStationWorldRunRepository,
+)
+
+
+def test_registered_run_matches_each_reference_journey_transition(
+    tmp_path: Path,
+) -> None:
+    source = execute_asw_8_reference_controller(
+        run_id="source-reference-journey",
+        world_branch_id="source-reference-branch",
+    ).run
+    oracle = create_coupled_run(
+        run_id="oracle-reference-journey",
+        world_branch_id="oracle-reference-branch",
+    )
+    registered = PumpStationWorldRun.create_reference_system(
+        repository=PumpStationWorldRunRepository(tmp_path / "run"),
+        run_id="registered-reference-journey",
+        episode_id="registered-reference-episode",
+        world_branch_id="registered-reference-branch",
+    )
+    compared_transition_ids: list[str] = []
+
+    for command in source.commands:
+        if command.kind == "handover":
+            continue
+        if command.kind == "actor":
+            arguments = command.arguments
+            backlog_item_id = arguments.get("backlog_item_id")
+            if isinstance(backlog_item_id, str) and not any(
+                item.item_id == backlog_item_id for item in oracle.state.backlog
+            ):
+                work_type = {
+                    "request_functional_check": "minimum_functional_check",
+                    "request_post_maintenance_verification": "post_maintenance_verification",
+                    "request_inspection": "collateral_duty_inspection",
+                }[command.action_name]
+                candidates = tuple(
+                    item.item_id
+                    for item in oracle.state.backlog
+                    if item.work_type == work_type
+                    and item.target_id == arguments.get("pump_id")
+                    and item.status.value in {"open", "planned"}
+                )
+                assert len(candidates) == 1
+                arguments["backlog_item_id"] = candidates[0]
+            oracle = oracle.apply_actor(
+                request_id=command.request_id,
+                action_name=command.action_name,
+                arguments=arguments,
+            )
+            observation = registered.observe_v4_actor(
+                session_id="registered-reference-session",
+                agent_tenure_id="reference-controller",
+            )
+            transition = registered.apply_v4_actor_action(
+                WorldActorActionRequest(
+                    request_id=command.request_id,
+                    action_name=command.action_name,
+                    binding=observation.binding,
+                    arguments=arguments,
+                )
+            )
+        else:
+            assert command.kind == "operations_review"
+            arguments = {
+                **command.arguments,
+                "base_state_id": oracle.state.state_id,
+            }
+            review = PumpStationOperationsBoundaryReviewRequest(**arguments)
+            oracle = oracle.apply_review(review)
+            snapshot = registered.snapshot()
+            transition = registered.apply_v4_control(
+                PumpStationBoundControlRequest(
+                    control_envelope_version=PUMP_STATION_BOUND_CONTROL_VERSION,
+                    request_id=review.review_id,
+                    run_id=snapshot.run_id,
+                    episode_id=snapshot.episode_id,
+                    world_branch_id=snapshot.world_branch_id,
+                    base_state_id=snapshot.state_id,
+                    base_commit_id=snapshot.commit_id,
+                    based_on_sequence=snapshot.sequence,
+                    control=review,
+                )
+            )
+        assert transition.state == oracle.state
+        assert transition.receipt == oracle.receipts[-1]
+        compared_transition_ids.append(transition.receipt.transition_id)
+
+    report = registered.verify_v4()
+
+    assert len(compared_transition_ids) == len(source.commands) - 1
+    assert registered.state == oracle.state
+    assert report.valid
+    assert report.replayed_transition_ids == tuple(compared_transition_ids)
+    assert not (tmp_path / "run" / "HEAD").exists()
+    assert not (tmp_path / "run" / "generations").exists()
+
+
+def test_v4_task_semantics_reject_pending_actor_view_identity(
+    tmp_path: Path,
+) -> None:
+    run = PumpStationWorldRun.create_reference_system(
+        repository=PumpStationWorldRunRepository(tmp_path / "pending-view"),
+        run_id="pending-view-run",
+        episode_id="pending-view-episode",
+        world_branch_id="pending-view-branch",
+    )
+    initial_state = run.state
+    observation = run.observe_v4_actor(
+        session_id="pending-view-session",
+        agent_tenure_id="pending-view-tenure",
+    )
+    run.apply_v4_actor_action(
+        WorldActorActionRequest(
+            request_id="pending-view-request",
+            action_name="request_post_maintenance_verification",
+            binding=observation.binding,
+            arguments={
+                "pump_id": "pump-a",
+                "backlog_item_id": "backlog-a-verification-001",
+                "reason": "Test the actor-view identity boundary.",
+            },
+        )
+    )
+    step = run.repository.v4_steps()[0]
+    assert step.proposal is not None
+    assert step.information_set is not None
+    forged_view = replace(
+        step.information_set.base_view,
+        view_id="pending",
+        episode_id="foreign-episode",
+    )
+    object.__setattr__(forged_view, "view_id", "pending")
+    forged_information_set = bind_information_set(
+        forged_view,
+        replace(
+            step.information_set.observation_history,
+            view_ids=("pending",),
+        ),
+        step.information_set.current_context,
+    )
+    forged_proposal = replace(
+        step.proposal,
+        context=replace(
+            step.proposal.context,
+            base_view_id="pending",
+            information_set_id=forged_information_set.information_set_id,
+        ),
+    )
+
+    with pytest.raises(PumpStationProposalError) as raised:
+        apply_stewardship_proposal_v4(
+            run.model,
+            initial_state,
+            forged_proposal,
+            information_set=forged_information_set,
+        )
+
+    assert raised.value.code == "proposal-binding"
+
+
+def test_v4_root_control_rejects_extra_command_arguments(
+    tmp_path: Path,
+) -> None:
+    run = PumpStationWorldRun.create_reference_system(
+        repository=PumpStationWorldRunRepository(tmp_path / "extra-control"),
+        run_id="extra-control-run",
+        episode_id="extra-control-episode",
+        world_branch_id="extra-control-branch",
+    )
+    initial_state = run.state
+    snapshot = run.snapshot()
+    control = PumpStationCommonBoundaryRequest(
+        version=PUMP_STATION_COMMON_BOUNDARY_CONTROL_VERSION,
+        request_id="extra-control-request",
+        authority_id="operations-controller",
+        boundary_kind="power",
+        available=False,
+        base_state_id=snapshot.state_id,
+    )
+    bound_control = PumpStationBoundControlRequest(
+        control_envelope_version=PUMP_STATION_BOUND_CONTROL_VERSION,
+        request_id=control.request_id,
+        run_id=snapshot.run_id,
+        episode_id=snapshot.episode_id,
+        world_branch_id=snapshot.world_branch_id,
+        base_state_id=snapshot.state_id,
+        base_commit_id=snapshot.commit_id,
+        based_on_sequence=snapshot.sequence,
+        control=control,
+    )
+    command = run._v4_control_command(bound_control)
+    arguments = json.loads(command.arguments_json)
+    arguments["ignored"] = "content"
+    malformed_command = replace(
+        command,
+        arguments_json=json.dumps(
+            arguments,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ),
+    )
+    transition = apply_stewardship_control_v4(initial_state, control)
+    manifest = run.manifest
+    assert isinstance(manifest, PumpStationWorldRunManifestV2)
+
+    with pytest.raises(PumpStationWorldRunError) as raised:
+        run.repository.stage_v4_transition(
+            manifest=manifest,
+            prior_snapshot=snapshot,
+            command=malformed_command,
+            transition=transition,
+        )
+
+    assert raised.value.code == "command-content"
+
+    valid_transition = run.apply_v4_control(bound_control)
+    step = run.repository.v4_steps()[0]
+    report = verify_stewardship_run_v4(
+        run.model,
+        initial_state,
+        (replace(step, command=malformed_command),),
+        expected_final_state_id=valid_transition.state.state_id,
+        expected_task_world_id=manifest.task_world_id,
+        expected_run_id=manifest.run_id,
+        expected_episode_id=manifest.episode_id,
+        expected_world_branch_id=manifest.world_branch_id,
+        expected_actor_id="pump-station-actor",
+        expected_source_artifact_ids=(
+            manifest.reference_system_content_id,
+            manifest.package_content_id,
+            manifest.temporal_bundle_content_id,
+        ),
+    )
+
+    assert report.valid is False
+    assert any("command-content" in issue for issue in report.issues)

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_registered_world_run_transitions.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_registered_world_run_transitions.py
@@ -1,0 +1,1098 @@
+# ABOUTME: Proves registered V4 actions use the existing pump world-run commit chain.
+# ABOUTME: Checks exact actor bindings, retry identity, and the absence of duplicate generation storage.
+
+from __future__ import annotations
+
+import multiprocessing
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import JsonValue
+
+from aec_bench.contracts.world_interface import WorldActorActionRequest
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.physical_models import (
+    PumpStationCoupledModel,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_models import (
+    PUMP_STATION_BOUND_CONTROL_VERSION,
+    PUMP_STATION_COMMON_BOUNDARY_CONTROL_VERSION,
+    PUMP_STATION_OPERATIONS_REVIEW_VERSION,
+    PUMP_STATION_PROCESS_OUTCOME_VERSION,
+    PumpStationBoundControlRequest,
+    PumpStationCommonBoundaryRequest,
+    PumpStationCoupledStewardshipState,
+    PumpStationOperationsBoundaryReviewRequest,
+    PumpStationProcessOutcomeRequest,
+    PumpStationRootControl,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_verifier import (
+    PumpStationRunStepV4,
+    PumpStationVerificationReportV4,
+    verify_stewardship_run_v4,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_views import (
+    PumpStationCoupledActorView,
+    coupled_actor_view_id,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run import (
+    PumpStationWorldRun,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_models import (
+    PUMP_STATION_SERIALIZATION_VERSION,
+    PumpStationStagedTransitionV4,
+    PumpStationStateSnapshotRef,
+    PumpStationWorldRunCommit,
+    PumpStationWorldRunCommitV2,
+    PumpStationWorldRunError,
+    PumpStationWorldRunManifestV2,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_repository import (
+    PumpStationWorldRunRepository,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_serialization import (
+    pump_station_artifact_id,
+)
+
+type PumpStationReferenceRun = PumpStationWorldRun[
+    PumpStationCoupledModel,
+    PumpStationCoupledStewardshipState,
+]
+
+
+def _apply_registered_actor_in_child(
+    root: Path,
+    snapshot: PumpStationStateSnapshotRef,
+    request_value: dict[str, Any],
+    ready: Any,
+    start: Any,
+    results: Any,
+) -> None:
+    run = PumpStationWorldRun.resume_reference_system(
+        repository=PumpStationWorldRunRepository(root),
+        snapshot=snapshot,
+    )
+    request = WorldActorActionRequest.model_validate(request_value)
+    ready.set()
+    if not start.wait(10):
+        results.put(("error", "start-timeout"))
+        return
+    try:
+        transition = run.apply_v4_actor_action(request)
+    except PumpStationWorldRunError as error:
+        results.put(("error", error.code))
+        return
+    results.put(
+        (
+            "applied",
+            transition.receipt.transition_id,
+            transition.state.state_id,
+            run.snapshot().commit_id,
+        )
+    )
+
+
+def _start_reference_run(root: Path) -> PumpStationReferenceRun:
+    return PumpStationWorldRun.create_reference_system(
+        repository=PumpStationWorldRunRepository(root),
+        run_id="run-v4-transitions",
+        episode_id="episode-v4-transitions",
+        world_branch_id="branch-v4-transitions",
+    )
+
+
+def _actor_request(
+    run: PumpStationReferenceRun,
+    *,
+    request_id: str,
+    action_name: str = "request_post_maintenance_verification",
+    arguments: dict[str, JsonValue] | None = None,
+    reason: str,
+) -> WorldActorActionRequest:
+    observation = run.observe_v4_actor(
+        session_id="session-v4-transitions",
+        agent_tenure_id="reference-controller",
+    )
+    return WorldActorActionRequest(
+        request_id=request_id,
+        action_name=action_name,
+        binding=observation.binding,
+        arguments={
+            **(
+                arguments
+                if arguments is not None
+                else {
+                    "pump_id": "pump-a",
+                    "backlog_item_id": "backlog-a-verification-001",
+                }
+            ),
+            "reason": reason,
+        },
+    )
+
+
+def _bound_control(
+    run: PumpStationReferenceRun,
+    control: PumpStationRootControl,
+) -> PumpStationBoundControlRequest:
+    snapshot = run.snapshot()
+    request_id = (
+        control.review_id if isinstance(control, PumpStationOperationsBoundaryReviewRequest) else control.request_id
+    )
+    return PumpStationBoundControlRequest(
+        control_envelope_version=PUMP_STATION_BOUND_CONTROL_VERSION,
+        request_id=request_id,
+        run_id=snapshot.run_id,
+        episode_id=snapshot.episode_id,
+        world_branch_id=snapshot.world_branch_id,
+        base_state_id=snapshot.state_id,
+        base_commit_id=snapshot.commit_id,
+        based_on_sequence=snapshot.sequence,
+        control=control,
+    )
+
+
+def _verify_recorded_v4_steps(
+    run: PumpStationReferenceRun,
+    initial_state: PumpStationCoupledStewardshipState,
+    steps: tuple[PumpStationRunStepV4, ...],
+    *,
+    expected_final_state_id: str,
+) -> PumpStationVerificationReportV4:
+    manifest = run.manifest
+    assert isinstance(manifest, PumpStationWorldRunManifestV2)
+    return verify_stewardship_run_v4(
+        run.model,
+        initial_state,
+        steps,
+        expected_final_state_id=expected_final_state_id,
+        expected_task_world_id=manifest.task_world_id,
+        expected_run_id=manifest.run_id,
+        expected_episode_id=manifest.episode_id,
+        expected_world_branch_id=manifest.world_branch_id,
+        expected_actor_id="pump-station-actor",
+        expected_source_artifact_ids=(
+            manifest.reference_system_content_id,
+            manifest.package_content_id,
+            manifest.temporal_bundle_content_id,
+        ),
+    )
+
+
+def _record_one_v4_actor_step(
+    root: Path,
+) -> tuple[
+    PumpStationReferenceRun,
+    PumpStationCoupledStewardshipState,
+    WorldActorActionRequest,
+    PumpStationRunStepV4,
+]:
+    run = _start_reference_run(root)
+    initial_state = run.state
+    request = _actor_request(
+        run,
+        request_id="recorded-v4-actor-step",
+        reason="Record one actor step for integrity checks.",
+    )
+    run.apply_v4_actor_action(request)
+    return run, initial_state, request, run.repository.v4_steps()[0]
+
+
+def _stage_unselected_v4_actor_outcome(
+    run: PumpStationReferenceRun,
+    request: WorldActorActionRequest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> PumpStationStagedTransitionV4:
+    captured: list[PumpStationStagedTransitionV4] = []
+
+    def interrupt_after_staging(staged: PumpStationStagedTransitionV4) -> None:
+        captured.append(staged)
+        raise OSError("interrupt after immutable V4 staging")
+
+    with monkeypatch.context() as patch:
+        patch.setattr(
+            run.repository,
+            "_publish_staged_v4_transition_under_lock",
+            interrupt_after_staging,
+        )
+        with pytest.raises(OSError, match="after immutable V4 staging"):
+            run.apply_v4_actor_action(request)
+    assert len(captured) == 1
+    return captured[0]
+
+
+def _publish_duplicate_v4_outcome(
+    repository: PumpStationWorldRunRepository,
+    staged: PumpStationStagedTransitionV4,
+) -> str:
+    duplicate_receipt = replace(
+        staged.transition.receipt,
+        reason=f"{staged.transition.receipt.reason} Duplicate durable outcome.",
+    )
+    duplicate_receipt_id = pump_station_artifact_id(
+        duplicate_receipt,
+        record_profile="v4",
+    )
+    repository._publish_content(
+        "receipts",
+        duplicate_receipt_id,
+        duplicate_receipt,
+        record_profile="v4",
+    )
+    duplicate_commit = replace(
+        staged.commit,
+        receipt_content_id=duplicate_receipt_id,
+    )
+    duplicate_commit_id = pump_station_artifact_id(
+        duplicate_commit,
+        record_profile="v4",
+    )
+    repository._publish_content(
+        "commits",
+        duplicate_commit_id,
+        duplicate_commit,
+        record_profile="v4",
+    )
+    return duplicate_commit_id
+
+
+def test_registered_actor_action_selects_one_existing_world_run_commit(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "run"
+    run = _start_reference_run(root)
+    request = _actor_request(
+        run,
+        request_id="verify-a-001",
+        reason="Start the required independent Pump A verification.",
+    )
+    opening = run.snapshot()
+
+    assert request.binding.commit_id == opening.commit_id
+    assert request.binding.commit_id != request.binding.state_id
+
+    transition = run.apply_v4_actor_action(request)
+    selected = run.snapshot()
+    commits = run.repository.commits()
+
+    assert transition.receipt.request_id == request.request_id
+    assert transition.receipt.actor_action
+    assert selected.sequence == 1
+    assert selected.state_id == transition.state.state_id
+    assert isinstance(commits[-1], PumpStationWorldRunCommitV2)
+    assert commits[-1].request_id == request.request_id
+    assert len(commits) == 2
+    assert not (root / "HEAD").exists()
+    assert not (root / "generations").exists()
+
+    repeated = run.apply_v4_actor_action(request)
+
+    assert repeated == transition
+    assert run.snapshot() == selected
+    assert run.repository.commits() == commits
+
+
+def test_registered_actor_request_id_rejects_changed_content(
+    tmp_path: Path,
+) -> None:
+    run = _start_reference_run(tmp_path / "run")
+    original = _actor_request(
+        run,
+        request_id="verify-a-conflict",
+        reason="Start the required independent Pump A verification.",
+    )
+    run.apply_v4_actor_action(original)
+    changed = WorldActorActionRequest(
+        request_id=original.request_id,
+        action_name=original.action_name,
+        binding=original.binding,
+        arguments={
+            **original.arguments,
+            "reason": "Use different content under the same request identity.",
+        },
+    )
+
+    with pytest.raises(PumpStationWorldRunError) as raised:
+        run.apply_v4_actor_action(changed)
+
+    assert raised.value.code == "v4-command-id-conflict"
+    assert run.snapshot().sequence == 1
+    assert len(run.repository.commits()) == 2
+
+
+def test_legacy_request_identity_cannot_be_reused_by_a_registered_action(
+    tmp_path: Path,
+) -> None:
+    run = _start_reference_run(tmp_path / "run")
+    opening = run.snapshot()
+    request_id = "cross-profile-legacy-to-v4"
+    legacy_commit = PumpStationWorldRunCommit(
+        serialization_version=PUMP_STATION_SERIALIZATION_VERSION,
+        run_id=run.manifest.run_id,
+        sequence=1,
+        parent_commit_id=opening.commit_id,
+        state_id=opening.state_id,
+        proposal_id=request_id,
+        proposal_content_id=None,
+        information_set_content_id=None,
+        receipt_content_id=None,
+        event_batch_content_id=None,
+    )
+    legacy_commit_id = pump_station_artifact_id(legacy_commit)
+    run.repository._publish_content("commits", legacy_commit_id, legacy_commit)
+    request = _actor_request(
+        run,
+        request_id=request_id,
+        reason="Try to reuse one legacy transition identity.",
+    )
+
+    with pytest.raises(PumpStationWorldRunError) as raised:
+        run.apply_v4_actor_action(request)
+
+    assert raised.value.code == "v4-command-id-conflict"
+    assert run.snapshot() == opening
+    assert run.repository.v4_steps() == ()
+
+
+def test_registered_request_identity_cannot_enter_the_legacy_proposal_path(
+    tmp_path: Path,
+) -> None:
+    run = _start_reference_run(tmp_path / "run")
+    opening = run.snapshot()
+    request = _actor_request(
+        run,
+        request_id="cross-profile-v4-to-legacy",
+        reason="Create one registered request identity.",
+    )
+    run.apply_v4_actor_action(request)
+    step = run.repository.v4_steps()[0]
+    assert step.proposal is not None
+    assert step.information_set is not None
+
+    with pytest.raises(PumpStationWorldRunError) as raised:
+        run.repository._reject_proposal_collision(
+            step.proposal,
+            information_set=step.information_set,
+            parent_commit_id=opening.commit_id,
+        )
+
+    assert raised.value.code == "proposal-id-conflict"
+    assert run.snapshot().sequence == 1
+
+
+def test_repository_rejects_false_actor_request_content_before_selection(
+    tmp_path: Path,
+) -> None:
+    _, _, _, step = _record_one_v4_actor_step(tmp_path / "donor")
+    target = _start_reference_run(tmp_path / "target")
+    opening = target.snapshot()
+    manifest = target.manifest
+    assert isinstance(manifest, PumpStationWorldRunManifestV2)
+    assert step.proposal is not None
+    assert step.information_set is not None
+    false_command = replace(step.command, request_content_id="0" * 64)
+
+    with pytest.raises(PumpStationWorldRunError) as raised:
+        staged = target.repository.stage_v4_transition(
+            manifest=manifest,
+            prior_snapshot=opening,
+            command=false_command,
+            proposal=step.proposal,
+            information_set=step.information_set,
+            transition=step.transition,
+        )
+        target.repository.publish_staged_v4_transition(staged)
+
+    assert raised.value.code == "command-content"
+    assert target.snapshot() == opening
+
+
+def test_repository_rejects_caller_manifest_that_differs_from_the_stored_run(
+    tmp_path: Path,
+) -> None:
+    _, _, request, step = _record_one_v4_actor_step(tmp_path / "donor")
+    target = _start_reference_run(tmp_path / "target")
+    opening = target.snapshot()
+    manifest = target.manifest
+    assert isinstance(manifest, PumpStationWorldRunManifestV2)
+    assert step.proposal is not None
+    assert step.information_set is not None
+    foreign_task_world_id = "foreign-task-world"
+    foreign_binding = request.binding.model_copy(
+        update={"task_world_id": foreign_task_world_id},
+    )
+    foreign_request = WorldActorActionRequest(
+        request_id=request.request_id,
+        action_name=request.action_name,
+        binding=foreign_binding,
+        arguments=request.arguments,
+    )
+    foreign_command = replace(
+        step.command,
+        task_world_id=foreign_task_world_id,
+        request_content_id=foreign_request.content_sha256,
+    )
+    foreign_manifest = replace(
+        manifest,
+        task_world_id=foreign_task_world_id,
+    )
+
+    with pytest.raises(PumpStationWorldRunError) as raised:
+        staged = target.repository.stage_v4_transition(
+            manifest=foreign_manifest,
+            prior_snapshot=opening,
+            command=foreign_command,
+            proposal=step.proposal,
+            information_set=step.information_set,
+            transition=step.transition,
+        )
+        target.repository.publish_staged_v4_transition(staged)
+
+    assert raised.value.code == "world-run-identity"
+    assert target.snapshot() == opening
+
+
+def test_v4_replay_rejects_forged_actor_view_content(
+    tmp_path: Path,
+) -> None:
+    run, initial_state, _, step = _record_one_v4_actor_step(tmp_path / "run")
+    assert step.information_set is not None
+    view = step.information_set.base_view
+    assert isinstance(view, PumpStationCoupledActorView)
+    pending_forged_view = replace(
+        view,
+        view_id="pending",
+        episode_id="foreign-episode",
+        world_branch_id="foreign-branch",
+        source_artifact_ids=("foreign-source",),
+    )
+    forged_view = replace(
+        pending_forged_view,
+        view_id=coupled_actor_view_id(pending_forged_view),
+    )
+    forged_step = replace(
+        step,
+        information_set=replace(step.information_set, base_view=forged_view),
+    )
+
+    report = _verify_recorded_v4_steps(
+        run,
+        initial_state,
+        (forged_step,),
+        expected_final_state_id=step.transition.state.state_id,
+    )
+
+    assert report.valid is False
+    assert any("actor-view" in issue for issue in report.issues)
+
+
+def test_v4_replay_rejects_self_consistent_foreign_command_scope(
+    tmp_path: Path,
+) -> None:
+    run, initial_state, request, step = _record_one_v4_actor_step(tmp_path / "run")
+    foreign_binding = request.binding.model_copy(
+        update={
+            "episode_id": "foreign-episode",
+            "world_branch_id": "foreign-branch",
+        },
+    )
+    foreign_request = WorldActorActionRequest(
+        request_id=request.request_id,
+        action_name=request.action_name,
+        binding=foreign_binding,
+        arguments=request.arguments,
+    )
+    foreign_step = replace(
+        step,
+        command=replace(
+            step.command,
+            episode_id="foreign-episode",
+            world_branch_id="foreign-branch",
+            request_content_id=foreign_request.content_sha256,
+        ),
+    )
+
+    report = _verify_recorded_v4_steps(
+        run,
+        initial_state,
+        (foreign_step,),
+        expected_final_state_id=step.transition.state.state_id,
+    )
+
+    assert report.valid is False
+    assert any("command-scope" in issue for issue in report.issues)
+
+
+def test_v4_replay_reports_malformed_actor_action_as_invalid(
+    tmp_path: Path,
+) -> None:
+    run, initial_state, request, step = _record_one_v4_actor_step(tmp_path / "run")
+    malformed_request = WorldActorActionRequest(
+        request_id=request.request_id,
+        action_name="unknown-actor-action",
+        binding=request.binding,
+        arguments=request.arguments,
+    )
+    malformed_step = replace(
+        step,
+        command=replace(
+            step.command,
+            action_name=malformed_request.action_name,
+            request_content_id=malformed_request.content_sha256,
+        ),
+    )
+
+    report = _verify_recorded_v4_steps(
+        run,
+        initial_state,
+        (malformed_step,),
+        expected_final_state_id=step.transition.state.state_id,
+    )
+
+    assert report.valid is False
+    assert any("transition-replay-error" in issue for issue in report.issues)
+
+
+def test_stale_actor_binding_fails_before_a_second_transition(
+    tmp_path: Path,
+) -> None:
+    run = _start_reference_run(tmp_path / "run")
+    first = _actor_request(
+        run,
+        request_id="condition-check-first",
+        action_name="request_condition_check",
+        arguments={"pump_id": "pump-a"},
+        reason="Record the first Pump A condition check.",
+    )
+    stale = WorldActorActionRequest(
+        request_id="condition-check-stale",
+        action_name="request_condition_check",
+        binding=first.binding,
+        arguments={
+            "pump_id": "pump-b",
+            "reason": "Try another check from the stale parent binding.",
+        },
+    )
+    run.apply_v4_actor_action(first)
+    selected = run.snapshot()
+
+    with pytest.raises(PumpStationWorldRunError) as raised:
+        run.apply_v4_actor_action(stale)
+
+    assert raised.value.code == "actor-request-binding"
+    assert run.snapshot() == selected
+    assert len(run.repository.v4_steps()) == 1
+
+
+def test_invalid_control_authority_leaves_the_selected_pointer_unchanged(
+    tmp_path: Path,
+) -> None:
+    run = _start_reference_run(tmp_path / "run")
+    opening = run.snapshot()
+    invalid = _bound_control(
+        run,
+        PumpStationCommonBoundaryRequest(
+            version=PUMP_STATION_COMMON_BOUNDARY_CONTROL_VERSION,
+            request_id="invalid-power-control",
+            authority_id="maintenance-controller",
+            boundary_kind="power",
+            available=False,
+            base_state_id=run.state.state_id,
+        ),
+    )
+
+    with pytest.raises(PumpStationWorldRunError) as raised:
+        run.apply_v4_control(invalid)
+
+    assert raised.value.code == "common-boundary-authority"
+    assert run.snapshot() == opening
+    assert run.repository.v4_steps() == ()
+
+
+def test_changed_control_content_conflicts_before_stale_scope_evaluation(
+    tmp_path: Path,
+) -> None:
+    run = _start_reference_run(tmp_path / "run")
+    original = _bound_control(
+        run,
+        PumpStationCommonBoundaryRequest(
+            version=PUMP_STATION_COMMON_BOUNDARY_CONTROL_VERSION,
+            request_id="common-boundary-conflict",
+            authority_id="operations-controller",
+            boundary_kind="power",
+            available=False,
+            base_state_id=run.state.state_id,
+        ),
+    )
+    run.apply_v4_control(original)
+    changed = PumpStationBoundControlRequest(
+        control_envelope_version=original.control_envelope_version,
+        request_id=original.request_id,
+        run_id=original.run_id,
+        episode_id=original.episode_id,
+        world_branch_id=original.world_branch_id,
+        base_state_id=original.base_state_id,
+        base_commit_id=original.base_commit_id,
+        based_on_sequence=original.based_on_sequence,
+        control=PumpStationCommonBoundaryRequest(
+            version=PUMP_STATION_COMMON_BOUNDARY_CONTROL_VERSION,
+            request_id=original.request_id,
+            authority_id="operations-controller",
+            boundary_kind="discharge",
+            available=False,
+            base_state_id=original.base_state_id,
+        ),
+    )
+
+    with pytest.raises(PumpStationWorldRunError) as raised:
+        run.apply_v4_control(changed)
+
+    assert raised.value.code == "v4-command-id-conflict"
+    assert run.snapshot().sequence == 1
+    assert len(run.repository.v4_steps()) == 1
+
+
+def test_root_host_controls_use_the_same_commit_chain_and_exact_retry(
+    tmp_path: Path,
+) -> None:
+    run = _start_reference_run(tmp_path / "run")
+    verification = _actor_request(
+        run,
+        request_id="verify-a-for-review",
+        reason="Start the required independent Pump A verification.",
+    )
+    run.apply_v4_actor_action(verification)
+    continuation = _actor_request(
+        run,
+        request_id="continue-to-verification",
+        action_name="continue_operation",
+        arguments={},
+        reason="Continue to the verification completion event.",
+    )
+    run.apply_v4_actor_action(continuation)
+    state = run.state
+    review = _bound_control(
+        run,
+        PumpStationOperationsBoundaryReviewRequest(
+            version=PUMP_STATION_OPERATIONS_REVIEW_VERSION,
+            review_id="operations-review-a-registered",
+            review_kind="post_verification_restriction",
+            pump_id="pump-a",
+            restriction_or_isolation_permit_id="restriction-a-run-in-001",
+            accepted_evidence_id="evidence-pump-a-verification-pass-001",
+            requested_outcome="release",
+            base_state_id=state.state_id,
+            operations_authority_id="operations-controller",
+            reason="Release the matched boundary after accepted verification.",
+        ),
+    )
+
+    transition = run.apply_v4_control(review)
+    selected = run.snapshot()
+    commits = run.repository.commits()
+
+    assert not transition.receipt.actor_action
+    assert transition.receipt.action_or_control_kind == "operations_boundary_review"
+    assert isinstance(commits[-1], PumpStationWorldRunCommitV2)
+    assert commits[-1].proposal_content_id is None
+    assert commits[-1].information_set_content_id is None
+
+    repeated = run.apply_v4_control(review)
+
+    assert repeated == transition
+    assert run.snapshot() == selected
+    assert run.repository.commits() == commits
+
+
+def test_process_outcome_and_common_boundary_controls_are_durable_root_transitions(
+    tmp_path: Path,
+) -> None:
+    process_run = _start_reference_run(tmp_path / "process-run")
+    process_run.apply_v4_actor_action(
+        _actor_request(
+            process_run,
+            request_id="verify-a-for-failure",
+            reason="Start the verification before recording its failed outcome.",
+        )
+    )
+    active = process_run.state.processes[-1]
+    process_control = _bound_control(
+        process_run,
+        PumpStationProcessOutcomeRequest(
+            version=PUMP_STATION_PROCESS_OUTCOME_VERSION,
+            request_id="verification-failed-001",
+            authority_id="verification-engineer-01",
+            process_id=active.process_id,
+            outcome="failed",
+            evidence_id="evidence-verification-failed-001",
+            base_state_id=process_run.state.state_id,
+        ),
+    )
+
+    process_transition = process_run.apply_v4_control(process_control)
+
+    assert process_transition.receipt.action_or_control_kind == "process_outcome"
+    assert process_transition.receipt.required_authorities == ("verification",)
+    assert process_run.repository.v4_steps()[-1].command.kind == "process_outcome"
+
+    boundary_run = _start_reference_run(tmp_path / "boundary-run")
+    boundary_control = _bound_control(
+        boundary_run,
+        PumpStationCommonBoundaryRequest(
+            version=PUMP_STATION_COMMON_BOUNDARY_CONTROL_VERSION,
+            request_id="power-unavailable-001",
+            authority_id="operations-controller",
+            boundary_kind="power",
+            available=False,
+            base_state_id=boundary_run.state.state_id,
+        ),
+    )
+
+    boundary_transition = boundary_run.apply_v4_control(boundary_control)
+
+    assert boundary_transition.receipt.action_or_control_kind == "common_boundary_control"
+    assert not boundary_transition.state.physical.common_boundary.power_available
+    assert boundary_run.repository.v4_steps()[-1].command.kind == "common_boundary"
+
+
+def test_registered_run_reopens_and_independently_replays_mixed_v4_history(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "run"
+    run = _start_reference_run(root)
+    actor_transition = run.apply_v4_actor_action(
+        _actor_request(
+            run,
+            request_id="condition-check-a-001",
+            action_name="request_condition_check",
+            arguments={"pump_id": "pump-a"},
+            reason="Record a current Pump A condition check.",
+        )
+    )
+    control = _bound_control(
+        run,
+        PumpStationCommonBoundaryRequest(
+            version=PUMP_STATION_COMMON_BOUNDARY_CONTROL_VERSION,
+            request_id="discharge-unavailable-001",
+            authority_id="operations-controller",
+            boundary_kind="discharge",
+            available=False,
+            base_state_id=run.state.state_id,
+        ),
+    )
+    control_transition = run.apply_v4_control(control)
+    selected = run.snapshot()
+
+    reopened = PumpStationWorldRun.resume_reference_system(
+        repository=PumpStationWorldRunRepository(root),
+        snapshot=selected,
+    )
+    report = reopened.verify_v4()
+
+    assert reopened.state == control_transition.state
+    assert report.valid
+    assert report.issues == ()
+    assert report.replayed_transition_ids == (
+        actor_transition.receipt.transition_id,
+        control_transition.receipt.transition_id,
+    )
+    assert report.final_state_id == selected.state_id
+
+
+def test_interrupted_v4_publication_recovers_one_exact_actor_effect(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = _start_reference_run(tmp_path / "run")
+    request = _actor_request(
+        run,
+        request_id="condition-check-recovery",
+        action_name="request_condition_check",
+        arguments={"pump_id": "pump-a"},
+        reason="Record one recoverable Pump A condition check.",
+    )
+    original_replace = run.repository._replace_current
+
+    def interrupt_before_pointer(_pointer: object) -> None:
+        raise OSError("injected interruption before current pointer replacement")
+
+    monkeypatch.setattr(run.repository, "_replace_current", interrupt_before_pointer)
+    with pytest.raises(OSError, match="before current pointer"):
+        run.apply_v4_actor_action(request)
+
+    assert run.snapshot().sequence == 0
+    monkeypatch.setattr(run.repository, "_replace_current", original_replace)
+
+    recovered = run.apply_v4_actor_action(request)
+
+    assert run.snapshot().sequence == 1
+    assert len(run.repository.v4_steps()) == 1
+    assert sum(evidence.evidence_id == "condition-check-pump-a-1" for evidence in recovered.state.evidence) == 1
+
+
+def test_unselected_exact_command_recovers_its_durable_transition(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "run"
+    run = _start_reference_run(root)
+    request = _actor_request(
+        run,
+        request_id="condition-check-staged-recovery",
+        action_name="request_condition_check",
+        arguments={"pump_id": "pump-a"},
+        reason="Recover the staged Pump A condition check.",
+    )
+    command = run._v4_actor_command(request)
+    original_replace = run.repository._replace_current
+
+    def interrupt_before_pointer(_pointer: object) -> None:
+        raise OSError("interrupt before current pointer")
+
+    monkeypatch.setattr(
+        run.repository,
+        "_replace_current",
+        interrupt_before_pointer,
+    )
+    with pytest.raises(OSError, match="before current pointer"):
+        run.apply_v4_actor_action(request)
+    monkeypatch.setattr(run.repository, "_replace_current", original_replace)
+
+    recovered = run.repository.recover_staged_v4_command(command)
+
+    assert recovered is not None
+    assert recovered.receipt.request_id == request.request_id
+    assert run.snapshot().sequence == 1
+    assert run.snapshot().commit_id in {path.stem for path in (root / "commits").glob("*.json")}
+    assert len(run.repository.v4_steps()) == 1
+
+
+def test_staged_v4_recovery_cannot_reselect_an_old_parent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = _start_reference_run(tmp_path / "run")
+    opening = run.snapshot()
+    orphan_request = _actor_request(
+        run,
+        request_id="condition-check-orphaned-parent",
+        action_name="request_condition_check",
+        arguments={"pump_id": "pump-a"},
+        reason="Leave one Pump A condition check staged on the opening parent.",
+    )
+    staged = _stage_unselected_v4_actor_outcome(
+        run,
+        orphan_request,
+        monkeypatch,
+    )
+    competing_request = _actor_request(
+        run,
+        request_id="condition-check-selected-parent",
+        action_name="request_condition_check",
+        arguments={"pump_id": "pump-b"},
+        reason="Select a different Pump B condition check from the opening parent.",
+    )
+    run.apply_v4_actor_action(competing_request)
+    selected = run.snapshot()
+
+    with pytest.raises(PumpStationWorldRunError) as raised:
+        run.repository.recover_staged_v4_command(staged.command)
+
+    assert raised.value.code == "stale-publication"
+    assert run.snapshot() == selected
+    assert selected != opening
+    assert selected.commit_id != staged.snapshot.commit_id
+    assert tuple(step.command.request_id for step in run.repository.v4_steps()) == (competing_request.request_id,)
+
+
+def test_staged_v4_recovery_rejects_multiple_durable_outcomes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = _start_reference_run(tmp_path / "run")
+    opening = run.snapshot()
+    request = _actor_request(
+        run,
+        request_id="condition-check-duplicate-outcome",
+        action_name="request_condition_check",
+        arguments={"pump_id": "pump-a"},
+        reason="Leave one Pump A condition check with duplicate durable outcomes.",
+    )
+    staged = _stage_unselected_v4_actor_outcome(
+        run,
+        request,
+        monkeypatch,
+    )
+    duplicate_commit_id = _publish_duplicate_v4_outcome(
+        run.repository,
+        staged,
+    )
+
+    with pytest.raises(PumpStationWorldRunError) as raised:
+        run.repository.recover_staged_v4_command(staged.command)
+
+    assert raised.value.code == "v4-command-id-conflict"
+    assert run.snapshot() == opening
+    assert duplicate_commit_id != staged.snapshot.commit_id
+    assert run.repository.v4_steps() == ()
+
+
+def test_restart_retry_after_pointer_selection_returns_the_selected_transition(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "run"
+    run = _start_reference_run(root)
+    request = _actor_request(
+        run,
+        request_id="condition-check-after-pointer",
+        action_name="request_condition_check",
+        arguments={"pump_id": "pump-a"},
+        reason="Record one Pump A condition check before response loss.",
+    )
+    original_publish = run.repository._publish_staged_v4_transition_under_lock
+
+    def interrupt_after_pointer(staged: Any) -> Any:
+        original_publish(staged)
+        raise OSError("injected response loss after current pointer replacement")
+
+    monkeypatch.setattr(
+        run.repository,
+        "_publish_staged_v4_transition_under_lock",
+        interrupt_after_pointer,
+    )
+    with pytest.raises(OSError, match="after current pointer"):
+        run.apply_v4_actor_action(request)
+
+    selected = run.snapshot()
+    assert selected.sequence == 1
+
+    reopened = PumpStationWorldRun.resume_reference_system(
+        repository=PumpStationWorldRunRepository(root),
+        snapshot=selected,
+    )
+    recovered = reopened.apply_v4_actor_action(request)
+
+    assert recovered.state.state_id == selected.state_id
+    assert reopened.snapshot() == selected
+    assert len(reopened.repository.v4_steps()) == 1
+
+
+def test_two_processes_recover_one_exact_registered_actor_commit(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "run"
+    run = _start_reference_run(root)
+    request = _actor_request(
+        run,
+        request_id="condition-check-concurrent",
+        action_name="request_condition_check",
+        arguments={"pump_id": "pump-a"},
+        reason="Record one concurrent Pump A condition check.",
+    )
+    opening = run.snapshot()
+    context = multiprocessing.get_context("spawn")
+    ready = (context.Event(), context.Event())
+    start = context.Event()
+    results = context.Queue()
+    processes = tuple(
+        context.Process(
+            target=_apply_registered_actor_in_child,
+            args=(
+                root,
+                opening,
+                request.model_dump(mode="json"),
+                ready[index],
+                start,
+                results,
+            ),
+        )
+        for index in range(2)
+    )
+
+    for process in processes:
+        process.start()
+    try:
+        assert all(signal.wait(10) for signal in ready)
+        start.set()
+        for process in processes:
+            process.join(20)
+            assert not process.is_alive()
+            assert process.exitcode == 0
+    finally:
+        start.set()
+        for process in processes:
+            if process.is_alive():
+                process.kill()
+                process.join()
+
+    outcomes = tuple(results.get(timeout=5) for _ in processes)
+    assert {outcome[0] for outcome in outcomes} == {"applied"}
+    assert len({outcome[1:] for outcome in outcomes}) == 1
+    assert run.snapshot().sequence == 1
+    assert len(run.repository.v4_steps()) == 1
+
+
+def test_two_processes_select_only_one_of_two_effects_from_the_same_parent(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "run"
+    run = _start_reference_run(root)
+    requests = (
+        _actor_request(
+            run,
+            request_id="condition-check-pump-a-concurrent",
+            action_name="request_condition_check",
+            arguments={"pump_id": "pump-a"},
+            reason="Record the concurrent Pump A condition check.",
+        ),
+        _actor_request(
+            run,
+            request_id="condition-check-pump-b-concurrent",
+            action_name="request_condition_check",
+            arguments={"pump_id": "pump-b"},
+            reason="Record the concurrent Pump B condition check.",
+        ),
+    )
+    opening = run.snapshot()
+    context = multiprocessing.get_context("spawn")
+    ready = (context.Event(), context.Event())
+    start = context.Event()
+    results = context.Queue()
+    processes = tuple(
+        context.Process(
+            target=_apply_registered_actor_in_child,
+            args=(
+                root,
+                opening,
+                request.model_dump(mode="json"),
+                ready[index],
+                start,
+                results,
+            ),
+        )
+        for index, request in enumerate(requests)
+    )
+
+    for process in processes:
+        process.start()
+    try:
+        assert all(signal.wait(10) for signal in ready)
+        start.set()
+        for process in processes:
+            process.join(20)
+            assert not process.is_alive()
+            assert process.exitcode == 0
+    finally:
+        start.set()
+        for process in processes:
+            if process.is_alive():
+                process.kill()
+                process.join()
+
+    outcomes = tuple(results.get(timeout=5) for _ in processes)
+    assert sum(outcome[0] == "applied" for outcome in outcomes) == 1
+    assert sum(outcome == ("error", "actor-request-binding") for outcome in outcomes) == 1
+    assert run.snapshot().sequence == 1
+    assert len(run.repository.v4_steps()) == 1

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_world_run_repository.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_world_run_repository.py
@@ -23,6 +23,8 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station import (
     PumpStationWorldRunError,
     RequestConditionalDeferral,
     RequestInspection,
+    RequestObstructionClearance,
+    RequestVerification,
     TransferDuty,
     pump_station_artifact_bytes,
     verify_stewardship_run,
@@ -105,6 +107,64 @@ def test_filesystem_run_reloads_complete_state_and_verifier_steps(tmp_path) -> N
     }
     for directory, expected_count in expected_counts.items():
         assert len(tuple((run.repository.root / directory).glob("*.json"))) == expected_count
+
+
+@pytest.mark.parametrize(
+    ("proposal_type", "parameters"),
+    (
+        (
+            RequestInspection,
+            {"pump_id": "pump-a", "backlog_item_id": "v4-inspection-binding"},
+        ),
+        (
+            RequestObstructionClearance,
+            {
+                "pump_id": "pump-a",
+                "inspection_evidence_id": "v4-inspection-evidence",
+                "backlog_item_id": "v4-clearance-binding",
+            },
+        ),
+        (
+            RequestVerification,
+            {"pump_id": "pump-a", "backlog_item_id": "v4-verification-binding"},
+        ),
+    ),
+)
+def test_legacy_run_rejects_v4_only_backlog_bindings_before_transition(
+    tmp_path: Path,
+    proposal_type: type,
+    parameters: dict[str, str],
+) -> None:
+    run = create_world_run(tmp_path / proposal_type.__name__)
+    proposal, information_set = bind_proposal(
+        run,
+        proposal_type,
+        f"legacy-rejects-{proposal_type.__name__}",
+        **parameters,
+    )
+    opening = run.snapshot()
+
+    with pytest.raises(PumpStationWorldRunError) as raised:
+        run.apply(proposal, information_set=information_set)
+
+    assert raised.value.code == "proposal-profile"
+    assert run.snapshot() == opening
+
+
+def test_legacy_inspection_without_v4_binding_retries_exactly(tmp_path: Path) -> None:
+    run = create_world_run(tmp_path / "run")
+    proposal, information_set = bind_proposal(
+        run,
+        RequestInspection,
+        "legacy-inspection-retry",
+        pump_id="pump-a",
+    )
+
+    applied = run.apply(proposal, information_set=information_set)
+    repeated = run.apply(proposal, information_set=information_set)
+
+    assert repeated == applied
+    assert len(run.steps()) == 1
 
 
 def test_repository_rejects_content_moved_under_the_wrong_identity(tmp_path) -> None:

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_world_run_serialization.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_world_run_serialization.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 from world_run_support import create_world_run
@@ -14,9 +15,48 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station import (
     load_pump_station_artifact,
     pump_station_artifact_bytes,
 )
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_models import (
+    PUMP_STATION_COMMAND_VERSION_V4,
+    PUMP_STATION_SERIALIZATION_VERSION,
+    PUMP_STATION_WORLD_MANIFEST_VERSION_V2,
+    PumpStationCommandV4,
+    PumpStationWorldRunCommit,
+    PumpStationWorldRunCommitV2,
+)
 
 
-def test_complete_state_round_trips_as_canonical_task_owned_json(tmp_path) -> None:
+def _actor_command(
+    arguments_json: str,
+    *,
+    session_id: str = "session-v4",
+    agent_tenure_id: str = "tenure-v4",
+    actor_view_id: str = "view-v4",
+    information_set_id: str = "information-v4",
+) -> PumpStationCommandV4:
+    return PumpStationCommandV4(
+        command_version=PUMP_STATION_COMMAND_VERSION_V4,
+        kind="actor",
+        request_id="request-v4-invalid",
+        request_content_id="1" * 64,
+        action_name="continue_operation",
+        arguments_json=arguments_json,
+        task_world_id="wastewater-pump-station-stewardship.v1",
+        run_id="run-v4",
+        episode_id="episode-v4",
+        world_branch_id="branch-v4",
+        based_on_sequence=0,
+        base_state_id="state-v4-0",
+        base_commit_id="commit-v4-0",
+        session_id=session_id,
+        agent_tenure_id=agent_tenure_id,
+        actor_view_id=actor_view_id,
+        information_set_id=information_set_id,
+    )
+
+
+def test_complete_state_round_trips_as_canonical_task_owned_json(
+    tmp_path: Path,
+) -> None:
     run = create_world_run(tmp_path / "run")
 
     payload = pump_station_artifact_bytes(run.state)
@@ -30,7 +70,7 @@ def test_complete_state_round_trips_as_canonical_task_owned_json(tmp_path) -> No
     assert payload.endswith(b"\n")
 
 
-def test_stored_state_rejects_unknown_fields_and_types(tmp_path) -> None:
+def test_stored_state_rejects_unknown_fields_and_types(tmp_path: Path) -> None:
     run = create_world_run(tmp_path / "run")
     document = json.loads(pump_station_artifact_bytes(run.state))
     document["unexpected"] = "not permitted"
@@ -55,4 +95,134 @@ def test_stored_state_rejects_unknown_fields_and_types(tmp_path) -> None:
         load_pump_station_artifact(
             json.dumps(document).encode(),
             PumpStationStewardshipState,
+        )
+
+
+def test_v4_command_and_commit_round_trip_under_their_own_profile() -> None:
+    command = PumpStationCommandV4(
+        command_version=PUMP_STATION_COMMAND_VERSION_V4,
+        kind="actor",
+        request_id="request-v4-001",
+        request_content_id="1" * 64,
+        action_name="continue_operation",
+        arguments_json='{"reason":"Continue to the next event."}',
+        task_world_id="wastewater-pump-station-stewardship.v1",
+        run_id="run-v4",
+        episode_id="episode-v4",
+        world_branch_id="branch-v4",
+        based_on_sequence=0,
+        base_state_id="state-v4-0",
+        base_commit_id="commit-v4-0",
+        session_id="session-v4",
+        agent_tenure_id="tenure-v4",
+        actor_view_id="view-v4",
+        information_set_id="information-v4",
+    )
+    commit = PumpStationWorldRunCommitV2(
+        serialization_version=PUMP_STATION_WORLD_MANIFEST_VERSION_V2,
+        run_id="run-v4",
+        sequence=1,
+        parent_commit_id="commit-v4-0",
+        state_id="state-v4-1",
+        request_id=command.request_id,
+        command_content_id="2" * 64,
+        proposal_content_id="3" * 64,
+        information_set_content_id="4" * 64,
+        receipt_content_id="5" * 64,
+    )
+
+    command_payload = pump_station_artifact_bytes(command)
+    commit_payload = pump_station_artifact_bytes(commit)
+
+    assert command_payload == pump_station_artifact_bytes(command, record_profile="v4")
+    assert commit_payload == pump_station_artifact_bytes(commit, record_profile="v4")
+    assert load_pump_station_artifact(command_payload, PumpStationCommandV4) == command
+    assert (
+        load_pump_station_artifact(
+            commit_payload,
+            PumpStationWorldRunCommit | PumpStationWorldRunCommitV2,
+        )
+        == commit
+    )
+
+
+def test_commit_union_keeps_the_legacy_record_exact() -> None:
+    legacy = PumpStationWorldRunCommit(
+        serialization_version=PUMP_STATION_SERIALIZATION_VERSION,
+        run_id="run-v1",
+        sequence=0,
+        parent_commit_id=None,
+        state_id="state-v1",
+        proposal_id=None,
+        proposal_content_id=None,
+        information_set_content_id=None,
+        receipt_content_id=None,
+        event_batch_content_id=None,
+    )
+
+    payload = pump_station_artifact_bytes(legacy)
+
+    assert (
+        load_pump_station_artifact(
+            payload,
+            PumpStationWorldRunCommit | PumpStationWorldRunCommitV2,
+        )
+        == legacy
+    )
+
+
+def test_v4_command_rejects_noncanonical_or_duplicate_arguments() -> None:
+    with pytest.raises(PumpStationWorldRunError, match="canonical-json"):
+        _actor_command('{"reason": "spacing differs"}')
+    with pytest.raises(PumpStationWorldRunError, match="duplicate field"):
+        _actor_command('{"reason":"one","reason":"two"}')
+
+    for nonstandard_json in (
+        '{"value":NaN}',
+        '{"value":Infinity}',
+        '{"value":-Infinity}',
+    ):
+        with pytest.raises(PumpStationWorldRunError, match="canonical-json"):
+            _actor_command(nonstandard_json)
+
+
+@pytest.mark.parametrize(
+    "empty_field",
+    (
+        "session_id",
+        "agent_tenure_id",
+        "actor_view_id",
+        "information_set_id",
+    ),
+)
+def test_v4_actor_command_rejects_empty_active_binding_fields(
+    empty_field: str,
+) -> None:
+    with pytest.raises(PumpStationWorldRunError, match=empty_field):
+        _actor_command(
+            '{"reason":"Continue to the next event."}',
+            session_id="" if empty_field == "session_id" else "session-v4",
+            agent_tenure_id=("" if empty_field == "agent_tenure_id" else "tenure-v4"),
+            actor_view_id="" if empty_field == "actor_view_id" else "view-v4",
+            information_set_id=("" if empty_field == "information_set_id" else "information-v4"),
+        )
+
+
+def test_v4_control_command_rejects_empty_authority() -> None:
+    with pytest.raises(PumpStationWorldRunError, match="authority_id"):
+        PumpStationCommandV4(
+            command_version=PUMP_STATION_COMMAND_VERSION_V4,
+            kind="common_boundary",
+            request_id="request-v4-empty-authority",
+            request_content_id="1" * 64,
+            action_name="common_boundary_control",
+            arguments_json='{"available":false}',
+            task_world_id="wastewater-pump-station-stewardship.v1",
+            run_id="run-v4",
+            episode_id="episode-v4",
+            world_branch_id="branch-v4",
+            based_on_sequence=0,
+            base_state_id="state-v4-0",
+            base_commit_id="commit-v4-0",
+            authority_id="",
         )

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/world_run_support.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/world_run_support.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from decimal import Decimal
 from pathlib import Path
 
@@ -54,7 +55,7 @@ def create_world_run(root: Path) -> PumpStationWorldRun:
 
 def bind_proposal(
     run: PumpStationWorldRun,
-    proposal_type: type[PumpStationProposal],
+    proposal_type: Callable[..., PumpStationProposal],
     proposal_id: str,
     **parameters: str,
 ) -> tuple[PumpStationProposal, PumpStationInformationSet]:


### PR DESCRIPTION
## Summary

- Route V4 actor actions and root controls through the existing world-run commit chain and current pointer.
- Bind commands to stored manifest scope, exact content identity, and complete actor-visible information sets.
- Add deterministic replay, exact retry, staged-publication recovery, and fail-closed legacy profile guards.
- Preserve V1 to V3 byte compatibility and keep rollout and branch mechanics out of this step.

## Focused validation

- 39 registered transition, parity, serialization, and byte-compatibility tests passed.
- 57 ASW-8 journey, boundary, persistence, and repository tests passed.
- 50 crash and publication-recovery tests passed.
- 14 post-fix boundary and recovery tests passed.
- Ruff passed on all 18 changed Python files.
- MyPy passed on all 12 changed source files and four typed test roots.
- Git whitespace check passed.

## Review notes

This PR targets the draft PR74 head branch. It must not merge to main.