### PR TITLE
feat: add chosen-point continual rollout groups

### DIFF
--- a/docs/CONTINUAL_WORLD_RUNTIME.md
+++ b/docs/CONTINUAL_WORLD_RUNTIME.md
@@ -676,13 +676,97 @@ the snapshot or progress operation when it needs the current world position.
 Step 6 session-evidence verification is an admission and deterministic replay
 integrity check. It proves that each selected actor transition used the durable
 session evidence bound to that transition. It does not score task outcomes or
-prove transport parity. Step 9 integrates the completed task verifier with
+prove transport parity. Step 10 integrates the completed task verifier with
 evaluation import, checks direct and transported outcomes, retires duplicate
 paths, and runs the final merge audit.
 
 This step does not change or certify CLI, Harbor, rollout, semantic evaluation,
 duplicate retirement, or coupled-path deletion. Those changes remain in their
 later sequence items.
+
+### 6.17 Chosen-point branches and rollout groups on the existing path
+
+Step 7 extends the existing rollout path. It does not repair or promote the
+parallel coupled rollout control. A rollout group creates one or more isolated
+child runs from one exact, verified parent snapshot. Several groups can use the
+same snapshot. Each child has its own run, episode, and branch identity.
+
+The parent is not rewound. A caller can select any immutable snapshot on the
+parent's selected commit history, including a snapshot that is no longer
+current. The runtime verifies the commit prefix through that snapshot and uses
+the stored state at that point. A staged, foreign, detached, or changed commit
+is not a valid origin. The parent can continue after the origin is selected
+without changing the child opening state or an exact retry.
+
+| Path | Owner | Compatibility and migration rule |
+| --- | --- | --- |
+| `contracts/continual_world.py` | Shared records | Define task-neutral snapshot, child, group, receipt, status, and lineage records. Keep task state and treatment fields out. |
+| `task_world_templates/continual/` | Shared rollout orchestration | Own safe group and child paths, per-group finalization locks, per-child materialization locks, immutable request and receipt publication, exact retry, partial recovery, ordered lineage, and child confinement. Import no pump or hydraulic task module. |
+| Registered task branch port | Task adapter | Verify one exact branchable snapshot, materialize the child, inherit permitted task evidence, reset private session state, and verify the completed child. |
+| `wastewater_pump_station/world_run_repository.py` | Pump durable history | Prove that the selected origin is on the parent commit chain and expose the exact replay prefix without changing `current.json`. |
+| `wastewater_pump_station/world_run.py` | Pump branch adapter | Build and resume a registered V4 child through the existing run and repository. Keep definition, profile, package, model, schedule, and temporal bindings exact. |
+| `wastewater_pump_station/temporal_evidence/` | Pump evidence adapter | Preserve the public evidence available at the origin. Start a fresh child-private retrieval and session history. |
+| `wastewater_pump_station/rollout_models.py`, `rollout_repository.py`, and `rollout_control.py` | Existing pump rollout path | Keep V1 records and bytes exact. Accept the shared continual request and lineage directly for registered runs. Keep only pump-owned branch evidence in pump models. Do not add actor execution to rollout control. |
+| `wastewater_pump_station/rollout_interface.py` | Installed V1 transport | Keep the V1 request, result, and dispatch exact in Step 7. Step 9 adds a separate V2 transport route; it must not widen the V1 schema. |
+| SSC-03 lifecycle branch adapter | Second real consumer | Treat a submitted checkpoint as its branchable snapshot unit. Preserve task-owned evidence, action, and budget rules while using the same group and lineage contract. |
+
+The shared rollout control has four operations: create a group, inspect a
+complete group, inspect group status, and resolve one child run reference. It
+does not open an actor session, execute an actor action, apply a task treatment,
+or select an agent provider or model. An actor enters a child through the
+existing session and action interfaces. A defect or other pump treatment uses
+the existing V4 host-control boundary. The legacy scheduled-treatment route
+remains an exact V1 route and rejects children made through the shared continual
+request. Step 9 binds child runs to agent and Harbor execution and can add
+agent-condition and sampling data to an exploration run.
+
+When the selected origin is historical, verification reads only the actor
+session and temporal evidence named by that immutable prefix. Later private
+session or retrieval records are outside that prefix and cannot change its
+validity. Full current-state verification still checks the complete current
+evidence set.
+
+Every group request binds the registered definition and profile, parent
+manifest, exact parent snapshot, host authority, ordered child identities, and
+a reason. Every child receipt binds its request, initial snapshot, child
+manifest, task-owned branch evidence, and ordered ancestor branches. The group
+becomes ready only after all child receipts are durable and independently
+verified. An exact retry returns the same lineage. Reuse of an identity with
+changed content fails closed.
+
+Every public read reloads the stored request against the registered definition
+and profile. A ready lineage must equal the ordered durable child requests and
+receipts. A child run reference is not available before the complete lineage is
+ready. Child destinations use descriptor-confined, host-private paths and
+reject symbolic links before a task adapter can read or write the child.
+
+For SSC-03, the branch-point reader is current-schema and read-only. The exact
+origin binds the complete ordered submitted-checkpoint prefix, the inherited
+action state, and the ordered branch ancestry. Parent run and checkpoint
+identities come from the verified host run and selected checkpoint; a caller
+cannot supply unverified labels. Nested ancestry is read from immutable branch
+evidence and does not follow a stored parent path into another host run.
+
+For a registered pump child, the initial state ID and sequence equal the chosen
+parent snapshot. The initial-state source records the complete parent and group
+provenance. Public temporal evidence is available in the child, but parent
+private retrieval records, active session authority, and handover selection are
+not inherited. A child of a child appends its direct parent branch to the
+existing ordered ancestor list.
+
+The coupled rollout files remain only as temporary migration evidence until
+the stable path proves V2 parity. The footprint gate moves the useful tests to
+behavior names and retires the duplicate rollout control and interface before
+transport work starts.
+
+The footprint gate uses `origin/main` as its fixed baseline. Net production
+growth must be no more than 16,500 lines before Step 9 starts. Delete the
+replaced coupled agent, Harbor, interface, rollout, run, and temporal paths
+after their callers use the canonical interfaces. Move only behavior that has
+no canonical owner from the remaining coupled runtime, work, evaluation, and
+execution modules. Then delete those old owners. Do not meet the limit by
+moving the same implementation to another file or by removing required
+verification.
 
 ## 7. Implementation sequence
 
@@ -697,10 +781,11 @@ merged.
 5. V4 pump transitions and replay through the existing run, state machine, and verifier.
 6. V4 session ownership through the existing session and separate actor and host-control interfaces.
 7. Existing rollout path extension and generic branch orchestration.
-8. Catalogue-driven CLI, Harbor, and agent execution.
-9. Verification and evaluation integration, duplicate retirement, research and test cleanup, and the requirement-by-requirement final merge audit.
+8. Footprint gate: classify every production addition, remove replaced coupled and parallel runtime paths, consolidate duplicate coverage, and measure the net production change against `origin/main`. Do not start transport work while two run, session, rollout, replay, or treatment paths remain, or while net production growth is above 16,500 lines.
+9. Catalogue-driven CLI, Harbor, and agent execution.
+10. Verification and evaluation integration, final research and test cleanup, and the requirement-by-requirement final merge audit.
 
-The ASW-8 pull request remains draft until item 9 passes.
+The ASW-8 pull request remains draft until item 10 passes.
 
 ## 8. Final gates
 

--- a/src/aec_bench/contracts/continual_world.py
+++ b/src/aec_bench/contracts/continual_world.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from enum import StrEnum
 from typing import Final, Literal, Self
 
 from pydantic import field_validator, model_validator
@@ -15,6 +16,27 @@ CONTINUAL_WORLD_DEFINITION_SCHEMA_VERSION: Final[Literal["aecbench.continual-wor
 )
 CONTINUAL_WORLD_PROFILE_SCHEMA_VERSION: Final[Literal["aecbench.continual-world-profile-ref.v1"]] = (
     "aecbench.continual-world-profile-ref.v1"
+)
+CONTINUAL_WORLD_SNAPSHOT_SCHEMA_VERSION: Final[Literal["aecbench.continual-world-snapshot.v1"]] = (
+    "aecbench.continual-world-snapshot.v1"
+)
+CONTINUAL_ROLLOUT_CHILD_REQUEST_SCHEMA_VERSION: Final[Literal["aecbench.continual-rollout-child-request.v1"]] = (
+    "aecbench.continual-rollout-child-request.v1"
+)
+CONTINUAL_ROLLOUT_GROUP_REQUEST_SCHEMA_VERSION: Final[Literal["aecbench.continual-rollout-group-request.v1"]] = (
+    "aecbench.continual-rollout-group-request.v1"
+)
+CONTINUAL_ROLLOUT_CHILD_RECEIPT_SCHEMA_VERSION: Final[Literal["aecbench.continual-rollout-child-receipt.v1"]] = (
+    "aecbench.continual-rollout-child-receipt.v1"
+)
+CONTINUAL_ROLLOUT_LINEAGE_SCHEMA_VERSION: Final[Literal["aecbench.continual-rollout-lineage.v1"]] = (
+    "aecbench.continual-rollout-lineage.v1"
+)
+CONTINUAL_ROLLOUT_GROUP_STATUS_SCHEMA_VERSION: Final[Literal["aecbench.continual-rollout-group-status.v1"]] = (
+    "aecbench.continual-rollout-group-status.v1"
+)
+CONTINUAL_ROLLOUT_CHILD_RUN_REF_SCHEMA_VERSION: Final[Literal["aecbench.continual-rollout-child-run-ref.v1"]] = (
+    "aecbench.continual-rollout-child-run-ref.v1"
 )
 
 
@@ -81,3 +103,238 @@ class ContinualWorldDefinitionSpec(ContentAddressedModel):
             definition_version=self.definition_version,
             content_sha256=self.content_sha256,
         )
+
+
+class ContinualWorldSnapshotRef(ContentAddressedModel):
+    """Task-neutral identity of one immutable point on a selected world history."""
+
+    schema_version: Literal["aecbench.continual-world-snapshot.v1"] = CONTINUAL_WORLD_SNAPSHOT_SCHEMA_VERSION
+    run_id: NonEmptyStr
+    episode_id: NonEmptyStr
+    world_branch_id: NonEmptyStr
+    sequence: int
+    state_id: NonEmptyStr
+    commit_id: NonEmptyStr
+
+    @model_validator(mode="after")
+    def validate_snapshot(self) -> Self:
+        if self.sequence < 0:
+            raise ValueError("snapshot sequence must be non-negative")
+        return self
+
+
+class ContinualRolloutChildRequest(ContentAddressedModel):
+    """One isolated child identity without actor, session, or treatment settings."""
+
+    schema_version: Literal["aecbench.continual-rollout-child-request.v1"] = (
+        CONTINUAL_ROLLOUT_CHILD_REQUEST_SCHEMA_VERSION
+    )
+    child_id: NonEmptyStr
+    run_id: NonEmptyStr
+    episode_id: NonEmptyStr
+    world_branch_id: NonEmptyStr
+
+
+class ContinualRolloutGroupRequest(ContentAddressedModel):
+    """One exact host request for ordered children from a verified snapshot."""
+
+    schema_version: Literal["aecbench.continual-rollout-group-request.v1"] = (
+        CONTINUAL_ROLLOUT_GROUP_REQUEST_SCHEMA_VERSION
+    )
+    request_id: NonEmptyStr
+    group_id: NonEmptyStr
+    task_world_id: NonEmptyStr
+    authority_id: NonEmptyStr
+    definition_ref: ContinualWorldDefinitionRef
+    profile_ref: ContinualWorldProfileRef
+    parent_manifest_content_sha256: str
+    parent_snapshot: ContinualWorldSnapshotRef
+    origin_verification_content_sha256: str
+    reason: NonEmptyStr
+    children: tuple[ContinualRolloutChildRequest, ...]
+
+    @field_validator("parent_manifest_content_sha256", "origin_verification_content_sha256")
+    @classmethod
+    def validate_group_sha256(cls, value: str) -> str:
+        return validate_sha256(value)
+
+    @model_validator(mode="after")
+    def validate_group(self) -> Self:
+        if self.definition_ref.task_world_id != self.task_world_id:
+            raise ValueError("continual-world definition must belong to the requested task world")
+        if self.profile_ref.task_world_id != self.task_world_id:
+            raise ValueError("continual-world profile must belong to the requested task world")
+        if not self.children:
+            raise ValueError("continual rollout group requires at least one child")
+        for field_name in ("child_id", "run_id", "episode_id", "world_branch_id"):
+            values = tuple(getattr(child, field_name) for child in self.children)
+            if len(values) != len(set(values)):
+                label = field_name.replace("_", " ")
+                raise ValueError(f"continual rollout child {label}s must be distinct")
+        if any(
+            child.run_id == self.parent_snapshot.run_id
+            or child.episode_id == self.parent_snapshot.episode_id
+            or child.world_branch_id == self.parent_snapshot.world_branch_id
+            for child in self.children
+        ):
+            raise ValueError("continual rollout child world identity must differ from the parent")
+        return self
+
+
+class ContinualRolloutChildReceipt(ContentAddressedModel):
+    """Immutable shared evidence for one verified child materialization."""
+
+    schema_version: Literal["aecbench.continual-rollout-child-receipt.v1"] = (
+        CONTINUAL_ROLLOUT_CHILD_RECEIPT_SCHEMA_VERSION
+    )
+    group_id: NonEmptyStr
+    child_id: NonEmptyStr
+    child_request_content_sha256: str
+    parent_snapshot: ContinualWorldSnapshotRef
+    initial_snapshot: ContinualWorldSnapshotRef
+    child_manifest_content_sha256: str
+    task_branch_receipt_content_sha256: str
+    ancestor_world_branch_ids: tuple[NonEmptyStr, ...]
+
+    @field_validator(
+        "child_request_content_sha256",
+        "child_manifest_content_sha256",
+        "task_branch_receipt_content_sha256",
+    )
+    @classmethod
+    def validate_receipt_sha256(cls, value: str) -> str:
+        return validate_sha256(value)
+
+    @model_validator(mode="after")
+    def validate_receipt(self) -> Self:
+        if (
+            self.initial_snapshot.sequence,
+            self.initial_snapshot.state_id,
+        ) != (
+            self.parent_snapshot.sequence,
+            self.parent_snapshot.state_id,
+        ):
+            raise ValueError("continual rollout child must open at the selected parent state")
+        if not self.ancestor_world_branch_ids:
+            raise ValueError("continual rollout receipt requires an ordered branch ancestry")
+        if self.initial_snapshot.world_branch_id in self.ancestor_world_branch_ids:
+            raise ValueError("continual rollout branch ancestry must exclude the child branch")
+        if self.ancestor_world_branch_ids[-1] != self.parent_snapshot.world_branch_id:
+            raise ValueError("continual rollout branch ancestry must end at the parent branch")
+        if len(self.ancestor_world_branch_ids) != len(set(self.ancestor_world_branch_ids)):
+            raise ValueError("continual rollout branch ancestry must not contain a cycle")
+        return self
+
+
+class ContinualRolloutLineage(ContentAddressedModel):
+    """Complete immutable lineage for one ready rollout group."""
+
+    schema_version: Literal["aecbench.continual-rollout-lineage.v1"] = CONTINUAL_ROLLOUT_LINEAGE_SCHEMA_VERSION
+    request_id: NonEmptyStr
+    group_id: NonEmptyStr
+    task_world_id: NonEmptyStr
+    definition_ref: ContinualWorldDefinitionRef
+    profile_ref: ContinualWorldProfileRef
+    request_content_sha256: str
+    parent_manifest_content_sha256: str
+    parent_snapshot: ContinualWorldSnapshotRef
+    origin_verification_content_sha256: str
+    children: tuple[ContinualRolloutChildReceipt, ...]
+
+    @field_validator(
+        "request_content_sha256",
+        "parent_manifest_content_sha256",
+        "origin_verification_content_sha256",
+    )
+    @classmethod
+    def validate_lineage_sha256(cls, value: str) -> str:
+        return validate_sha256(value)
+
+    @model_validator(mode="after")
+    def validate_lineage(self) -> Self:
+        if self.definition_ref.task_world_id != self.task_world_id:
+            raise ValueError("continual rollout lineage definition belongs to another task world")
+        if self.profile_ref.task_world_id != self.task_world_id:
+            raise ValueError("continual rollout lineage profile belongs to another task world")
+        if not self.children:
+            raise ValueError("continual rollout lineage requires at least one child")
+        if any(child.group_id != self.group_id for child in self.children):
+            raise ValueError("continual rollout child receipt belongs to another group")
+        if any(child.parent_snapshot != self.parent_snapshot for child in self.children):
+            raise ValueError("continual rollout child receipt must use the lineage parent snapshot")
+        child_ids = tuple(child.child_id for child in self.children)
+        if len(child_ids) != len(set(child_ids)):
+            raise ValueError("continual rollout lineage child ids must be distinct")
+        return self
+
+
+class ContinualRolloutGroupState(StrEnum):
+    """Durable creation state for one rollout group."""
+
+    PREPARING = "preparing"
+    READY = "ready"
+
+
+class ContinualRolloutGroupStatus(FrozenStrictModel):
+    """Recoverable progress view for one rollout group."""
+
+    schema_version: Literal["aecbench.continual-rollout-group-status.v1"] = (
+        CONTINUAL_ROLLOUT_GROUP_STATUS_SCHEMA_VERSION
+    )
+    group_id: NonEmptyStr
+    request_id: NonEmptyStr
+    state: ContinualRolloutGroupState
+    requested_child_ids: tuple[NonEmptyStr, ...]
+    created_child_ids: tuple[NonEmptyStr, ...]
+
+    @model_validator(mode="after")
+    def validate_status(self) -> Self:
+        if not self.requested_child_ids:
+            raise ValueError("continual rollout status requires requested children")
+        if len(self.requested_child_ids) != len(set(self.requested_child_ids)):
+            raise ValueError("continual rollout requested child ids must be distinct")
+        if len(self.created_child_ids) != len(set(self.created_child_ids)):
+            raise ValueError("continual rollout created child ids must be distinct")
+        if any(child_id not in self.requested_child_ids for child_id in self.created_child_ids):
+            raise ValueError("continual rollout created child is not in the request")
+        requested_order = {child_id: index for index, child_id in enumerate(self.requested_child_ids)}
+        if tuple(sorted(self.created_child_ids, key=requested_order.__getitem__)) != self.created_child_ids:
+            raise ValueError("continual rollout created child ids must preserve request order")
+        if self.state is ContinualRolloutGroupState.READY and self.created_child_ids != self.requested_child_ids:
+            raise ValueError("ready continual rollout status requires every child")
+        return self
+
+
+class ContinualRolloutChildRunRef(FrozenStrictModel):
+    """Private host reference for one materialized child run."""
+
+    schema_version: Literal["aecbench.continual-rollout-child-run-ref.v1"] = (
+        CONTINUAL_ROLLOUT_CHILD_RUN_REF_SCHEMA_VERSION
+    )
+    group_id: NonEmptyStr
+    child_id: NonEmptyStr
+    task_world_id: NonEmptyStr
+    run_id: NonEmptyStr
+    episode_id: NonEmptyStr
+    world_branch_id: NonEmptyStr
+    initial_snapshot: ContinualWorldSnapshotRef
+    child_manifest_content_sha256: str
+
+    @field_validator("child_manifest_content_sha256")
+    @classmethod
+    def validate_child_manifest_content_sha256(cls, value: str) -> str:
+        return validate_sha256(value)
+
+    @model_validator(mode="after")
+    def validate_run_ref(self) -> Self:
+        if (
+            self.run_id,
+            self.episode_id,
+            self.world_branch_id,
+        ) != (
+            self.initial_snapshot.run_id,
+            self.initial_snapshot.episode_id,
+            self.initial_snapshot.world_branch_id,
+        ):
+            raise ValueError("continual rollout child identity differs from its initial snapshot")
+        return self

--- a/src/aec_bench/ledger/immutable_artifact_store.py
+++ b/src/aec_bench/ledger/immutable_artifact_store.py
@@ -262,6 +262,39 @@ class ImmutableByteStore:
         payload = self.load_bytes(relative_path)
         return self._artifact(parts, payload)
 
+    def prepare_directory_destination(
+        self,
+        parent_relative_path: str,
+        directory_name: str,
+    ) -> Path:
+        """Prepare a confined parent and require its optional directory leaf to be safe."""
+        parent_parts = _relative_parts(parent_relative_path)
+        leaf_parts = _relative_parts(directory_name)
+        if len(leaf_parts) != 1:
+            raise ImmutableArtifactConfinementError(
+                "immutable directory destination leaf must be one name",
+            )
+        with self._open_parent((*parent_parts, ".directory-destination"), create=True) as parent_descriptor:
+            leaf_descriptor: int | None = None
+            try:
+                leaf_descriptor = self._open_child_directory(
+                    parent_descriptor,
+                    leaf_parts[0],
+                    create=False,
+                )
+            except _ImmutableArtifactMissingError:
+                pass
+            finally:
+                if leaf_descriptor is not None:
+                    try:
+                        os.close(leaf_descriptor)
+                    except OSError as cause:
+                        raise ImmutableArtifactStoreError(
+                            f"immutable directory destination cannot be closed: {cause}",
+                        ) from cause
+        self._assert_root_binding()
+        return self._root.joinpath(*parent_parts, leaf_parts[0])
+
     def _path(self, relative_path: str) -> Path:
         """Return one validated logical path for compatibility-layer policies."""
 

--- a/src/aec_bench/meta_harness/evidence_lifecycle.py
+++ b/src/aec_bench/meta_harness/evidence_lifecycle.py
@@ -10,8 +10,9 @@ import shutil
 import tempfile
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import ValidationError
 
@@ -101,6 +102,16 @@ from aec_bench.meta_harness.lifecycle_operation_store import (
 from aec_bench.task_world_templates.contracts import EvidenceCheckpointSpec, EvidenceLifecycleSpec
 
 LifecycleVerifier = Callable[[Path, Path], dict[str, Any] | LifecycleVerificationResult]
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceLifecycleBranchSnapshot:
+    """Detached current-schema state and action identity for one branch checkpoint."""
+
+    state: EvidenceLifecycleRunState
+    checkpoint_id: str
+    checkpoint_index: int
+    branch_action_state_sha256: str
 
 
 class LifecycleEpisodeExecutionError(EvidenceLifecycleError):
@@ -553,6 +564,9 @@ def branch_evidence_lifecycle(
     checkpoint_id: str,
     branch_id: str,
     reason: str,
+    submission_validation_scope: Literal["complete-run", "selected-checkpoint-prefix"] = "complete-run",
+    expected_parent_submission_sha256: str | None = None,
+    expected_parent_action_state_sha256: str | None = None,
 ) -> dict[str, Any]:
     """Create an isolated derived run that reopens one submitted checkpoint."""
     package = Path(package_dir)
@@ -566,6 +580,9 @@ def branch_evidence_lifecycle(
             checkpoint_id=checkpoint_id,
             branch_id=branch_id,
             reason=reason,
+            submission_validation_scope=submission_validation_scope,
+            expected_parent_submission_sha256=expected_parent_submission_sha256,
+            expected_parent_action_state_sha256=expected_parent_action_state_sha256,
         )
 
 
@@ -577,17 +594,41 @@ def _branch_evidence_lifecycle_locked(
     checkpoint_id: str,
     branch_id: str,
     reason: str,
+    submission_validation_scope: Literal["complete-run", "selected-checkpoint-prefix"],
+    expected_parent_submission_sha256: str | None,
+    expected_parent_action_state_sha256: str | None,
 ) -> dict[str, Any]:
     """Create a branch from a stable parent state held under its mutation lock."""
     spec = load_evidence_lifecycle_spec(package)
-    parent_state = _load_state(package, parent_run, spec, lock_held=True)
-    _assert_prior_submissions_unchanged(parent_run, parent_state)
     try:
         branch_index = next(
             index for index, checkpoint in enumerate(spec.checkpoints) if checkpoint.checkpoint_id == checkpoint_id
         )
     except StopIteration as exc:
         raise EvidenceLifecycleError(f"unknown checkpoint: {checkpoint_id}") from exc
+    if submission_validation_scope == "selected-checkpoint-prefix":
+        if expected_parent_submission_sha256 is None or expected_parent_action_state_sha256 is None:
+            raise EvidenceLifecycleError("selected checkpoint prefix validation requires the expected parent state")
+        branch_snapshot = _read_evidence_lifecycle_branch_snapshot_locked(
+            package,
+            parent_run,
+            spec,
+            checkpoint_id=checkpoint_id,
+        )
+        parent_state = branch_snapshot.state
+        parent_action_state_sha256 = branch_snapshot.branch_action_state_sha256
+    elif submission_validation_scope == "complete-run":
+        if expected_parent_submission_sha256 is not None or expected_parent_action_state_sha256 is not None:
+            raise EvidenceLifecycleError("expected parent state requires selected checkpoint prefix validation")
+        parent_state = _load_state(package, parent_run, spec, lock_held=True)
+        _assert_prior_submissions_unchanged(parent_run, parent_state)
+        parent_action_state_sha256 = _branch_action_state_sha256(
+            parent_state,
+            branch_index=branch_index,
+            inherited_only=False,
+        )
+    else:
+        raise EvidenceLifecycleError(f"unknown branch submission validation scope: {submission_validation_scope}")
     parent_checkpoint = parent_state.checkpoint(checkpoint_id)
     if parent_checkpoint.status != CheckpointRunStatus.SUBMITTED:
         raise EvidenceLifecycleError(f"checkpoint is not available for branching: {checkpoint_id}")
@@ -595,6 +636,11 @@ def _branch_evidence_lifecycle_locked(
         raise EvidenceLifecycleError(f"branch run directory already exists: {branch_run}")
     if parent_checkpoint.submission_sha256 is None:
         raise EvidenceLifecycleError(f"submitted checkpoint is missing its sha256: {checkpoint_id}")
+    if submission_validation_scope == "selected-checkpoint-prefix" and (
+        parent_checkpoint.submission_sha256 != expected_parent_submission_sha256
+        or parent_action_state_sha256 != expected_parent_action_state_sha256
+    ):
+        raise EvidenceLifecycleError("selected checkpoint parent state changed before branching")
 
     checkpoint_runs: list[CheckpointRunRecord] = []
     for index, checkpoint in enumerate(spec.checkpoints):
@@ -688,11 +734,7 @@ def _branch_evidence_lifecycle_locked(
             parent_run_dir=str(parent_run),
             branched_from_checkpoint_id=checkpoint_id,
             parent_submission_sha256=parent_checkpoint.submission_sha256,
-            parent_action_state_sha256=_branch_action_state_sha256(
-                parent_state,
-                branch_index=branch_index,
-                inherited_only=False,
-            ),
+            parent_action_state_sha256=parent_action_state_sha256,
             reason=reason,
         ),
     )
@@ -1711,6 +1753,75 @@ def read_evidence_lifecycle_state(package_dir: Path, run_dir: Path) -> dict[str,
     return _result_context(run, state)
 
 
+def read_evidence_lifecycle_branch_snapshot(
+    package_dir: Path,
+    run_dir: Path,
+    *,
+    checkpoint_id: str,
+) -> EvidenceLifecycleBranchSnapshot:
+    """Read one current-schema branch point without migration, recovery, or ledger writes."""
+    package = Path(package_dir)
+    run = Path(run_dir)
+    spec = load_evidence_lifecycle_spec(package)
+    with _lifecycle_state_lock(run):
+        return _read_evidence_lifecycle_branch_snapshot_locked(
+            package,
+            run,
+            spec,
+            checkpoint_id=checkpoint_id,
+        )
+
+
+def _read_evidence_lifecycle_branch_snapshot_locked(
+    package: Path,
+    run: Path,
+    spec: EvidenceLifecycleSpec,
+    *,
+    checkpoint_id: str,
+) -> EvidenceLifecycleBranchSnapshot:
+    """Read one selected checkpoint prefix while holding its parent run lock."""
+    path = _state_path(run)
+    if not path.is_file() or path.is_symlink():
+        raise EvidenceLifecycleError(f"lifecycle state not found or unsafe: {path}")
+    payload = _read_json(path)
+    if payload.get("schema_version") != "5":
+        raise EvidenceLifecycleError("branch snapshot requires current lifecycle state schema version 5")
+    try:
+        state = EvidenceLifecycleRunState.model_validate(payload)
+    except ValidationError as exc:
+        raise EvidenceLifecycleError(f"invalid lifecycle state: {path}") from exc
+    expected_ids = [checkpoint.checkpoint_id for checkpoint in spec.checkpoints]
+    actual_ids = [checkpoint.checkpoint_id for checkpoint in state.checkpoint_runs]
+    if state.lifecycle_id != spec.lifecycle_id or state.world_id != spec.world_id or actual_ids != expected_ids:
+        raise EvidenceLifecycleError("run state does not match the lifecycle package")
+    if state.lifecycle_spec_sha256 != _spec_sha256(spec):
+        raise EvidenceLifecycleError("lifecycle contract does not match lifecycle run")
+    if state.package_sha256 != _package_sha256(package):
+        raise EvidenceLifecycleError("package does not match lifecycle run")
+    _validate_evidence_request_state_contract(state, spec)
+    validate_lifecycle_operation_run_state(state, spec)
+    try:
+        checkpoint_index = expected_ids.index(checkpoint_id)
+    except ValueError as exc:
+        raise EvidenceLifecycleError(f"unknown checkpoint: {checkpoint_id}") from exc
+    _assert_prior_submissions_unchanged(
+        run,
+        state,
+        through_checkpoint_index=checkpoint_index,
+    )
+    action_state_sha256 = _branch_action_state_sha256(
+        state,
+        branch_index=checkpoint_index,
+        inherited_only=False,
+    )
+    return EvidenceLifecycleBranchSnapshot(
+        state=state.model_copy(deep=True),
+        checkpoint_id=checkpoint_id,
+        checkpoint_index=checkpoint_index,
+        branch_action_state_sha256=action_state_sha256,
+    )
+
+
 def load_validated_lifecycle_submissions(
     package_dir: Path,
     run_dir: Path,
@@ -1851,7 +1962,12 @@ def _load_state(
     return state
 
 
-def _assert_prior_submissions_unchanged(run_dir: Path, state: EvidenceLifecycleRunState) -> None:
+def _assert_prior_submissions_unchanged(
+    run_dir: Path,
+    state: EvidenceLifecycleRunState,
+    *,
+    through_checkpoint_index: int | None = None,
+) -> None:
     if state.branch is not None:
         checkpoint_id = state.branch.branched_from_checkpoint_id
         branch_origin = _workspace(run_dir) / "branch_origin" / f"{checkpoint_id}.json"
@@ -1867,7 +1983,13 @@ def _assert_prior_submissions_unchanged(run_dir: Path, state: EvidenceLifecycleR
         )
         if action_state_sha256 != state.branch.parent_action_state_sha256:
             raise EvidenceLifecycleError(f"branch origin action state changed: {checkpoint_id}")
-    for completed in state.checkpoint_runs:
+    if through_checkpoint_index is None:
+        submitted_scope = state.checkpoint_runs
+    elif 0 <= through_checkpoint_index < len(state.checkpoint_runs):
+        submitted_scope = state.checkpoint_runs[: through_checkpoint_index + 1]
+    else:
+        raise EvidenceLifecycleError("submission validation checkpoint index is out of range")
+    for completed in submitted_scope:
         if completed.status != CheckpointRunStatus.SUBMITTED:
             continue
         if completed.submission_path is None or completed.submission_sha256 is None:

--- a/src/aec_bench/task_world_templates/continual/__init__.py
+++ b/src/aec_bench/task_world_templates/continual/__init__.py
@@ -1,6 +1,11 @@
 # ABOUTME: Exposes task-neutral continual-world definition, catalogue, and local durability boundaries.
 # ABOUTME: Imports no concrete task world or execution transport.
 
+from aec_bench.task_world_templates.continual.branch_port import (
+    ContinualWorldBranchMaterialization,
+    ContinualWorldBranchPort,
+    VerifiedContinualWorldBranchOrigin,
+)
 from aec_bench.task_world_templates.continual.catalogue import ContinualWorldCatalogue
 from aec_bench.task_world_templates.continual.definition import (
     ContinualWorldDefinition,
@@ -23,9 +28,15 @@ from aec_bench.task_world_templates.continual.durability import (
     mkdir_durable,
     replace_file_bytes_durable,
 )
+from aec_bench.task_world_templates.continual.rollout_control import (
+    ContinualRolloutControl,
+    ContinualRolloutError,
+)
 
 __all__ = [
     "ContinualWorldCatalogue",
+    "ContinualWorldBranchMaterialization",
+    "ContinualWorldBranchPort",
     "ContinualWorldDefinition",
     "ContinualWorldLockConfinementError",
     "ContinualWorldLockError",
@@ -39,6 +50,9 @@ __all__ = [
     "ImmutableArtifactStoreError",
     "ImmutableByteStore",
     "LoadedContinualWorldProfile",
+    "ContinualRolloutControl",
+    "ContinualRolloutError",
+    "VerifiedContinualWorldBranchOrigin",
     "exclusive_local_file_lock",
     "mkdir_durable",
     "python_source_sha256",

--- a/src/aec_bench/task_world_templates/continual/branch_port.py
+++ b/src/aec_bench/task_world_templates/continual/branch_port.py
@@ -1,0 +1,79 @@
+# ABOUTME: Defines the task port used by shared chosen-point rollout orchestration.
+# ABOUTME: Keeps task state opaque while requiring exact origin and child verification.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from aec_bench.contracts.continual_world import (
+    ContinualRolloutChildReceipt,
+    ContinualRolloutChildRequest,
+    ContinualRolloutGroupRequest,
+    ContinualWorldSnapshotRef,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class VerifiedContinualWorldBranchOrigin:
+    """Exact task-verified origin plus opaque task context for materialization."""
+
+    parent_snapshot: ContinualWorldSnapshotRef
+    parent_manifest_content_sha256: str
+    origin_verification_content_sha256: str
+    ancestor_world_branch_ids: tuple[str, ...]
+    task_context: object
+
+
+@dataclass(frozen=True, slots=True)
+class ContinualWorldBranchMaterialization:
+    """Shared child facts returned by one task-owned branch implementation."""
+
+    initial_snapshot: ContinualWorldSnapshotRef
+    child_manifest_content_sha256: str
+    task_branch_receipt_content_sha256: str
+    ancestor_world_branch_ids: tuple[str, ...]
+
+
+class ContinualWorldBranchPort(Protocol):
+    """Task-owned operations required by the shared rollout coordinator."""
+
+    def verify_origin(
+        self,
+        *,
+        profile_value: object,
+        package_root: Path | None,
+        parent_run_root: Path,
+        request: ContinualRolloutGroupRequest,
+    ) -> VerifiedContinualWorldBranchOrigin:
+        """Verify one exact branchable snapshot without changing the parent."""
+
+    def materialize_child(
+        self,
+        *,
+        profile_value: object,
+        package_root: Path | None,
+        parent_run_root: Path,
+        child_run_root: Path,
+        request: ContinualRolloutGroupRequest,
+        child: ContinualRolloutChildRequest,
+        origin: VerifiedContinualWorldBranchOrigin,
+    ) -> ContinualWorldBranchMaterialization:
+        """Create or exactly recover one isolated child from the verified origin.
+
+        The shared coordinator serializes calls for one group and child identity.
+        """
+
+    def verify_child(
+        self,
+        *,
+        profile_value: object,
+        package_root: Path | None,
+        parent_run_root: Path,
+        child_run_root: Path,
+        request: ContinualRolloutGroupRequest,
+        child: ContinualRolloutChildRequest,
+        receipt: ContinualRolloutChildReceipt,
+    ) -> None:
+        """Verify the persisted child against its immutable shared receipt."""

--- a/src/aec_bench/task_world_templates/continual/definition.py
+++ b/src/aec_bench/task_world_templates/continual/definition.py
@@ -14,6 +14,7 @@ from aec_bench.contracts.continual_world import (
     ContinualWorldDefinitionSpec,
     ContinualWorldProfileRef,
 )
+from aec_bench.task_world_templates.continual.branch_port import ContinualWorldBranchPort
 
 
 @dataclass(frozen=True)
@@ -30,6 +31,7 @@ class ContinualWorldDefinition:
 
     spec: ContinualWorldDefinitionSpec
     profile_loader: Callable[[ContinualWorldProfileRef], LoadedContinualWorldProfile]
+    branch_port: ContinualWorldBranchPort | None = None
 
     @property
     def ref(self) -> ContinualWorldDefinitionRef:

--- a/src/aec_bench/task_world_templates/continual/rollout_control.py
+++ b/src/aec_bench/task_world_templates/continual/rollout_control.py
@@ -1,0 +1,484 @@
+# ABOUTME: Coordinates durable chosen-point rollout groups through a registered task branch port.
+# ABOUTME: Exposes only group creation, inspection, status, and child run resolution.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from aec_bench.contracts.continual_world import (
+    ContinualRolloutChildReceipt,
+    ContinualRolloutChildRequest,
+    ContinualRolloutChildRunRef,
+    ContinualRolloutGroupRequest,
+    ContinualRolloutGroupState,
+    ContinualRolloutGroupStatus,
+    ContinualRolloutLineage,
+)
+from aec_bench.task_world_templates.continual.branch_port import (
+    ContinualWorldBranchMaterialization,
+    ContinualWorldBranchPort,
+    VerifiedContinualWorldBranchOrigin,
+)
+from aec_bench.task_world_templates.continual.definition import ContinualWorldDefinition
+from aec_bench.task_world_templates.continual.rollout_repository import (
+    ContinualRolloutError,
+    ContinualRolloutRepository,
+)
+
+
+class ContinualRolloutControl:
+    """Task-neutral durable coordinator for isolated child world creation."""
+
+    def __init__(
+        self,
+        definition: ContinualWorldDefinition,
+        *,
+        parent_run_root: Path,
+        rollout_repository_root: Path,
+        authorised_principal_ids: tuple[str, ...],
+        package_root: Path | None = None,
+    ) -> None:
+        if definition.branch_port is None:
+            raise ValueError("continual-world definition has no registered branch port")
+        if not authorised_principal_ids or any(not principal.strip() for principal in authorised_principal_ids):
+            raise ValueError("continual rollout control requires one authorised host principal")
+        if len(authorised_principal_ids) != len(set(authorised_principal_ids)):
+            raise ValueError("continual rollout host principals must be distinct")
+        self._definition = definition
+        self._branch_port: ContinualWorldBranchPort = definition.branch_port
+        self._parent_run_root = Path(parent_run_root)
+        self._package_root = Path(package_root) if package_root is not None else None
+        disjoint_roots = (self._parent_run_root,) + ((self._package_root,) if self._package_root is not None else ())
+        self._repository = ContinualRolloutRepository(
+            rollout_repository_root,
+            disjoint_roots=disjoint_roots,
+        )
+        self._authorised_principal_ids = frozenset(authorised_principal_ids)
+
+    def create_group(self, request: ContinualRolloutGroupRequest) -> ContinualRolloutLineage:
+        """Create or exactly recover all ordered children in one rollout group."""
+        selected, profile_value = self._validated_request(request)
+        self._repository.validate_storage_identities(
+            selected.group_id,
+            tuple(child.child_id for child in selected.children),
+        )
+        origin = self._verify_origin(profile_value, selected)
+        with self._repository.locked(selected.group_id):
+            self._repository.publish_group_request(selected)
+            if self._repository.lineage_exists(selected.group_id):
+                lineage = self._load_complete_lineage(selected)
+                self._verify_persisted_children(
+                    selected,
+                    profile_value,
+                    lineage.children,
+                    expected_ancestor_world_branch_ids=origin.ancestor_world_branch_ids,
+                )
+                return lineage
+            for child in selected.children:
+                self._repository.publish_child_request(selected.group_id, child)
+
+        candidates = tuple(
+            self._materialize_or_load_child(
+                profile_value=profile_value,
+                request=selected,
+                child=child,
+                origin=origin,
+            )
+            for child in selected.children
+        )
+
+        with self._repository.locked(selected.group_id):
+            self._repository.publish_group_request(selected)
+            self._require_persisted_child_requests(selected)
+            receipts = tuple(
+                self._publish_or_load_child_receipt(
+                    profile_value=profile_value,
+                    request=selected,
+                    child=child,
+                    candidate=candidate,
+                    expected_ancestor_world_branch_ids=origin.ancestor_world_branch_ids,
+                )
+                for child, candidate in zip(selected.children, candidates, strict=True)
+            )
+            lineage = ContinualRolloutLineage(
+                request_id=selected.request_id,
+                group_id=selected.group_id,
+                task_world_id=selected.task_world_id,
+                definition_ref=selected.definition_ref,
+                profile_ref=selected.profile_ref,
+                request_content_sha256=selected.content_sha256,
+                parent_manifest_content_sha256=selected.parent_manifest_content_sha256,
+                parent_snapshot=selected.parent_snapshot,
+                origin_verification_content_sha256=selected.origin_verification_content_sha256,
+                children=receipts,
+            )
+            self._repository.publish_lineage(lineage)
+            return self._load_complete_lineage(selected)
+
+    def inspect_group(self, group_id: str) -> ContinualRolloutLineage:
+        """Load the complete immutable lineage for one ready group."""
+        with self._repository.locked(group_id):
+            request, _ = self._validated_request(self._repository.load_group_request(group_id))
+            return self._load_complete_lineage(request)
+
+    def group_status(self, group_id: str) -> ContinualRolloutGroupStatus:
+        """Return ordered durable progress for one complete or interrupted group."""
+        with self._repository.locked(group_id):
+            request, _ = self._validated_request(self._repository.load_group_request(group_id))
+            requested = tuple(child.child_id for child in request.children)
+            created_items: list[str] = []
+            lineage_exists = self._repository.lineage_exists(request.group_id)
+            for child in request.children:
+                child_request_exists = self._repository.child_request_exists(
+                    request.group_id,
+                    child.child_id,
+                )
+                child_receipt_exists = self._repository.child_receipt_exists(
+                    request.group_id,
+                    child.child_id,
+                )
+                if not child_request_exists:
+                    if lineage_exists or child_receipt_exists:
+                        raise ContinualRolloutError(
+                            "child-request-integrity",
+                            child.child_id,
+                        )
+                    continue
+                stored_child = self._repository.load_child_request(request.group_id, child.child_id)
+                if stored_child != child:
+                    raise ContinualRolloutError("child-request-integrity", child.child_id)
+                if not child_receipt_exists:
+                    if lineage_exists:
+                        raise ContinualRolloutError(
+                            "child-receipt-integrity",
+                            child.child_id,
+                        )
+                    continue
+                receipt = self._repository.load_child_receipt(request.group_id, child.child_id)
+                self._require_receipt_matches_child(receipt, request, child)
+                created_items.append(child.child_id)
+            created = tuple(created_items)
+            ready = lineage_exists and created == requested
+            if ready:
+                self._load_complete_lineage(request)
+            return ContinualRolloutGroupStatus(
+                group_id=request.group_id,
+                request_id=request.request_id,
+                state=ContinualRolloutGroupState.READY if ready else ContinualRolloutGroupState.PREPARING,
+                requested_child_ids=requested,
+                created_child_ids=created,
+            )
+
+    def child_run_ref(self, group_id: str, child_id: str) -> ContinualRolloutChildRunRef:
+        """Resolve one materialized child without exposing sibling or actor settings."""
+        with self._repository.locked(group_id):
+            request, profile_value = self._validated_request(
+                self._repository.load_group_request(group_id),
+            )
+            lineage = self._load_complete_lineage(request)
+            try:
+                child_index = tuple(child.child_id for child in request.children).index(child_id)
+            except ValueError as exc:
+                raise ContinualRolloutError("child-not-found", child_id) from exc
+            child = request.children[child_index]
+            receipt = lineage.children[child_index]
+            self._require_receipt_matches_child(receipt, request, child)
+            self._verify_child(
+                profile_value,
+                request,
+                child,
+                self._repository.child_world_root(group_id, child_id),
+                receipt,
+            )
+            return ContinualRolloutChildRunRef(
+                group_id=group_id,
+                child_id=child_id,
+                task_world_id=request.task_world_id,
+                run_id=receipt.initial_snapshot.run_id,
+                episode_id=receipt.initial_snapshot.episode_id,
+                world_branch_id=receipt.initial_snapshot.world_branch_id,
+                initial_snapshot=receipt.initial_snapshot,
+                child_manifest_content_sha256=receipt.child_manifest_content_sha256,
+            )
+
+    def _load_complete_lineage(
+        self,
+        request: ContinualRolloutGroupRequest,
+    ) -> ContinualRolloutLineage:
+        if not self._repository.lineage_exists(request.group_id):
+            raise ContinualRolloutError("group-not-ready", request.group_id)
+        lineage = self._repository.load_lineage(request.group_id)
+        self._require_lineage_matches_request(lineage, request)
+        requested_ids = tuple(child.child_id for child in request.children)
+        if tuple(receipt.child_id for receipt in lineage.children) != requested_ids:
+            raise ContinualRolloutError("lineage-integrity", "child order differs from the request")
+        self._require_persisted_child_requests(request)
+        for child, lineage_receipt in zip(request.children, lineage.children, strict=True):
+            stored_receipt = self._repository.load_child_receipt(request.group_id, child.child_id)
+            if stored_receipt != lineage_receipt:
+                raise ContinualRolloutError("child-receipt-integrity", child.child_id)
+            self._require_receipt_matches_child(stored_receipt, request, child)
+        return lineage
+
+    def _validated_request(
+        self,
+        request: ContinualRolloutGroupRequest,
+    ) -> tuple[ContinualRolloutGroupRequest, object]:
+        try:
+            selected = ContinualRolloutGroupRequest.model_validate(request.model_dump(mode="json"))
+        except ValidationError as exc:
+            raise ContinualRolloutError("request-integrity", str(exc)) from exc
+        if selected.authority_id not in self._authorised_principal_ids:
+            raise ContinualRolloutError("authority", "rollout authority is not authorised")
+        if selected.definition_ref != self._definition.ref:
+            raise ContinualRolloutError("definition", "rollout definition reference does not match")
+        if selected.task_world_id != self._definition.ref.task_world_id:
+            raise ContinualRolloutError("task-world", "rollout task world does not match")
+        try:
+            profile_value = self._definition.load_profile(selected.profile_ref).value
+        except (KeyError, ValueError) as exc:
+            raise ContinualRolloutError("profile", str(exc)) from exc
+        return selected, profile_value
+
+    def _verify_origin(
+        self,
+        profile_value: object,
+        request: ContinualRolloutGroupRequest,
+    ) -> VerifiedContinualWorldBranchOrigin:
+        try:
+            origin = self._branch_port.verify_origin(
+                profile_value=profile_value,
+                package_root=self._package_root,
+                parent_run_root=self._parent_run_root,
+                request=request,
+            )
+        except ContinualRolloutError:
+            raise
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise ContinualRolloutError("origin-verification", str(exc)) from exc
+        if (
+            origin.parent_snapshot != request.parent_snapshot
+            or origin.parent_manifest_content_sha256 != request.parent_manifest_content_sha256
+            or origin.origin_verification_content_sha256 != request.origin_verification_content_sha256
+        ):
+            raise ContinualRolloutError("origin-verification", "branch port returned another origin")
+        if not origin.ancestor_world_branch_ids:
+            raise ContinualRolloutError("origin-verification", "branch ancestry is empty")
+        if len(origin.ancestor_world_branch_ids) != len(set(origin.ancestor_world_branch_ids)):
+            raise ContinualRolloutError("origin-verification", "branch ancestry contains a cycle")
+        if origin.ancestor_world_branch_ids[-1] != request.parent_snapshot.world_branch_id:
+            raise ContinualRolloutError("origin-verification", "branch ancestry does not end at the parent")
+        return origin
+
+    def _materialize_or_load_child(
+        self,
+        *,
+        profile_value: object,
+        request: ContinualRolloutGroupRequest,
+        child: ContinualRolloutChildRequest,
+        origin: VerifiedContinualWorldBranchOrigin,
+    ) -> ContinualRolloutChildReceipt:
+        with self._repository.materializing_child(request.group_id, child.child_id):
+            return self._materialize_or_load_child_serially(
+                profile_value=profile_value,
+                request=request,
+                child=child,
+                origin=origin,
+            )
+
+    def _materialize_or_load_child_serially(
+        self,
+        *,
+        profile_value: object,
+        request: ContinualRolloutGroupRequest,
+        child: ContinualRolloutChildRequest,
+        origin: VerifiedContinualWorldBranchOrigin,
+    ) -> ContinualRolloutChildReceipt:
+        child_root = self._repository.child_world_root(request.group_id, child.child_id)
+        if self._repository.child_receipt_exists(request.group_id, child.child_id):
+            receipt = self._repository.load_child_receipt(request.group_id, child.child_id)
+            self._require_receipt_matches_child(receipt, request, child)
+            self._require_receipt_ancestry(receipt, origin.ancestor_world_branch_ids)
+            self._verify_child(profile_value, request, child, child_root, receipt)
+            return receipt
+        try:
+            materialization = self._branch_port.materialize_child(
+                profile_value=profile_value,
+                package_root=self._package_root,
+                parent_run_root=self._parent_run_root,
+                child_run_root=child_root,
+                request=request,
+                child=child,
+                origin=origin,
+            )
+        except ContinualRolloutError:
+            raise
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise ContinualRolloutError("child-materialization", str(exc)) from exc
+        if materialization.ancestor_world_branch_ids != origin.ancestor_world_branch_ids:
+            raise ContinualRolloutError(
+                "child-lineage",
+                "branch port returned ancestry that differs from the verified origin",
+            )
+        receipt = self._receipt_from_materialization(request, child, materialization)
+        self._require_receipt_matches_child(receipt, request, child)
+        self._require_receipt_ancestry(receipt, origin.ancestor_world_branch_ids)
+        self._verify_child(profile_value, request, child, child_root, receipt)
+        return receipt
+
+    def _publish_or_load_child_receipt(
+        self,
+        *,
+        profile_value: object,
+        request: ContinualRolloutGroupRequest,
+        child: ContinualRolloutChildRequest,
+        candidate: ContinualRolloutChildReceipt,
+        expected_ancestor_world_branch_ids: tuple[str, ...],
+    ) -> ContinualRolloutChildReceipt:
+        self._require_receipt_matches_child(candidate, request, child)
+        self._require_receipt_ancestry(candidate, expected_ancestor_world_branch_ids)
+        if self._repository.child_receipt_exists(request.group_id, child.child_id):
+            receipt = self._repository.load_child_receipt(request.group_id, child.child_id)
+        else:
+            self._verify_child(
+                profile_value,
+                request,
+                child,
+                self._repository.child_world_root(request.group_id, child.child_id),
+                candidate,
+            )
+            self._repository.publish_child_receipt(candidate)
+            receipt = self._repository.load_child_receipt(request.group_id, child.child_id)
+        self._require_receipt_matches_child(receipt, request, child)
+        self._require_receipt_ancestry(receipt, expected_ancestor_world_branch_ids)
+        self._verify_child(
+            profile_value,
+            request,
+            child,
+            self._repository.child_world_root(request.group_id, child.child_id),
+            receipt,
+        )
+        return receipt
+
+    def _require_persisted_child_requests(
+        self,
+        request: ContinualRolloutGroupRequest,
+    ) -> None:
+        for child in request.children:
+            if not self._repository.child_request_exists(request.group_id, child.child_id):
+                raise ContinualRolloutError("child-request-integrity", child.child_id)
+            stored_child = self._repository.load_child_request(request.group_id, child.child_id)
+            if stored_child != child:
+                raise ContinualRolloutError("child-request-integrity", child.child_id)
+
+    def _verify_child(
+        self,
+        profile_value: object,
+        request: ContinualRolloutGroupRequest,
+        child: ContinualRolloutChildRequest,
+        child_root: Path,
+        receipt: ContinualRolloutChildReceipt,
+    ) -> None:
+        try:
+            self._branch_port.verify_child(
+                profile_value=profile_value,
+                package_root=self._package_root,
+                parent_run_root=self._parent_run_root,
+                child_run_root=child_root,
+                request=request,
+                child=child,
+                receipt=receipt,
+            )
+        except ContinualRolloutError:
+            raise
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise ContinualRolloutError("child-verification", str(exc)) from exc
+
+    @staticmethod
+    def _receipt_from_materialization(
+        request: ContinualRolloutGroupRequest,
+        child: ContinualRolloutChildRequest,
+        materialization: ContinualWorldBranchMaterialization,
+    ) -> ContinualRolloutChildReceipt:
+        return ContinualRolloutChildReceipt(
+            group_id=request.group_id,
+            child_id=child.child_id,
+            child_request_content_sha256=child.content_sha256,
+            parent_snapshot=request.parent_snapshot,
+            initial_snapshot=materialization.initial_snapshot,
+            child_manifest_content_sha256=materialization.child_manifest_content_sha256,
+            task_branch_receipt_content_sha256=materialization.task_branch_receipt_content_sha256,
+            ancestor_world_branch_ids=materialization.ancestor_world_branch_ids,
+        )
+
+    def _verify_persisted_children(
+        self,
+        request: ContinualRolloutGroupRequest,
+        profile_value: object,
+        receipts: tuple[ContinualRolloutChildReceipt, ...],
+        *,
+        expected_ancestor_world_branch_ids: tuple[str, ...],
+    ) -> None:
+        if tuple(receipt.child_id for receipt in receipts) != tuple(child.child_id for child in request.children):
+            raise ContinualRolloutError("lineage-integrity", "child order differs from the request")
+        for child, receipt in zip(request.children, receipts, strict=True):
+            self._require_receipt_matches_child(receipt, request, child)
+            self._require_receipt_ancestry(receipt, expected_ancestor_world_branch_ids)
+            self._verify_child(
+                profile_value,
+                request,
+                child,
+                self._repository.child_world_root(request.group_id, child.child_id),
+                receipt,
+            )
+
+    @staticmethod
+    def _require_receipt_matches_child(
+        receipt: ContinualRolloutChildReceipt,
+        request: ContinualRolloutGroupRequest,
+        child: ContinualRolloutChildRequest,
+    ) -> None:
+        if (
+            receipt.group_id != request.group_id
+            or receipt.child_id != child.child_id
+            or receipt.child_request_content_sha256 != child.content_sha256
+            or receipt.parent_snapshot != request.parent_snapshot
+            or (
+                receipt.initial_snapshot.run_id,
+                receipt.initial_snapshot.episode_id,
+                receipt.initial_snapshot.world_branch_id,
+            )
+            != (child.run_id, child.episode_id, child.world_branch_id)
+        ):
+            raise ContinualRolloutError("child-receipt-integrity", child.child_id)
+
+    @staticmethod
+    def _require_lineage_matches_request(
+        lineage: ContinualRolloutLineage,
+        request: ContinualRolloutGroupRequest,
+    ) -> None:
+        if (
+            lineage.request_id != request.request_id
+            or lineage.group_id != request.group_id
+            or lineage.task_world_id != request.task_world_id
+            or lineage.definition_ref != request.definition_ref
+            or lineage.profile_ref != request.profile_ref
+            or lineage.request_content_sha256 != request.content_sha256
+            or lineage.parent_manifest_content_sha256 != request.parent_manifest_content_sha256
+            or lineage.parent_snapshot != request.parent_snapshot
+            or lineage.origin_verification_content_sha256 != request.origin_verification_content_sha256
+        ):
+            raise ContinualRolloutError("lineage-integrity", request.group_id)
+
+    @staticmethod
+    def _require_receipt_ancestry(
+        receipt: ContinualRolloutChildReceipt,
+        expected_ancestor_world_branch_ids: tuple[str, ...],
+    ) -> None:
+        if receipt.ancestor_world_branch_ids != expected_ancestor_world_branch_ids:
+            raise ContinualRolloutError("child-lineage", receipt.child_id)
+
+
+__all__ = ["ContinualRolloutControl", "ContinualRolloutError"]

--- a/src/aec_bench/task_world_templates/continual/rollout_repository.py
+++ b/src/aec_bench/task_world_templates/continual/rollout_repository.py
@@ -1,0 +1,210 @@
+# ABOUTME: Stores immutable rollout requests, child receipts, and ordered lineage records.
+# ABOUTME: Confines host-private group paths and provides one durable lock per rollout group.
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TypeVar
+
+from pydantic import BaseModel, ValidationError
+
+from aec_bench.contracts.continual_world import (
+    ContinualRolloutChildReceipt,
+    ContinualRolloutChildRequest,
+    ContinualRolloutGroupRequest,
+    ContinualRolloutLineage,
+)
+from aec_bench.task_world_templates.continual.durability import (
+    ImmutableArtifactCollisionError,
+    ImmutableArtifactStoreError,
+    ImmutableByteStore,
+    exclusive_local_file_lock,
+)
+
+_SAFE_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}\Z")
+_ModelT = TypeVar("_ModelT", bound=BaseModel)
+
+
+class ContinualRolloutError(RuntimeError):
+    """Stable shared failure for rollout validation, storage, and task ports."""
+
+    def __init__(self, code: str, detail: str) -> None:
+        self.code = code
+        self.detail = detail
+        super().__init__(f"{code}: {detail}")
+
+
+class ContinualRolloutRepository:
+    """Host-private immutable repository for generic rollout orchestration."""
+
+    def __init__(self, root: Path, *, disjoint_roots: tuple[Path, ...] = ()) -> None:
+        try:
+            self._store = ImmutableByteStore(
+                Path(root),
+                disjoint_roots=disjoint_roots,
+                host_private=True,
+            )
+        except ImmutableArtifactStoreError as exc:
+            raise ContinualRolloutError("artifact-confinement", str(exc)) from exc
+
+    @property
+    def root(self) -> Path:
+        """Return the trusted physical repository root."""
+        return self._store.root
+
+    def validate_storage_identities(
+        self,
+        group_id: str,
+        child_ids: tuple[str, ...],
+    ) -> None:
+        """Validate every path identity without preparing storage."""
+        _safe_id(group_id, label="group")
+        for child_id in child_ids:
+            _safe_id(child_id, label="child")
+
+    @contextmanager
+    def locked(self, group_id: str) -> Iterator[None]:
+        """Hold the confined mutation lock for exactly one rollout group."""
+        selected = _safe_id(group_id, label="group")
+        with exclusive_local_file_lock(
+            self.root,
+            f".locks/groups/{selected}.lock",
+            error_factory=lambda error: ContinualRolloutError("artifact-confinement", str(error)),
+        ):
+            yield
+
+    @contextmanager
+    def materializing_child(self, group_id: str, child_id: str) -> Iterator[None]:
+        """Serialize task-port materialization for one exact child identity."""
+        selected_group = _safe_id(group_id, label="group")
+        selected_child = _safe_id(child_id, label="child")
+        with exclusive_local_file_lock(
+            self.root,
+            f".locks/groups/{selected_group}/children/{selected_child}.lock",
+            error_factory=lambda error: ContinualRolloutError("artifact-confinement", str(error)),
+        ):
+            yield
+
+    def publish_group_request(self, request: ContinualRolloutGroupRequest) -> None:
+        self._publish(
+            self._request_path(request.group_id),
+            request,
+            conflict_code="request-conflict",
+        )
+
+    def load_group_request(self, group_id: str) -> ContinualRolloutGroupRequest:
+        return self._load(self._request_path(group_id), ContinualRolloutGroupRequest)
+
+    def publish_child_request(
+        self,
+        group_id: str,
+        child: ContinualRolloutChildRequest,
+    ) -> None:
+        self._publish(
+            self._child_request_path(group_id, child.child_id),
+            child,
+            conflict_code="child-request-conflict",
+        )
+
+    def load_child_request(self, group_id: str, child_id: str) -> ContinualRolloutChildRequest:
+        return self._load(
+            self._child_request_path(group_id, child_id),
+            ContinualRolloutChildRequest,
+        )
+
+    def child_request_exists(self, group_id: str, child_id: str) -> bool:
+        return self._exists(self._child_request_path(group_id, child_id))
+
+    def publish_child_receipt(self, receipt: ContinualRolloutChildReceipt) -> None:
+        self._publish(
+            self._child_receipt_path(receipt.group_id, receipt.child_id),
+            receipt,
+            conflict_code="child-receipt-conflict",
+        )
+
+    def load_child_receipt(self, group_id: str, child_id: str) -> ContinualRolloutChildReceipt:
+        return self._load(
+            self._child_receipt_path(group_id, child_id),
+            ContinualRolloutChildReceipt,
+        )
+
+    def child_receipt_exists(self, group_id: str, child_id: str) -> bool:
+        return self._exists(self._child_receipt_path(group_id, child_id))
+
+    def publish_lineage(self, lineage: ContinualRolloutLineage) -> None:
+        self._publish(
+            self._lineage_path(lineage.group_id),
+            lineage,
+            conflict_code="lineage-conflict",
+        )
+
+    def load_lineage(self, group_id: str) -> ContinualRolloutLineage:
+        return self._load(self._lineage_path(group_id), ContinualRolloutLineage)
+
+    def lineage_exists(self, group_id: str) -> bool:
+        return self._exists(self._lineage_path(group_id))
+
+    def child_world_root(self, group_id: str, child_id: str) -> Path:
+        """Return the confined task-owned world destination for one reserved child."""
+        selected_group = _safe_id(group_id, label="group")
+        selected_child = _safe_id(child_id, label="child")
+        try:
+            return self._store.prepare_directory_destination(
+                f"groups/{selected_group}/children/{selected_child}",
+                "world",
+            )
+        except ImmutableArtifactStoreError as exc:
+            raise ContinualRolloutError("artifact-confinement", str(exc)) from exc
+
+    def _publish(self, relative_path: str, value: BaseModel, *, conflict_code: str) -> None:
+        payload = _canonical_json_bytes(value)
+        try:
+            self._store.publish_bytes(relative_path, payload)
+        except ImmutableArtifactCollisionError as exc:
+            raise ContinualRolloutError(conflict_code, relative_path) from exc
+        except ImmutableArtifactStoreError as exc:
+            raise ContinualRolloutError("artifact-confinement", str(exc)) from exc
+
+    def _load(self, relative_path: str, model_type: type[_ModelT]) -> _ModelT:
+        try:
+            payload = self._store.load_bytes(relative_path)
+            return model_type.model_validate_json(payload)
+        except (ImmutableArtifactStoreError, ValidationError) as exc:
+            raise ContinualRolloutError("artifact-integrity", f"{relative_path}: {exc}") from exc
+
+    def _exists(self, relative_path: str) -> bool:
+        try:
+            return self._store.exists(relative_path)
+        except ImmutableArtifactStoreError as exc:
+            raise ContinualRolloutError("artifact-confinement", str(exc)) from exc
+
+    @staticmethod
+    def _request_path(group_id: str) -> str:
+        return f"groups/{_safe_id(group_id, label='group')}/request.json"
+
+    @staticmethod
+    def _lineage_path(group_id: str) -> str:
+        return f"groups/{_safe_id(group_id, label='group')}/lineage.json"
+
+    @staticmethod
+    def _child_request_path(group_id: str, child_id: str) -> str:
+        return f"groups/{_safe_id(group_id, label='group')}/children/{_safe_id(child_id, label='child')}/request.json"
+
+    @staticmethod
+    def _child_receipt_path(group_id: str, child_id: str) -> str:
+        return f"groups/{_safe_id(group_id, label='group')}/children/{_safe_id(child_id, label='child')}/receipt.json"
+
+
+def _safe_id(value: str, *, label: str) -> str:
+    if not _SAFE_ID.fullmatch(value):
+        raise ContinualRolloutError("unsafe-identity", f"invalid {label} id")
+    return value
+
+
+def _canonical_json_bytes(value: BaseModel) -> bytes:
+    payload = value.model_dump(mode="json")
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")

--- a/src/aec_bench/task_world_templates/lifecycles/ssc03_hydraulic_continual_definition.py
+++ b/src/aec_bench/task_world_templates/lifecycles/ssc03_hydraulic_continual_definition.py
@@ -36,6 +36,11 @@ from aec_bench.task_world_templates.lifecycles.ssc03_hydraulic_interaction_varia
     TEMPLATE_ID,
     get_ssc03_hydraulic_interaction_variant,
 )
+from aec_bench.task_world_templates.lifecycles.ssc03_hydraulic_rollout_adapter import (
+    Ssc03HydraulicContinualBranchPort,
+    ssc03_hydraulic_continual_branch_port,
+    ssc03_hydraulic_rollout_source_sha256,
+)
 
 SSC03_HYDRAULIC_CONTINUAL_WORLD_ID = "aec.task_world.composite.hydraulic-interaction-lifecycle-review"
 SSC03_HYDRAULIC_CONTINUAL_DEFINITION_VERSION = "1"
@@ -174,6 +179,8 @@ def _implementation_content_sha256(adapter: LifecycleWorldAdapter) -> str:
             "loaded_profile": python_source_sha256(Ssc03HydraulicContinualProfile),
             "profile_loader": python_source_sha256(_load_ssc03_hydraulic_profile),
             "profile_reference": python_source_sha256(_profile_ref),
+            "rollout_branch_port": python_source_sha256(Ssc03HydraulicContinualBranchPort),
+            "rollout_branch_source": ssc03_hydraulic_rollout_source_sha256(),
         }
     )
 
@@ -197,4 +204,5 @@ def ssc03_hydraulic_continual_world_definition() -> ContinualWorldDefinition:
     return ContinualWorldDefinition(
         spec=_ssc03_definition_spec(),
         profile_loader=_load_ssc03_hydraulic_profile,
+        branch_port=ssc03_hydraulic_continual_branch_port(),
     )

--- a/src/aec_bench/task_world_templates/lifecycles/ssc03_hydraulic_rollout_adapter.py
+++ b/src/aec_bench/task_world_templates/lifecycles/ssc03_hydraulic_rollout_adapter.py
@@ -1,0 +1,604 @@
+# ABOUTME: Adapts real SSC-03 submitted checkpoints to the shared continual rollout branch port.
+# ABOUTME: Preserves lifecycle evidence and budgets while verifying exact retry and branch lineage.
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from functools import cache
+from pathlib import Path
+from typing import Literal, Protocol, Self, cast
+
+from pydantic import field_validator, model_validator
+
+from aec_bench.contracts.continual_world import (
+    ContinualRolloutChildReceipt,
+    ContinualRolloutChildRequest,
+    ContinualRolloutGroupRequest,
+    ContinualWorldSnapshotRef,
+)
+from aec_bench.contracts.harness_kernel import (
+    ContentAddressedModel,
+    canonical_content_sha256,
+    validate_sha256,
+)
+from aec_bench.contracts.validators import NonEmptyStr
+from aec_bench.meta_harness.evidence_lifecycle import (
+    EvidenceLifecycleBranchSnapshot,
+    EvidenceLifecycleError,
+    branch_evidence_lifecycle,
+    load_evidence_lifecycle_spec,
+    read_evidence_lifecycle_branch_snapshot,
+)
+from aec_bench.meta_harness.evidence_lifecycle_state import (
+    CheckpointRunStatus,
+    EvidenceLifecycleRunState,
+)
+from aec_bench.task_world_templates.continual.branch_port import (
+    ContinualWorldBranchMaterialization,
+    ContinualWorldBranchPort,
+    VerifiedContinualWorldBranchOrigin,
+)
+from aec_bench.task_world_templates.continual.durability import ImmutableByteStore
+
+_ROOT_BRANCH_ID = "root"
+_TASK_RECEIPT_PATH = "rollout-branch-receipt.json"
+
+
+class _Ssc03ProfilePort(Protocol):
+    def validate_package(self, package_dir: Path) -> dict[str, object] | None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class Ssc03HydraulicRolloutOrigin:
+    """Public exact request inputs for one submitted SSC-03 checkpoint."""
+
+    parent_manifest_content_sha256: str
+    parent_snapshot: ContinualWorldSnapshotRef
+    origin_verification_content_sha256: str
+
+
+class Ssc03HydraulicSubmittedCheckpointRef(ContentAddressedModel):
+    """One immutable submitted checkpoint in an SSC-03 branch prefix."""
+
+    checkpoint_id: NonEmptyStr
+    submission_sha256: str
+
+    @field_validator("submission_sha256")
+    @classmethod
+    def validate_submission_sha256(cls, value: str) -> str:
+        return validate_sha256(value)
+
+
+class Ssc03HydraulicRolloutBranchReceipt(ContentAddressedModel):
+    """Task-owned immutable evidence for one materialized SSC-03 child."""
+
+    schema_version: Literal["aecbench.ssc03-hydraulic-rollout-branch-receipt.v1"] = (
+        "aecbench.ssc03-hydraulic-rollout-branch-receipt.v1"
+    )
+    group_id: NonEmptyStr
+    child_id: NonEmptyStr
+    task_world_id: NonEmptyStr
+    definition_content_sha256: str
+    profile_content_sha256: str
+    group_request_content_sha256: str
+    child_request_content_sha256: str
+    parent_manifest_content_sha256: str
+    origin_verification_content_sha256: str
+    parent_snapshot: ContinualWorldSnapshotRef
+    initial_snapshot: ContinualWorldSnapshotRef
+    lifecycle_id: NonEmptyStr
+    lifecycle_spec_sha256: str
+    package_sha256: str
+    checkpoint_id: NonEmptyStr
+    branch_id: NonEmptyStr
+    parent_submission_sha256: str
+    parent_action_state_sha256: str
+    reason: NonEmptyStr
+    submitted_checkpoint_prefix: tuple[Ssc03HydraulicSubmittedCheckpointRef, ...]
+    ancestor_world_branch_ids: tuple[NonEmptyStr, ...]
+
+    @field_validator(
+        "definition_content_sha256",
+        "profile_content_sha256",
+        "group_request_content_sha256",
+        "child_request_content_sha256",
+        "parent_manifest_content_sha256",
+        "origin_verification_content_sha256",
+        "lifecycle_spec_sha256",
+        "package_sha256",
+        "parent_submission_sha256",
+        "parent_action_state_sha256",
+    )
+    @classmethod
+    def validate_receipt_sha256(cls, value: str) -> str:
+        return validate_sha256(value)
+
+    @model_validator(mode="after")
+    def validate_branch_scope(self) -> Self:
+        checkpoint_ids = tuple(item.checkpoint_id for item in self.submitted_checkpoint_prefix)
+        if not checkpoint_ids or len(checkpoint_ids) != len(set(checkpoint_ids)):
+            raise ValueError("SSC-03 rollout checkpoint prefix must be non-empty and ordered")
+        if (
+            checkpoint_ids[-1] != self.checkpoint_id
+            or self.submitted_checkpoint_prefix[-1].submission_sha256 != self.parent_submission_sha256
+        ):
+            raise ValueError("SSC-03 rollout checkpoint prefix must end at the branch origin")
+        if (
+            self.initial_snapshot.sequence != self.parent_snapshot.sequence
+            or self.initial_snapshot.state_id != self.parent_snapshot.state_id
+            or self.initial_snapshot.world_branch_id != self.branch_id
+        ):
+            raise ValueError("SSC-03 rollout child snapshot differs from the branch scope")
+        if (
+            not self.ancestor_world_branch_ids
+            or len(self.ancestor_world_branch_ids) != len(set(self.ancestor_world_branch_ids))
+            or self.branch_id in self.ancestor_world_branch_ids
+            or self.ancestor_world_branch_ids[-1] != self.parent_snapshot.world_branch_id
+        ):
+            raise ValueError("SSC-03 rollout branch ancestry is invalid")
+        return self
+
+
+@dataclass(frozen=True, slots=True)
+class _Ssc03OriginContext:
+    checkpoint_id: str
+    checkpoint_index: int
+    parent_action_state_sha256: str
+    submitted_checkpoint_prefix: tuple[Ssc03HydraulicSubmittedCheckpointRef, ...]
+    ancestor_world_branch_ids: tuple[str, ...]
+
+
+class Ssc03HydraulicContinualBranchPort:
+    """Real lifecycle implementation of the shared continual branch contract."""
+
+    def verify_origin(
+        self,
+        *,
+        profile_value: object,
+        package_root: Path | None,
+        parent_run_root: Path,
+        request: ContinualRolloutGroupRequest,
+    ) -> VerifiedContinualWorldBranchOrigin:
+        package = _validated_package(profile_value, package_root)
+        spec = load_evidence_lifecycle_spec(package)
+        checkpoint_index = request.parent_snapshot.sequence - 1
+        if checkpoint_index < 0 or checkpoint_index >= len(spec.checkpoints):
+            raise ValueError("SSC-03 rollout snapshot sequence does not select a checkpoint")
+        checkpoint_id = spec.checkpoints[checkpoint_index].checkpoint_id
+        branch_snapshot = _validated_state(
+            package,
+            parent_run_root,
+            checkpoint_id=checkpoint_id,
+        )
+        state = branch_snapshot.state
+        expected = _origin_from_state(
+            package,
+            parent_run_root,
+            state,
+            checkpoint_id=checkpoint_id,
+            branch_action_state_sha256=branch_snapshot.branch_action_state_sha256,
+        )
+        if expected.parent_snapshot != request.parent_snapshot:
+            raise ValueError("SSC-03 rollout snapshot does not match the submitted checkpoint")
+        if expected.parent_manifest_content_sha256 != request.parent_manifest_content_sha256:
+            raise ValueError("SSC-03 rollout parent manifest does not match the lifecycle package")
+        if expected.origin_verification_content_sha256 != request.origin_verification_content_sha256:
+            raise ValueError("SSC-03 rollout origin verification content differs")
+        _, ancestors = _run_identity_and_ancestor_branch_ids(package, parent_run_root, state)
+        submitted_prefix = _submitted_checkpoint_prefix(state, checkpoint_index)
+        return VerifiedContinualWorldBranchOrigin(
+            parent_snapshot=expected.parent_snapshot,
+            parent_manifest_content_sha256=expected.parent_manifest_content_sha256,
+            origin_verification_content_sha256=expected.origin_verification_content_sha256,
+            ancestor_world_branch_ids=ancestors,
+            task_context=_Ssc03OriginContext(
+                checkpoint_id=checkpoint_id,
+                checkpoint_index=checkpoint_index,
+                parent_action_state_sha256=expected.parent_snapshot.commit_id,
+                submitted_checkpoint_prefix=submitted_prefix,
+                ancestor_world_branch_ids=ancestors,
+            ),
+        )
+
+    def materialize_child(
+        self,
+        *,
+        profile_value: object,
+        package_root: Path | None,
+        parent_run_root: Path,
+        child_run_root: Path,
+        request: ContinualRolloutGroupRequest,
+        child: ContinualRolloutChildRequest,
+        origin: VerifiedContinualWorldBranchOrigin,
+    ) -> ContinualWorldBranchMaterialization:
+        package = _validated_package(profile_value, package_root)
+        context = cast(_Ssc03OriginContext, origin.task_context)
+        if not isinstance(context, _Ssc03OriginContext):
+            raise ValueError("SSC-03 rollout origin context is invalid")
+        if child_run_root.is_symlink():
+            raise ValueError("SSC-03 rollout child destination is unsafe")
+        if not child_run_root.exists():
+            try:
+                branch_evidence_lifecycle(
+                    package,
+                    parent_run_root,
+                    child_run_root,
+                    checkpoint_id=context.checkpoint_id,
+                    branch_id=child.world_branch_id,
+                    reason=request.reason,
+                    submission_validation_scope="selected-checkpoint-prefix",
+                    expected_parent_submission_sha256=request.parent_snapshot.state_id,
+                    expected_parent_action_state_sha256=context.parent_action_state_sha256,
+                )
+            except EvidenceLifecycleError:
+                if not child_run_root.is_dir() or child_run_root.is_symlink():
+                    raise
+        initial_snapshot, task_receipt = _child_scope(
+            package,
+            parent_run_root,
+            child_run_root,
+            request,
+            child,
+            context,
+        )
+        artifact = _task_receipt_store(
+            child_run_root,
+            package_root=package,
+            parent_run_root=parent_run_root,
+        ).publish_bytes(
+            _TASK_RECEIPT_PATH,
+            _canonical_model_bytes(task_receipt),
+        )
+        return ContinualWorldBranchMaterialization(
+            initial_snapshot=initial_snapshot,
+            child_manifest_content_sha256=task_receipt.package_sha256,
+            task_branch_receipt_content_sha256=artifact.sha256,
+            ancestor_world_branch_ids=task_receipt.ancestor_world_branch_ids,
+        )
+
+    def verify_child(
+        self,
+        *,
+        profile_value: object,
+        package_root: Path | None,
+        parent_run_root: Path,
+        child_run_root: Path,
+        request: ContinualRolloutGroupRequest,
+        child: ContinualRolloutChildRequest,
+        receipt: ContinualRolloutChildReceipt,
+    ) -> None:
+        package = _validated_package(profile_value, package_root)
+        checkpoint_index = request.parent_snapshot.sequence - 1
+        spec = load_evidence_lifecycle_spec(package)
+        if checkpoint_index < 0 or checkpoint_index >= len(spec.checkpoints):
+            raise ValueError("SSC-03 rollout receipt snapshot does not select a checkpoint")
+        payload = _task_receipt_store(
+            child_run_root,
+            package_root=package,
+            parent_run_root=parent_run_root,
+        ).load_bytes(
+            _TASK_RECEIPT_PATH,
+            expected_sha256=receipt.task_branch_receipt_content_sha256,
+        )
+        task_receipt = Ssc03HydraulicRolloutBranchReceipt.model_validate_json(payload)
+        context = _Ssc03OriginContext(
+            checkpoint_id=spec.checkpoints[checkpoint_index].checkpoint_id,
+            checkpoint_index=checkpoint_index,
+            parent_action_state_sha256=request.parent_snapshot.commit_id,
+            submitted_checkpoint_prefix=task_receipt.submitted_checkpoint_prefix,
+            ancestor_world_branch_ids=receipt.ancestor_world_branch_ids,
+        )
+        initial_snapshot, expected_task_receipt = _child_scope(
+            package,
+            parent_run_root,
+            child_run_root,
+            request,
+            child,
+            context,
+        )
+        if task_receipt != expected_task_receipt:
+            raise ValueError("SSC-03 rollout task receipt differs from the child")
+        if (
+            initial_snapshot != receipt.initial_snapshot
+            or task_receipt.package_sha256 != receipt.child_manifest_content_sha256
+            or task_receipt.ancestor_world_branch_ids != receipt.ancestor_world_branch_ids
+        ):
+            raise ValueError("SSC-03 rollout child differs from its immutable receipt")
+
+
+def ssc03_hydraulic_rollout_origin(
+    package_root: Path,
+    parent_run_root: Path,
+    *,
+    checkpoint_id: str,
+) -> Ssc03HydraulicRolloutOrigin:
+    """Build exact generic origin fields for one submitted SSC-03 checkpoint."""
+    package = Path(package_root)
+    branch_snapshot = _validated_state(
+        package,
+        parent_run_root,
+        checkpoint_id=checkpoint_id,
+    )
+    return _origin_from_state(
+        package,
+        parent_run_root,
+        branch_snapshot.state,
+        checkpoint_id=checkpoint_id,
+        branch_action_state_sha256=branch_snapshot.branch_action_state_sha256,
+    )
+
+
+def ssc03_hydraulic_rollout_source_sha256() -> str:
+    """Return the exact source identity of the complete SSC-03 rollout adapter module."""
+    return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()
+
+
+@cache
+def ssc03_hydraulic_continual_branch_port() -> ContinualWorldBranchPort:
+    """Return the registered SSC-03 branch port singleton."""
+    return Ssc03HydraulicContinualBranchPort()
+
+
+def _validated_package(profile_value: object, package_root: Path | None) -> Path:
+    if package_root is None:
+        raise ValueError("SSC-03 rollout requires the materialized lifecycle package")
+    profile = cast(_Ssc03ProfilePort, profile_value)
+    if not callable(getattr(profile, "validate_package", None)):
+        raise ValueError("SSC-03 rollout profile does not expose package validation")
+    package = Path(package_root)
+    metadata = profile.validate_package(package)
+    if metadata is None:
+        raise ValueError("SSC-03 rollout lifecycle package is not valid")
+    return package
+
+
+def _validated_state(
+    package_root: Path,
+    run_root: Path,
+    *,
+    checkpoint_id: str,
+) -> EvidenceLifecycleBranchSnapshot:
+    return read_evidence_lifecycle_branch_snapshot(
+        package_root,
+        run_root,
+        checkpoint_id=checkpoint_id,
+    )
+
+
+def _origin_from_state(
+    package_root: Path,
+    run_root: Path,
+    state: EvidenceLifecycleRunState,
+    *,
+    checkpoint_id: str,
+    branch_action_state_sha256: str,
+) -> Ssc03HydraulicRolloutOrigin:
+    spec = load_evidence_lifecycle_spec(package_root)
+    try:
+        checkpoint_index = next(
+            index for index, checkpoint in enumerate(spec.checkpoints) if checkpoint.checkpoint_id == checkpoint_id
+        )
+    except StopIteration as exc:
+        raise ValueError(f"unknown SSC-03 branch checkpoint: {checkpoint_id}") from exc
+    checkpoint = state.checkpoint(checkpoint_id)
+    if checkpoint.status is not CheckpointRunStatus.SUBMITTED or checkpoint.submission_sha256 is None:
+        raise ValueError(f"SSC-03 checkpoint is not available for branching: {checkpoint_id}")
+    branch_id = state.branch.branch_id if state.branch is not None else _ROOT_BRANCH_ID
+    run_id, ancestors = _run_identity_and_ancestor_branch_ids(package_root, run_root, state)
+    snapshot = ContinualWorldSnapshotRef(
+        run_id=run_id,
+        episode_id=_checkpoint_episode_id(checkpoint_id),
+        world_branch_id=branch_id,
+        sequence=checkpoint_index + 1,
+        state_id=checkpoint.submission_sha256,
+        commit_id=branch_action_state_sha256,
+    )
+    submitted_prefix = _submitted_checkpoint_prefix(state, checkpoint_index)
+    verification_sha256 = canonical_content_sha256(
+        {
+            "schema_version": "aecbench.ssc03-rollout-origin-verification.v1",
+            "lifecycle_id": state.lifecycle_id,
+            "world_id": state.world_id,
+            "lifecycle_spec_sha256": state.lifecycle_spec_sha256,
+            "package_sha256": state.package_sha256,
+            "checkpoint_id": checkpoint_id,
+            "snapshot": snapshot.model_dump(mode="json"),
+            "submitted_checkpoint_prefix": [item.model_dump(mode="json") for item in submitted_prefix],
+            "ancestor_world_branch_ids": ancestors,
+        }
+    )
+    return Ssc03HydraulicRolloutOrigin(
+        parent_manifest_content_sha256=state.package_sha256,
+        parent_snapshot=snapshot,
+        origin_verification_content_sha256=verification_sha256,
+    )
+
+
+def _host_run_id(run_root: Path) -> str:
+    selected = str(Path(run_root).expanduser().resolve(strict=True)).encode("utf-8")
+    return f"ssc03-run-{hashlib.sha256(selected).hexdigest()}"
+
+
+def _checkpoint_episode_id(checkpoint_id: str) -> str:
+    return f"ssc03-checkpoint-{checkpoint_id}"
+
+
+def _child_scope(
+    package_root: Path,
+    parent_run_root: Path,
+    child_run_root: Path,
+    request: ContinualRolloutGroupRequest,
+    child: ContinualRolloutChildRequest,
+    context: _Ssc03OriginContext,
+) -> tuple[ContinualWorldSnapshotRef, Ssc03HydraulicRolloutBranchReceipt]:
+    state = _validated_state(
+        package_root,
+        child_run_root,
+        checkpoint_id=context.checkpoint_id,
+    ).state
+    branch = state.branch
+    if branch is None:
+        raise ValueError("SSC-03 rollout child is missing its branch record")
+    if (
+        branch.branch_id != child.world_branch_id
+        or Path(branch.parent_run_dir).resolve() != Path(parent_run_root).resolve()
+        or branch.branched_from_checkpoint_id != context.checkpoint_id
+        or branch.parent_submission_sha256 != request.parent_snapshot.state_id
+        or branch.parent_action_state_sha256 != context.parent_action_state_sha256
+        or branch.reason != request.reason
+        or state.active_checkpoint_id != context.checkpoint_id
+    ):
+        raise ValueError("SSC-03 rollout child branch record differs from the request")
+    submitted_prefix = _child_submitted_checkpoint_prefix(
+        state,
+        branch_checkpoint_index=context.checkpoint_index,
+        parent_submission_sha256=branch.parent_submission_sha256,
+    )
+    if submitted_prefix != context.submitted_checkpoint_prefix:
+        raise ValueError("SSC-03 rollout child inherited submission prefix differs from the origin")
+    initial_snapshot = ContinualWorldSnapshotRef(
+        run_id=child.run_id,
+        episode_id=child.episode_id,
+        world_branch_id=child.world_branch_id,
+        sequence=request.parent_snapshot.sequence,
+        state_id=request.parent_snapshot.state_id,
+        commit_id=canonical_content_sha256(
+            {
+                "schema_version": "aecbench.ssc03-rollout-child-commit.v1",
+                "child_request": child.model_dump(mode="json"),
+                "parent_commit_id": request.parent_snapshot.commit_id,
+                "branch": branch.model_dump(mode="json"),
+            }
+        ),
+    )
+    task_receipt = Ssc03HydraulicRolloutBranchReceipt(
+        group_id=request.group_id,
+        child_id=child.child_id,
+        task_world_id=request.task_world_id,
+        definition_content_sha256=request.definition_ref.content_sha256,
+        profile_content_sha256=request.profile_ref.profile_content_sha256,
+        group_request_content_sha256=request.content_sha256,
+        child_request_content_sha256=child.content_sha256,
+        parent_manifest_content_sha256=request.parent_manifest_content_sha256,
+        origin_verification_content_sha256=request.origin_verification_content_sha256,
+        parent_snapshot=request.parent_snapshot,
+        initial_snapshot=initial_snapshot,
+        lifecycle_id=state.lifecycle_id,
+        lifecycle_spec_sha256=state.lifecycle_spec_sha256,
+        package_sha256=state.package_sha256,
+        checkpoint_id=context.checkpoint_id,
+        branch_id=branch.branch_id,
+        parent_submission_sha256=branch.parent_submission_sha256,
+        parent_action_state_sha256=branch.parent_action_state_sha256,
+        reason=branch.reason,
+        submitted_checkpoint_prefix=submitted_prefix,
+        ancestor_world_branch_ids=context.ancestor_world_branch_ids,
+    )
+    return initial_snapshot, task_receipt
+
+
+def _task_receipt_store(
+    child_run_root: Path,
+    *,
+    package_root: Path,
+    parent_run_root: Path,
+) -> ImmutableByteStore:
+    return ImmutableByteStore(
+        child_run_root,
+        disjoint_roots=(package_root, parent_run_root),
+        host_private=True,
+    )
+
+
+def _submitted_checkpoint_prefix(
+    state: EvidenceLifecycleRunState,
+    checkpoint_index: int,
+) -> tuple[Ssc03HydraulicSubmittedCheckpointRef, ...]:
+    prefix: list[Ssc03HydraulicSubmittedCheckpointRef] = []
+    for checkpoint in state.checkpoint_runs[: checkpoint_index + 1]:
+        if checkpoint.status is not CheckpointRunStatus.SUBMITTED or checkpoint.submission_sha256 is None:
+            raise ValueError(f"SSC-03 checkpoint prefix is not submitted: {checkpoint.checkpoint_id}")
+        prefix.append(
+            Ssc03HydraulicSubmittedCheckpointRef(
+                checkpoint_id=checkpoint.checkpoint_id,
+                submission_sha256=checkpoint.submission_sha256,
+            )
+        )
+    return tuple(prefix)
+
+
+def _child_submitted_checkpoint_prefix(
+    state: EvidenceLifecycleRunState,
+    *,
+    branch_checkpoint_index: int,
+    parent_submission_sha256: str,
+) -> tuple[Ssc03HydraulicSubmittedCheckpointRef, ...]:
+    prefix = list(_submitted_checkpoint_prefix(state, branch_checkpoint_index - 1))
+    checkpoint = state.checkpoint_runs[branch_checkpoint_index]
+    if checkpoint.status is not CheckpointRunStatus.ACTIVE:
+        raise ValueError("SSC-03 branch checkpoint is not active in the child")
+    prefix.append(
+        Ssc03HydraulicSubmittedCheckpointRef(
+            checkpoint_id=checkpoint.checkpoint_id,
+            submission_sha256=parent_submission_sha256,
+        )
+    )
+    return tuple(prefix)
+
+
+def _canonical_model_bytes(value: ContentAddressedModel) -> bytes:
+    return json.dumps(
+        value.model_dump(mode="json"),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
+def _run_identity_and_ancestor_branch_ids(
+    package_root: Path,
+    run_root: Path,
+    state: EvidenceLifecycleRunState,
+) -> tuple[str, tuple[str, ...]]:
+    if state.branch is None:
+        return _host_run_id(run_root), (_ROOT_BRANCH_ID,)
+    store = ImmutableByteStore(
+        run_root,
+        disjoint_roots=(package_root,),
+        host_private=True,
+    )
+    task_receipt = Ssc03HydraulicRolloutBranchReceipt.model_validate_json(store.load_bytes(_TASK_RECEIPT_PATH))
+    branch = state.branch
+    if (
+        task_receipt.task_world_id != state.world_id
+        or task_receipt.lifecycle_id != state.lifecycle_id
+        or task_receipt.lifecycle_spec_sha256 != state.lifecycle_spec_sha256
+        or task_receipt.package_sha256 != state.package_sha256
+        or task_receipt.checkpoint_id != branch.branched_from_checkpoint_id
+        or task_receipt.branch_id != branch.branch_id
+        or task_receipt.parent_submission_sha256 != branch.parent_submission_sha256
+        or task_receipt.parent_action_state_sha256 != branch.parent_action_state_sha256
+        or task_receipt.reason != branch.reason
+    ):
+        raise ValueError("SSC-03 rollout ancestry receipt differs from the branch state")
+    ancestors = task_receipt.ancestor_world_branch_ids
+    if (
+        not ancestors
+        or len(ancestors) != len(set(ancestors))
+        or branch.branch_id in ancestors
+        or ancestors[-1] != task_receipt.parent_snapshot.world_branch_id
+    ):
+        raise ValueError("SSC-03 rollout ancestry receipt is invalid")
+    return task_receipt.initial_snapshot.run_id, (*ancestors, branch.branch_id)
+
+
+__all__ = [
+    "Ssc03HydraulicContinualBranchPort",
+    "Ssc03HydraulicRolloutBranchReceipt",
+    "Ssc03HydraulicRolloutOrigin",
+    "ssc03_hydraulic_continual_branch_port",
+    "ssc03_hydraulic_rollout_origin",
+    "ssc03_hydraulic_rollout_source_sha256",
+]

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/continual_definition.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/continual_definition.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import inspect
 from collections.abc import Mapping
 from dataclasses import dataclass
 from functools import cache
@@ -89,6 +91,13 @@ def _load_pump_station_profile(reference: ContinualWorldProfileRef) -> LoadedCon
 
 
 def _implementation_content_sha256() -> str:
+    from aec_bench.task_world_templates.stewardship.wastewater_pump_station import (
+        continual_rollout_adapter,
+    )
+
+    adapter_source_sha256 = hashlib.sha256(
+        inspect.getsource(continual_rollout_adapter).encode("utf-8"),
+    ).hexdigest()
     return canonical_content_sha256(
         {
             "loaded_profile": python_source_sha256(PumpStationContinualProfile),
@@ -99,6 +108,7 @@ def _implementation_content_sha256() -> str:
             "v2_reference_package_loader": python_source_sha256(load_v2_reference_package),
             "model_factory": python_source_sha256(coupled_pump_station_model_from_package),
             "opening_state_factory": python_source_sha256(create_asw_8_world_state),
+            "branch_adapter_module": adapter_source_sha256,
         }
     )
 
@@ -106,6 +116,10 @@ def _implementation_content_sha256() -> str:
 @cache
 def pump_station_continual_world_definition() -> ContinualWorldDefinition:
     """Return the content-pinned pump definition without starting a world run."""
+    from aec_bench.task_world_templates.stewardship.wastewater_pump_station.continual_rollout_adapter import (
+        PumpStationContinualWorldBranchPort,
+    )
+
     system, _ = _validated_profile_data()
     task_world_id = str(system.descriptor.get("task_world_id"))
     profile = ContinualWorldProfileRef(
@@ -122,4 +136,5 @@ def pump_station_continual_world_definition() -> ContinualWorldDefinition:
             profiles=(profile,),
         ),
         profile_loader=_load_pump_station_profile,
+        branch_port=PumpStationContinualWorldBranchPort(),
     )

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/continual_rollout_adapter.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/continual_rollout_adapter.py
@@ -1,0 +1,454 @@
+# ABOUTME: Adapts registered pump runs to shared chosen-point rollout orchestration.
+# ABOUTME: Verifies exact origins, materializes children, and records pump lineage evidence.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import cast
+
+from aec_bench.contracts.continual_world import (
+    ContinualRolloutChildReceipt,
+    ContinualRolloutChildRequest,
+    ContinualRolloutGroupRequest,
+    ContinualWorldSnapshotRef,
+)
+from aec_bench.task_world_templates.continual.branch_port import (
+    ContinualWorldBranchMaterialization,
+    VerifiedContinualWorldBranchOrigin,
+)
+from aec_bench.task_world_templates.continual.durability import ImmutableByteStore
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.continual_definition import (
+    PumpStationContinualProfile,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.rollout_models import (
+    PUMP_STATION_ROLLOUT_BRANCH_RECEIPT_VERSION_V2,
+    PumpStationRolloutBranchReceiptV2,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_identity import (
+    stewardship_content_id,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_models import (
+    PUMP_STATION_STATE_VERSION_V4,
+    PumpStationCoupledStewardshipState,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.temporal_evidence.models import (
+    TemporalEvidenceBundle,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.temporal_evidence.repository import (
+    TemporalEvidenceRepository,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run import (
+    PumpStationWorldRun,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_models import (
+    PumpStationInitialStateSource,
+    PumpStationStateSnapshotRef,
+    PumpStationWorldRunManifestV2,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_repository import (
+    PumpStationWorldRunRepository,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_serialization import (
+    load_pump_station_artifact,
+    pump_station_artifact_bytes,
+    pump_station_artifact_id,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _PumpStationVerifiedRolloutOrigin:
+    """Pump values captured from one prefix-verified selected-history origin."""
+
+    manifest: PumpStationWorldRunManifestV2
+    state: PumpStationCoupledStewardshipState
+    bundle: TemporalEvidenceBundle
+    snapshot: PumpStationStateSnapshotRef
+    remaining_schedule_sha256: str
+
+
+class PumpStationContinualWorldBranchPort:
+    """Materialize registered pump children through the durable V4 world run."""
+
+    _TASK_RECEIPT_PATH = "rollout-branch-receipt.json"
+
+    def verify_origin(
+        self,
+        *,
+        profile_value: object,
+        package_root: Path | None,
+        parent_run_root: Path,
+        request: ContinualRolloutGroupRequest,
+    ) -> VerifiedContinualWorldBranchOrigin:
+        """Capture and prefix-verify one selected pump snapshot under its run lock."""
+
+        del package_root
+        profile = self._profile(profile_value)
+        repository = PumpStationWorldRunRepository(parent_run_root)
+        manifest = repository.load_manifest()
+        if not isinstance(manifest, PumpStationWorldRunManifestV2):
+            raise ValueError("registered pump rollout requires manifest v2")
+        if (
+            PumpStationWorldRun._definition_ref(manifest) != request.definition_ref
+            or PumpStationWorldRun._profile_ref(manifest) != request.profile_ref
+        ):
+            raise ValueError("registered pump rollout identity differs")
+        manifest_content_id = pump_station_artifact_id(
+            manifest,
+            record_profile="manifest-v2",
+        )
+        if manifest_content_id != request.parent_manifest_content_sha256:
+            raise ValueError("registered pump parent manifest differs")
+        run = PumpStationWorldRun._resume_reference_system_for_historical_prefix(
+            repository=repository,
+            snapshot=repository.current_snapshot(),
+        )
+        snapshot = _pump_snapshot(
+            request.parent_snapshot,
+            snapshot_version=manifest.snapshot_version,
+        )
+        with repository.locked():
+            repository.commits_through(snapshot)
+            report = run._verify_v4_under_lock(snapshot)
+            if not report.valid or report.final_state_id != snapshot.state_id:
+                raise ValueError("registered pump rollout origin replay differs")
+            report_content_id = pump_station_artifact_id(
+                report,
+                record_profile="v4",
+            )
+            if report_content_id != request.origin_verification_content_sha256:
+                raise ValueError("registered pump rollout origin verification differs")
+            state = repository.load_state(snapshot.state_id)
+            if state.state_version != PUMP_STATION_STATE_VERSION_V4:
+                raise ValueError("registered pump rollout selected a non-V4 state")
+            selected_state = cast(PumpStationCoupledStewardshipState, state)
+            bundle = TemporalEvidenceRepository(
+                repository.root / "temporal-evidence",
+            ).load_bundle(package=profile.station_package)
+            remaining_schedule_sha256 = _remaining_schedule_sha256(selected_state)
+        ancestors = (
+            *manifest.initial_state_source.ancestor_branch_ids,
+            manifest.world_branch_id,
+        )
+        if len(ancestors) != len(set(ancestors)):
+            raise ValueError("registered pump rollout ancestry contains a cycle")
+        return VerifiedContinualWorldBranchOrigin(
+            parent_snapshot=request.parent_snapshot,
+            parent_manifest_content_sha256=manifest_content_id,
+            origin_verification_content_sha256=report_content_id,
+            ancestor_world_branch_ids=ancestors,
+            task_context=_PumpStationVerifiedRolloutOrigin(
+                manifest=manifest,
+                state=selected_state,
+                bundle=bundle,
+                snapshot=snapshot,
+                remaining_schedule_sha256=remaining_schedule_sha256,
+            ),
+        )
+
+    def materialize_child(
+        self,
+        *,
+        profile_value: object,
+        package_root: Path | None,
+        parent_run_root: Path,
+        child_run_root: Path,
+        request: ContinualRolloutGroupRequest,
+        child: ContinualRolloutChildRequest,
+        origin: VerifiedContinualWorldBranchOrigin,
+    ) -> ContinualWorldBranchMaterialization:
+        """Create or recover one child with inherited public temporal evidence."""
+
+        del package_root
+        profile = self._profile(profile_value)
+        context = self._origin_context(origin)
+        source = PumpStationInitialStateSource(
+            kind="rollout_parent_snapshot",
+            opening_specification_id=context.manifest.opening_state_specification_id,
+            opening_specification_sha256=context.manifest.opening_state_specification_sha256,
+            parent_run_id=context.snapshot.run_id,
+            parent_branch_id=context.snapshot.world_branch_id,
+            parent_state_id=context.snapshot.state_id,
+            parent_commit_id=context.snapshot.commit_id,
+            rollout_group_request_id=request.request_id,
+            child_request_content_id=child.content_sha256,
+            rollout_group_request_content_id=request.content_sha256,
+            parent_manifest_content_id=request.parent_manifest_content_sha256,
+            origin_verification_content_id=request.origin_verification_content_sha256,
+            parent_origin_remaining_schedule_sha256=context.remaining_schedule_sha256,
+            ancestor_branch_ids=origin.ancestor_world_branch_ids,
+        )
+        manifest = replace(
+            context.manifest,
+            run_id=child.run_id,
+            episode_id=child.episode_id,
+            world_branch_id=child.world_branch_id,
+            initial_sequence=context.snapshot.sequence,
+            initial_state_id=context.snapshot.state_id,
+            initial_state_source=source,
+        )
+        repository = PumpStationWorldRunRepository(child_run_root)
+        repository.initialize(
+            manifest,
+            context.state,
+            before_select=lambda: PumpStationWorldRun._initialize_reference_temporal_evidence(
+                repository=repository,
+                package=profile.station_package,
+                bundle=context.bundle,
+            ),
+        )
+        PumpStationWorldRun._verify_reference_temporal_evidence(
+            repository=repository,
+            package=profile.station_package,
+            manifest=manifest,
+            expected=context.bundle,
+        )
+        run = PumpStationWorldRun.resume_reference_system(
+            repository=repository,
+            snapshot=repository.current_snapshot(),
+        )
+        if not run.verify_v4().valid:
+            raise ValueError("registered pump child replay differs")
+        initial_snapshot = _initial_snapshot(repository, manifest)
+        task_receipt = PumpStationRolloutBranchReceiptV2(
+            receipt_version=PUMP_STATION_ROLLOUT_BRANCH_RECEIPT_VERSION_V2,
+            group_id=request.group_id,
+            child_id=child.child_id,
+            shared_group_request_content_sha256=request.content_sha256,
+            shared_child_request_content_sha256=child.content_sha256,
+            parent_snapshot=context.snapshot,
+            initial_snapshot=initial_snapshot,
+            child_manifest_content_id=pump_station_artifact_id(
+                manifest,
+                record_profile="manifest-v2",
+            ),
+            temporal_bundle_content_id=manifest.temporal_bundle_content_id,
+            parent_origin_remaining_schedule_sha256=context.remaining_schedule_sha256,
+            ancestor_branch_ids=origin.ancestor_world_branch_ids,
+        )
+        artifact = _task_store(
+            repository.root,
+            parent_run_root=parent_run_root,
+        ).publish_bytes(
+            self._TASK_RECEIPT_PATH,
+            pump_station_artifact_bytes(task_receipt, record_profile="v4"),
+        )
+        return ContinualWorldBranchMaterialization(
+            initial_snapshot=_shared_snapshot(initial_snapshot),
+            child_manifest_content_sha256=task_receipt.child_manifest_content_id,
+            task_branch_receipt_content_sha256=artifact.sha256,
+            ancestor_world_branch_ids=task_receipt.ancestor_branch_ids,
+        )
+
+    def verify_child(
+        self,
+        *,
+        profile_value: object,
+        package_root: Path | None,
+        parent_run_root: Path,
+        child_run_root: Path,
+        request: ContinualRolloutGroupRequest,
+        child: ContinualRolloutChildRequest,
+        receipt: ContinualRolloutChildReceipt,
+    ) -> None:
+        """Verify the child, complete source provenance, and task receipt."""
+
+        del package_root
+        self._profile(profile_value)
+        repository = PumpStationWorldRunRepository(child_run_root)
+        manifest = repository.load_manifest()
+        if not isinstance(manifest, PumpStationWorldRunManifestV2):
+            raise ValueError("registered pump child requires manifest v2")
+        run = PumpStationWorldRun.resume_reference_system(
+            repository=repository,
+            snapshot=repository.current_snapshot(),
+        )
+        if not run.verify_v4().valid:
+            raise ValueError("registered pump child replay differs")
+        initial_snapshot = _initial_snapshot(repository, manifest)
+        manifest_content_id = pump_station_artifact_id(
+            manifest,
+            record_profile="manifest-v2",
+        )
+        if (
+            receipt.initial_snapshot != _shared_snapshot(initial_snapshot)
+            or receipt.child_manifest_content_sha256 != manifest_content_id
+        ):
+            raise ValueError("registered pump shared child receipt differs")
+        payload = _task_store(
+            repository.root,
+            parent_run_root=parent_run_root,
+        ).load_bytes(
+            self._TASK_RECEIPT_PATH,
+            expected_sha256=receipt.task_branch_receipt_content_sha256,
+        )
+        task_receipt = load_pump_station_artifact(
+            payload,
+            PumpStationRolloutBranchReceiptV2,
+        )
+        parent_snapshot = _pump_snapshot(
+            request.parent_snapshot,
+            snapshot_version=manifest.snapshot_version,
+        )
+        initial_state = repository.load_state(manifest.initial_state_id)
+        if initial_state.state_version != PUMP_STATION_STATE_VERSION_V4:
+            raise ValueError("registered pump child initial state is not V4")
+        remaining_schedule_sha256 = _remaining_schedule_sha256(
+            cast(PumpStationCoupledStewardshipState, initial_state),
+        )
+        source = manifest.initial_state_source
+        expected_source_scope = (
+            "rollout_parent_snapshot",
+            request.parent_snapshot.run_id,
+            request.parent_snapshot.world_branch_id,
+            request.parent_snapshot.state_id,
+            request.parent_snapshot.commit_id,
+            request.request_id,
+            child.content_sha256,
+            request.content_sha256,
+            request.parent_manifest_content_sha256,
+            request.origin_verification_content_sha256,
+            remaining_schedule_sha256,
+            receipt.ancestor_world_branch_ids,
+        )
+        observed_source_scope = (
+            source.kind,
+            source.parent_run_id,
+            source.parent_branch_id,
+            source.parent_state_id,
+            source.parent_commit_id,
+            source.rollout_group_request_id,
+            source.child_request_content_id,
+            source.rollout_group_request_content_id,
+            source.parent_manifest_content_id,
+            source.origin_verification_content_id,
+            source.parent_origin_remaining_schedule_sha256,
+            source.ancestor_branch_ids,
+        )
+        expected_task_scope = (
+            PUMP_STATION_ROLLOUT_BRANCH_RECEIPT_VERSION_V2,
+            request.group_id,
+            child.child_id,
+            request.content_sha256,
+            child.content_sha256,
+            parent_snapshot,
+            initial_snapshot,
+            manifest_content_id,
+            manifest.temporal_bundle_content_id,
+            remaining_schedule_sha256,
+            receipt.ancestor_world_branch_ids,
+        )
+        observed_task_scope = (
+            task_receipt.receipt_version,
+            task_receipt.group_id,
+            task_receipt.child_id,
+            task_receipt.shared_group_request_content_sha256,
+            task_receipt.shared_child_request_content_sha256,
+            task_receipt.parent_snapshot,
+            task_receipt.initial_snapshot,
+            task_receipt.child_manifest_content_id,
+            task_receipt.temporal_bundle_content_id,
+            task_receipt.parent_origin_remaining_schedule_sha256,
+            task_receipt.ancestor_branch_ids,
+        )
+        if (
+            observed_source_scope != expected_source_scope
+            or observed_task_scope != expected_task_scope
+            or (manifest.initial_sequence, manifest.initial_state_id)
+            != (parent_snapshot.sequence, parent_snapshot.state_id)
+            or (manifest.run_id, manifest.episode_id, manifest.world_branch_id)
+            != (child.run_id, child.episode_id, child.world_branch_id)
+        ):
+            raise ValueError("registered pump child rollout provenance differs")
+
+    @staticmethod
+    def _profile(value: object) -> PumpStationContinualProfile:
+        if not isinstance(value, PumpStationContinualProfile):
+            raise ValueError("registered pump profile has another task-owned value")
+        return value
+
+    @staticmethod
+    def _origin_context(
+        origin: VerifiedContinualWorldBranchOrigin,
+    ) -> _PumpStationVerifiedRolloutOrigin:
+        if not isinstance(origin.task_context, _PumpStationVerifiedRolloutOrigin):
+            raise ValueError("registered pump rollout origin context differs")
+        return origin.task_context
+
+
+def _remaining_schedule_sha256(
+    state: PumpStationCoupledStewardshipState,
+) -> str:
+    remaining = tuple(
+        requirement
+        for requirement in state.service_schedule
+        if requirement.end_calendar_seconds > state.calendar_seconds
+    )
+    return stewardship_content_id(
+        (
+            state.calendar_seconds,
+            remaining,
+            tuple((pool.pool_id, getattr(pool, "availability", ())) for pool in state.resources.pools),
+        ),
+        record_profile="v4",
+    )
+
+
+def _pump_snapshot(
+    snapshot: ContinualWorldSnapshotRef,
+    *,
+    snapshot_version: str,
+) -> PumpStationStateSnapshotRef:
+    return PumpStationStateSnapshotRef(
+        snapshot_version=snapshot_version,
+        run_id=snapshot.run_id,
+        episode_id=snapshot.episode_id,
+        world_branch_id=snapshot.world_branch_id,
+        sequence=snapshot.sequence,
+        state_id=snapshot.state_id,
+        commit_id=snapshot.commit_id,
+    )
+
+
+def _shared_snapshot(
+    snapshot: PumpStationStateSnapshotRef,
+) -> ContinualWorldSnapshotRef:
+    return ContinualWorldSnapshotRef(
+        run_id=snapshot.run_id,
+        episode_id=snapshot.episode_id,
+        world_branch_id=snapshot.world_branch_id,
+        sequence=snapshot.sequence,
+        state_id=snapshot.state_id,
+        commit_id=snapshot.commit_id,
+    )
+
+
+def _initial_snapshot(
+    repository: PumpStationWorldRunRepository,
+    manifest: PumpStationWorldRunManifestV2,
+) -> PumpStationStateSnapshotRef:
+    first = repository.commits()[0]
+    return PumpStationStateSnapshotRef(
+        snapshot_version=manifest.snapshot_version,
+        run_id=manifest.run_id,
+        episode_id=manifest.episode_id,
+        world_branch_id=manifest.world_branch_id,
+        sequence=first.sequence,
+        state_id=first.state_id,
+        commit_id=pump_station_artifact_id(first),
+    )
+
+
+def _task_store(
+    child_run_root: Path,
+    *,
+    parent_run_root: Path,
+) -> ImmutableByteStore:
+    return ImmutableByteStore(
+        child_run_root,
+        disjoint_roots=(Path(parent_run_root),),
+        host_private=True,
+    )
+
+
+__all__ = ["PumpStationContinualWorldBranchPort"]

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/coupled_runtime.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/coupled_runtime.py
@@ -3,10 +3,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from dataclasses import dataclass, replace
+from dataclasses import replace
 from decimal import Decimal
-from typing import TYPE_CHECKING, Any, Literal, NoReturn, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Literal, NoReturn, cast
 
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.coupled_work import (
     D_RUNTIME_SECONDS,
@@ -69,15 +68,13 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewards
     stewardship_content_id,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_models import (
-    PUMP_STATION_AUTHORITY_POLICY_VERSION_V4,
     PUMP_STATION_COMMON_BOUNDARY_CONTROL_VERSION,
     PUMP_STATION_OPERATIONS_REVIEW_VERSION,
     PUMP_STATION_PROCESS_OUTCOME_VERSION,
-    PUMP_STATION_RECEIPT_VERSION_V4,
     PUMP_STATION_STATE_VERSION_V4,
-    PUMP_STATION_TRANSITION_RULE_VERSION_V4,
     PumpStationAuthority,
     PumpStationCommonBoundaryRequest,
+    PumpStationCoupledTreatmentRequest,
     PumpStationEvidence,
     PumpStationEvidenceKind,
     PumpStationObligation,
@@ -93,6 +90,15 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewards
     PumpStationTransitionV4,
     PumpStationWorkOrder,
     PumpStationWorkOrderStatus,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_models import (
+    PUMP_STATION_COUPLED_TREATMENT_VERSION as PUMP_STATION_COUPLED_TREATMENT_VERSION,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_state_machine import (
+    apply_coupled_treatment as _apply_stable_coupled_treatment,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_state_machine import (
+    finish_coupled_transition as _finish_transition,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_views import (
     PumpStationContinuityCarrier,
@@ -115,7 +121,6 @@ PUMP_STATION_SNAPSHOT_VERSION_V4 = "pump-station-state-snapshot.v4"
 PUMP_STATION_ACTOR_PROJECTION_VERSION_V5 = "pump-station-current-state.v5"
 PUMP_STATION_ACTOR_VIEW_SCHEMA_V4 = "pump-station.actor-view.v4"
 PUMP_STATION_INFORMATION_BOUNDARY_V4 = "pump-station-actor-view.v4"
-PUMP_STATION_COUPLED_TREATMENT_VERSION = "pump-station.coupled-treatment.v1"
 if TYPE_CHECKING:
     type PumpStationCoupledWorldState = PumpStationStewardshipState[
         PumpStationCoupledPhysicalState,
@@ -139,25 +144,6 @@ class PumpStationCoupledWorldError(ValueError):
 
 def _fail(code: str, detail: str) -> NoReturn:
     raise PumpStationCoupledWorldError(code, detail)
-
-
-@dataclass(frozen=True, slots=True)
-class PumpStationCoupledTreatmentRequest:
-    """Host-private common-cause treatment for one isolated v4 child."""
-
-    version: str
-    request_id: str
-    authority_id: str
-    treatment_label: str
-    affected_pump_ids: tuple[str, ...]
-    obstruction_delta: Decimal
-    clearance_loss_delta: Decimal
-    base_state_id: str
-
-    @property
-    def content_id(self) -> str:
-        """Return the exact private treatment identity."""
-        return stewardship_content_id(self, record_profile="v4")
 
 
 PumpStationCoupledTransitionReceipt = PumpStationTransitionReceiptV4
@@ -1256,147 +1242,6 @@ def _apply_event_effects(
     return updated
 
 
-_RecordT = TypeVar("_RecordT")
-
-
-def _changed_owner_ids(
-    before: tuple[_RecordT, ...],
-    after: tuple[_RecordT, ...],
-    identity: Callable[[_RecordT], str],
-) -> tuple[str, ...]:
-    """Return stable identities whose canonical owner record changed."""
-    before_by_id = {identity(item): item for item in before}
-    after_by_id = {identity(item): item for item in after}
-    return tuple(
-        sorted(
-            record_id
-            for record_id in before_by_id.keys() | after_by_id.keys()
-            if before_by_id.get(record_id) != after_by_id.get(record_id)
-        )
-    )
-
-
-def _liability_owner_records(
-    state: PumpStationCoupledWorldState,
-) -> dict[str, object]:
-    """Return canonical liability owners without a separate mutable ledger."""
-    owners: dict[str, object] = {item.obligation_id: item for item in state.obligations}
-    owners.update({item.episode_id: item for item in state.outage_episodes})
-    owners.update({item.item_id: item for item in state.backlog if item.generation_rule_id in {"WG-06", "WG-07"}})
-    return owners
-
-
-def _changed_liability_owner_ids(
-    before: PumpStationCoupledWorldState,
-    after: PumpStationCoupledWorldState,
-) -> tuple[str, ...]:
-    before_owners = _liability_owner_records(before)
-    after_owners = _liability_owner_records(after)
-    return tuple(
-        sorted(
-            owner_id
-            for owner_id in before_owners.keys() | after_owners.keys()
-            if before_owners.get(owner_id) != after_owners.get(owner_id)
-        )
-    )
-
-
-def _finish_transition(
-    before: PumpStationCoupledWorldState,
-    after: PumpStationCoupledWorldState,
-    *,
-    request_id: str,
-    action_kind: str,
-    actor_action: bool,
-    target_id: str | None,
-    backlog_item_id: str | None,
-    reason: str,
-    changed_record_ids: tuple[str, ...],
-    operating_interval_id: str | None = None,
-    authority_requirements: tuple[str, ...] | None = None,
-) -> PumpStationCoupledTransition:
-    sequenced = replace(after, sequence=before.sequence + 1)
-    transition_id = f"transition-{sequenced.sequence}-{request_id}"
-    required_authorities = authority_requirements or _required_authorities(action_kind)
-    permit_ids = (f"controlled-test-permit-{request_id}",) if action_kind == "request_functional_check" else ()
-    receipt = PumpStationCoupledTransitionReceipt(
-        receipt_version=PUMP_STATION_RECEIPT_VERSION_V4,
-        authority_policy_version=PUMP_STATION_AUTHORITY_POLICY_VERSION_V4,
-        transition_rule_version=PUMP_STATION_TRANSITION_RULE_VERSION_V4,
-        sequence=sequenced.sequence,
-        transition_id=transition_id,
-        request_id=request_id,
-        action_or_control_kind=action_kind,
-        actor_action=actor_action,
-        authority_outcome="permitted",
-        required_authorities=required_authorities,
-        authority_decision_detail=("All required task authorities accepted the bound request."),
-        permit_ids=permit_ids,
-        execution_status="applied",
-        before_state_id=before.state_id,
-        after_state_id=sequenced.state_id,
-        start_calendar_seconds=before.calendar_seconds,
-        end_calendar_seconds=sequenced.calendar_seconds,
-        target_id=target_id,
-        backlog_item_id=backlog_item_id,
-        reason=reason,
-        changed_record_ids=changed_record_ids,
-        changed_pool_ids=_changed_owner_ids(
-            before.resources.pools,
-            sequenced.resources.pools,
-            lambda item: item.pool_id,
-        ),
-        changed_reservation_ids=_changed_owner_ids(
-            before.resource_reservations,
-            sequenced.resource_reservations,
-            lambda item: item.reservation_id,
-        ),
-        changed_backlog_item_ids=_changed_owner_ids(
-            before.backlog,
-            sequenced.backlog,
-            lambda item: item.item_id,
-        ),
-        generation_record_ids=_changed_owner_ids(
-            before.generation_records,
-            sequenced.generation_records,
-            lambda item: item.backlog_item_id,
-        ),
-        changed_liability_owner_ids=_changed_liability_owner_ids(
-            before,
-            sequenced,
-        ),
-        operating_interval_id=operating_interval_id,
-    )
-    return PumpStationCoupledTransition(state=sequenced, receipt=receipt)
-
-
-def _required_authorities(action_kind: str) -> tuple[str, ...]:
-    if action_kind == "request_functional_check":
-        return ("maintenance", "operations")
-    if action_kind in {
-        "continue_operation",
-        "request_duty_assignment",
-        "request_provisional_return",
-        "operations_boundary_review",
-        "common_boundary_control",
-    }:
-        return ("operations",)
-    if action_kind in {
-        "request_inspection",
-        "request_obstruction_clearance",
-        "resume_process",
-        "cancel_process",
-    }:
-        return ("maintenance",)
-    if action_kind in {"request_post_maintenance_verification", "process_outcome"}:
-        return ("verification",)
-    if action_kind in {"request_provisional_closure", "request_dependency_waiver"}:
-        return ("work_management",)
-    if action_kind == "request_condition_check":
-        return ("engineering",)
-    return ("host",)
-
-
 def pump_station_root_control_operations(
     state: PumpStationCoupledWorldState | None,
     *,
@@ -2008,65 +1853,8 @@ def apply_coupled_treatment(
     state: PumpStationCoupledWorldState,
     request: PumpStationCoupledTreatmentRequest,
 ) -> PumpStationCoupledTransition:
-    """Apply one private treatment without adding its label to projection v5."""
-    if request.version != PUMP_STATION_COUPLED_TREATMENT_VERSION:
-        _fail("coupled-treatment-version", request.version)
-    if request.authority_id != "rollout-host":
-        _fail("coupled-treatment-authority", request.authority_id)
-    if request.base_state_id != state.state_id:
-        _fail("stale-coupled-treatment", request.request_id)
-    if not request.treatment_label.strip():
-        _fail("coupled-treatment-label", request.request_id)
-    pump_ids = tuple(pump.pump_id for pump in state.physical.pumps)
-    if (
-        not request.affected_pump_ids
-        or len(set(request.affected_pump_ids)) != len(request.affected_pump_ids)
-        or not set(request.affected_pump_ids) <= set(pump_ids)
-    ):
-        _fail("coupled-treatment-targets", request.request_id)
-    if request.obstruction_delta < 0 or request.clearance_loss_delta < 0:
-        _fail("coupled-treatment-delta", request.request_id)
-    updated_pumps = []
-    for pump in state.physical.pumps:
-        if pump.pump_id not in request.affected_pump_ids:
-            updated_pumps.append(pump)
-            continue
-        obstruction = pump.condition.obstruction + request.obstruction_delta
-        clearance_loss = pump.condition.clearance_loss + request.clearance_loss_delta
-        if obstruction > 1 or clearance_loss > 1:
-            _fail("coupled-treatment-range", pump.pump_id)
-        updated_pumps.append(
-            replace(
-                pump,
-                condition=PumpCondition(
-                    obstruction=obstruction,
-                    clearance_loss=clearance_loss,
-                ),
-            )
-        )
-    physical = replace(
-        state.physical,
-        pumps=cast(
-            tuple[Any, Any, Any],
-            tuple(updated_pumps),
-        ),
-    )
-    updated = replace(
-        state,
-        physical=physical,
-        event_effect_ids=(*state.event_effect_ids, request.content_id),
-    )
-    return _finish_transition(
-        state,
-        updated,
-        request_id=request.request_id,
-        action_kind="coupled_physical_treatment",
-        actor_action=False,
-        target_id=None,
-        backlog_item_id=None,
-        reason="Apply the authorised child-only common-cause treatment.",
-        changed_record_ids=(request.content_id, *request.affected_pump_ids),
-    )
+    """Call the stable task-owned private treatment transition."""
+    return _apply_stable_coupled_treatment(state, request)
 
 
 def apply_process_outcome(

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/rollout_control.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/rollout_control.py
@@ -4,14 +4,31 @@
 from __future__ import annotations
 
 import hashlib
+import json
 from pathlib import Path
+from typing import Any, Never, overload
 
+from aec_bench.contracts.continual_world import (
+    CONTINUAL_ROLLOUT_GROUP_REQUEST_SCHEMA_VERSION,
+    ContinualRolloutGroupRequest,
+    ContinualRolloutLineage,
+)
 from aec_bench.contracts.world_session import (
     STEWARDSHIP_STATE_SNAPSHOT_SCHEMA_VERSION,
     StewardshipStateSnapshotRef,
     WorldSessionExecutionKind,
     WorldSessionOpenMode,
     WorldSessionRequest,
+)
+from aec_bench.task_world_templates.continual.rollout_control import (
+    ContinualRolloutControl,
+    ContinualRolloutError,
+)
+from aec_bench.task_world_templates.continual.rollout_repository import (
+    ContinualRolloutRepository,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.continual_definition import (
+    pump_station_continual_world_definition,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.physical_kernel import (
     pump_station_model_from_package,
@@ -56,6 +73,7 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_ru
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_models import (
     PumpStationStateSnapshotRef,
+    PumpStationWorldRunManifestV2,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_repository import (
     PumpStationWorldRunRepository,
@@ -91,17 +109,39 @@ class PumpStationRolloutControl:
         if len(set(authorised_principal_ids)) != len(authorised_principal_ids):
             raise ValueError("rollout control host principals must be distinct")
         self._parent_repository_root = Path(parent_repository_root)
-        self._repository = PumpStationRolloutRepository(rollout_repository_root)
+        self._rollout_repository_root = Path(rollout_repository_root)
+        self._repository = PumpStationRolloutRepository(self._rollout_repository_root)
         self._authorised_principal_ids = frozenset(authorised_principal_ids)
+        self._authorised_principal_sequence = authorised_principal_ids
         self._package_root = package_root
         self._rich_work_processes = rich_work_processes or evidence_health
         self._evidence_health = evidence_health
 
+    @overload
     def create_group(
         self,
         request: PumpStationRolloutGroupRequest,
-    ) -> PumpStationRolloutLineage:
+    ) -> PumpStationRolloutLineage: ...
+
+    @overload
+    def create_group(self, request: ContinualRolloutGroupRequest) -> ContinualRolloutLineage: ...
+
+    def create_group(
+        self,
+        request: PumpStationRolloutGroupRequest | ContinualRolloutGroupRequest,
+    ) -> PumpStationRolloutLineage | ContinualRolloutLineage:
         """Create or exactly recover all requested children from the live parent origin."""
+
+        if isinstance(request, ContinualRolloutGroupRequest):
+            if len(request.children) < 2:
+                raise PumpStationRolloutError(
+                    "rollout-children",
+                    "a pump rollout group requires at least two children",
+                )
+            try:
+                return self._continual_rollout_control().create_group(request)
+            except ContinualRolloutError as error:
+                self._raise_continual_error(error)
 
         verification = self.validate_origin(request)
         parent = self._resume_run(self._parent_repository_root)
@@ -172,10 +212,16 @@ class PumpStationRolloutControl:
 
     def create_child(
         self,
-        request: PumpStationRolloutGroupRequest,
+        request: PumpStationRolloutGroupRequest | ContinualRolloutGroupRequest,
         child_id: str,
     ) -> PumpStationRolloutChildReceipt:
         """Create or recover one declared child without completing its sibling group."""
+
+        if isinstance(request, ContinualRolloutGroupRequest):
+            raise PumpStationRolloutError(
+                "rollout-operation",
+                "registered rollouts create complete groups only",
+            )
 
         self.validate_origin(request)
         child = next((item for item in request.children if item.child_id == child_id), None)
@@ -197,14 +243,54 @@ class PumpStationRolloutControl:
                 event_schedule_sha256,
             )
 
-    def inspect_group(self, group_id: str) -> PumpStationRolloutLineage:
+    def inspect_group(
+        self,
+        group_id: str,
+    ) -> PumpStationRolloutLineage | ContinualRolloutLineage:
         """Load the complete private lineage for one rollout group."""
 
+        if self._group_uses_continual_rollout(group_id):
+            try:
+                return self._continual_rollout_control().inspect_group(group_id)
+            except ContinualRolloutError as error:
+                self._raise_continual_error(error)
         return self._repository.load_lineage(group_id)
+
+    def require_group_request_version(
+        self,
+        group_id: str,
+        expected_version: str,
+    ) -> None:
+        """Reject an existing group that belongs to another transport version."""
+
+        if expected_version != PUMP_STATION_ROLLOUT_REQUEST_VERSION:
+            raise PumpStationRolloutError("rollout-version", expected_version)
+        actual_version = (
+            CONTINUAL_ROLLOUT_GROUP_REQUEST_SCHEMA_VERSION
+            if self._group_uses_continual_rollout(group_id)
+            else PUMP_STATION_ROLLOUT_REQUEST_VERSION
+        )
+        if actual_version != expected_version:
+            raise PumpStationRolloutError(
+                "rollout-version",
+                f"group {group_id} uses {actual_version}",
+            )
 
     def group_status(self, group_id: str) -> PumpStationRolloutGroupStatus:
         """Enumerate complete or interrupted child creation progress."""
 
+        if self._group_uses_continual_rollout(group_id):
+            try:
+                status = self._continual_rollout_control().group_status(group_id)
+            except ContinualRolloutError as error:
+                self._raise_continual_error(error)
+            return PumpStationRolloutGroupStatus(
+                group_id=status.group_id,
+                request_id=status.request_id,
+                state=PumpStationRolloutGroupState(status.state.value),
+                requested_child_ids=tuple(status.requested_child_ids),
+                created_child_ids=tuple(status.created_child_ids),
+            )
         request = self._repository.load_group_request(group_id)
         requested = tuple(child.child_id for child in request.children)
         created = tuple(child_id for child_id in requested if self._repository.child_receipt_exists(group_id, child_id))
@@ -236,10 +322,47 @@ class PumpStationRolloutControl:
     ) -> PumpStationWorldSession:
         """Open only the selected child with no sibling or selection metadata."""
 
-        lineage = self.inspect_group(group_id)
-        receipt = self._child_receipt(lineage, child_id)
-        child_root = self._repository.child_world_root(group_id, child_id)
-        snapshot = PumpStationWorldRunRepository(child_root).current_snapshot()
+        if self._group_uses_continual_rollout(group_id):
+            try:
+                child_ref = self._continual_rollout_control().child_run_ref(
+                    group_id,
+                    child_id,
+                )
+            except ContinualRolloutError as error:
+                self._raise_continual_error(error)
+            child_root = self._continual_child_world_root(group_id, child_id)
+            snapshot = PumpStationWorldRunRepository(child_root).current_snapshot()
+            if (
+                child_ref.group_id,
+                child_ref.child_id,
+                child_ref.task_world_id,
+                snapshot.run_id,
+                snapshot.episode_id,
+                snapshot.world_branch_id,
+            ) != (
+                group_id,
+                child_id,
+                PUMP_STATION_TASK_WORLD_ID,
+                child_ref.run_id,
+                child_ref.episode_id,
+                child_ref.world_branch_id,
+            ):
+                raise PumpStationRolloutError(
+                    "rollout-child-run-ref",
+                    "registered child identity differs from its verified run reference",
+                )
+            world_branch_id = child_ref.world_branch_id
+        else:
+            lineage = self.inspect_group(group_id)
+            if not isinstance(lineage, PumpStationRolloutLineage):
+                raise PumpStationRolloutError(
+                    "rollout-version",
+                    CONTINUAL_ROLLOUT_GROUP_REQUEST_SCHEMA_VERSION,
+                )
+            receipt = self._child_receipt(lineage, child_id)
+            child_root = self._repository.child_world_root(group_id, child_id)
+            snapshot = PumpStationWorldRunRepository(child_root).current_snapshot()
+            world_branch_id = receipt.initial_snapshot.world_branch_id
         request = WorldSessionRequest(
             execution_kind=WorldSessionExecutionKind.STEWARDSHIP,
             open_mode=WorldSessionOpenMode.RESUME,
@@ -248,7 +371,7 @@ class PumpStationRolloutControl:
             agent_tenure_id=agent_tenure_id,
             run_id=snapshot.run_id,
             episode_id=snapshot.episode_id,
-            world_branch_id=receipt.initial_snapshot.world_branch_id,
+            world_branch_id=world_branch_id,
             start_snapshot=_shared_snapshot(snapshot),
         )
         return PumpStationWorldSessionFactory(
@@ -270,8 +393,15 @@ class PumpStationRolloutControl:
         if request.task_world_id != PUMP_STATION_TASK_WORLD_ID:
             raise PumpStationRolloutError("treatment-task-world", request.task_world_id)
         lineage = self.inspect_group(request.group_id)
+        if isinstance(lineage, ContinualRolloutLineage):
+            raise PumpStationRolloutError(
+                "rollout-operation",
+                "legacy scheduled treatments do not accept registered children",
+            )
         child = self._child_receipt(lineage, request.child_id)
-        run = self._resume_run(self._repository.child_world_root(request.group_id, request.child_id))
+        run = self._resume_run(
+            self._repository.child_world_root(request.group_id, request.child_id),
+        )
         current = run.snapshot()
         observed_scope = (
             request.child_run_id,
@@ -369,6 +499,13 @@ class PumpStationRolloutControl:
             )
             request = scheduled.request
             self._require_authority(request.authority_id)
+            lineage = self.inspect_group(group_id)
+            if isinstance(lineage, ContinualRolloutLineage):
+                raise PumpStationRolloutError(
+                    "rollout-operation",
+                    "legacy scheduled treatments do not accept registered children",
+                )
+            self._child_receipt(lineage, child_id)
             child_root = self._repository.child_world_root(group_id, child_id)
             run = self._resume_run(child_root)
             if self._repository.activation_request_exists(
@@ -444,6 +581,38 @@ class PumpStationRolloutControl:
                 treatment_request_id,
             )
 
+    def _continual_child_world_root(self, group_id: str, child_id: str) -> Path:
+        disjoint_roots = (self._parent_repository_root,) + (
+            (Path(self._package_root),) if self._package_root is not None else ()
+        )
+        return ContinualRolloutRepository(
+            self._rollout_repository_root,
+            disjoint_roots=disjoint_roots,
+        ).child_world_root(
+            group_id,
+            child_id,
+        )
+
+    def _continual_rollout_control(self) -> ContinualRolloutControl:
+        return ContinualRolloutControl(
+            pump_station_continual_world_definition(),
+            parent_run_root=self._parent_repository_root,
+            rollout_repository_root=self._rollout_repository_root,
+            authorised_principal_ids=self._authorised_principal_sequence,
+            package_root=self._package_root,
+        )
+
+    @staticmethod
+    def _raise_continual_error(error: ContinualRolloutError) -> Never:
+        code = {
+            "request-conflict": "request-id-conflict",
+            "child-request-conflict": "child-id-conflict",
+            "child-receipt-conflict": "child-id-conflict",
+            "lineage-conflict": "lineage-conflict",
+            "authority": "rollout-unauthorised",
+        }.get(error.code, error.code)
+        raise PumpStationRolloutError(code, error.detail) from error
+
     def _create_child(
         self,
         request: PumpStationRolloutGroupRequest,
@@ -484,9 +653,14 @@ class PumpStationRolloutControl:
         self._repository.publish_child_receipt(receipt)
         return self._repository.load_child_receipt(request.group_id, child.child_id)
 
-    def _resume_run(self, root: Path) -> PumpStationWorldRun:
+    def _resume_run(self, root: Path) -> PumpStationWorldRun[Any, Any]:
         repository = PumpStationWorldRunRepository(root)
         snapshot = repository.current_snapshot()
+        if isinstance(repository.load_manifest(), PumpStationWorldRunManifestV2):
+            return PumpStationWorldRun.resume_reference_system(
+                repository=repository,
+                snapshot=snapshot,
+            )
         package = load_reference_package(self._package_root)
         model = pump_station_model_from_package(package)
         return PumpStationWorldRun.resume(
@@ -572,6 +746,33 @@ class PumpStationRolloutControl:
             if child.child_id == child_id:
                 return child
         raise PumpStationRolloutError("rollout-child-not-found", child_id)
+
+    def _group_uses_continual_rollout(self, group_id: str) -> bool:
+        payload = self._repository.group_request_payload_if_present(group_id)
+        if payload is None:
+            return False
+        try:
+            value = json.loads(payload)
+        except (TypeError, ValueError) as error:
+            raise PumpStationRolloutError(
+                "rollout-artifact",
+                "group request is not strict JSON",
+            ) from error
+        if not isinstance(value, dict) or "schema_version" not in value:
+            return False
+        if value.get("schema_version") != CONTINUAL_ROLLOUT_GROUP_REQUEST_SCHEMA_VERSION:
+            raise PumpStationRolloutError(
+                "rollout-version",
+                str(value.get("schema_version")),
+            )
+        try:
+            ContinualRolloutGroupRequest.model_validate_json(payload)
+        except ValueError as error:
+            raise PumpStationRolloutError(
+                "rollout-artifact",
+                "continual rollout request is invalid",
+            ) from error
+        return True
 
     def _require_authority(self, authority_id: str) -> None:
         if authority_id not in self._authorised_principal_ids:

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/rollout_interface.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/rollout_interface.py
@@ -15,8 +15,10 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.physical
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.rollout_control import (
     PumpStationRolloutControl,
+    PumpStationRolloutError,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.rollout_models import (
+    PUMP_STATION_ROLLOUT_REQUEST_VERSION,
     PumpStationPhysicalTreatmentActivationReceipt,
     PumpStationPhysicalTreatmentScheduleReceipt,
     PumpStationRolloutChildReceipt,
@@ -192,14 +194,28 @@ def execute_pump_station_rollout_request(
         lineage = control.create_group(request.group_request)
     elif request.operation == "inspect_rollout_group":
         assert request.group_id is not None
+        control.require_group_request_version(
+            request.group_id,
+            PUMP_STATION_ROLLOUT_REQUEST_VERSION,
+        )
         group_status = control.group_status(request.group_id)
         if group_status.state.value == "ready":
-            lineage = control.inspect_group(request.group_id)
+            inspected_lineage = control.inspect_group(request.group_id)
+            if not isinstance(inspected_lineage, PumpStationRolloutLineage):
+                raise PumpStationRolloutError(
+                    "rollout-version",
+                    f"group {request.group_id} does not contain V1 lineage",
+                )
+            lineage = inspected_lineage
     elif request.operation == "open_rollout_actor_session":
         assert request.group_id is not None
         assert request.child_id is not None
         assert request.session_id is not None
         assert request.agent_tenure_id is not None
+        control.require_group_request_version(
+            request.group_id,
+            PUMP_STATION_ROLLOUT_REQUEST_VERSION,
+        )
         session_result = control.open_actor_session(
             group_id=request.group_id,
             child_id=request.child_id,
@@ -208,11 +224,19 @@ def execute_pump_station_rollout_request(
         ).result
     elif request.operation == "schedule_physical_treatment":
         assert request.treatment_request is not None
+        control.require_group_request_version(
+            request.treatment_request.group_id,
+            PUMP_STATION_ROLLOUT_REQUEST_VERSION,
+        )
         treatment_schedule = control.schedule_treatment(request.treatment_request)
     elif request.operation == "inspect_physical_treatment":
         assert request.group_id is not None
         assert request.child_id is not None
         assert request.treatment_request_id is not None
+        control.require_group_request_version(
+            request.group_id,
+            PUMP_STATION_ROLLOUT_REQUEST_VERSION,
+        )
         treatment = control.inspect_treatment(
             group_id=request.group_id,
             child_id=request.child_id,
@@ -226,6 +250,10 @@ def execute_pump_station_rollout_request(
         assert request.group_id is not None
         assert request.child_id is not None
         assert request.treatment_request_id is not None
+        control.require_group_request_version(
+            request.group_id,
+            PUMP_STATION_ROLLOUT_REQUEST_VERSION,
+        )
         treatment_activation = control.recover_treatment(
             group_id=request.group_id,
             child_id=request.child_id,

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/rollout_models.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/rollout_models.py
@@ -19,6 +19,7 @@ PUMP_STATION_ROLLOUT_LINEAGE_VERSION = "pump-station.rollout-lineage.v1"
 PUMP_STATION_ROLLOUT_CHILD_RECEIPT_VERSION = "pump-station.rollout-child-receipt.v1"
 PUMP_STATION_TREATMENT_RECEIPT_VERSION = "pump-station.treatment-receipt.v1"
 PUMP_STATION_FIXED_CONDITION_POLICY = "fixed-future-conditions.v1"
+PUMP_STATION_ROLLOUT_BRANCH_RECEIPT_VERSION_V2 = "pump-station.rollout-branch-receipt.v2"
 
 
 class PumpStationRolloutGroupState(StrEnum):
@@ -64,6 +65,23 @@ class PumpStationRolloutGroupRequest:
     children: tuple[PumpStationRolloutChildRequest, ...]
     request_version: str = PUMP_STATION_ROLLOUT_REQUEST_VERSION
     fixed_condition_policy: str = PUMP_STATION_FIXED_CONDITION_POLICY
+
+
+@dataclass(frozen=True, slots=True)
+class PumpStationRolloutBranchReceiptV2:
+    """Task-owned evidence for one materialized registered branch."""
+
+    receipt_version: str
+    group_id: str
+    child_id: str
+    shared_group_request_content_sha256: str
+    shared_child_request_content_sha256: str
+    parent_snapshot: PumpStationStateSnapshotRef
+    initial_snapshot: PumpStationStateSnapshotRef
+    child_manifest_content_id: str
+    temporal_bundle_content_id: str
+    parent_origin_remaining_schedule_sha256: str
+    ancestor_branch_ids: tuple[str, ...]
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/rollout_repository.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/rollout_repository.py
@@ -113,6 +113,14 @@ class PumpStationRolloutRepository:
             PumpStationRolloutGroupRequest,
         )
 
+    def group_request_payload_if_present(self, group_id: str) -> bytes | None:
+        """Load confined request bytes without selecting a rollout schema."""
+
+        path = self.group_root(group_id) / "request.json"
+        if not path.exists():
+            return None
+        return self._read(path)
+
     def publish_child_receipt(self, receipt: PumpStationRolloutChildReceipt) -> None:
         """Publish one child creation receipt."""
 

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/stewardship_models.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/stewardship_models.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from decimal import Decimal
 from enum import StrEnum
 from typing import Any, Generic, NoReturn, TypeVar, cast
 
@@ -53,6 +54,7 @@ PUMP_STATION_TRANSITION_RULE_VERSION_V4 = "pump-station-transition-rules.v4"
 PUMP_STATION_OPERATIONS_REVIEW_VERSION = "pump-station.operations-boundary-review.v1"
 PUMP_STATION_PROCESS_OUTCOME_VERSION = "pump-station.process-outcome.v1"
 PUMP_STATION_COMMON_BOUNDARY_CONTROL_VERSION = "pump-station.common-boundary-control.v1"
+PUMP_STATION_COUPLED_TREATMENT_VERSION = "pump-station.coupled-treatment.v1"
 PUMP_STATION_BOUND_CONTROL_VERSION = "pump-station.bound-control.v1"
 
 PUMP_STATION_RECEIPT_VERSION = PUMP_STATION_RECEIPT_VERSION_V1
@@ -1052,8 +1054,34 @@ class PumpStationCommonBoundaryRequest:
         return stewardship_content_id(self, record_profile="v4")
 
 
+@dataclass(frozen=True, slots=True)
+class PumpStationCoupledTreatmentRequest:
+    """Host-private physical treatment for one isolated V4 rollout child."""
+
+    version: str
+    request_id: str
+    authority_id: str
+    treatment_label: str
+    affected_pump_ids: tuple[str, ...]
+    obstruction_delta: Decimal
+    clearance_loss_delta: Decimal
+    base_state_id: str
+
+    @property
+    def content_id(self) -> str:
+        """Return the exact private treatment identity."""
+        from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_identity import (
+            stewardship_content_id,
+        )
+
+        return stewardship_content_id(self, record_profile="v4")
+
+
 type PumpStationRootControl = (
-    PumpStationOperationsBoundaryReviewRequest | PumpStationProcessOutcomeRequest | PumpStationCommonBoundaryRequest
+    PumpStationOperationsBoundaryReviewRequest
+    | PumpStationProcessOutcomeRequest
+    | PumpStationCommonBoundaryRequest
+    | PumpStationCoupledTreatmentRequest
 )
 
 

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/stewardship_state_machine.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/stewardship_state_machine.py
@@ -3,7 +3,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import replace
+from typing import Any, TypeVar, cast
 
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.evidence_health import (
     PUMP_STATION_EVIDENCE_DELAY_SECONDS,
@@ -24,6 +26,7 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.physical
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.physical_models import (
     OperatingInterval,
+    PumpCondition,
     PumpStationChangeKind,
     PumpStationCoupledModel,
     PumpStationEnvironment,
@@ -68,15 +71,19 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewards
     PUMP_STATION_AUTHORITY_POLICY_VERSION,
     PUMP_STATION_AUTHORITY_POLICY_VERSION_V2,
     PUMP_STATION_AUTHORITY_POLICY_VERSION_V3,
+    PUMP_STATION_AUTHORITY_POLICY_VERSION_V4,
+    PUMP_STATION_COUPLED_TREATMENT_VERSION,
     PUMP_STATION_RECEIPT_VERSION,
     PUMP_STATION_RECEIPT_VERSION_V2,
     PUMP_STATION_RECEIPT_VERSION_V3,
+    PUMP_STATION_RECEIPT_VERSION_V4,
     PUMP_STATION_STATE_VERSION_V1,
     PUMP_STATION_STATE_VERSION_V2,
     PUMP_STATION_STATE_VERSION_V3,
     PUMP_STATION_TRANSITION_RULE_VERSION,
     PUMP_STATION_TRANSITION_RULE_VERSION_V2,
     PUMP_STATION_TRANSITION_RULE_VERSION_V3,
+    PUMP_STATION_TRANSITION_RULE_VERSION_V4,
     CancelProcess,
     ContinueOperation,
     PumpStationAuthority,
@@ -84,6 +91,7 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewards
     PumpStationAuthorityOutcome,
     PumpStationCommonBoundaryRequest,
     PumpStationCoupledStewardshipState,
+    PumpStationCoupledTreatmentRequest,
     PumpStationEventType,
     PumpStationEvidence,
     PumpStationEvidenceKind,
@@ -108,6 +116,7 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewards
     PumpStationStewardshipState,
     PumpStationTransition,
     PumpStationTransitionReceipt,
+    PumpStationTransitionReceiptV4,
     PumpStationTransitionV4,
     PumpStationWorkOrder,
     PumpStationWorkOrderStatus,
@@ -1618,6 +1627,143 @@ def _v4_proposal_arguments(proposal: object) -> tuple[str, dict[str, object]]:
     )
 
 
+_CoupledRecordT = TypeVar("_CoupledRecordT")
+
+
+def _changed_coupled_owner_ids(
+    before: tuple[_CoupledRecordT, ...],
+    after: tuple[_CoupledRecordT, ...],
+    identity: Callable[[_CoupledRecordT], str],
+) -> tuple[str, ...]:
+    before_by_id = {identity(item): item for item in before}
+    after_by_id = {identity(item): item for item in after}
+    return tuple(
+        sorted(
+            record_id
+            for record_id in before_by_id.keys() | after_by_id.keys()
+            if before_by_id.get(record_id) != after_by_id.get(record_id)
+        )
+    )
+
+
+def _coupled_liability_owner_records(
+    state: PumpStationCoupledStewardshipState,
+) -> dict[str, object]:
+    owners: dict[str, object] = {item.obligation_id: item for item in state.obligations}
+    owners.update({item.episode_id: item for item in state.outage_episodes})
+    owners.update({item.item_id: item for item in state.backlog if item.generation_rule_id in {"WG-06", "WG-07"}})
+    return owners
+
+
+def _changed_coupled_liability_owner_ids(
+    before: PumpStationCoupledStewardshipState,
+    after: PumpStationCoupledStewardshipState,
+) -> tuple[str, ...]:
+    before_owners = _coupled_liability_owner_records(before)
+    after_owners = _coupled_liability_owner_records(after)
+    return tuple(
+        sorted(
+            owner_id
+            for owner_id in before_owners.keys() | after_owners.keys()
+            if before_owners.get(owner_id) != after_owners.get(owner_id)
+        )
+    )
+
+
+def _required_coupled_authorities(action_kind: str) -> tuple[str, ...]:
+    if action_kind == "request_functional_check":
+        return ("maintenance", "operations")
+    if action_kind in {
+        "continue_operation",
+        "request_duty_assignment",
+        "request_provisional_return",
+        "operations_boundary_review",
+        "common_boundary_control",
+    }:
+        return ("operations",)
+    if action_kind in {
+        "request_inspection",
+        "request_obstruction_clearance",
+        "resume_process",
+        "cancel_process",
+    }:
+        return ("maintenance",)
+    if action_kind in {"request_post_maintenance_verification", "process_outcome"}:
+        return ("verification",)
+    if action_kind in {"request_provisional_closure", "request_dependency_waiver"}:
+        return ("work_management",)
+    if action_kind == "request_condition_check":
+        return ("engineering",)
+    return ("host",)
+
+
+def finish_coupled_transition(
+    before: PumpStationCoupledStewardshipState,
+    after: PumpStationCoupledStewardshipState,
+    *,
+    request_id: str,
+    action_kind: str,
+    actor_action: bool,
+    target_id: str | None,
+    backlog_item_id: str | None,
+    reason: str,
+    changed_record_ids: tuple[str, ...],
+    operating_interval_id: str | None = None,
+    authority_requirements: tuple[str, ...] | None = None,
+) -> PumpStationTransitionV4:
+    """Finish one V4 transition with the shared task-owned receipt rules."""
+    sequenced = replace(after, sequence=before.sequence + 1)
+    receipt = PumpStationTransitionReceiptV4(
+        receipt_version=PUMP_STATION_RECEIPT_VERSION_V4,
+        authority_policy_version=PUMP_STATION_AUTHORITY_POLICY_VERSION_V4,
+        transition_rule_version=PUMP_STATION_TRANSITION_RULE_VERSION_V4,
+        sequence=sequenced.sequence,
+        transition_id=f"transition-{sequenced.sequence}-{request_id}",
+        request_id=request_id,
+        action_or_control_kind=action_kind,
+        actor_action=actor_action,
+        authority_outcome="permitted",
+        required_authorities=authority_requirements or _required_coupled_authorities(action_kind),
+        authority_decision_detail="All required task authorities accepted the bound request.",
+        permit_ids=(f"controlled-test-permit-{request_id}",) if action_kind == "request_functional_check" else (),
+        execution_status="applied",
+        before_state_id=before.state_id,
+        after_state_id=sequenced.state_id,
+        start_calendar_seconds=before.calendar_seconds,
+        end_calendar_seconds=sequenced.calendar_seconds,
+        target_id=target_id,
+        backlog_item_id=backlog_item_id,
+        reason=reason,
+        changed_record_ids=changed_record_ids,
+        changed_pool_ids=_changed_coupled_owner_ids(
+            before.resources.pools,
+            sequenced.resources.pools,
+            lambda item: item.pool_id,
+        ),
+        changed_reservation_ids=_changed_coupled_owner_ids(
+            before.resource_reservations,
+            sequenced.resource_reservations,
+            lambda item: item.reservation_id,
+        ),
+        changed_backlog_item_ids=_changed_coupled_owner_ids(
+            before.backlog,
+            sequenced.backlog,
+            lambda item: item.item_id,
+        ),
+        generation_record_ids=_changed_coupled_owner_ids(
+            before.generation_records,
+            sequenced.generation_records,
+            lambda item: item.backlog_item_id,
+        ),
+        changed_liability_owner_ids=_changed_coupled_liability_owner_ids(
+            before,
+            sequenced,
+        ),
+        operating_interval_id=operating_interval_id,
+    )
+    return PumpStationTransitionV4(state=sequenced, receipt=receipt)
+
+
 def apply_stewardship_control_v4(
     state: PumpStationCoupledStewardshipState,
     control: PumpStationRootControl,
@@ -1635,9 +1781,72 @@ def apply_stewardship_control_v4(
         return apply_process_outcome(state, control)
     if isinstance(control, PumpStationCommonBoundaryRequest):
         return apply_common_boundary_control(state, control)
+    if isinstance(control, PumpStationCoupledTreatmentRequest):
+        return apply_coupled_treatment(state, control)
     raise PumpStationProposalError(
         "control-type",
         f"unsupported V4 control type {type(control).__name__}",
+    )
+
+
+def apply_coupled_treatment(
+    state: PumpStationCoupledStewardshipState,
+    request: PumpStationCoupledTreatmentRequest,
+) -> PumpStationTransitionV4:
+    """Apply one private physical treatment to selected pumps in one child."""
+    if request.version != PUMP_STATION_COUPLED_TREATMENT_VERSION:
+        raise PumpStationProposalError("coupled-treatment-version", request.version)
+    if request.authority_id != "rollout-host":
+        raise PumpStationProposalError("coupled-treatment-authority", request.authority_id)
+    if request.base_state_id != state.state_id:
+        raise PumpStationProposalError("stale-coupled-treatment", request.request_id)
+    if not request.treatment_label.strip():
+        raise PumpStationProposalError("coupled-treatment-label", request.request_id)
+    pump_ids = tuple(pump.pump_id for pump in state.physical.pumps)
+    if (
+        not request.affected_pump_ids
+        or len(set(request.affected_pump_ids)) != len(request.affected_pump_ids)
+        or not set(request.affected_pump_ids) <= set(pump_ids)
+    ):
+        raise PumpStationProposalError("coupled-treatment-targets", request.request_id)
+    if request.obstruction_delta < 0 or request.clearance_loss_delta < 0:
+        raise PumpStationProposalError("coupled-treatment-delta", request.request_id)
+    updated_pumps: list[Any] = []
+    for pump in state.physical.pumps:
+        if pump.pump_id not in request.affected_pump_ids:
+            updated_pumps.append(pump)
+            continue
+        obstruction = pump.condition.obstruction + request.obstruction_delta
+        clearance_loss = pump.condition.clearance_loss + request.clearance_loss_delta
+        if obstruction > 1 or clearance_loss > 1:
+            raise PumpStationProposalError("coupled-treatment-range", pump.pump_id)
+        updated_pumps.append(
+            replace(
+                pump,
+                condition=PumpCondition(
+                    obstruction=obstruction,
+                    clearance_loss=clearance_loss,
+                ),
+            )
+        )
+    updated = replace(
+        state,
+        physical=replace(
+            state.physical,
+            pumps=cast(tuple[Any, Any, Any], tuple(updated_pumps)),
+        ),
+        event_effect_ids=(*state.event_effect_ids, request.content_id),
+    )
+    return finish_coupled_transition(
+        state,
+        updated,
+        request_id=request.request_id,
+        action_kind="coupled_physical_treatment",
+        actor_action=False,
+        target_id=None,
+        backlog_item_id=None,
+        reason="Apply the authorised child-only common-cause treatment.",
+        changed_record_ids=(request.content_id, *request.affected_pump_ids),
     )
 
 

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/temporal_evidence/repository.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/temporal_evidence/repository.py
@@ -287,6 +287,11 @@ class TemporalEvidenceRepository:
             "evidence reliance record",
         )
 
+    def has_evidence_reliance(self, action_request_id: str) -> bool:
+        """Return whether one action names a durable reliance record."""
+
+        return self._path(_reliance_path(action_request_id)).is_file()
+
     def access_commits(self) -> tuple[TemporalAccessCommit, ...]:
         """Reload every immutable access commit in stable request order."""
 
@@ -299,6 +304,236 @@ class TemporalEvidenceRepository:
                 ),
                 key=lambda item: (item.session_key, item.request_id),
             )
+        )
+
+    def select_verification_evidence(
+        self,
+        session_information_sets: tuple[TemporalSessionInformationSetManifestV2, ...],
+    ) -> tuple[
+        tuple[TemporalAccessCommit, ...],
+        tuple[TemporalRetrievalStateCarrier, ...],
+        tuple[TemporalRetrievalHandoverReceipt, ...],
+        tuple[TemporalRetrievalHandoverInstallReceipt, ...],
+    ]:
+        """Select only immutable retrieval evidence named by session bindings."""
+
+        commits: dict[tuple[str, str], TemporalAccessCommit] = {}
+        carriers: dict[str, TemporalRetrievalStateCarrier] = {}
+        handover_receipts: dict[str, TemporalRetrievalHandoverReceipt] = {}
+        install_receipts: dict[str, TemporalRetrievalHandoverInstallReceipt] = {}
+        verified_states: set[tuple[str, str]] = set()
+        selected_state_ids_by_session: dict[tuple[str, str, str, str, str], set[str]] = {}
+        for information_set in session_information_sets:
+            identity = (
+                information_set.run_id,
+                information_set.episode_id,
+                information_set.world_branch_id,
+                information_set.agent_tenure_id,
+                information_set.session_id,
+            )
+            selected_state_ids_by_session.setdefault(identity, set()).add(
+                information_set.retrieval_state_content_id,
+            )
+        for information_set in session_information_sets:
+            session_key = _session_identity_key(
+                run_id=information_set.run_id,
+                session_id=information_set.session_id,
+                agent_tenure_id=information_set.agent_tenure_id,
+            )
+            root = f"private/sessions/{session_key}"
+            session = self._load_model(
+                f"{root}/manifest.json",
+                TemporalRetrievalSessionManifest,
+                "retrieval session manifest",
+            )
+            if (
+                session.session_key,
+                session.run_id,
+                session.episode_id,
+                session.world_branch_id,
+                session.actor_id,
+                session.agent_tenure_id,
+                session.session_id,
+            ) != (
+                session_key,
+                information_set.run_id,
+                information_set.episode_id,
+                information_set.world_branch_id,
+                information_set.actor_id,
+                information_set.agent_tenure_id,
+                information_set.session_id,
+            ):
+                raise TemporalEvidenceIntegrityError("retrieval session context differs")
+            state_id = information_set.retrieval_state_content_id
+            selected_states: set[tuple[str, str]] = set()
+            while (session_key, state_id) not in verified_states:
+                state_marker = (session_key, state_id)
+                if state_marker in selected_states:
+                    raise TemporalEvidenceIntegrityError("retrieval state chain contains a cycle")
+                selected_states.add(state_marker)
+                state = self.load_retrieval_state_artifact(
+                    session_key=session_key,
+                    state_id=state_id,
+                )
+                prior_state_id = state.previous_state_id
+                if prior_state_id is None:
+                    if state.state_sequence != 0 or state_id != session.initial_state_id:
+                        raise TemporalEvidenceIntegrityError("retrieval state chain has no valid origin")
+                    break
+                prior = self.load_retrieval_state_artifact(
+                    session_key=session_key,
+                    state_id=prior_state_id,
+                )
+                if state.state_sequence != prior.state_sequence + 1:
+                    raise TemporalEvidenceIntegrityError("retrieval state sequence is not contiguous")
+                if state.installed_carrier_id != prior.installed_carrier_id:
+                    carrier_id = state.installed_carrier_id
+                    if prior.installed_carrier_id is not None or carrier_id is None:
+                        raise TemporalEvidenceIntegrityError("retrieval carrier state is not append-only")
+                    carrier = self._load_model(
+                        f"public/carriers/{carrier_id}.json",
+                        TemporalRetrievalStateCarrier,
+                        "retrieval carrier",
+                    )
+                    if (
+                        carrier.content_sha256 != carrier_id
+                        or carrier.run_id != information_set.run_id
+                        or carrier.episode_id != information_set.episode_id
+                        or carrier.world_branch_id != information_set.world_branch_id
+                        or carrier.to_agent_tenure_id != information_set.agent_tenure_id
+                        or carrier.to_session_id != information_set.session_id
+                        or prior.state_sequence != 0
+                        or prior.access_result_ids
+                        or state.access_result_ids != tuple(item.content_sha256 for item in carrier.access_results)
+                        or state.remaining_budget != carrier.remaining_budget
+                    ):
+                        raise TemporalEvidenceIntegrityError("retrieval carrier differs from selected state")
+                    carriers[carrier_id] = carrier
+                    source_identity = (
+                        carrier.run_id,
+                        carrier.episode_id,
+                        carrier.world_branch_id,
+                        carrier.from_agent_tenure_id,
+                        carrier.from_session_id,
+                    )
+                    source_session_key = _session_identity_key(
+                        run_id=carrier.run_id,
+                        session_id=carrier.from_session_id,
+                        agent_tenure_id=carrier.from_agent_tenure_id,
+                    )
+                    expected_handover_receipts: list[TemporalRetrievalHandoverReceipt] = []
+                    carrier_result_ids = tuple(item.content_sha256 for item in carrier.access_results)
+                    carried_references = {
+                        reference.opaque_reference
+                        for result in carrier.access_results
+                        for reference in result.references
+                    }
+                    for source_state_id in sorted(
+                        selected_state_ids_by_session.get(source_identity, ()),
+                    ):
+                        source_state = self.load_retrieval_state_artifact(
+                            session_key=source_session_key,
+                            state_id=source_state_id,
+                        )
+                        source_results = tuple(
+                            self.load_access_result(result_id) for result_id in source_state.access_result_ids
+                        )
+                        projected_results = tuple(
+                            result
+                            for result in source_results
+                            if carrier.include_fetched_content or result.operation is TemporalEvidenceAccessKind.SEARCH
+                        )
+                        projected_result_ids = tuple(result.content_sha256 for result in projected_results)
+                        if (
+                            projected_result_ids != carrier_result_ids
+                            or source_state.remaining_budget != carrier.remaining_budget
+                            or tuple(
+                                result_id
+                                for result_id in source_state.unresolved_search_ids
+                                if result_id in projected_result_ids
+                            )
+                            != carrier.unresolved_search_ids
+                        ):
+                            continue
+                        expected = TemporalRetrievalHandoverReceipt(
+                            carrier_id=carrier_id,
+                            source_state_id=source_state_id,
+                            from_agent_tenure_id=carrier.from_agent_tenure_id,
+                            from_session_id=carrier.from_session_id,
+                            to_agent_tenure_id=carrier.to_agent_tenure_id,
+                            to_session_id=carrier.to_session_id,
+                            carried_result_ids=carrier_result_ids,
+                            carried_reference_count=len(carried_references),
+                            remaining_budget=carrier.remaining_budget,
+                        )
+                        if self._path(
+                            f"private/handover-receipts/{expected.content_sha256}.json",
+                        ).is_file():
+                            expected_handover_receipts.append(expected)
+                    if len(expected_handover_receipts) != 1:
+                        raise TemporalEvidenceIntegrityError(
+                            "selected retrieval carrier has no unique projection receipt",
+                        )
+                    expected_handover = expected_handover_receipts[0]
+                    handover_receipt = self._load_model(
+                        f"private/handover-receipts/{expected_handover.content_sha256}.json",
+                        TemporalRetrievalHandoverReceipt,
+                        "selected retrieval handover receipt",
+                    )
+                    if handover_receipt != expected_handover:
+                        raise TemporalEvidenceIntegrityError(
+                            "selected retrieval handover receipt differs",
+                        )
+                    handover_receipts[handover_receipt.content_sha256] = handover_receipt
+                    expected_install = TemporalRetrievalHandoverInstallReceipt(
+                        carrier_id=carrier_id,
+                        target_session_key=session_key,
+                        prior_state_id=prior_state_id,
+                        next_state_id=state_id,
+                        to_agent_tenure_id=information_set.agent_tenure_id,
+                        to_session_id=information_set.session_id,
+                    )
+                    install_receipt = self._load_model(
+                        f"private/handover-install-receipts/{expected_install.content_sha256}.json",
+                        TemporalRetrievalHandoverInstallReceipt,
+                        "selected retrieval handover install receipt",
+                    )
+                    if install_receipt != expected_install:
+                        raise TemporalEvidenceIntegrityError(
+                            "selected retrieval handover install receipt differs",
+                        )
+                    install_receipts[install_receipt.content_sha256] = install_receipt
+                else:
+                    if (
+                        len(state.access_result_ids) != len(prior.access_result_ids) + 1
+                        or state.access_result_ids[:-1] != prior.access_result_ids
+                    ):
+                        raise TemporalEvidenceIntegrityError("retrieval access state is not append-only")
+                    result = self.load_access_result(state.access_result_ids[-1])
+                    commit = self._load_model(
+                        _transaction_path(result.request_id),
+                        TemporalAccessCommit,
+                        "temporal access commit",
+                    )
+                    if (
+                        commit.session_key != session_key
+                        or commit.prior_state_id != prior_state_id
+                        or commit.next_state_id != state_id
+                        or commit.result_id != result.content_sha256
+                    ):
+                        raise TemporalEvidenceIntegrityError("temporal access commit differs from selected state")
+                    commit_key = (session_key, commit.request_id)
+                    prior_commit = commits.get(commit_key)
+                    if prior_commit is not None and prior_commit != commit:
+                        raise TemporalEvidenceIntegrityError("temporal access request identity conflict")
+                    commits[commit_key] = commit
+                state_id = prior_state_id
+            verified_states.update(selected_states)
+        return (
+            tuple(sorted(commits.values(), key=lambda item: (item.session_key, item.request_id))),
+            tuple(sorted(carriers.values(), key=lambda item: item.content_sha256)),
+            tuple(sorted(handover_receipts.values(), key=lambda item: item.content_sha256)),
+            tuple(sorted(install_receipts.values(), key=lambda item: item.content_sha256)),
         )
 
     def load_access_publication(

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/temporal_evidence/verification.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/temporal_evidence/verification.py
@@ -18,6 +18,7 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.temporal
     TemporalActorVisibleEvent,
     TemporalEvidenceAccessKind,
     TemporalEvidenceRelianceRecord,
+    TemporalSessionInformationSetManifestV2,
     temporal_actor_event_id,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.temporal_evidence.gateway import (
@@ -77,6 +78,7 @@ def verify_temporal_evidence_repository(
     *,
     package: ReferencePackage,
     proposal_bindings: Mapping[str, tuple[str, str]] | None = None,
+    selected_session_information_sets: tuple[TemporalSessionInformationSetManifestV2, ...] | None = None,
 ) -> TemporalEvidenceVerificationReport:
     """Recompute every deterministic access and cross-check all continuing state."""
 
@@ -89,7 +91,18 @@ def verify_temporal_evidence_repository(
     try:
         bundle = repository.load_bundle(package=package)
         gateway = TemporalEvidenceGateway(bundle)
-        commits = repository.access_commits()
+        if selected_session_information_sets is None:
+            commits = repository.access_commits()
+            selected_carriers = None
+            selected_handover_receipts = None
+            selected_install_receipts = None
+        else:
+            (
+                commits,
+                selected_carriers,
+                selected_handover_receipts,
+                selected_install_receipts,
+            ) = repository.select_verification_evidence(selected_session_information_sets)
         access_count = len(commits)
         for commit in commits:
             try:
@@ -118,8 +131,7 @@ def verify_temporal_evidence_repository(
                         state=prior_state,
                         resulting_information_set_id=access_receipt.resulting_information_set_id,
                     )
-                    if publication.decision.result.operation
-                    is TemporalEvidenceAccessKind.SEARCH
+                    if publication.decision.result.operation is TemporalEvidenceAccessKind.SEARCH
                     else gateway.fetch(
                         request_id=access_receipt.request_id,
                         reference=access_receipt.requested_reference or "",
@@ -166,7 +178,15 @@ def verify_temporal_evidence_repository(
                     )
                 )
 
-        reliance_records = repository.evidence_reliance_records()
+        reliance_records = (
+            repository.evidence_reliance_records()
+            if selected_session_information_sets is None
+            else tuple(
+                repository.load_evidence_reliance(action_request_id)
+                for action_request_id in sorted(proposal_bindings or {})
+                if repository.has_evidence_reliance(action_request_id)
+            )
+        )
         reliance_count = len(reliance_records)
         for record in reliance_records:
             _verify_reliance(
@@ -178,14 +198,18 @@ def verify_temporal_evidence_repository(
                 action_sets=action_sets,
             )
 
-        carriers = repository.retrieval_carriers()
+        carriers = repository.retrieval_carriers() if selected_carriers is None else selected_carriers
         carrier_count = len(carriers)
         carriers_by_id = {item.content_sha256: item for item in carriers}
-        for handover_receipt in repository.retrieval_handover_receipts():
+        handover_receipts = (
+            repository.retrieval_handover_receipts()
+            if selected_handover_receipts is None
+            else selected_handover_receipts
+        )
+        for handover_receipt in handover_receipts:
             carrier = carriers_by_id.get(handover_receipt.carrier_id)
             if carrier is None or (
-                handover_receipt.carried_result_ids
-                != tuple(item.content_sha256 for item in carrier.access_results)
+                handover_receipt.carried_result_ids != tuple(item.content_sha256 for item in carrier.access_results)
                 or handover_receipt.remaining_budget != carrier.remaining_budget
             ):
                 issues.append(
@@ -195,7 +219,12 @@ def verify_temporal_evidence_repository(
                         artifact_id=handover_receipt.carrier_id,
                     )
                 )
-        for install_receipt in repository.retrieval_handover_install_receipts():
+        install_receipts = (
+            repository.retrieval_handover_install_receipts()
+            if selected_install_receipts is None
+            else selected_install_receipts
+        )
+        for install_receipt in install_receipts:
             carrier = carriers_by_id.get(install_receipt.carrier_id)
             state = repository.load_retrieval_state_artifact(
                 session_key=install_receipt.target_session_key,
@@ -291,10 +320,7 @@ def _verify_reliance(
         for item in result.references:
             if item.version_id not in observed_versions:
                 observed_versions.append(item.version_id)
-        if (
-            result.fetched_content is not None
-            and result.fetched_content.version_id not in observed_versions
-        ):
+        if result.fetched_content is not None and result.fetched_content.version_id not in observed_versions:
             observed_versions.append(result.fetched_content.version_id)
     if not set(record.evidence_version_ids).issubset(observed_versions):
         issues.append(
@@ -318,9 +344,7 @@ def _verify_reliance(
         TemporalActionEvidenceSets(
             action_request_id=record.action_request_id,
             information_set_id=record.information_set_id,
-            accessible_version_ids=tuple(
-                item.version_id for item in gateway.accessible_versions(context)
-            ),
+            accessible_version_ids=tuple(item.version_id for item in gateway.accessible_versions(context)),
             observed_version_ids=tuple(observed_versions),
             relied_on_version_ids=record.evidence_version_ids,
             recorded_evidence_refs=record.recorded_evidence_refs,

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_control.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_control.py
@@ -43,6 +43,7 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.referenc
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_models import (
     PumpStationBoundControlRequest,
     PumpStationCommonBoundaryRequest,
+    PumpStationCoupledTreatmentRequest,
     PumpStationOperationsBoundaryReviewRequest,
     PumpStationProcessOutcomeRequest,
     PumpStationSchedule,
@@ -91,6 +92,7 @@ PUMP_STATION_ROOT_CONTROL_OPERATIONS = (
     "operations_review",
     "process_outcome",
     "common_boundary",
+    "coupled_treatment",
 )
 
 
@@ -212,7 +214,8 @@ class PumpStationWorldControl:
         operations: tuple[str, ...] = PUMP_STATION_CONTROL_OPERATIONS
         registered_v4 = self._registered_v4_selected()
         if registered_v4:
-            state = self._resume_run().state if (self._repository_root / "current.json").is_file() else None
+            run = self._resume_run() if (self._repository_root / "current.json").is_file() else None
+            state = run.state if run is not None else None
             operations = (
                 *operations,
                 *pump_station_root_control_operations(
@@ -220,6 +223,13 @@ class PumpStationWorldControl:
                     authority_id=authority_id,
                 ),
             )
+            if (
+                authority_id == "rollout-host"
+                and run is not None
+                and isinstance(run.manifest, PumpStationWorldRunManifestV2)
+                and run.manifest.initial_state_source.kind == "rollout_parent_snapshot"
+            ):
+                operations = (*operations, "coupled_treatment")
         elif self._evidence_health:
             operations = (*operations, *PUMP_STATION_EVIDENCE_CONTROL_OPERATIONS)
         return WorldControlCapabilityCatalogue(
@@ -359,6 +369,8 @@ class PumpStationWorldControl:
             if isinstance(request.control, PumpStationProcessOutcomeRequest)
             else "common_boundary"
             if isinstance(request.control, PumpStationCommonBoundaryRequest)
+            else "coupled_treatment"
+            if isinstance(request.control, PumpStationCoupledTreatmentRequest)
             else ""
         )
         if operation not in PUMP_STATION_ROOT_CONTROL_OPERATIONS:

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run.py
@@ -57,6 +57,7 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewards
     PumpStationBoundControlRequest,
     PumpStationCommonBoundaryRequest,
     PumpStationCoupledStewardshipState,
+    PumpStationCoupledTreatmentRequest,
     PumpStationLegacyStewardshipState,
     PumpStationOperationsBoundaryReviewRequest,
     PumpStationProcessOutcomeRequest,
@@ -117,6 +118,9 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_se
 if TYPE_CHECKING:
     from aec_bench.task_world_templates.stewardship.wastewater_pump_station.continual_definition import (
         PumpStationContinualProfile,
+    )
+    from aec_bench.task_world_templates.stewardship.wastewater_pump_station.temporal_evidence.access_models import (
+        TemporalSessionInformationSetManifestV2,
     )
     from aec_bench.task_world_templates.stewardship.wastewater_pump_station.temporal_evidence.models import (
         TemporalEvidenceBundle,
@@ -276,7 +280,64 @@ class PumpStationWorldRun(Generic[_RunModelT, _RunStateT]):
         repository: PumpStationWorldRunRepository,
         snapshot: PumpStationStateSnapshotRef,
     ) -> PumpStationWorldRun[PumpStationCoupledModel, PumpStationCoupledStewardshipState]:
-        """Resume one manifest-bound RS1 run without caller-supplied profile data."""
+        """Resume one RS1 run after full world and temporal-ledger validation."""
+
+        manifest, profile, bundle = cls._load_reference_system_identity(
+            repository=repository,
+            snapshot=snapshot,
+        )
+        cls._verify_reference_temporal_evidence(
+            repository=repository,
+            package=profile.station_package,
+            manifest=manifest,
+            expected=bundle,
+        )
+        return PumpStationWorldRun[PumpStationCoupledModel, PumpStationCoupledStewardshipState](
+            repository=repository,
+            package=profile.station_package,
+            model=profile.model,
+            manifest=manifest,
+        )
+
+    @classmethod
+    def _resume_reference_system_for_historical_prefix(
+        cls,
+        *,
+        repository: PumpStationWorldRunRepository,
+        snapshot: PumpStationStateSnapshotRef,
+    ) -> PumpStationWorldRun[PumpStationCoupledModel, PumpStationCoupledStewardshipState]:
+        """Construct one RS1 run for a separate selected-prefix verification."""
+
+        manifest, profile, bundle = cls._load_reference_system_identity(
+            repository=repository,
+            snapshot=snapshot,
+        )
+        cls._verify_reference_temporal_evidence_identity(
+            repository=repository,
+            package=profile.station_package,
+            manifest=manifest,
+            expected=bundle,
+        )
+        return PumpStationWorldRun[PumpStationCoupledModel, PumpStationCoupledStewardshipState](
+            repository=repository,
+            package=profile.station_package,
+            model=profile.model,
+            manifest=manifest,
+        )
+
+    @classmethod
+    def _load_reference_system_identity(
+        cls,
+        *,
+        repository: PumpStationWorldRunRepository,
+        snapshot: PumpStationStateSnapshotRef,
+    ) -> tuple[
+        PumpStationWorldRunManifestV2,
+        PumpStationContinualProfile,
+        TemporalEvidenceBundle,
+    ]:
+        """Load and validate immutable RS1 identity without checking mutable history."""
+
         manifest = repository.load_manifest()
         if not isinstance(manifest, PumpStationWorldRunManifestV2):
             _fail(
@@ -294,6 +355,9 @@ class PumpStationWorldRun(Generic[_RunModelT, _RunStateT]):
         from aec_bench.task_world_templates.stewardship.wastewater_pump_station.temporal_evidence.corpus import (
             build_asw_8_reference_temporal_evidence_bundle,
         )
+        from aec_bench.task_world_templates.stewardship.wastewater_pump_station.temporal_evidence.repository import (
+            TemporalEvidenceRepository,
+        )
 
         try:
             definition = default_continual_world_catalogue().resolve(definition_ref)
@@ -303,10 +367,15 @@ class PumpStationWorldRun(Generic[_RunModelT, _RunStateT]):
         if not isinstance(loaded.value, PumpStationContinualProfile):
             _fail("world-run-identity", "registered profile has another task-owned value")
         profile = loaded.value
-        bundle = build_asw_8_reference_temporal_evidence_bundle(
-            profile.station_package,
-            world_branch_id=manifest.world_branch_id,
-        )
+        if manifest.initial_state_source.kind == "reference_system_specification":
+            bundle = build_asw_8_reference_temporal_evidence_bundle(
+                profile.station_package,
+                world_branch_id=manifest.world_branch_id,
+            )
+        else:
+            bundle = TemporalEvidenceRepository(
+                repository.root / "temporal-evidence",
+            ).load_bundle(package=profile.station_package)
         expected_manifest = cls._reference_system_manifest(
             definition_ref=definition_ref,
             profile_ref=profile_ref,
@@ -316,23 +385,29 @@ class PumpStationWorldRun(Generic[_RunModelT, _RunStateT]):
             episode_id=manifest.episode_id,
             world_branch_id=manifest.world_branch_id,
         )
+        if manifest.initial_state_source.kind == "rollout_parent_snapshot":
+            source = manifest.initial_state_source
+            if (
+                source.parent_state_id != manifest.initial_state_id
+                or source.parent_branch_id != source.ancestor_branch_ids[-1]
+                or manifest.world_branch_id in source.ancestor_branch_ids
+            ):
+                _fail(
+                    "world-run-identity",
+                    "registered rollout-child provenance differs",
+                )
+            expected_manifest = replace(
+                expected_manifest,
+                initial_sequence=manifest.initial_sequence,
+                initial_state_id=manifest.initial_state_id,
+                initial_state_source=source,
+            )
         if manifest != expected_manifest:
             _fail("world-run-identity", "registered reference-system manifest differs")
-        cls._verify_reference_temporal_evidence(
-            repository=repository,
-            package=profile.station_package,
-            manifest=manifest,
-            expected=bundle,
-        )
         current = repository.current_snapshot()
         if current != snapshot:
             _fail("snapshot-drift", "requested snapshot is not the selected world state")
-        return PumpStationWorldRun[PumpStationCoupledModel, PumpStationCoupledStewardshipState](
-            repository=repository,
-            package=profile.station_package,
-            model=profile.model,
-            manifest=manifest,
-        )
+        return manifest, profile, bundle
 
     def migrate_to_v2(
         self,
@@ -719,6 +794,14 @@ class PumpStationWorldRun(Generic[_RunModelT, _RunStateT]):
     ) -> PumpStationTransitionV4:
         """Apply or exactly recover one bound root host-control request."""
         manifest = self._reference_manifest()
+        if (
+            isinstance(request.control, PumpStationCoupledTreatmentRequest)
+            and manifest.initial_state_source.kind != "rollout_parent_snapshot"
+        ):
+            _fail(
+                "control-wrong-profile",
+                "coupled treatment requires a registered rollout child",
+            )
         command = self._v4_control_command(request)
         with self._repository.locked():
             committed = self._repository.find_committed_v4_command(request.request_id)
@@ -763,7 +846,7 @@ class PumpStationWorldRun(Generic[_RunModelT, _RunStateT]):
                     state,
                     request.control,
                 )
-            except PumpStationCoupledWorldError as error:
+            except (PumpStationProposalError, PumpStationCoupledWorldError) as error:
                 _fail(error.code, str(error))
             staged = self._repository.stage_v4_transition(
                 manifest=manifest,
@@ -937,8 +1020,74 @@ class PumpStationWorldRun(Generic[_RunModelT, _RunStateT]):
         """Reload all selected run steps for independent replay."""
         return self._repository.steps()
 
-    def verify_v4(self) -> PumpStationVerificationReportV4:
-        """Independently replay the selected V4 command chain."""
+    def _v4_verification_session_bindings(
+        self,
+        manifest: PumpStationWorldRunManifestV2,
+        *,
+        root_binding_ids: tuple[str, ...] | None,
+    ) -> dict[str, PumpStationSessionActivationBinding]:
+        """Load the current session chain or only command-referenced prefixes."""
+
+        roots: tuple[PumpStationSessionActivationBinding, ...]
+        if root_binding_ids is None:
+            selected = self._repository._selected_session_activation_if_present(
+                manifest,
+            )
+            roots = () if selected is None else (selected[1],)
+        else:
+            roots = tuple(
+                self._repository._load_session_binding(binding_id, manifest) for binding_id in root_binding_ids
+            )
+        bindings_by_id: dict[str, PumpStationSessionActivationBinding] = {}
+        for root in roots:
+            binding = root
+            expected_event_sequence = binding.session_event_sequence
+            expected_host_authority = binding.host_authority_id
+            seen: set[str] = set()
+            while True:
+                if binding.binding_id in seen:
+                    raise ValueError("session binding chain contains a cycle")
+                seen.add(binding.binding_id)
+                if (
+                    binding.session_event_sequence != expected_event_sequence
+                    or binding.host_authority_id != expected_host_authority
+                ):
+                    raise ValueError("session binding chain position differs")
+                claim = self._repository._load_session_activation_claim(
+                    binding.active_activation_id,
+                )
+                if claim.binding_id != binding.binding_id:
+                    raise ValueError("session activation claim differs")
+                prior = bindings_by_id.get(binding.binding_id)
+                if prior is not None and prior != binding:
+                    raise ValueError("session binding identity differs")
+                bindings_by_id[binding.binding_id] = binding
+                if binding.prior_binding_id is None:
+                    if binding.session_event_sequence != 0:
+                        raise ValueError("session binding chain has no origin")
+                    break
+                expected_event_sequence -= 1
+                binding = self._repository._load_session_binding(
+                    binding.prior_binding_id,
+                    manifest,
+                )
+        return bindings_by_id
+
+    def verify_v4(
+        self,
+        snapshot: PumpStationStateSnapshotRef | None = None,
+    ) -> PumpStationVerificationReportV4:
+        """Independently replay the selected V4 history or one exact prefix."""
+
+        with self._repository.locked():
+            return self._verify_v4_under_lock(snapshot)
+
+    def _verify_v4_under_lock(
+        self,
+        snapshot: PumpStationStateSnapshotRef | None = None,
+    ) -> PumpStationVerificationReportV4:
+        """Replay one V4 history while the caller holds the world-run lock."""
+
         from aec_bench.task_world_templates.stewardship.wastewater_pump_station.temporal_evidence import (
             TemporalEvidenceIntegrityError,
             TemporalEvidenceRepository,
@@ -953,43 +1102,29 @@ class PumpStationWorldRun(Generic[_RunModelT, _RunStateT]):
             self._repository.load_state(manifest.initial_state_id),
         )
         session_issues: list[str] = []
-        bindings_by_id: dict[str, PumpStationSessionActivationBinding] = {}
         try:
-            with self._repository.locked():
-                steps = self._repository.v4_steps()
-                expected_final_state_id = self._repository.current_snapshot().state_id
-                selected = self._repository._selected_session_activation_if_present(
-                    manifest,
+            selected_snapshot = snapshot or self._repository.current_snapshot()
+            steps = (
+                self._repository.v4_steps_through(selected_snapshot)
+                if snapshot is not None
+                else self._repository.v4_steps()
+            )
+            expected_final_state_id = selected_snapshot.state_id
+            root_binding_ids = (
+                None
+                if snapshot is None
+                else tuple(
+                    dict.fromkeys(
+                        step.command.session_binding_id
+                        for step in steps
+                        if step.command.kind == "actor" and step.command.session_binding_id is not None
+                    )
                 )
-                if selected is not None:
-                    _, binding = selected
-                    expected_event_sequence = binding.session_event_sequence
-                    expected_host_authority = binding.host_authority_id
-                    seen: set[str] = set()
-                    while True:
-                        if binding.binding_id in seen:
-                            raise ValueError("session binding chain contains a cycle")
-                        seen.add(binding.binding_id)
-                        if (
-                            binding.session_event_sequence != expected_event_sequence
-                            or binding.host_authority_id != expected_host_authority
-                        ):
-                            raise ValueError("session binding chain position differs")
-                        claim = self._repository._load_session_activation_claim(
-                            binding.active_activation_id,
-                        )
-                        if claim.binding_id != binding.binding_id:
-                            raise ValueError("session activation claim differs")
-                        bindings_by_id[binding.binding_id] = binding
-                        if binding.prior_binding_id is None:
-                            if binding.session_event_sequence != 0:
-                                raise ValueError("session binding chain has no origin")
-                            break
-                        expected_event_sequence -= 1
-                        binding = self._repository._load_session_binding(
-                            binding.prior_binding_id,
-                            manifest,
-                        )
+            )
+            bindings_by_id = self._v4_verification_session_bindings(
+                manifest,
+                root_binding_ids=root_binding_ids,
+            )
         except (OSError, PumpStationWorldRunError, TypeError, ValueError) as error:
             return PumpStationVerificationReportV4(
                 valid=False,
@@ -1015,10 +1150,14 @@ class PumpStationWorldRun(Generic[_RunModelT, _RunStateT]):
                 or historical_binding.session_event_sequence > active_at_position.session_event_sequence
             ):
                 active_bindings_by_world_position[world_position] = historical_binding
+        temporal_repository = TemporalEvidenceRepository(
+            self._repository.root / "temporal-evidence",
+        )
         information_sets_by_binding_id: dict[str, PumpStationInformationSet] = {}
+        selected_temporal_information_sets: list[TemporalSessionInformationSetManifestV2] = []
         for historical_binding_id, historical_binding in bindings_by_id.items():
             try:
-                snapshot = PumpStationStateSnapshotRef(
+                binding_snapshot = PumpStationStateSnapshotRef(
                     snapshot_version=manifest.snapshot_version,
                     run_id=manifest.run_id,
                     episode_id=manifest.episode_id,
@@ -1027,10 +1166,18 @@ class PumpStationWorldRun(Generic[_RunModelT, _RunStateT]):
                     state_id=historical_binding.state_id,
                     commit_id=historical_binding.commit_id,
                 )
-                information_sets_by_binding_id[historical_binding_id] = self._v4_session_information_set(
-                    snapshot,
-                    session_binding=historical_binding,
+                temporal_manifest = temporal_repository.load_session_information_set(
+                    historical_binding.information_set_manifest_content_id,
+                    run_id=manifest.run_id,
+                    session_id=historical_binding.session_id,
+                    agent_tenure_id=historical_binding.agent_tenure_id,
                 )
+                information_sets_by_binding_id[historical_binding_id] = self._v4_session_information_set(
+                    binding_snapshot,
+                    session_binding=historical_binding,
+                    temporal_manifest=temporal_manifest,
+                )
+                selected_temporal_information_sets.append(temporal_manifest)
             except (
                 OSError,
                 PumpStationWorldRunError,
@@ -1089,9 +1236,6 @@ class PumpStationWorldRun(Generic[_RunModelT, _RunStateT]):
                 manifest.temporal_bundle_content_id,
             ),
         )
-        temporal_repository = TemporalEvidenceRepository(
-            self._repository.root / "temporal-evidence",
-        )
         proposal_bindings = {
             step.command.request_id: (
                 step.command.information_set_id or "",
@@ -1104,6 +1248,7 @@ class PumpStationWorldRun(Generic[_RunModelT, _RunStateT]):
             temporal_repository,
             package=self._package,
             proposal_bindings=proposal_bindings,
+            selected_session_information_sets=(None if snapshot is None else tuple(selected_temporal_information_sets)),
         )
         temporal_issues: tuple[str, ...] = tuple(
             f"temporal-evidence-invalid:{issue.code}:{issue.artifact_id or '-'}" for issue in temporal_report.issues
@@ -1275,7 +1420,14 @@ class PumpStationWorldRun(Generic[_RunModelT, _RunStateT]):
         manifest: PumpStationWorldRunManifestV2,
         expected: TemporalEvidenceBundle,
     ) -> None:
-        """Require stored RS1 temporal evidence to match immutable run metadata."""
+        """Require the static corpus and complete temporal ledger to be valid."""
+
+        PumpStationWorldRun._verify_reference_temporal_evidence_identity(
+            repository=repository,
+            package=package,
+            manifest=manifest,
+            expected=expected,
+        )
         from aec_bench.task_world_templates.stewardship.wastewater_pump_station.temporal_evidence.models import (
             TemporalEvidenceIntegrityError,
         )
@@ -1288,11 +1440,44 @@ class PumpStationWorldRun(Generic[_RunModelT, _RunStateT]):
 
         temporal_repository = TemporalEvidenceRepository(repository.root / "temporal-evidence")
         try:
-            loaded = temporal_repository.load_bundle(package=package)
+            steps = repository.v4_steps()
+            proposal_bindings = {
+                step.command.request_id: (
+                    step.command.information_set_id or "",
+                    step.command.actor_view_id or "",
+                )
+                for step in steps
+                if step.command.kind == "actor"
+            }
             report = verify_temporal_evidence_repository(
                 temporal_repository,
                 package=package,
+                proposal_bindings=proposal_bindings,
             )
+        except (OSError, ValueError, PumpStationWorldRunError, TemporalEvidenceIntegrityError) as error:
+            _fail("temporal-evidence", f"RS1 temporal evidence ledger is invalid: {error}")
+        if not report.valid:
+            _fail("temporal-evidence", "RS1 temporal evidence ledger differs")
+
+    @staticmethod
+    def _verify_reference_temporal_evidence_identity(
+        *,
+        repository: PumpStationWorldRunRepository,
+        package: ReferencePackage,
+        manifest: PumpStationWorldRunManifestV2,
+        expected: TemporalEvidenceBundle,
+    ) -> None:
+        """Require the stored RS1 temporal corpus to match immutable run metadata."""
+        from aec_bench.task_world_templates.stewardship.wastewater_pump_station.temporal_evidence.models import (
+            TemporalEvidenceIntegrityError,
+        )
+        from aec_bench.task_world_templates.stewardship.wastewater_pump_station.temporal_evidence.repository import (
+            TemporalEvidenceRepository,
+        )
+
+        temporal_repository = TemporalEvidenceRepository(repository.root / "temporal-evidence")
+        try:
+            loaded = temporal_repository.load_bundle(package=package)
         except (OSError, ValueError, TemporalEvidenceIntegrityError) as error:
             _fail("temporal-evidence", f"RS1 temporal evidence is invalid: {error}")
         observed = (
@@ -1305,7 +1490,7 @@ class PumpStationWorldRun(Generic[_RunModelT, _RunStateT]):
             manifest.temporal_corpus_content_id,
             manifest.temporal_capability_content_id,
         )
-        if loaded != expected or observed != bound or not report.valid:
+        if loaded != expected or observed != bound:
             _fail("temporal-evidence", "RS1 temporal evidence differs from the run manifest")
 
     @staticmethod
@@ -1401,6 +1586,7 @@ class PumpStationWorldRun(Generic[_RunModelT, _RunStateT]):
         snapshot: PumpStationStateSnapshotRef,
         *,
         session_binding: PumpStationSessionActivationBinding,
+        temporal_manifest: TemporalSessionInformationSetManifestV2 | None = None,
     ) -> PumpStationInformationSet:
         """Rebuild one complete V4 information set from durable session evidence."""
         from aec_bench.task_world_templates.stewardship.wastewater_pump_station.temporal_evidence import (
@@ -1411,7 +1597,7 @@ class PumpStationWorldRun(Generic[_RunModelT, _RunStateT]):
         temporal_repository = TemporalEvidenceRepository(
             self._repository.root / "temporal-evidence",
         )
-        temporal = temporal_repository.load_session_information_set(
+        temporal = temporal_manifest or temporal_repository.load_session_information_set(
             session_binding.information_set_manifest_content_id,
             run_id=manifest.run_id,
             session_id=session_binding.session_id,
@@ -1479,7 +1665,10 @@ class PumpStationWorldRun(Generic[_RunModelT, _RunStateT]):
             temporal.workspace_tool_ids,
             temporal.tool_contract_id,
         )
-        if observed_scope != expected_scope or temporal.branch_ancestor_ids:
+        if (
+            observed_scope != expected_scope
+            or temporal.branch_ancestor_ids != manifest.initial_state_source.ancestor_branch_ids
+        ):
             _fail(
                 "actor-session-binding",
                 "temporal session manifest differs from the selected world",
@@ -1588,6 +1777,9 @@ class PumpStationWorldRun(Generic[_RunModelT, _RunStateT]):
         elif isinstance(control, PumpStationCommonBoundaryRequest):
             kind = "common_boundary"
             action_name = "common_boundary_control"
+        elif isinstance(control, PumpStationCoupledTreatmentRequest):
+            kind = "coupled_treatment"
+            action_name = "coupled_physical_treatment"
         else:
             _fail("control-type", f"unsupported V4 control {type(control).__name__}")
         manifest = self._reference_manifest()

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_commands.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_commands.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+from decimal import Decimal, InvalidOperation
 from typing import NoReturn, cast
 
 from pydantic import JsonValue
@@ -14,6 +15,7 @@ from aec_bench.contracts.world_interface import (
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_models import (
     PumpStationCommonBoundaryRequest,
+    PumpStationCoupledTreatmentRequest,
     PumpStationOperationsBoundaryReviewRequest,
     PumpStationProcessOutcomeRequest,
     PumpStationRootControl,
@@ -58,6 +60,18 @@ _ROOT_CONTROL_ARGUMENT_FIELDS = {
             "authority_id",
             "boundary_kind",
             "available",
+            "base_state_id",
+        }
+    ),
+    "coupled_treatment": frozenset(
+        {
+            "version",
+            "request_id",
+            "authority_id",
+            "treatment_label",
+            "affected_pump_ids",
+            "obstruction_delta",
+            "clearance_loss_delta",
             "base_state_id",
         }
     ),
@@ -182,6 +196,17 @@ def _root_control_from_command(
             available=_bool_argument(arguments, "available"),
             base_state_id=_text_argument(arguments, "base_state_id"),
         )
+    if command.kind == "coupled_treatment":
+        return PumpStationCoupledTreatmentRequest(
+            version=_text_argument(arguments, "version"),
+            request_id=_text_argument(arguments, "request_id"),
+            authority_id=_text_argument(arguments, "authority_id"),
+            treatment_label=_text_argument(arguments, "treatment_label"),
+            affected_pump_ids=_text_tuple_argument(arguments, "affected_pump_ids"),
+            obstruction_delta=_decimal_argument(arguments, "obstruction_delta"),
+            clearance_loss_delta=_decimal_argument(arguments, "clearance_loss_delta"),
+            base_state_id=_text_argument(arguments, "base_state_id"),
+        )
     _fail("command-content", f"unsupported V4 control kind {command.kind}")
 
 
@@ -197,3 +222,26 @@ def _bool_argument(arguments: dict[str, object], field_name: str) -> bool:
     if not isinstance(value, bool):
         _fail("command-content", f"control field {field_name} must be Boolean")
     return value
+
+
+def _text_tuple_argument(
+    arguments: dict[str, object],
+    field_name: str,
+) -> tuple[str, ...]:
+    value = arguments.get(field_name)
+    if not isinstance(value, list) or any(not isinstance(item, str) or not item.strip() for item in value):
+        _fail("command-content", f"control field {field_name} must be a text list")
+    return tuple(value)
+
+
+def _decimal_argument(arguments: dict[str, object], field_name: str) -> Decimal:
+    value = arguments.get(field_name)
+    if isinstance(value, bool) or not isinstance(value, str | int | float):
+        _fail("command-content", f"control field {field_name} must be decimal content")
+    try:
+        return Decimal(str(value))
+    except InvalidOperation as error:
+        raise PumpStationWorldRunError(
+            "command-content",
+            f"control field {field_name} must be decimal content",
+        ) from error

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_models.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_models.py
@@ -506,6 +506,7 @@ class PumpStationCommandV4:
             "operations_review": "operations_boundary_review",
             "process_outcome": "process_outcome",
             "common_boundary": "common_boundary_control",
+            "coupled_treatment": "coupled_physical_treatment",
         }
         if self.kind != "actor" and self.kind not in expected_actions:
             raise PumpStationWorldRunError("command-kind", self.kind)

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_repository.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_run_repository.py
@@ -1152,6 +1152,39 @@ class PumpStationWorldRunRepository:
         self._validate_chain(tuple(chain), pointer)
         return tuple(chain)
 
+    def commits_through(
+        self,
+        snapshot: PumpStationStateSnapshotRef,
+    ) -> tuple[PumpStationWorldRunCommitRecord, ...]:
+        """Return the selected commit prefix that ends at one exact snapshot."""
+
+        manifest = self.load_manifest()
+        if (
+            snapshot.snapshot_version,
+            snapshot.run_id,
+            snapshot.episode_id,
+            snapshot.world_branch_id,
+        ) != (
+            manifest.snapshot_version,
+            manifest.run_id,
+            manifest.episode_id,
+            manifest.world_branch_id,
+        ):
+            _fail("snapshot-drift", "requested snapshot belongs to another world run")
+        chain = self.commits()
+        for index, commit in enumerate(chain):
+            commit_id = pump_station_artifact_id(commit)
+            if commit_id != snapshot.commit_id:
+                continue
+            if (commit.sequence, commit.state_id) != (
+                snapshot.sequence,
+                snapshot.state_id,
+            ):
+                _fail("snapshot-drift", "requested snapshot and commit differ")
+            self.load_state(snapshot.state_id)
+            return chain[: index + 1]
+        _fail("snapshot-drift", "requested snapshot is not on the selected history")
+
     def steps(self) -> tuple[PumpStationRunStep, ...]:
         """Reload every committed proposal, information set, receipt, event batch, and state."""
         steps: list[PumpStationRunStep] = []
@@ -1190,6 +1223,27 @@ class PumpStationWorldRunRepository:
         """Reload every selected V4 command and its complete transition evidence."""
         steps: list[PumpStationRunStepV4] = []
         for commit in self.commits()[1:]:
+            if not isinstance(commit, PumpStationWorldRunCommitV2):
+                _fail("record-versions", "V4 step access selected a legacy commit")
+            command, proposal, information_set, transition = self._load_v4_step(commit)
+            steps.append(
+                PumpStationRunStepV4(
+                    command=command,
+                    proposal=proposal,
+                    information_set=information_set,
+                    transition=transition,
+                )
+            )
+        return tuple(steps)
+
+    def v4_steps_through(
+        self,
+        snapshot: PumpStationStateSnapshotRef,
+    ) -> tuple[PumpStationRunStepV4, ...]:
+        """Reload the selected V4 step prefix through one exact snapshot."""
+
+        steps: list[PumpStationRunStepV4] = []
+        for commit in self.commits_through(snapshot)[1:]:
             if not isinstance(commit, PumpStationWorldRunCommitV2):
                 _fail("record-versions", "V4 step access selected a legacy commit")
             command, proposal, information_set, transition = self._load_v4_step(commit)

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_session.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/world_session.py
@@ -677,7 +677,7 @@ class PumpStationWorldSession:
             episode_id=self._request.episode_id,
             world_instance_id=self._run.manifest.run_id,
             world_branch_id=self._request.world_branch_id,
-            branch_ancestor_ids=(),
+            branch_ancestor_ids=self._branch_ancestor_ids(),
             world_state_id=snapshot.state_id,
             world_commit_id=snapshot.commit_id,
             world_sequence=snapshot.sequence,
@@ -1984,8 +1984,16 @@ class PumpStationWorldSession:
             base_view_id=self._view.view_id,
             prior_information_set_id=self._information_set.information_set_id,
             tool_contract_id=self.actor_capabilities.content_sha256,
-            branch_ancestor_ids=(),
+            branch_ancestor_ids=self._branch_ancestor_ids(),
         )
+
+    def _branch_ancestor_ids(self) -> tuple[str, ...]:
+        """Return the ordered branch ancestry bound by the durable manifest."""
+
+        manifest = self._run.manifest
+        if isinstance(manifest, PumpStationWorldRunManifestV2):
+            return manifest.initial_state_source.ancestor_branch_ids
+        return ()
 
     def _temporal_information_set_manifest(self) -> TemporalInformationSetManifest:
         return TemporalInformationSetManifest(

--- a/tests/task_world_templates/continual/test_rollout_contract.py
+++ b/tests/task_world_templates/continual/test_rollout_contract.py
@@ -1,0 +1,244 @@
+# ABOUTME: Tests the task-neutral records for chosen-point continual-world rollout groups.
+# ABOUTME: Proves exact identity, ordered children, and exclusion of actor execution settings.
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from aec_bench.contracts.continual_world import (
+    ContinualRolloutChildReceipt,
+    ContinualRolloutChildRequest,
+    ContinualRolloutGroupRequest,
+    ContinualRolloutGroupState,
+    ContinualRolloutGroupStatus,
+    ContinualRolloutLineage,
+    ContinualWorldDefinitionRef,
+    ContinualWorldProfileRef,
+    ContinualWorldSnapshotRef,
+)
+
+
+def _snapshot() -> ContinualWorldSnapshotRef:
+    return ContinualWorldSnapshotRef(
+        run_id="parent-run",
+        episode_id="parent-episode",
+        world_branch_id="root",
+        sequence=7,
+        state_id="state-7",
+        commit_id="commit-7",
+    )
+
+
+def _request(**updates: object) -> ContinualRolloutGroupRequest:
+    values: dict[str, object] = {
+        "request_id": "request-1",
+        "group_id": "group-1",
+        "task_world_id": "world.example",
+        "authority_id": "host-control",
+        "definition_ref": ContinualWorldDefinitionRef(
+            task_world_id="world.example",
+            definition_version="1",
+            content_sha256="a" * 64,
+        ),
+        "profile_ref": ContinualWorldProfileRef(
+            task_world_id="world.example",
+            profile_id="profile.example",
+            profile_version="1",
+            profile_content_sha256="b" * 64,
+        ),
+        "parent_manifest_content_sha256": "c" * 64,
+        "parent_snapshot": _snapshot(),
+        "origin_verification_content_sha256": "d" * 64,
+        "reason": "Compare two deterministic continuations.",
+        "children": (
+            ContinualRolloutChildRequest(
+                child_id="child-a",
+                run_id="child-run-a",
+                episode_id="child-episode-a",
+                world_branch_id="branch-a",
+            ),
+            ContinualRolloutChildRequest(
+                child_id="child-b",
+                run_id="child-run-b",
+                episode_id="child-episode-b",
+                world_branch_id="branch-b",
+            ),
+        ),
+    }
+    values.update(updates)
+    return ContinualRolloutGroupRequest(**values)
+
+
+def test_rollout_group_request_has_stable_content_identity_and_child_order() -> None:
+    request = _request()
+    recovered = ContinualRolloutGroupRequest.model_validate(request.model_dump(mode="json"))
+
+    assert recovered == request
+    assert recovered.content_sha256 == request.content_sha256
+    assert tuple(child.child_id for child in recovered.children) == ("child-a", "child-b")
+    assert all(child.content_sha256 for child in recovered.children)
+
+
+@pytest.mark.parametrize("identity_field", ("child_id", "run_id", "episode_id", "world_branch_id"))
+def test_rollout_group_request_rejects_reused_child_identity(identity_field: str) -> None:
+    first, second = _request().children
+    duplicate_payload = second.model_dump(mode="python", exclude={"content_sha256"})
+    duplicate_payload[identity_field] = getattr(first, identity_field)
+    duplicate = ContinualRolloutChildRequest(**duplicate_payload)
+
+    with pytest.raises(ValidationError, match=f"{identity_field.replace('_', ' ')}s must be distinct"):
+        _request(children=(first, duplicate))
+
+
+def test_rollout_group_request_rejects_foreign_definition_or_profile() -> None:
+    request = _request()
+    foreign_definition = request.definition_ref.model_copy(update={"task_world_id": "world.foreign"})
+    foreign_profile = request.profile_ref.model_copy(update={"task_world_id": "world.foreign"})
+
+    with pytest.raises(ValidationError, match="definition must belong to the requested task world"):
+        _request(definition_ref=foreign_definition)
+    with pytest.raises(ValidationError, match="profile must belong to the requested task world"):
+        _request(profile_ref=foreign_profile)
+
+
+@pytest.mark.parametrize(
+    ("identity_field", "parent_value"),
+    (
+        ("run_id", "parent-run"),
+        ("episode_id", "parent-episode"),
+        ("world_branch_id", "root"),
+    ),
+)
+def test_rollout_group_request_rejects_child_identity_reused_from_parent(
+    identity_field: str,
+    parent_value: str,
+) -> None:
+    child_payload = _request().children[0].model_dump(mode="python", exclude={"content_sha256"})
+    child_payload[identity_field] = parent_value
+
+    with pytest.raises(ValidationError, match="child world identity must differ from the parent"):
+        _request(children=(ContinualRolloutChildRequest(**child_payload),))
+
+
+def test_rollout_child_receipt_ancestry_ends_at_parent_and_excludes_child() -> None:
+    request = _request()
+    child = request.children[0]
+    initial = ContinualWorldSnapshotRef(
+        run_id=child.run_id,
+        episode_id=child.episode_id,
+        world_branch_id=child.world_branch_id,
+        sequence=request.parent_snapshot.sequence,
+        state_id=request.parent_snapshot.state_id,
+        commit_id="child-commit-7",
+    )
+
+    receipt = ContinualRolloutChildReceipt(
+        group_id=request.group_id,
+        child_id=child.child_id,
+        child_request_content_sha256=child.content_sha256,
+        parent_snapshot=request.parent_snapshot,
+        initial_snapshot=initial,
+        child_manifest_content_sha256="e" * 64,
+        task_branch_receipt_content_sha256="f" * 64,
+        ancestor_world_branch_ids=(request.parent_snapshot.world_branch_id,),
+    )
+
+    assert receipt.ancestor_world_branch_ids == ("root",)
+    with pytest.raises(ValidationError, match="must exclude the child branch"):
+        ContinualRolloutChildReceipt.model_validate(
+            {
+                **receipt.model_dump(mode="python", exclude={"content_sha256"}),
+                "ancestor_world_branch_ids": ("root", child.world_branch_id),
+            }
+        )
+    with pytest.raises(ValidationError, match="must end at the parent branch"):
+        ContinualRolloutChildReceipt.model_validate(
+            {
+                **receipt.model_dump(mode="python", exclude={"content_sha256"}),
+                "ancestor_world_branch_ids": ("foreign",),
+            }
+        )
+
+
+def test_rollout_lineage_rejects_child_receipt_from_another_parent_snapshot() -> None:
+    request = _request()
+    child = request.children[0]
+    foreign_parent = ContinualWorldSnapshotRef(
+        run_id="foreign-parent-run",
+        episode_id="foreign-parent-episode",
+        world_branch_id="foreign-parent-branch",
+        sequence=request.parent_snapshot.sequence,
+        state_id=request.parent_snapshot.state_id,
+        commit_id=request.parent_snapshot.commit_id,
+    )
+    receipt = ContinualRolloutChildReceipt(
+        group_id=request.group_id,
+        child_id=child.child_id,
+        child_request_content_sha256=child.content_sha256,
+        parent_snapshot=foreign_parent,
+        initial_snapshot=ContinualWorldSnapshotRef(
+            run_id=child.run_id,
+            episode_id=child.episode_id,
+            world_branch_id=child.world_branch_id,
+            sequence=foreign_parent.sequence,
+            state_id=foreign_parent.state_id,
+            commit_id="child-commit-7",
+        ),
+        child_manifest_content_sha256="e" * 64,
+        task_branch_receipt_content_sha256="f" * 64,
+        ancestor_world_branch_ids=(foreign_parent.world_branch_id,),
+    )
+
+    with pytest.raises(ValidationError, match="child receipt must use the lineage parent snapshot"):
+        ContinualRolloutLineage(
+            request_id=request.request_id,
+            group_id=request.group_id,
+            task_world_id=request.task_world_id,
+            definition_ref=request.definition_ref,
+            profile_ref=request.profile_ref,
+            request_content_sha256=request.content_sha256,
+            parent_manifest_content_sha256=request.parent_manifest_content_sha256,
+            parent_snapshot=request.parent_snapshot,
+            origin_verification_content_sha256=request.origin_verification_content_sha256,
+            children=(receipt,),
+        )
+
+
+def test_rollout_group_status_rejects_duplicate_created_child_ids() -> None:
+    with pytest.raises(ValidationError, match="created child ids must be distinct"):
+        ContinualRolloutGroupStatus(
+            group_id="group-1",
+            request_id="request-1",
+            state=ContinualRolloutGroupState.PREPARING,
+            requested_child_ids=("child-a", "child-b"),
+            created_child_ids=("child-a", "child-a"),
+        )
+
+
+def test_generic_rollout_child_rejects_actor_and_provider_settings() -> None:
+    with pytest.raises(ValidationError):
+        ContinualRolloutChildRequest.model_validate(
+            {
+                "child_id": "child-a",
+                "run_id": "child-run-a",
+                "episode_id": "child-episode-a",
+                "world_branch_id": "branch-a",
+                "agent_condition_id": "agent-condition-a",
+                "agent_seed": 41,
+                "provider": "provider-a",
+                "model": "model-a",
+            }
+        )
+
+
+def test_continual_snapshot_rejects_negative_sequence() -> None:
+    with pytest.raises(ValidationError, match="snapshot sequence must be non-negative"):
+        ContinualWorldSnapshotRef(
+            run_id="parent-run",
+            episode_id="parent-episode",
+            world_branch_id="root",
+            sequence=-1,
+            state_id="state-7",
+            commit_id="commit-7",
+        )

--- a/tests/task_world_templates/continual/test_ssc03_rollout_control.py
+++ b/tests/task_world_templates/continual/test_ssc03_rollout_control.py
@@ -1,0 +1,656 @@
+# ABOUTME: Tests shared rollout orchestration through the real SSC-03 lifecycle branch port.
+# ABOUTME: Proves chosen-point branching, exact retry, isolation, and ordered lineage.
+
+from __future__ import annotations
+
+import hashlib
+import json
+import stat
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from threading import Barrier
+
+import pytest
+from pydantic import ValidationError
+
+from aec_bench.contracts.continual_world import (
+    ContinualRolloutChildRequest,
+    ContinualRolloutGroupRequest,
+    ContinualRolloutGroupState,
+    ContinualRolloutLineage,
+    ContinualWorldDefinitionSpec,
+)
+from aec_bench.meta_harness.evidence_lifecycle import (
+    EvidenceLifecycleError,
+    read_evidence_lifecycle_branch_snapshot,
+    read_evidence_lifecycle_state,
+    run_evidence_lifecycle,
+    submit_evidence_checkpoint,
+)
+from aec_bench.task_world_templates.continual.definition import ContinualWorldDefinition
+from aec_bench.task_world_templates.continual.rollout_control import (
+    ContinualRolloutControl,
+    ContinualRolloutError,
+)
+from aec_bench.task_world_templates.continual.rollout_repository import ContinualRolloutRepository
+from aec_bench.task_world_templates.lifecycles.ssc03_hydraulic_continual_definition import (
+    Ssc03HydraulicContinualProfile,
+    ssc03_hydraulic_continual_world_definition,
+)
+from aec_bench.task_world_templates.lifecycles.ssc03_hydraulic_rollout_adapter import (
+    Ssc03HydraulicRolloutBranchReceipt,
+    ssc03_hydraulic_rollout_origin,
+)
+
+
+def _tree_bytes(root: Path) -> dict[str, bytes]:
+    return {path.relative_to(root).as_posix(): path.read_bytes() for path in sorted(root.rglob("*")) if path.is_file()}
+
+
+def test_shared_control_rejects_all_unsafe_storage_identities_before_origin_or_writes(
+    tmp_path: Path,
+) -> None:
+    definition = ssc03_hydraulic_continual_world_definition()
+    profile_ref = definition.profile_ref("major_idf_revision", "1")
+    loaded = definition.load_profile(profile_ref)
+    assert isinstance(loaded.value, Ssc03HydraulicContinualProfile)
+    compiled = loaded.value.compile(tmp_path / "package")
+    environment = loaded.value.build_smoke_environment(compiled.package_dir)
+    assert environment is not None
+    parent_run = tmp_path / "parent-run"
+    run_evidence_lifecycle(compiled.package_dir, parent_run, episode_environment=environment)
+    origin = ssc03_hydraulic_rollout_origin(
+        compiled.package_dir,
+        parent_run,
+        checkpoint_id="revision_analysis",
+    )
+    child = ContinualRolloutChildRequest(
+        child_id="valid-child",
+        run_id="storage-preflight-child-run",
+        episode_id="storage-preflight-child-episode",
+        world_branch_id="storage-preflight-child-branch",
+    )
+    base_request = ContinualRolloutGroupRequest(
+        request_id="storage-preflight-request",
+        group_id="storage-preflight-group",
+        task_world_id=definition.ref.task_world_id,
+        authority_id="host-control",
+        definition_ref=definition.ref,
+        profile_ref=profile_ref,
+        parent_manifest_content_sha256=origin.parent_manifest_content_sha256,
+        parent_snapshot=origin.parent_snapshot,
+        origin_verification_content_sha256=origin.origin_verification_content_sha256,
+        reason="Reject unsafe storage identities before any durable work.",
+        children=(child,),
+    )
+    rollout_root = tmp_path / "rollouts"
+    control = ContinualRolloutControl(
+        definition,
+        parent_run_root=parent_run,
+        rollout_repository_root=rollout_root,
+        authorised_principal_ids=("host-control",),
+        package_root=compiled.package_dir,
+    )
+    parent_before = _tree_bytes(parent_run)
+    foreign_snapshot_payload = origin.parent_snapshot.model_dump(mode="python", exclude={"content_sha256"})
+    foreign_snapshot_payload["run_id"] = "foreign-parent-run"
+    foreign_snapshot = type(origin.parent_snapshot)(**foreign_snapshot_payload)
+
+    unsafe_group_payload = base_request.model_dump(mode="python", exclude={"content_sha256"})
+    unsafe_group_payload.update(
+        request_id="unsafe-group-request",
+        group_id="../unsafe-group",
+        parent_snapshot=foreign_snapshot,
+    )
+    with pytest.raises(ContinualRolloutError, match="unsafe-identity: invalid group id"):
+        control.create_group(ContinualRolloutGroupRequest(**unsafe_group_payload))
+
+    unsafe_child = ContinualRolloutChildRequest(
+        child_id="../unsafe-child",
+        run_id="unsafe-storage-child-run",
+        episode_id="unsafe-storage-child-episode",
+        world_branch_id="unsafe-storage-child-branch",
+    )
+    unsafe_child_payload = base_request.model_dump(mode="python", exclude={"content_sha256"})
+    unsafe_child_payload.update(
+        request_id="unsafe-child-before-origin-request",
+        group_id="unsafe-child-before-origin-group",
+        parent_snapshot=foreign_snapshot,
+        children=(unsafe_child,),
+    )
+    with pytest.raises(ContinualRolloutError, match="unsafe-identity: invalid child id"):
+        control.create_group(ContinualRolloutGroupRequest(**unsafe_child_payload))
+
+    unsafe_child_payload.update(
+        request_id="unsafe-child-no-write-request",
+        group_id="unsafe-child-no-write-group",
+        parent_snapshot=origin.parent_snapshot,
+    )
+    with pytest.raises(ContinualRolloutError, match="unsafe-identity: invalid child id"):
+        control.create_group(ContinualRolloutGroupRequest(**unsafe_child_payload))
+
+    assert _tree_bytes(parent_run) == parent_before
+    assert tuple(rollout_root.iterdir()) == ()
+
+
+def test_shared_control_branches_two_real_ssc03_children_from_one_chosen_checkpoint(
+    tmp_path: Path,
+) -> None:
+    definition = ssc03_hydraulic_continual_world_definition()
+    profile_ref = definition.profile_ref("major_idf_revision", "1")
+    loaded = definition.load_profile(profile_ref)
+    assert isinstance(loaded.value, Ssc03HydraulicContinualProfile)
+    compiled = loaded.value.compile(tmp_path / "package")
+    environment = loaded.value.build_smoke_environment(compiled.package_dir)
+    assert environment is not None
+    parent_run = tmp_path / "parent-run"
+    run_evidence_lifecycle(
+        compiled.package_dir,
+        parent_run,
+        episode_environment=environment,
+    )
+    lifecycle_before = _tree_bytes(parent_run)
+    branch_snapshot = read_evidence_lifecycle_branch_snapshot(
+        compiled.package_dir,
+        parent_run,
+        checkpoint_id="revision_analysis",
+    )
+    assert branch_snapshot.checkpoint_id == "revision_analysis"
+    assert _tree_bytes(parent_run) == lifecycle_before
+    parent_before = (parent_run / "state.json").read_bytes()
+    origin = ssc03_hydraulic_rollout_origin(
+        compiled.package_dir,
+        parent_run,
+        checkpoint_id="revision_analysis",
+    )
+    expected_run_id = f"ssc03-run-{hashlib.sha256(str(parent_run.resolve()).encode('utf-8')).hexdigest()}"
+    assert origin.parent_snapshot.run_id == expected_run_id
+    assert origin.parent_snapshot.episode_id == "ssc03-checkpoint-revision_analysis"
+    request = ContinualRolloutGroupRequest(
+        request_id="request-ssc03-1",
+        group_id="group-ssc03-1",
+        task_world_id=definition.ref.task_world_id,
+        authority_id="host-control",
+        definition_ref=definition.ref,
+        profile_ref=profile_ref,
+        parent_manifest_content_sha256=origin.parent_manifest_content_sha256,
+        parent_snapshot=origin.parent_snapshot,
+        origin_verification_content_sha256=origin.origin_verification_content_sha256,
+        reason="Recheck the submitted response from two isolated continuations.",
+        children=(
+            ContinualRolloutChildRequest(
+                child_id="child-a",
+                run_id="ssc03-child-run-a",
+                episode_id="ssc03-child-episode-a",
+                world_branch_id="ssc03-branch-a",
+            ),
+            ContinualRolloutChildRequest(
+                child_id="child-b",
+                run_id="ssc03-child-run-b",
+                episode_id="ssc03-child-episode-b",
+                world_branch_id="ssc03-branch-b",
+            ),
+        ),
+    )
+    control = ContinualRolloutControl(
+        definition,
+        parent_run_root=parent_run,
+        rollout_repository_root=tmp_path / "rollouts",
+        authorised_principal_ids=("host-control",),
+        package_root=compiled.package_dir,
+    )
+
+    foreign_snapshot_payload = origin.parent_snapshot.model_dump(mode="python", exclude={"content_sha256"})
+    foreign_snapshot_payload["run_id"] = "caller-selected-parent-run"
+    foreign_payload = request.model_dump(mode="python", exclude={"content_sha256"})
+    foreign_payload.update(
+        request_id="request-ssc03-foreign-parent",
+        group_id="group-ssc03-foreign-parent",
+        parent_snapshot=type(origin.parent_snapshot)(**foreign_snapshot_payload),
+    )
+    with pytest.raises(ContinualRolloutError, match="origin-verification"):
+        control.create_group(ContinualRolloutGroupRequest(**foreign_payload))
+    assert not (tmp_path / "rollouts" / "groups" / "group-ssc03-foreign-parent").exists()
+
+    lineage = control.create_group(request)
+    replayed = control.create_group(request)
+
+    assert replayed == lineage
+    assert tuple(child.child_id for child in lineage.children) == ("child-a", "child-b")
+    assert tuple(child.ancestor_world_branch_ids for child in lineage.children) == (("root",), ("root",))
+    assert control.group_status(request.group_id).state is ContinualRolloutGroupState.READY
+    assert control.child_run_ref(request.group_id, "child-a").initial_snapshot.world_branch_id == "ssc03-branch-a"
+    assert (parent_run / "state.json").read_bytes() == parent_before
+
+    for child_id, branch_id in (("child-a", "ssc03-branch-a"), ("child-b", "ssc03-branch-b")):
+        child_run = tmp_path / "rollouts" / "groups" / request.group_id / "children" / child_id / "world"
+        state = read_evidence_lifecycle_state(compiled.package_dir, child_run)
+        assert state["active_checkpoint_id"] == "revision_analysis"
+        assert state["branch"]["branch_id"] == branch_id
+        task_receipt_path = child_run / "rollout-branch-receipt.json"
+        task_receipt_bytes = task_receipt_path.read_bytes()
+        generic_receipt = next(item for item in lineage.children if item.child_id == child_id)
+        assert hashlib.sha256(task_receipt_bytes).hexdigest() == generic_receipt.task_branch_receipt_content_sha256
+        assert stat.S_IMODE(task_receipt_path.stat().st_mode) == 0o600
+        task_receipt = Ssc03HydraulicRolloutBranchReceipt.model_validate_json(task_receipt_bytes)
+        assert tuple(item.checkpoint_id for item in task_receipt.submitted_checkpoint_prefix) == (
+            "baseline_analysis",
+            "revision_analysis",
+        )
+        if child_id == "child-a":
+            foreign_ancestry = task_receipt.model_dump(mode="python", exclude={"content_sha256"})
+            foreign_ancestry["ancestor_world_branch_ids"] = ("foreign-branch",)
+            with pytest.raises(ValidationError, match="rollout branch ancestry is invalid"):
+                Ssc03HydraulicRolloutBranchReceipt(**foreign_ancestry)
+
+    changed_payload = request.model_dump(mode="python", exclude={"content_sha256"})
+    changed_payload["reason"] = "Changed request."
+    with pytest.raises(ContinualRolloutError, match="request-conflict"):
+        control.create_group(ContinualRolloutGroupRequest(**changed_payload))
+
+    stale_spec_payload = definition.spec.model_dump(mode="python", exclude={"content_sha256"})
+    stale_spec_payload["implementation_content_sha256"] = "f" * 64
+    stale_definition = ContinualWorldDefinition(
+        spec=ContinualWorldDefinitionSpec(**stale_spec_payload),
+        profile_loader=definition.profile_loader,
+        branch_port=definition.branch_port,
+    )
+    stale_control = ContinualRolloutControl(
+        stale_definition,
+        parent_run_root=parent_run,
+        rollout_repository_root=tmp_path / "rollouts",
+        authorised_principal_ids=("host-control",),
+        package_root=compiled.package_dir,
+    )
+    with pytest.raises(ContinualRolloutError, match="definition"):
+        stale_control.inspect_group(request.group_id)
+
+    receipt_a_path = tmp_path / "rollouts" / "groups" / request.group_id / "children" / "child-a" / "receipt.json"
+    receipt_b_path = tmp_path / "rollouts" / "groups" / request.group_id / "children" / "child-b" / "receipt.json"
+    receipt_a_bytes = receipt_a_path.read_bytes()
+    receipt_a_path.write_bytes(receipt_b_path.read_bytes())
+    with pytest.raises(ContinualRolloutError, match="child-receipt-integrity"):
+        control.inspect_group(request.group_id)
+    receipt_a_path.write_bytes(receipt_a_bytes)
+    assert control.inspect_group(request.group_id) == lineage
+
+    child_state_path = (
+        tmp_path / "rollouts" / "groups" / request.group_id / "children" / "child-a" / "world" / "state.json"
+    )
+    child_state = json.loads(child_state_path.read_text(encoding="utf-8"))
+    child_state["branch"]["branch_id"] = "tampered-branch"
+    child_state_path.write_text(json.dumps(child_state, indent=2) + "\n", encoding="utf-8")
+    with pytest.raises(ContinualRolloutError, match="child-verification"):
+        control.child_run_ref(request.group_id, "child-a")
+
+    parent_state_path = parent_run / "state.json"
+    parent_state = json.loads(parent_state_path.read_text(encoding="utf-8"))
+    baseline = next(
+        checkpoint
+        for checkpoint in parent_state["checkpoint_runs"]
+        if checkpoint["checkpoint_id"] == "baseline_analysis"
+    )
+    baseline_archive = parent_run / "episodes" / "baseline_analysis" / "submission.json"
+    baseline_workspace = parent_run / "workspace" / baseline["submission_path"]
+    changed_baseline = baseline_archive.read_bytes() + b"\n"
+    baseline_archive.write_bytes(changed_baseline)
+    baseline_workspace.write_bytes(changed_baseline)
+    baseline["submission_sha256"] = hashlib.sha256(changed_baseline).hexdigest()
+    parent_state_path.write_text(json.dumps(parent_state, indent=2) + "\n", encoding="utf-8")
+
+    changed_origin = ssc03_hydraulic_rollout_origin(
+        compiled.package_dir,
+        parent_run,
+        checkpoint_id="revision_analysis",
+    )
+    assert changed_origin.parent_snapshot == origin.parent_snapshot
+    assert changed_origin.origin_verification_content_sha256 != origin.origin_verification_content_sha256
+    with pytest.raises(ContinualRolloutError, match="origin-verification"):
+        control.create_group(request)
+    assert control.inspect_group(request.group_id) == lineage
+    assert control.group_status(request.group_id).state is ContinualRolloutGroupState.READY
+    assert control.child_run_ref(request.group_id, "child-b").world_branch_id == "ssc03-branch-b"
+
+
+def test_nested_ssc03_rollout_keeps_declared_parent_run_identity_and_lineage(
+    tmp_path: Path,
+) -> None:
+    definition = ssc03_hydraulic_continual_world_definition()
+    profile_ref = definition.profile_ref("major_idf_revision", "1")
+    loaded = definition.load_profile(profile_ref)
+    assert isinstance(loaded.value, Ssc03HydraulicContinualProfile)
+    compiled = loaded.value.compile(tmp_path / "package")
+    environment = loaded.value.build_smoke_environment(compiled.package_dir)
+    assert environment is not None
+    parent_run = tmp_path / "parent-run"
+    run_evidence_lifecycle(compiled.package_dir, parent_run, episode_environment=environment)
+    parent_origin = ssc03_hydraulic_rollout_origin(
+        compiled.package_dir,
+        parent_run,
+        checkpoint_id="revision_analysis",
+    )
+    parent_child = ContinualRolloutChildRequest(
+        child_id="nested-parent-child",
+        run_id="declared-nested-parent-run",
+        episode_id="declared-nested-parent-episode",
+        world_branch_id="declared-nested-parent-branch",
+    )
+    parent_request = ContinualRolloutGroupRequest(
+        request_id="nested-parent-request",
+        group_id="nested-parent-group",
+        task_world_id=definition.ref.task_world_id,
+        authority_id="host-control",
+        definition_ref=definition.ref,
+        profile_ref=profile_ref,
+        parent_manifest_content_sha256=parent_origin.parent_manifest_content_sha256,
+        parent_snapshot=parent_origin.parent_snapshot,
+        origin_verification_content_sha256=parent_origin.origin_verification_content_sha256,
+        reason="Create the durable parent for a nested continuation.",
+        children=(parent_child,),
+    )
+    parent_control = ContinualRolloutControl(
+        definition,
+        parent_run_root=parent_run,
+        rollout_repository_root=tmp_path / "parent-rollouts",
+        authorised_principal_ids=("host-control",),
+        package_root=compiled.package_dir,
+    )
+    parent_control.create_group(parent_request)
+    nested_parent_root = (
+        tmp_path / "parent-rollouts" / "groups" / parent_request.group_id / "children" / parent_child.child_id / "world"
+    )
+    submit_evidence_checkpoint(compiled.package_dir, nested_parent_root)
+
+    nested_origin = ssc03_hydraulic_rollout_origin(
+        compiled.package_dir,
+        nested_parent_root,
+        checkpoint_id="revision_analysis",
+    )
+
+    assert nested_origin.parent_snapshot.run_id == parent_child.run_id
+    assert nested_origin.parent_snapshot.world_branch_id == parent_child.world_branch_id
+    nested_child = ContinualRolloutChildRequest(
+        child_id="nested-child",
+        run_id="declared-nested-child-run",
+        episode_id="declared-nested-child-episode",
+        world_branch_id="declared-nested-child-branch",
+    )
+    nested_request = ContinualRolloutGroupRequest(
+        request_id="nested-request",
+        group_id="nested-group",
+        task_world_id=definition.ref.task_world_id,
+        authority_id="host-control",
+        definition_ref=definition.ref,
+        profile_ref=profile_ref,
+        parent_manifest_content_sha256=nested_origin.parent_manifest_content_sha256,
+        parent_snapshot=nested_origin.parent_snapshot,
+        origin_verification_content_sha256=nested_origin.origin_verification_content_sha256,
+        reason="Continue from the declared child run without changing its identity.",
+        children=(nested_child,),
+    )
+    nested_control = ContinualRolloutControl(
+        definition,
+        parent_run_root=nested_parent_root,
+        rollout_repository_root=tmp_path / "nested-rollouts",
+        authorised_principal_ids=("host-control",),
+        package_root=compiled.package_dir,
+    )
+
+    nested_lineage = nested_control.create_group(nested_request)
+
+    assert nested_lineage.parent_snapshot.run_id == parent_child.run_id
+    assert nested_lineage.children[0].ancestor_world_branch_ids == (
+        "root",
+        parent_child.world_branch_id,
+    )
+    nested_receipt_path = (
+        tmp_path
+        / "nested-rollouts"
+        / "groups"
+        / nested_request.group_id
+        / "children"
+        / nested_child.child_id
+        / "world"
+        / "rollout-branch-receipt.json"
+    )
+    nested_receipt = Ssc03HydraulicRolloutBranchReceipt.model_validate_json(nested_receipt_path.read_bytes())
+    assert nested_receipt.parent_snapshot.run_id == parent_child.run_id
+    assert nested_receipt.ancestor_world_branch_ids == ("root", parent_child.world_branch_id)
+
+    parent_receipt_path = nested_parent_root / "rollout-branch-receipt.json"
+    parent_receipt_payload = json.loads(parent_receipt_path.read_text(encoding="utf-8"))
+    parent_receipt_payload["initial_snapshot"]["run_id"] = "tampered-parent-run"
+    parent_receipt_path.write_text(json.dumps(parent_receipt_payload, sort_keys=True), encoding="utf-8")
+    with pytest.raises(ValidationError, match="content_sha256"):
+        ssc03_hydraulic_rollout_origin(
+            compiled.package_dir,
+            nested_parent_root,
+            checkpoint_id="revision_analysis",
+        )
+
+
+def test_shared_control_recovers_real_ssc03_child_created_before_its_receipt(
+    tmp_path: Path,
+) -> None:
+    definition = ssc03_hydraulic_continual_world_definition()
+    profile_ref = definition.profile_ref("major_idf_revision", "1")
+    loaded = definition.load_profile(profile_ref)
+    assert isinstance(loaded.value, Ssc03HydraulicContinualProfile)
+    compiled = loaded.value.compile(tmp_path / "package")
+    environment = loaded.value.build_smoke_environment(compiled.package_dir)
+    assert environment is not None
+    parent_run = tmp_path / "parent-run"
+    run_evidence_lifecycle(compiled.package_dir, parent_run, episode_environment=environment)
+    origin_fields = ssc03_hydraulic_rollout_origin(
+        compiled.package_dir,
+        parent_run,
+        checkpoint_id="revision_analysis",
+    )
+    child = ContinualRolloutChildRequest(
+        child_id="interrupted-child",
+        run_id="ssc03-interrupted-run",
+        episode_id="ssc03-interrupted-episode",
+        world_branch_id="ssc03-interrupted-branch",
+    )
+    request = ContinualRolloutGroupRequest(
+        request_id="interrupted-request",
+        group_id="interrupted-group",
+        task_world_id=definition.ref.task_world_id,
+        authority_id="host-control",
+        definition_ref=definition.ref,
+        profile_ref=profile_ref,
+        parent_manifest_content_sha256=origin_fields.parent_manifest_content_sha256,
+        parent_snapshot=origin_fields.parent_snapshot,
+        origin_verification_content_sha256=origin_fields.origin_verification_content_sha256,
+        reason="Recover an interrupted child publication.",
+        children=(child,),
+    )
+    repository = ContinualRolloutRepository(
+        tmp_path / "rollouts",
+        disjoint_roots=(parent_run, compiled.package_dir),
+    )
+    control = ContinualRolloutControl(
+        definition,
+        parent_run_root=parent_run,
+        rollout_repository_root=tmp_path / "rollouts",
+        authorised_principal_ids=("host-control",),
+        package_root=compiled.package_dir,
+    )
+    assert definition.branch_port is not None
+    verified_origin = definition.branch_port.verify_origin(
+        profile_value=loaded.value,
+        package_root=compiled.package_dir,
+        parent_run_root=parent_run,
+        request=request,
+    )
+    with repository.locked(request.group_id):
+        repository.publish_group_request(request)
+    assert control.group_status(request.group_id).state is ContinualRolloutGroupState.PREPARING
+    with repository.locked(request.group_id):
+        repository.publish_child_request(request.group_id, child)
+    definition.branch_port.materialize_child(
+        profile_value=loaded.value,
+        package_root=compiled.package_dir,
+        parent_run_root=parent_run,
+        child_run_root=repository.child_world_root(request.group_id, child.child_id),
+        request=request,
+        child=child,
+        origin=verified_origin,
+    )
+
+    interrupted_request_path = (
+        repository.root / "groups" / request.group_id / "children" / child.child_id / "request.json"
+    )
+    interrupted_request_bytes = interrupted_request_path.read_bytes()
+    different_child = ContinualRolloutChildRequest(
+        child_id=child.child_id,
+        run_id="different-interrupted-run",
+        episode_id="different-interrupted-episode",
+        world_branch_id="different-interrupted-branch",
+    )
+    interrupted_request_path.write_bytes(
+        json.dumps(
+            different_child.model_dump(mode="json"),
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    )
+    with pytest.raises(ContinualRolloutError, match="child-request-integrity"):
+        control.group_status(request.group_id)
+    interrupted_request_path.write_bytes(interrupted_request_bytes)
+    assert control.group_status(request.group_id).state is ContinualRolloutGroupState.PREPARING
+    with pytest.raises(ContinualRolloutError, match="group-not-ready"):
+        control.child_run_ref(request.group_id, child.child_id)
+
+    lineage = control.create_group(request)
+
+    assert tuple(receipt.child_id for receipt in lineage.children) == ("interrupted-child",)
+    assert control.group_status(request.group_id).state is ContinualRolloutGroupState.READY
+    child_receipt_path = repository.root / "groups" / request.group_id / "children" / child.child_id / "receipt.json"
+    moved_child_receipt_path = child_receipt_path.with_suffix(".missing")
+    child_receipt_path.rename(moved_child_receipt_path)
+    with pytest.raises(ContinualRolloutError, match="child-receipt-integrity"):
+        control.group_status(request.group_id)
+    moved_child_receipt_path.rename(child_receipt_path)
+
+    concurrent_child = ContinualRolloutChildRequest(
+        child_id="concurrent-child",
+        run_id="ssc03-concurrent-run",
+        episode_id="ssc03-concurrent-episode",
+        world_branch_id="ssc03-concurrent-branch",
+    )
+    concurrent_payload = request.model_dump(mode="python", exclude={"content_sha256"})
+    concurrent_payload.update(
+        request_id="concurrent-request",
+        group_id="concurrent-group",
+        reason="Create one exact child through two concurrent retries.",
+        children=(concurrent_child,),
+    )
+    concurrent_request = ContinualRolloutGroupRequest(**concurrent_payload)
+    barrier = Barrier(2)
+
+    def create_concurrently() -> ContinualRolloutLineage:
+        barrier.wait()
+        return control.create_group(concurrent_request)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = tuple(executor.submit(create_concurrently) for _ in range(2))
+        concurrent_lineages = tuple(future.result() for future in futures)
+
+    assert concurrent_lineages[0] == concurrent_lineages[1]
+    assert tuple(receipt.child_id for receipt in concurrent_lineages[0].children) == ("concurrent-child",)
+
+    unsafe_child = ContinualRolloutChildRequest(
+        child_id="unsafe-child",
+        run_id="ssc03-unsafe-run",
+        episode_id="ssc03-unsafe-episode",
+        world_branch_id="ssc03-unsafe-branch",
+    )
+    unsafe_payload = request.model_dump(mode="python", exclude={"content_sha256"})
+    unsafe_payload.update(
+        request_id="unsafe-request",
+        group_id="unsafe-group",
+        reason="Reject a child destination that escapes the rollout repository.",
+        children=(unsafe_child,),
+    )
+    unsafe_request = ContinualRolloutGroupRequest(**unsafe_payload)
+    with repository.locked(unsafe_request.group_id):
+        repository.publish_group_request(unsafe_request)
+        repository.publish_child_request(unsafe_request.group_id, unsafe_child)
+    outside = tmp_path / "outside-child"
+    outside.mkdir()
+    unsafe_world = repository.root / "groups" / unsafe_request.group_id / "children" / unsafe_child.child_id / "world"
+    unsafe_world.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ContinualRolloutError, match="artifact-confinement"):
+        control.create_group(unsafe_request)
+    assert tuple(outside.iterdir()) == ()
+
+
+def test_ssc03_historical_rollout_validates_only_the_selected_submission_prefix(
+    tmp_path: Path,
+) -> None:
+    definition = ssc03_hydraulic_continual_world_definition()
+    profile_ref = definition.profile_ref("major_idf_revision", "1")
+    loaded = definition.load_profile(profile_ref)
+    assert isinstance(loaded.value, Ssc03HydraulicContinualProfile)
+    compiled = loaded.value.compile(tmp_path / "package")
+    environment = loaded.value.build_smoke_environment(compiled.package_dir)
+    assert environment is not None
+    parent_run = tmp_path / "parent-run"
+    run_evidence_lifecycle(compiled.package_dir, parent_run, episode_environment=environment)
+
+    later_archive = parent_run / "episodes" / "closeout_review" / "submission.json"
+    later_archive_bytes = later_archive.read_bytes()
+    later_archive.write_bytes(later_archive_bytes + b"\n")
+
+    with pytest.raises(EvidenceLifecycleError, match="archived checkpoint submission changed: closeout_review"):
+        read_evidence_lifecycle_state(compiled.package_dir, parent_run)
+
+    origin = ssc03_hydraulic_rollout_origin(
+        compiled.package_dir,
+        parent_run,
+        checkpoint_id="revision_analysis",
+    )
+    child = ContinualRolloutChildRequest(
+        child_id="historical-prefix-child",
+        run_id="historical-prefix-child-run",
+        episode_id="historical-prefix-child-episode",
+        world_branch_id="historical-prefix-child-branch",
+    )
+    request = ContinualRolloutGroupRequest(
+        request_id="historical-prefix-request",
+        group_id="historical-prefix-group",
+        task_world_id=definition.ref.task_world_id,
+        authority_id="host-control",
+        definition_ref=definition.ref,
+        profile_ref=profile_ref,
+        parent_manifest_content_sha256=origin.parent_manifest_content_sha256,
+        parent_snapshot=origin.parent_snapshot,
+        origin_verification_content_sha256=origin.origin_verification_content_sha256,
+        reason="Continue from revision analysis without depending on later closeout evidence.",
+        children=(child,),
+    )
+    control = ContinualRolloutControl(
+        definition,
+        parent_run_root=parent_run,
+        rollout_repository_root=tmp_path / "rollouts",
+        authorised_principal_ids=("host-control",),
+        package_root=compiled.package_dir,
+    )
+
+    lineage = control.create_group(request)
+
+    assert lineage.parent_snapshot == origin.parent_snapshot
+    assert lineage.children[0].child_id == child.child_id
+
+    later_archive.write_bytes(later_archive_bytes)
+    selected_archive = parent_run / "episodes" / "revision_analysis" / "submission.json"
+    selected_archive.write_bytes(selected_archive.read_bytes() + b"\n")
+
+    with pytest.raises(EvidenceLifecycleError, match="archived checkpoint submission changed: revision_analysis"):
+        ssc03_hydraulic_rollout_origin(
+            compiled.package_dir,
+            parent_run,
+            checkpoint_id="revision_analysis",
+        )

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_registered_rollout_orchestration.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_registered_rollout_orchestration.py
@@ -1,0 +1,987 @@
+# ABOUTME: Tests registered V4 rollout branches through the existing pump rollout control.
+# ABOUTME: Proves one selected snapshot creates isolated children with complete ancestry.
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from aec_bench.contracts.continual_world import (
+    ContinualRolloutChildRequest,
+    ContinualRolloutGroupRequest,
+    ContinualWorldSnapshotRef,
+)
+from aec_bench.contracts.world_interface import WorldActorActionRequest, WorldInterfaceError
+from aec_bench.contracts.world_session import (
+    StewardshipStateSnapshotRef,
+    WorldSessionExecutionKind,
+    WorldSessionOpenMode,
+    WorldSessionRequest,
+)
+from aec_bench.harness.world_interface import invoke_world_actor, observe_world_actor
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.continual_definition import (
+    pump_station_continual_world_definition,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.coupled_runtime import (
+    project_coupled_actor_view,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.physical_models import (
+    PumpStationCoupledModel,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.rollout_control import (
+    PumpStationRolloutControl,
+    PumpStationRolloutError,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_identity import (
+    canonical_stewardship_value,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_models import (
+    PUMP_STATION_BOUND_CONTROL_VERSION,
+    PUMP_STATION_COUPLED_TREATMENT_VERSION,
+    PumpStationBoundControlRequest,
+    PumpStationCoupledStewardshipState,
+    PumpStationCoupledTreatmentRequest,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.temporal_evidence import (
+    TemporalEvidenceRepository,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_control import (
+    PumpStationRootControlResult,
+    PumpStationWorldControl,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run import (
+    PumpStationWorldRun,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_models import (
+    PumpStationStateSnapshotRef,
+    PumpStationWorldRunError,
+    PumpStationWorldRunManifestV2,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_repository import (
+    PumpStationWorldRunRepository,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_serialization import (
+    pump_station_artifact_id,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_session import (
+    PUMP_STATION_TASK_WORLD_ID,
+    PumpStationWorldSession,
+    PumpStationWorldSessionFactory,
+)
+
+type RegisteredRun = PumpStationWorldRun[
+    PumpStationCoupledModel,
+    PumpStationCoupledStewardshipState,
+]
+
+
+def _shared_snapshot(snapshot: PumpStationStateSnapshotRef) -> StewardshipStateSnapshotRef:
+    return StewardshipStateSnapshotRef(
+        run_id=snapshot.run_id,
+        episode_id=snapshot.episode_id,
+        world_branch_id=snapshot.world_branch_id,
+        sequence=snapshot.sequence,
+        state_id=snapshot.state_id,
+        commit_id=snapshot.commit_id,
+    )
+
+
+def _continual_snapshot(snapshot: PumpStationStateSnapshotRef) -> ContinualWorldSnapshotRef:
+    return ContinualWorldSnapshotRef(
+        run_id=snapshot.run_id,
+        episode_id=snapshot.episode_id,
+        world_branch_id=snapshot.world_branch_id,
+        sequence=snapshot.sequence,
+        state_id=snapshot.state_id,
+        commit_id=snapshot.commit_id,
+    )
+
+
+def _start_registered_parent(root: Path) -> RegisteredRun:
+    return PumpStationWorldRun.create_reference_system(
+        repository=PumpStationWorldRunRepository(root),
+        run_id="registered-rollout-parent",
+        episode_id="registered-rollout-episode",
+        world_branch_id="registered-rollout-parent-branch",
+    )
+
+
+def _open_registered_session(
+    root: Path,
+    run: RegisteredRun,
+    *,
+    session_id: str,
+    agent_tenure_id: str,
+) -> PumpStationWorldSession:
+    manifest = run.manifest
+    assert isinstance(manifest, PumpStationWorldRunManifestV2)
+    return PumpStationWorldSessionFactory(root).open(
+        WorldSessionRequest(
+            execution_kind=WorldSessionExecutionKind.STEWARDSHIP,
+            open_mode=WorldSessionOpenMode.RESUME,
+            session_id=session_id,
+            task_world_id=manifest.task_world_id,
+            agent_tenure_id=agent_tenure_id,
+            run_id=manifest.run_id,
+            episode_id=manifest.episode_id,
+            world_branch_id=manifest.world_branch_id,
+            start_snapshot=_shared_snapshot(run.snapshot()),
+        )
+    )
+
+
+def _group_request(
+    parent: RegisteredRun,
+    *,
+    group_id: str,
+    child_prefix: str,
+) -> ContinualRolloutGroupRequest:
+    manifest = parent.manifest
+    assert isinstance(manifest, PumpStationWorldRunManifestV2)
+    origin = parent.snapshot()
+    definition = pump_station_continual_world_definition()
+    children = tuple(
+        ContinualRolloutChildRequest(
+            child_id=child_id,
+            run_id=f"{child_prefix}-{child_id}-run",
+            episode_id=f"{child_prefix}-{child_id}-episode",
+            world_branch_id=f"{child_prefix}-{child_id}-branch",
+        )
+        for child_id in ("control", "candidate")
+    )
+    return ContinualRolloutGroupRequest(
+        request_id=f"{group_id}-request",
+        group_id=group_id,
+        task_world_id=PUMP_STATION_TASK_WORLD_ID,
+        authority_id="rollout-host",
+        definition_ref=definition.ref,
+        profile_ref=definition.spec.profiles[0],
+        reason="Create isolated registered branches from this verified world position.",
+        parent_snapshot=_continual_snapshot(origin),
+        parent_manifest_content_sha256=pump_station_artifact_id(
+            manifest,
+            record_profile="manifest-v2",
+        ),
+        origin_verification_content_sha256=pump_station_artifact_id(
+            parent.verify_v4(),
+            record_profile="v4",
+        ),
+        children=children,
+    )
+
+
+def _child_session(
+    control: PumpStationRolloutControl,
+    *,
+    group_id: str,
+    child_id: str,
+) -> PumpStationWorldSession:
+    return control.open_actor_session(
+        group_id=group_id,
+        child_id=child_id,
+        session_id=f"{group_id}-{child_id}-session",
+        agent_tenure_id=f"{group_id}-{child_id}-tenure",
+    )
+
+
+def _advance_session(
+    session: PumpStationWorldSession,
+    *,
+    request_id: str,
+    pump_id: str = "pump-a",
+) -> None:
+    invoke_world_actor(
+        session,
+        WorldActorActionRequest(
+            request_id=request_id,
+            action_name="request_condition_check",
+            binding=observe_world_actor(session).binding,
+            arguments={
+                "pump_id": pump_id,
+                "reason": f"Record the visible condition of {pump_id} in this selected branch.",
+            },
+        ),
+    )
+
+
+def _bound_treatment(
+    run: RegisteredRun,
+    *,
+    request_id: str,
+    treatment_label: str,
+) -> PumpStationBoundControlRequest:
+    snapshot = run.snapshot()
+    return PumpStationBoundControlRequest(
+        control_envelope_version=PUMP_STATION_BOUND_CONTROL_VERSION,
+        request_id=request_id,
+        run_id=snapshot.run_id,
+        episode_id=snapshot.episode_id,
+        world_branch_id=snapshot.world_branch_id,
+        base_state_id=snapshot.state_id,
+        base_commit_id=snapshot.commit_id,
+        based_on_sequence=snapshot.sequence,
+        control=PumpStationCoupledTreatmentRequest(
+            version=PUMP_STATION_COUPLED_TREATMENT_VERSION,
+            request_id=request_id,
+            authority_id="rollout-host",
+            treatment_label=treatment_label,
+            affected_pump_ids=("pump-a", "pump-c"),
+            obstruction_delta=Decimal("0.01"),
+            clearance_loss_delta=Decimal("0.005"),
+            base_state_id=snapshot.state_id,
+        ),
+    )
+
+
+def test_registered_rollout_child_treatment_uses_v4_control_and_replays_without_leaking(
+    tmp_path: Path,
+) -> None:
+    parent_root = tmp_path / "parent"
+    parent = _start_registered_parent(parent_root)
+    rollout_control = PumpStationRolloutControl(
+        parent_repository_root=parent_root,
+        rollout_repository_root=tmp_path / "rollouts",
+        authorised_principal_ids=("rollout-host",),
+    )
+    request = _group_request(
+        parent,
+        group_id="registered-treatment-group",
+        child_prefix="registered-treatment",
+    )
+    rollout_control.create_group(request)
+    candidate = _child_session(
+        rollout_control,
+        group_id=request.group_id,
+        child_id="candidate",
+    ).run
+    sibling = _child_session(
+        rollout_control,
+        group_id=request.group_id,
+        child_id="control",
+    ).run
+    candidate_before = candidate.state
+    candidate_snapshot_before = candidate.snapshot()
+    parent_before = parent.snapshot()
+    sibling_before = sibling.snapshot()
+    treatment = _bound_treatment(
+        candidate,
+        request_id="registered-child-treatment-001",
+        treatment_label="private-selected-pump-condition",
+    )
+    assert isinstance(treatment.control, PumpStationCoupledTreatmentRequest)
+    control = PumpStationWorldControl(
+        candidate.repository.root,
+        authorised_principal_ids=("rollout-host",),
+    )
+
+    wrong_authority_treatment = replace(
+        treatment,
+        request_id="registered-child-treatment-wrong-authority",
+        control=replace(
+            treatment.control,
+            request_id="registered-child-treatment-wrong-authority",
+            authority_id="operations-controller",
+        ),
+    )
+    wrong_authority_control = PumpStationWorldControl(
+        candidate.repository.root,
+        authorised_principal_ids=("operations-controller",),
+    )
+    with pytest.raises(WorldInterfaceError, match="control-capability-unavailable"):
+        wrong_authority_control.execute(wrong_authority_treatment)
+    assert candidate.snapshot() == candidate_snapshot_before
+
+    assert "coupled_treatment" in {item.operation for item in control.capabilities("rollout-host").operations}
+    result = control.execute(treatment)
+
+    assert isinstance(result, PumpStationRootControlResult)
+    assert result.receipt.operation == "coupled_treatment"
+    treated = candidate.state
+    before_by_id = {pump.pump_id: pump for pump in candidate_before.physical.pumps}
+    after_by_id = {pump.pump_id: pump for pump in treated.physical.pumps}
+    for pump_id in ("pump-a", "pump-c"):
+        assert after_by_id[pump_id].condition.obstruction == (
+            before_by_id[pump_id].condition.obstruction + Decimal("0.01")
+        )
+        assert after_by_id[pump_id].condition.clearance_loss == (
+            before_by_id[pump_id].condition.clearance_loss + Decimal("0.005")
+        )
+    assert after_by_id["pump-b"] == before_by_id["pump-b"]
+    assert parent.snapshot() == parent_before
+    assert sibling.snapshot() == sibling_before
+    public_view = json.dumps(
+        canonical_stewardship_value(
+            project_coupled_actor_view(treated),
+            record_profile="v4",
+        ),
+        sort_keys=True,
+    )
+    assert treatment.request_id not in public_view
+    assert treatment.control.treatment_label not in public_view
+    verification = candidate.verify_v4()
+    assert verification.valid is True
+    assert verification.replayed_transition_ids[-1] == result.transition_receipt["transition_id"]
+    selected_after = candidate.snapshot()
+
+    assert control.execute(treatment) == result
+    assert candidate.snapshot() == selected_after
+
+    parent_control = PumpStationWorldControl(
+        parent_root,
+        authorised_principal_ids=("rollout-host",),
+    )
+    assert "coupled_treatment" not in {
+        item.operation for item in parent_control.capabilities("rollout-host").operations
+    }
+    with pytest.raises(WorldInterfaceError, match="control-capability-unavailable"):
+        parent_control.execute(
+            _bound_treatment(
+                parent,
+                request_id="root-treatment-must-fail",
+                treatment_label="private-root-condition",
+            )
+        )
+
+
+def test_registered_rollout_group_creates_two_isolated_children_from_one_selected_snapshot(
+    tmp_path: Path,
+) -> None:
+    parent_root = tmp_path / "parent"
+    parent = _start_registered_parent(parent_root)
+    origin = parent.snapshot()
+    control = PumpStationRolloutControl(
+        parent_repository_root=parent_root,
+        rollout_repository_root=tmp_path / "rollouts",
+        authorised_principal_ids=("rollout-host",),
+    )
+    request = _group_request(
+        parent,
+        group_id="registered-rollout-group",
+        child_prefix="registered-rollout",
+    )
+
+    lineage = control.create_group(request)
+
+    assert lineage.request_content_sha256 == request.content_sha256
+    assert lineage.parent_snapshot == _continual_snapshot(origin)
+    assert tuple(child.child_id for child in lineage.children) == (
+        "control",
+        "candidate",
+    )
+    assert parent.snapshot() == origin
+    for receipt, child_request in zip(lineage.children, request.children, strict=True):
+        assert receipt.child_request_content_sha256 == child_request.content_sha256
+        assert receipt.parent_snapshot == _continual_snapshot(origin)
+        assert receipt.initial_snapshot.sequence == origin.sequence
+        assert receipt.initial_snapshot.state_id == origin.state_id
+        assert receipt.ancestor_world_branch_ids == (origin.world_branch_id,)
+
+    control_child = _child_session(
+        control,
+        group_id=request.group_id,
+        child_id="control",
+    )
+    candidate_child = _child_session(
+        control,
+        group_id=request.group_id,
+        child_id="candidate",
+    )
+    control_initial = control_child.run.snapshot()
+    candidate_manifest = candidate_child.run.manifest
+    assert isinstance(candidate_manifest, PumpStationWorldRunManifestV2)
+    assert candidate_manifest.initial_sequence == origin.sequence
+    assert candidate_manifest.initial_state_id == origin.state_id
+    assert candidate_manifest.initial_state_source.parent_run_id == origin.run_id
+    assert candidate_manifest.initial_state_source.parent_branch_id == origin.world_branch_id
+    assert candidate_manifest.initial_state_source.parent_state_id == origin.state_id
+    assert candidate_manifest.initial_state_source.parent_commit_id == origin.commit_id
+    assert candidate_manifest.initial_state_source.ancestor_branch_ids == (origin.world_branch_id,)
+
+    _advance_session(
+        candidate_child,
+        request_id="registered-rollout-candidate-condition-check",
+    )
+
+    assert candidate_child.run.snapshot().sequence == origin.sequence + 1
+    assert control_child.run.snapshot() == control_initial
+    assert parent.snapshot() == origin
+    assert candidate_child.verify().valid is True
+    assert control_child.verify().valid is True
+
+
+def test_two_registered_rollout_groups_start_independently_from_the_same_selected_snapshot(
+    tmp_path: Path,
+) -> None:
+    parent_root = tmp_path / "parent"
+    parent = _start_registered_parent(parent_root)
+    origin = parent.snapshot()
+    control = PumpStationRolloutControl(
+        parent_repository_root=parent_root,
+        rollout_repository_root=tmp_path / "rollouts",
+        authorised_principal_ids=("rollout-host",),
+    )
+    first_request = _group_request(
+        parent,
+        group_id="first-registered-rollout-group",
+        child_prefix="first-registered-rollout",
+    )
+    second_request = _group_request(
+        parent,
+        group_id="second-registered-rollout-group",
+        child_prefix="second-registered-rollout",
+    )
+
+    first = control.create_group(first_request)
+    second = control.create_group(second_request)
+
+    assert first.group_id != second.group_id
+    assert first.parent_snapshot == second.parent_snapshot == _continual_snapshot(origin)
+    assert {child.initial_snapshot.state_id for lineage in (first, second) for child in lineage.children} == {
+        origin.state_id
+    }
+    first_candidate = _child_session(
+        control,
+        group_id=first.group_id,
+        child_id="candidate",
+    )
+    second_candidate = _child_session(
+        control,
+        group_id=second.group_id,
+        child_id="candidate",
+    )
+    second_initial = second_candidate.run.snapshot()
+
+    _advance_session(
+        first_candidate,
+        request_id="first-group-candidate-condition-check",
+    )
+
+    assert first_candidate.run.snapshot().sequence == origin.sequence + 1
+    assert second_candidate.run.snapshot() == second_initial
+    assert parent.snapshot() == origin
+    assert first_candidate.verify().valid is True
+    assert second_candidate.verify().valid is True
+
+
+def test_registered_rollout_uses_an_older_selected_commit_after_the_parent_advances(
+    tmp_path: Path,
+) -> None:
+    parent_root = tmp_path / "parent"
+    parent = _start_registered_parent(parent_root)
+    origin = parent.snapshot()
+    control = PumpStationRolloutControl(
+        parent_repository_root=parent_root,
+        rollout_repository_root=tmp_path / "rollouts",
+        authorised_principal_ids=("rollout-host",),
+    )
+    request = _group_request(
+        parent,
+        group_id="historical-origin-rollout-group",
+        child_prefix="historical-origin-rollout",
+    )
+    parent_session = _open_registered_session(
+        parent_root,
+        parent,
+        session_id="historical-origin-parent-session",
+        agent_tenure_id="historical-origin-parent-tenure",
+    )
+    _advance_session(
+        parent_session,
+        request_id="parent-condition-check-after-origin",
+    )
+    selected_after_first_action = parent.snapshot()
+    assert selected_after_first_action.sequence == origin.sequence + 1
+
+    lineage = control.create_group(request)
+
+    assert lineage.parent_snapshot == _continual_snapshot(origin)
+    assert all(
+        (
+            child.initial_snapshot.sequence,
+            child.initial_snapshot.state_id,
+        )
+        == (origin.sequence, origin.state_id)
+        for child in lineage.children
+    )
+    child_snapshots = {
+        child.child_id: _child_session(
+            control,
+            group_id=lineage.group_id,
+            child_id=child.child_id,
+        ).run.snapshot()
+        for child in lineage.children
+    }
+
+    _advance_session(
+        parent_session,
+        request_id="parent-second-condition-check-after-origin",
+        pump_id="pump-b",
+    )
+    selected_after_second_action = parent.snapshot()
+    repeated = control.create_group(request)
+
+    assert repeated == lineage
+    assert selected_after_second_action.sequence == origin.sequence + 2
+    assert parent.snapshot() == selected_after_second_action
+    assert {
+        child_id: _child_session(
+            control,
+            group_id=lineage.group_id,
+            child_id=child_id,
+        ).run.snapshot()
+        for child_id in child_snapshots
+    } == child_snapshots
+    assert parent.verify_v4().valid is True
+
+
+def test_registered_rollout_prefix_ignores_later_private_session_corruption(
+    tmp_path: Path,
+) -> None:
+    parent_root = tmp_path / "parent"
+    parent = _start_registered_parent(parent_root)
+    source = _open_registered_session(
+        parent_root,
+        parent,
+        session_id="historical-private-source-session",
+        agent_tenure_id="historical-private-source-tenure",
+    )
+    invoke_world_actor(
+        source,
+        WorldActorActionRequest(
+            request_id="historical-private-search",
+            action_name="search_evidence",
+            binding=observe_world_actor(source).binding,
+            arguments={
+                "query": "controlled test permit",
+                "scope": "operations",
+                "limit": 1,
+            },
+        ),
+    )
+    _advance_session(
+        source,
+        request_id="historical-private-source-condition-check",
+    )
+    origin = parent.snapshot()
+    origin_report = parent.verify_v4(origin)
+    control = PumpStationRolloutControl(
+        parent_repository_root=parent_root,
+        rollout_repository_root=tmp_path / "rollouts",
+        authorised_principal_ids=("rollout-host",),
+    )
+    request = _group_request(
+        parent,
+        group_id="historical-private-corruption-group",
+        child_prefix="historical-private-corruption",
+    )
+    carrier = source.create_retrieval_handover(
+        to_tenure_id="historical-private-recipient-tenure",
+        to_session_id="historical-private-recipient-session",
+        include_fetched_content=True,
+    )
+    recipient = _open_registered_session(
+        parent_root,
+        parent,
+        session_id="historical-private-recipient-session",
+        agent_tenure_id="historical-private-recipient-tenure",
+    )
+    handover = recipient.create_structured_handover(
+        maximum_history_entries=8,
+    )
+    recipient.install_structured_handover(handover)
+    recipient.install_retrieval_handover(carrier)
+    _advance_session(
+        recipient,
+        request_id="historical-private-recipient-condition-check",
+    )
+    receipt_paths = tuple((parent_root / "temporal-evidence" / "private" / "handover-install-receipts").glob("*.json"))
+    assert len(receipt_paths) == 1
+    receipt_content = json.loads(receipt_paths[0].read_text(encoding="utf-8"))
+    receipt_content["next_state_id"] = "corrupted-later-private-state"
+    receipt_paths[0].write_text(
+        json.dumps(receipt_content),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(PumpStationWorldRunError, match="temporal-evidence"):
+        PumpStationWorldRun.resume_reference_system(
+            repository=PumpStationWorldRunRepository(parent_root),
+            snapshot=parent.snapshot(),
+        )
+    current_report = parent.verify_v4()
+
+    assert current_report.valid is False
+    assert any(issue.startswith("temporal-evidence-invalid:") for issue in current_report.issues)
+    assert parent.verify_v4(origin) == origin_report
+    lineage = control.create_group(request)
+    assert lineage.parent_snapshot == _continual_snapshot(origin)
+    selected_receipts = tuple((parent_root / "temporal-evidence" / "private" / "receipts").glob("*.json"))
+    assert len(selected_receipts) == 1
+    selected_receipts[0].unlink()
+    assert parent.verify_v4(origin).valid is False
+
+
+@pytest.mark.parametrize(
+    ("receipt_directory", "corrupted_field"),
+    (
+        ("handover-receipts", "source_state_id"),
+        ("handover-install-receipts", "next_state_id"),
+    ),
+)
+def test_registered_rollout_prefix_verifies_its_selected_retrieval_handover_receipts(
+    tmp_path: Path,
+    receipt_directory: str,
+    corrupted_field: str,
+) -> None:
+    parent_root = tmp_path / "parent"
+    parent = _start_registered_parent(parent_root)
+    source = _open_registered_session(
+        parent_root,
+        parent,
+        session_id="selected-handover-source-session",
+        agent_tenure_id="selected-handover-source-tenure",
+    )
+    invoke_world_actor(
+        source,
+        WorldActorActionRequest(
+            request_id="selected-handover-search",
+            action_name="search_evidence",
+            binding=observe_world_actor(source).binding,
+            arguments={
+                "query": "controlled test permit",
+                "scope": "operations",
+                "limit": 1,
+            },
+        ),
+    )
+    _advance_session(
+        source,
+        request_id="selected-handover-source-condition-check",
+    )
+    carrier = source.create_retrieval_handover(
+        to_tenure_id="selected-handover-recipient-tenure",
+        to_session_id="selected-handover-recipient-session",
+        include_fetched_content=True,
+    )
+    recipient = _open_registered_session(
+        parent_root,
+        parent,
+        session_id="selected-handover-recipient-session",
+        agent_tenure_id="selected-handover-recipient-tenure",
+    )
+    handover = recipient.create_structured_handover(maximum_history_entries=8)
+    recipient.install_structured_handover(handover)
+    recipient.install_retrieval_handover(carrier)
+    _advance_session(
+        recipient,
+        request_id="selected-handover-recipient-condition-check",
+    )
+    origin = parent.snapshot()
+    request = _group_request(
+        parent,
+        group_id=f"selected-{receipt_directory}-group",
+        child_prefix=f"selected-{receipt_directory}",
+    )
+    receipt_paths = tuple((parent_root / "temporal-evidence" / "private" / receipt_directory).glob("*.json"))
+    assert len(receipt_paths) == 1
+    receipt_content = json.loads(receipt_paths[0].read_text(encoding="utf-8"))
+    receipt_content[corrupted_field] = "corrupted-selected-handover-value"
+    receipt_paths[0].write_text(json.dumps(receipt_content), encoding="utf-8")
+
+    report = parent.verify_v4(origin)
+
+    assert report.valid is False
+    assert any(issue.startswith("temporal-evidence-invalid:") for issue in report.issues)
+    control = PumpStationRolloutControl(
+        parent_repository_root=parent_root,
+        rollout_repository_root=tmp_path / "rollouts",
+        authorised_principal_ids=("rollout-host",),
+    )
+    with pytest.raises((PumpStationRolloutError, PumpStationWorldRunError, ValueError)):
+        control.create_group(request)
+
+
+def test_nested_registered_rollout_records_the_complete_ordered_branch_ancestry(
+    tmp_path: Path,
+) -> None:
+    parent_root = tmp_path / "parent"
+    parent = _start_registered_parent(parent_root)
+    parent_control = PumpStationRolloutControl(
+        parent_repository_root=parent_root,
+        rollout_repository_root=tmp_path / "parent-rollouts",
+        authorised_principal_ids=("rollout-host",),
+    )
+    parent_request = _group_request(
+        parent,
+        group_id="parent-rollout-group",
+        child_prefix="parent-rollout",
+    )
+    parent_lineage = parent_control.create_group(parent_request)
+    candidate = _child_session(
+        parent_control,
+        group_id=parent_lineage.group_id,
+        child_id="candidate",
+    )
+    sibling = _child_session(
+        parent_control,
+        group_id=parent_lineage.group_id,
+        child_id="control",
+    )
+    _advance_session(
+        candidate,
+        request_id="candidate-condition-check-before-nested-rollout",
+    )
+    candidate_origin = candidate.run.snapshot()
+    sibling_before = sibling.run.snapshot()
+    parent_before = parent.snapshot()
+    candidate_root = candidate.run.repository.root
+    nested_control = PumpStationRolloutControl(
+        parent_repository_root=candidate_root,
+        rollout_repository_root=tmp_path / "nested-rollouts",
+        authorised_principal_ids=("rollout-host",),
+    )
+    nested_request = _group_request(
+        candidate.run,
+        group_id="nested-rollout-group",
+        child_prefix="nested-rollout",
+    )
+
+    nested_lineage = nested_control.create_group(nested_request)
+    nested_child = _child_session(
+        nested_control,
+        group_id=nested_lineage.group_id,
+        child_id="candidate",
+    )
+    nested_manifest = nested_child.run.manifest
+    assert isinstance(nested_manifest, PumpStationWorldRunManifestV2)
+    expected_ancestors = (
+        parent_before.world_branch_id,
+        candidate_origin.world_branch_id,
+    )
+
+    assert nested_lineage.parent_snapshot == _continual_snapshot(candidate_origin)
+    assert all(receipt.ancestor_world_branch_ids == expected_ancestors for receipt in nested_lineage.children)
+    assert nested_manifest.initial_state_source.ancestor_branch_ids == expected_ancestors
+    assert nested_manifest.initial_state_source.parent_commit_id == candidate_origin.commit_id
+    assert nested_child.run.snapshot().state_id == candidate_origin.state_id
+    assert candidate.run.snapshot() == candidate_origin
+    assert sibling.run.snapshot() == sibling_before
+    assert parent.snapshot() == parent_before
+    assert nested_child.verify().valid is True
+
+
+@pytest.mark.parametrize("origin_kind", ("foreign", "tampered"))
+def test_registered_rollout_rejects_foreign_or_tampered_origin_before_group_publication(
+    tmp_path: Path,
+    origin_kind: str,
+) -> None:
+    parent_root = tmp_path / "parent"
+    rollout_root = tmp_path / "rollouts"
+    parent = _start_registered_parent(parent_root)
+    control = PumpStationRolloutControl(
+        parent_repository_root=parent_root,
+        rollout_repository_root=rollout_root,
+        authorised_principal_ids=("rollout-host",),
+    )
+    request = _group_request(
+        parent,
+        group_id=f"{origin_kind}-origin-rollout-group",
+        child_prefix=f"{origin_kind}-origin-rollout",
+    )
+    if origin_kind == "foreign":
+        foreign = PumpStationWorldRun.create_reference_system(
+            repository=PumpStationWorldRunRepository(tmp_path / "foreign-parent"),
+            run_id="foreign-registered-rollout-parent",
+            episode_id="foreign-registered-rollout-episode",
+            world_branch_id="foreign-registered-rollout-branch",
+        )
+        parent_payload = request.parent_snapshot.model_dump(
+            mode="python",
+            exclude={"content_sha256"},
+        )
+        parent_payload["commit_id"] = foreign.snapshot().commit_id
+        request_payload = request.model_dump(
+            mode="python",
+            exclude={"content_sha256"},
+        )
+        request_payload["parent_snapshot"] = ContinualWorldSnapshotRef.model_validate(
+            parent_payload,
+        )
+        request = ContinualRolloutGroupRequest.model_validate(
+            request_payload,
+        )
+    else:
+        commit_path = parent_root / "commits" / f"{request.parent_snapshot.commit_id}.json"
+        commit_path.write_bytes(commit_path.read_bytes() + b" ")
+
+    with pytest.raises((PumpStationRolloutError, PumpStationWorldRunError)):
+        control.create_group(request)
+
+    assert not (rollout_root / "groups" / request.group_id).exists()
+
+
+def test_registered_rollout_inherits_public_temporal_corpus_without_parent_private_authority(
+    tmp_path: Path,
+) -> None:
+    parent_root = tmp_path / "parent"
+    rollout_root = tmp_path / "rollouts"
+    parent = _start_registered_parent(parent_root)
+    parent_session = _open_registered_session(
+        parent_root,
+        parent,
+        session_id="parent-private-session",
+        agent_tenure_id="parent-private-tenure",
+    )
+    invoke_world_actor(
+        parent_session,
+        WorldActorActionRequest(
+            request_id="parent-private-temporal-search",
+            action_name="search_evidence",
+            binding=observe_world_actor(parent_session).binding,
+            arguments={
+                "query": "controlled test permit",
+                "scope": "operations",
+                "limit": 1,
+            },
+        ),
+    )
+    parent_binding = parent.repository.load_selected_session_activation()
+    parent_bundle = TemporalEvidenceRepository(parent_root / "temporal-evidence").load_bundle(package=parent.package)
+    assert (parent_root / "temporal-evidence" / "private").is_dir()
+    assert (parent_root / "session-authority").is_dir()
+    control = PumpStationRolloutControl(
+        parent_repository_root=parent_root,
+        rollout_repository_root=rollout_root,
+        authorised_principal_ids=("rollout-host",),
+    )
+    request = _group_request(
+        parent,
+        group_id="temporal-inheritance-rollout-group",
+        child_prefix="temporal-inheritance-rollout",
+    )
+
+    lineage = control.create_group(request)
+    candidate_root = rollout_root / "groups" / lineage.group_id / "children" / "candidate" / "world"
+
+    child_bundle = TemporalEvidenceRepository(candidate_root / "temporal-evidence").load_bundle(package=parent.package)
+    assert child_bundle == parent_bundle
+    assert not (candidate_root / "temporal-evidence" / "private").exists()
+    assert not (candidate_root / "session-authority").exists()
+
+    child = _child_session(
+        control,
+        group_id=lineage.group_id,
+        child_id="candidate",
+    )
+    child_binding = child.run.repository.load_selected_session_activation()
+
+    assert child_binding.binding_id != parent_binding.binding_id
+    assert child_binding.run_id == child.run.manifest.run_id
+    assert child_binding.world_branch_id == child.run.manifest.world_branch_id
+    assert child_binding.prior_binding_id is None
+    assert child_binding.session_event_sequence == 0
+    assert parent.repository.load_selected_session_activation() == parent_binding
+
+
+def test_registered_rollout_rejects_changed_request_for_an_existing_group_id(
+    tmp_path: Path,
+) -> None:
+    parent_root = tmp_path / "parent"
+    parent = _start_registered_parent(parent_root)
+    control = PumpStationRolloutControl(
+        parent_repository_root=parent_root,
+        rollout_repository_root=tmp_path / "rollouts",
+        authorised_principal_ids=("rollout-host",),
+    )
+    request = _group_request(
+        parent,
+        group_id="request-conflict-rollout-group",
+        child_prefix="request-conflict-rollout",
+    )
+    lineage = control.create_group(request)
+    changed_payload = request.model_dump(
+        mode="python",
+        exclude={"content_sha256"},
+    )
+    changed_payload["reason"] = "Use changed branch intent under the existing rollout group identity."
+    changed = ContinualRolloutGroupRequest.model_validate(
+        changed_payload,
+    )
+
+    with pytest.raises(PumpStationRolloutError) as raised:
+        control.create_group(changed)
+
+    assert raised.value.code == "request-id-conflict"
+    assert control.inspect_group(request.group_id) == lineage
+
+
+@pytest.mark.parametrize(
+    "field_name",
+    ("child_id", "run_id", "episode_id", "world_branch_id"),
+)
+def test_registered_rollout_rejects_changed_child_identity_for_an_existing_group_id(
+    tmp_path: Path,
+    field_name: str,
+) -> None:
+    parent_root = tmp_path / "parent"
+    parent = _start_registered_parent(parent_root)
+    control = PumpStationRolloutControl(
+        parent_repository_root=parent_root,
+        rollout_repository_root=tmp_path / "rollouts",
+        authorised_principal_ids=("rollout-host",),
+    )
+    request = _group_request(
+        parent,
+        group_id=f"changed-{field_name}-rollout-group",
+        child_prefix=f"changed-{field_name}-rollout",
+    )
+    lineage = control.create_group(request)
+    changed_child_payload = request.children[0].model_dump(
+        mode="python",
+        exclude={"content_sha256"},
+    )
+    changed_child_payload[field_name] = f"changed-{field_name}"
+    changed_child = ContinualRolloutChildRequest.model_validate(
+        changed_child_payload,
+    )
+    changed_children = (changed_child, *request.children[1:])
+    changed_payload = request.model_dump(
+        mode="python",
+        exclude={"content_sha256"},
+    )
+    changed_payload["children"] = changed_children
+    changed = ContinualRolloutGroupRequest.model_validate(
+        changed_payload,
+    )
+
+    with pytest.raises(PumpStationRolloutError) as raised:
+        control.create_group(changed)
+
+    assert raised.value.code == "request-id-conflict"
+    assert control.inspect_group(request.group_id) == lineage
+
+
+def test_registered_rollout_rejects_single_child_creation(
+    tmp_path: Path,
+) -> None:
+    parent_root = tmp_path / "parent"
+    parent = _start_registered_parent(parent_root)
+    control = PumpStationRolloutControl(
+        parent_repository_root=parent_root,
+        rollout_repository_root=tmp_path / "rollouts",
+        authorised_principal_ids=("rollout-host",),
+    )
+    request = _group_request(
+        parent,
+        group_id="single-child-operation-rollout-group",
+        child_prefix="single-child-operation-rollout",
+    )
+
+    with pytest.raises(PumpStationRolloutError) as raised:
+        control.create_child(request, "control")
+
+    assert raised.value.code == "rollout-operation"

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_rollout_transport_boundaries.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_rollout_transport_boundaries.py
@@ -1,0 +1,285 @@
+# ABOUTME: Tests strict version and filesystem boundaries around pump rollout control transports.
+# ABOUTME: Proves the installed V1 API cannot operate on registered child worlds.
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from aec_bench.contracts.continual_world import (
+    ContinualRolloutChildRequest,
+    ContinualRolloutGroupRequest,
+    ContinualRolloutLineage,
+    ContinualWorldSnapshotRef,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.continual_definition import (
+    pump_station_continual_world_definition,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.physical_treatments import (
+    PUMP_STATION_PHYSICAL_TREATMENT_DECISION_RIGHT,
+    PUMP_STATION_PHYSICAL_TREATMENT_VERSION,
+    PUMP_STATION_PHYSICAL_TREATMENT_VISIBILITY,
+    PumpStationPhysicalTreatmentClass,
+    PumpStationPhysicalTreatmentRequest,
+    PumpStationTreatmentSeverity,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.rollout_control import (
+    PumpStationRolloutControl,
+    PumpStationRolloutError,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.rollout_interface import (
+    PumpStationRolloutControlRequest,
+    execute_pump_station_rollout_request,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.rollout_models import (
+    PUMP_STATION_TREATMENT_RECEIPT_VERSION,
+    PumpStationPhysicalTreatmentScheduleReceipt,
+    PumpStationRolloutTreatmentStatus,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.rollout_repository import (
+    PumpStationRolloutRepository,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run import (
+    PumpStationWorldRun,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_models import (
+    PumpStationWorldRunManifestV2,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_repository import (
+    PumpStationWorldRunRepository,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_serialization import (
+    pump_station_artifact_id,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_session import (
+    PUMP_STATION_TASK_WORLD_ID,
+)
+
+
+def _created_registered_group(
+    tmp_path: Path,
+) -> tuple[
+    PumpStationRolloutControl,
+    Path,
+    ContinualRolloutGroupRequest,
+    ContinualRolloutLineage,
+]:
+    parent_root = tmp_path / "parent"
+    rollout_root = tmp_path / "rollouts"
+    parent = PumpStationWorldRun.create_reference_system(
+        repository=PumpStationWorldRunRepository(parent_root),
+        run_id="transport-boundary-parent",
+        episode_id="transport-boundary-episode",
+        world_branch_id="transport-boundary-parent-branch",
+    )
+    manifest = parent.manifest
+    assert isinstance(manifest, PumpStationWorldRunManifestV2)
+    definition = pump_station_continual_world_definition()
+    children = tuple(
+        ContinualRolloutChildRequest(
+            child_id=child_id,
+            run_id=f"transport-boundary-{child_id}-run",
+            episode_id=f"transport-boundary-{child_id}-episode",
+            world_branch_id=f"transport-boundary-{child_id}-branch",
+        )
+        for child_id in ("control", "candidate")
+    )
+    parent_snapshot = parent.snapshot()
+    request = ContinualRolloutGroupRequest(
+        request_id="transport-boundary-group-request",
+        group_id="transport-boundary-group",
+        task_world_id=PUMP_STATION_TASK_WORLD_ID,
+        authority_id="rollout-host",
+        definition_ref=definition.ref,
+        profile_ref=definition.spec.profiles[0],
+        parent_snapshot=ContinualWorldSnapshotRef(
+            run_id=parent_snapshot.run_id,
+            episode_id=parent_snapshot.episode_id,
+            world_branch_id=parent_snapshot.world_branch_id,
+            sequence=parent_snapshot.sequence,
+            state_id=parent_snapshot.state_id,
+            commit_id=parent_snapshot.commit_id,
+        ),
+        parent_manifest_content_sha256=pump_station_artifact_id(
+            manifest,
+            record_profile="manifest-v2",
+        ),
+        origin_verification_content_sha256=pump_station_artifact_id(
+            parent.verify_v4(),
+            record_profile="v4",
+        ),
+        children=children,
+        reason="Test the strict transport boundary around one registered rollout group.",
+    )
+    control = PumpStationRolloutControl(
+        parent_repository_root=parent_root,
+        rollout_repository_root=rollout_root,
+        authorised_principal_ids=("rollout-host",),
+    )
+    lineage = control.create_group(request)
+    assert isinstance(lineage, ContinualRolloutLineage)
+    return control, rollout_root, request, lineage
+
+
+def _legacy_treatment_request(
+    lineage: ContinualRolloutLineage,
+    *,
+    request_id: str,
+) -> PumpStationPhysicalTreatmentRequest:
+    child = next(item for item in lineage.children if item.child_id == "candidate")
+    return PumpStationPhysicalTreatmentRequest(
+        request_id=request_id,
+        task_world_id=PUMP_STATION_TASK_WORLD_ID,
+        authority_id="rollout-host",
+        group_id=lineage.group_id,
+        child_id=child.child_id,
+        child_run_id=child.initial_snapshot.run_id,
+        child_episode_id=child.initial_snapshot.episode_id,
+        child_world_branch_id=child.initial_snapshot.world_branch_id,
+        base_state_id=child.initial_snapshot.state_id,
+        base_commit_id=child.initial_snapshot.commit_id,
+        based_on_sequence=child.initial_snapshot.sequence,
+        parent_state_id=lineage.parent_snapshot.state_id,
+        treatment_class=PumpStationPhysicalTreatmentClass.RECURRENT_OBSTRUCTION,
+        treatment_version=PUMP_STATION_PHYSICAL_TREATMENT_VERSION,
+        affected_pump_ids=("pump-a",),
+        activation_calendar_seconds=0,
+        severity=PumpStationTreatmentSeverity.MODERATE,
+        random_stream_id="transport-boundary-treatment-stream",
+        random_seed=37,
+        visibility_policy=PUMP_STATION_PHYSICAL_TREATMENT_VISIBILITY,
+        decision_right_id=PUMP_STATION_PHYSICAL_TREATMENT_DECISION_RIGHT,
+    )
+
+
+@pytest.mark.parametrize("operation", ("inspect_rollout_group", "open_rollout_actor_session"))
+def test_installed_v1_transport_rejects_a_registered_group(
+    tmp_path: Path,
+    operation: str,
+) -> None:
+    control, _, request, _ = _created_registered_group(tmp_path)
+    payload = {
+        "request_id": f"v1-{operation}-v2-group",
+        "operation": operation,
+        "task_world_id": PUMP_STATION_TASK_WORLD_ID,
+        "authority_id": "rollout-host",
+        "group_id": request.group_id,
+    }
+    if operation == "open_rollout_actor_session":
+        payload.update(
+            child_id="candidate",
+            session_id="v1-transport-v2-child-session",
+            agent_tenure_id="v1-transport-v2-child-tenure",
+        )
+    installed_request = PumpStationRolloutControlRequest.model_validate(payload)
+
+    with pytest.raises(PumpStationRolloutError) as raised:
+        execute_pump_station_rollout_request(control, installed_request)
+
+    assert raised.value.code == "rollout-version"
+
+
+def test_legacy_treatment_controls_reject_a_registered_group_without_legacy_world(
+    tmp_path: Path,
+) -> None:
+    control, rollout_root, _, lineage = _created_registered_group(tmp_path)
+    request = _legacy_treatment_request(
+        lineage,
+        request_id="legacy-schedule-on-v2-child",
+    )
+    legacy_world_root = rollout_root / "groups" / lineage.group_id / "children" / request.child_id / "world-run"
+    assert not legacy_world_root.exists()
+
+    with pytest.raises(PumpStationRolloutError) as schedule_error:
+        control.schedule_treatment(request)
+
+    assert schedule_error.value.code == "rollout-operation"
+    assert not legacy_world_root.exists()
+
+    recovery_request = replace(
+        request,
+        request_id="legacy-recovery-on-v2-child",
+    )
+    PumpStationRolloutRepository(rollout_root).publish_treatment_schedule(
+        PumpStationPhysicalTreatmentScheduleReceipt(
+            receipt_version=PUMP_STATION_TREATMENT_RECEIPT_VERSION,
+            request=recovery_request,
+            request_content_sha256=pump_station_artifact_id(recovery_request),
+            status=PumpStationRolloutTreatmentStatus.SCHEDULED,
+            affected_pump_ids=recovery_request.affected_pump_ids,
+            unaffected_pump_ids=("pump-b",),
+        )
+    )
+
+    with pytest.raises(PumpStationRolloutError) as recovery_error:
+        control.recover_treatment(
+            group_id=recovery_request.group_id,
+            child_id=recovery_request.child_id,
+            treatment_request_id=recovery_request.request_id,
+        )
+
+    assert recovery_error.value.code == "rollout-operation"
+    assert not legacy_world_root.exists()
+
+
+def test_registered_child_symlink_blocks_open_but_not_durable_lineage_inspection(
+    tmp_path: Path,
+) -> None:
+    control, rollout_root, request, lineage = _created_registered_group(tmp_path)
+    child = next(item for item in lineage.children if item.child_id == "candidate")
+    child_root = rollout_root / "groups" / request.group_id / "children" / child.child_id
+    world_root = child_root / "world"
+    relocated_world_root = child_root / "relocated-world"
+    world_root.rename(relocated_world_root)
+    world_root.symlink_to(relocated_world_root.name, target_is_directory=True)
+    assert world_root.is_symlink()
+    assert control.inspect_group(request.group_id) == lineage
+
+    with pytest.raises(PumpStationRolloutError) as raised:
+        control.open_actor_session(
+            group_id=request.group_id,
+            child_id=child.child_id,
+            session_id="symlinked-child-session",
+            agent_tenure_id="symlinked-child-tenure",
+        )
+
+    assert raised.value.code == "artifact-confinement"
+
+
+def test_registered_actor_open_rejects_a_tampered_task_branch_receipt(
+    tmp_path: Path,
+) -> None:
+    control, rollout_root, request, lineage = _created_registered_group(tmp_path)
+    child = next(item for item in lineage.children if item.child_id == "candidate")
+    receipt_path = (
+        rollout_root
+        / "groups"
+        / request.group_id
+        / "children"
+        / child.child_id
+        / "world"
+        / "rollout-branch-receipt.json"
+    )
+    payload = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert payload["shared_group_request_content_sha256"] == request.content_sha256
+    assert payload["shared_child_request_content_sha256"] == child.child_request_content_sha256
+    assert "group_request_content_id" not in payload
+    assert "child_request_content_id" not in payload
+    payload["parent_origin_remaining_schedule_sha256"] = "0" * 64
+    receipt_path.write_text(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(PumpStationRolloutError) as raised:
+        control.open_actor_session(
+            group_id=request.group_id,
+            child_id=child.child_id,
+            session_id="tampered-task-receipt-session",
+            agent_tenure_id="tampered-task-receipt-tenure",
+        )
+
+    assert raised.value.code == "child-verification"


### PR DESCRIPTION
## Summary

- add one task-neutral continual rollout coordinator with durable group, child, receipt, and lineage records
- use the common request and lineage directly from the pump path, with real pump and SSC-03 branch adapters
- support repeated rollouts from a chosen immutable point, nested ancestry, exact retry, partial recovery, and child isolation
- preserve the installed pump V1 transport and keep actor execution outside rollout control
- verify historical pump and SSC prefixes without allowing later private or checkpoint data to change an earlier origin
- add a hard footprint gate before CLI and Harbor transport work

## Focused validation

- 50 rollout, transport, temporal, and session tests passed
- Ruff format and lint passed on all changed Python files
- strict mypy passed on 27 changed source files
- staged whitespace validation passed

## Footprint note

Step 7 adds 3,136 net production lines. The full ASW-8 branch is 21,075 net production lines over main. Step 8 is now a hard stop: remove the parallel coupled paths and reduce net production growth to at most 16,500 lines before transport work starts.

PR74 remains draft and must not merge to main from this correction PR.