### PR TITLE
Add repository agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,301 @@
+# ABOUTME: Repository-wide guidance for coding agents working on AEC-Bench.
+# ABOUTME: Protects benchmark validity while keeping implementation changes direct, simple, and replaceable.
+
+# AEC-Bench Agent Guide
+
+## Project purpose and status
+
+AEC-Bench is a Python platform for creating, running, and evaluating Architecture, Engineering, and Construction benchmark tasks for AI agents.
+
+- The project is pre-1.0 and is being actively simplified.
+- Python support starts at 3.13; the repository currently pins Python 3.13.2.
+- The main CLI entry point is `aec-bench`, implemented by `aec_bench.cli.main:run`.
+- The optional Web UI uses FastAPI and a Svelte/Vite frontend.
+- The benchmark objective order is:
+  `validity > reproducibility > coverage > cost > throughput`.
+- When those objectives are equal, prefer the simpler final system.
+
+Do not preserve obsolete code, package structure, or documentation only because it already exists. The task is to leave the current system coherent, not to preserve its full history.
+
+## Start with the relevant authority
+
+Read the implementation and tests for the area you will change. Then read only the documents that govern that change:
+
+- `docs/INVARIANTS.md`: non-negotiable benchmark-validity and reproducibility rules.
+- `docs/CONTRACTS.md`: logical data contracts at real domain boundaries.
+- `docs/ARCHITECTURE.md`: domain ownership and dependency direction.
+- `README.md`: documented public commands, installation, and user-visible behaviour.
+- `pyproject.toml`: Python dependencies, build configuration, and tool settings.
+- `docs/PROJECT_STRUCTURE.md`: navigation and design context, not a requirement to preserve obsolete packages or paths.
+- Planning, work-item, research, and draft documents: context only unless the task explicitly selects them as requirements.
+
+Use this order when sources disagree:
+
+1. The current task and its accepted behaviour.
+2. Applicable invariants and boundary contracts.
+3. Explicit documented public behaviour and supported persisted formats.
+4. Current implementation and tests as evidence of existing behaviour.
+5. Planning documents and historical structure descriptions.
+
+Do not resolve a conflict by supporting both old and new behaviour. Identify the intended authority, implement one path, and update the other sources in the same change. An old test is evidence, not an automatic compatibility promise.
+
+## Repository map
+
+- `src/aec_bench/`: production Python package.
+- `tests/`: Python regression, integration, boundary, and public-surface tests.
+- `tasks/`: benchmark tasks and task-owned assets.
+- `seeds/`: expert-authored task seeds.
+- `agents/`: ready-to-use Harbor agent implementations.
+- `docs/`: repository-owned architecture, contracts, invariants, and project guidance.
+- `scripts/`: local maintenance and workflow scripts.
+- `src/aec_bench/web/frontend/`: Svelte/Vite frontend source.
+- `typings/`: local type stubs used by mypy.
+- `.github/workflows/`: automated checks. A workflow may cover only one area; its presence is not proof of full repository verification.
+
+Prefer a short stable map like this over copied package inventories or test counts, which become stale quickly.
+
+## Commands
+
+Run commands from the repository root unless a command changes directory.
+
+### Python setup and checks
+
+- Install development dependencies: `uv sync --extra webui --dev`
+- Run one test: `uv run pytest tests/path/test_file.py::test_name -q`
+- Run tests for one area: `uv run pytest tests/path/ -q`
+- Run the full Python test suite: `uv run pytest tests/ -q`
+- Lint core Python: `uv run ruff check src/ tests/`
+- Check core formatting: `uv run ruff format --check src/ tests/`
+- Format changed Python paths: `uv run ruff format <paths>`
+- Run strict type checking: `uv run mypy`
+- Build the Python package: `uv build`
+
+When Python outside `src/` or `tests/` changes, include those changed paths in the relevant Ruff command.
+
+### Frontend checks
+
+Run these from `src/aec_bench/web/frontend/`:
+
+- Clean install from the lockfile: `npm ci`
+- Update dependencies intentionally: `npm install`
+- Run frontend tests: `npm test`
+- Build the frontend: `npm run build`
+- Start Vite development mode: `npm run dev`
+
+A release build must compile the frontend before `uv build`, because the package includes `src/aec_bench/web/frontend/dist/` as a build artifact.
+
+### Commands with external effects
+
+Commands that run models, hosted evaluation, Harbor backends, Modal, Morph Cloud, Prime, or provider APIs can require credentials, network access, containers, or paid services.
+
+- Prefer `--dry-run` when the command supports it.
+- Do not run a paid, hosted, production-like, or credentialed workflow unless the task requires it and Theo has authorised it.
+- Do not infer success from a dry run. State exactly what was and was not exercised.
+
+## Compatibility policy
+
+AEC-Bench is pre-1.0. There is no general backward-compatibility promise for internal implementation.
+
+### Internal and unreleased behaviour
+
+- Do not preserve backward compatibility for private modules, internal APIs, helpers, fixtures, unreleased schemas, temporary formats, or generated local data unless the task explicitly requires it.
+- Update all repository callers directly.
+- Remove obsolete paths instead of adding compatibility shims, fallback branches, deprecation layers, dual implementations, or `v2` copies.
+- Do not retain old behaviour only because an existing test, private import, or historical document references it.
+- Regenerate disposable local and test artifacts instead of writing migrations for them.
+
+### Protected boundaries
+
+Treat a boundary as supported only when it is explicitly documented or used outside the repository. Examples include:
+
+- documented CLI commands and options;
+- published dataset, trial, evidence, or export formats;
+- persisted records that users must retain;
+- external provider and Harbor protocols;
+- deliberately documented Python exports;
+- public-versus-holdout visibility rules.
+
+Ask Theo before breaking a protected boundary. When an approved change affects supported persisted data, use the smallest migration or conversion that protects real data. Do not generalise that migration machinery to internal state.
+
+## Domain immutability is not implementation immutability
+
+AEC-Bench has real immutable and append-only domain artifacts. That requirement is narrow.
+
+- Preserve append-only or immutable semantics for trial evidence, benchmark datasets, provenance records, and ledger artifacts where the contracts or invariants require them.
+- Do not apply those semantics to the whole codebase.
+- Source code, internal APIs, tests, configuration, documentation, service objects, and in-memory application state are not an immutable ledger.
+- Replace and delete obsolete implementation instead of recording every historical form.
+- Do not introduce event sourcing, command/event separation, replay infrastructure, audit logs, snapshots, versioned internal state, or receipt objects unless the current product requirement needs them.
+- Do not model every mutation as a new immutable object when direct state is simpler and correct.
+- Use immutable value objects only when value semantics, hashing, concurrency safety, or artifact integrity gives a concrete benefit.
+
+When changing the ledger or dataset domains, preserve their explicit integrity rules. Do not copy their architecture into unrelated domains.
+
+## Architecture and boundary rules
+
+- Dependencies flow from foundational contracts toward higher-level orchestration and presentation. Do not import upward to avoid passing an explicit dependency.
+- Put Pydantic models at actual domain or external boundaries. Do not create boundary models for local intermediate values only for uniformity.
+- Use `StrictModel` for validated internal contracts and `LenientModel` only where an external upstream system may add fields.
+- Keep task definitions provider-neutral.
+- Adapters translate provider or execution protocol. They do not contain task-specific branches, rewrite task intent, select benchmark policy, or score outputs.
+- Evaluation owns scoring and behavioural analysis.
+- Ledger code owns persistence and queries, not evaluation policy.
+- Communication and presentation surfaces report established results. They do not invent a second metric definition.
+- State that can change benchmark outcomes must be explicit and reproducible. Ordinary implementation details do not need to become persisted provenance.
+- Keep public and holdout material separate. Holdout content must not enter public catalogues, examples, reports, or generated documentation.
+
+These rules protect domain ownership. They do not require one class, service, or package per concept.
+
+### Continual-world changes
+
+- Read `docs/CONTINUAL_WORLD_RUNTIME.md` before changing a persistent, replayable, branchable, or controllable task world.
+- Do not add a task-specific run, repository, session, rollout, Harbor, replay, or evaluation stack when the world type already has one.
+- Keep actor actions and host controls in separate validated envelopes.
+- Keep state, action semantics, events, projections, and verifier rules with the task world. The runtime may store and route them, but it must not interpret task fields.
+- Register world definitions at the composition boundary. Do not add task-stage branches to agents, adapters, CLI dispatch, Harbor, or evaluation.
+- Before shared-runtime promotion, record ownership and migration, then prove one stable contract with two real task consumers. A mock, duplicate wrapper, or second profile is not a second consumer.
+- Stop for architecture review if a change needs a second durable repository, run type, replay path, combined actor/control interface, or transport bridge.
+- Move useful coverage before an old path is retired. Preserve accepted artifact bytes and replay results during migration.
+
+### Delivery ownership
+
+Before pull request completion, place each maintained artifact under its permanent owner:
+
+| Artifact | Permanent owner |
+|---|---|
+| Shared library or runtime behaviour | `src/aec_bench/` |
+| Task-template behaviour or data | `src/aec_bench/task_world_templates/<family>/` |
+| Maintained repository command | `scripts/`, unless it is part of the installed API |
+| Permanent tests and test support | `tests/` |
+| Normative architecture and operating guidance | `docs/` |
+| Notes, experiments, generated evidence, and temporary output | Local ignored research or output storage |
+
+Do not deliver maintained code from a research, planning, output, or phase directory. A rarely run generator or certifier is maintained code when the current system needs it. The feature must still build, package, test, and run when local research and phase directories are absent.
+
+## Implementation policy
+
+- Choose the simplest coherent implementation that fully meets current requirements, including required validation, errors, and reliability.
+- Optimise for the simplicity of the resulting system, not only for a small diff.
+- Modify the existing execution path unless the requirement truly needs a separate path.
+- Remove superseded code, tests, comments, adapters, flags, and configuration in the touched scope.
+- Do not keep old and new implementations in parallel as insurance.
+- Avoid speculative abstractions, plugin systems, registries, factories, managers, service layers, configuration options, and extension points.
+- A new abstraction must represent a real boundary, repeated policy, or established repository pattern. One caller is normally not enough.
+- Build the smallest working end-to-end increment. Verify it before expanding the design.
+- Do not land unused scaffolding or half-integrated infrastructure for a later task.
+- Each increment may replace and simplify the previous design. Incremental delivery does not mean permanent layering.
+- When requirements are uncertain, choose the simplest reversible decision.
+- Prefer a simple design that can change over a complex design that tries to predict future change.
+- A temporary measure is acceptable only when the task requires it. State its scope and removal condition; do not quietly turn it into architecture.
+
+## Dependencies
+
+Use this preference order when it fits the problem:
+
+1. An existing repository capability.
+2. The Python or browser platform standard library.
+3. An existing project dependency.
+4. A small direct local implementation.
+5. A new dependency.
+
+Before concluding that an installed library lacks a capability, inspect:
+
+- the version in `pyproject.toml`, `uv.lock`, `package.json`, or `package-lock.json`;
+- its local types and API;
+- its official documentation for that version;
+- how the repository already uses it.
+
+Prefer an established, actively maintained library when it materially reduces total implementation, maintenance, or reliability risk. Do not reimplement complex parsers, protocols, cryptography, authentication, or security-sensitive standards without a clear reason.
+
+Ask Theo before adding, replacing, or substantially upgrading a production dependency. A dependency must reduce total system complexity, not only local lines of code. Update lockfiles through `uv` or `npm`; do not edit them by hand.
+
+## Testing policy
+
+- Test changed behaviour.
+- Name test modules, classes, and functions after stable behaviour, contracts, boundaries, or failure modes. Do not name them after delivery stages, milestones, or temporary work items.
+- For a bug fix, add or identify a regression test that demonstrates the defect when practical.
+- Use the lowest test layer that proves the behaviour.
+- Add integration or end-to-end coverage only when the change crosses those boundaries or cannot be proved below them.
+- Focused fakes, stubs, recorded fixtures, and replay clients are valid at external boundaries. Do not add a production mock mode or fake-success path.
+- Default tests must be deterministic and must not require paid services, production credentials, or live model providers.
+- Prefer factories and helpers in `tests/support/` over repeated setup.
+- Mirror the source package structure in `tests/` when it improves discoverability; do not preserve empty test hierarchy only for symmetry.
+- Run targeted tests during implementation. Run the broader checks appropriate to the changed boundary before handoff.
+- For frontend changes, run the relevant Vitest tests and a frontend build.
+- For package, public-surface, or release-manifest changes, run the relevant top-level tests and `uv build`.
+- For documentation-only changes, validate links, commands, and referenced behaviour; do not run unrelated test layers by ritual.
+- Do not weaken assertions, suppress diagnostics, or disable functionality only to make checks pass.
+- If an intended change makes a test obsolete, update or remove the test. Do not preserve obsolete production code for it.
+- Report pre-existing failures separately from failures caused by the change.
+- Do not record a fixed test count in instructions or documentation.
+
+## Generated, local, and packaged files
+
+- Do not edit generated output by hand. Change the source or generator and regenerate it.
+- `src/aec_bench/web/frontend/dist/` is generated by `npm run build` and is included in package builds.
+- `tasks/generated/`, `jobs/`, `runs/`, `artefacts/`, local workspaces, and sealed local packages are execution output, not hand-maintained source.
+- `uv.lock` and `src/aec_bench/web/frontend/package-lock.json` are tool-managed lockfiles.
+- Do not commit credentials, local caches, downloaded provider output, or ignored run artifacts.
+- Do not edit vendored or generated material merely to make style checks pass.
+
+## Python and file conventions
+
+- Use Python 3.13 syntax and complete type annotations on function signatures.
+- Ruff uses a line length of 120 and the configured `E`, `F`, `I`, `B`, and `UP` rule sets.
+- New hand-written Python files must begin with two `# ABOUTME:` lines that explain the file's purpose. Put required shebangs or encoding declarations first.
+- Keep the header when substantially rewriting an existing Python file, but do not edit unrelated files only to add one.
+- Do not add these headers to JSON, YAML, TOML, generated files, lockfiles, data files, or formats that do not support them.
+- Match the local style of TypeScript, Svelte, Markdown, task data, and configuration files.
+- Comments explain intent, domain constraints, or non-obvious decisions. Update or remove comments that become stale or redundant.
+- Use evergreen names. Do not create `new`, `improved`, `enhanced`, `legacy`, or version-suffixed implementations to avoid replacing the current one, unless the name is part of a real external version contract.
+
+## Documentation policy
+
+Treat repository documentation as a set of scoped contracts, not as an append-only design diary.
+
+- Update `README.md` when public setup, commands, or user-visible behaviour changes.
+- Update `docs/CONTRACTS.md` when a logical boundary contract changes.
+- Update `docs/INVARIANTS.md` only when a benchmark guarantee changes deliberately.
+- Update `docs/ARCHITECTURE.md` when durable domain ownership or dependency direction changes.
+- Update `docs/PROJECT_STRUCTURE.md` only for stable physical layout decisions. Do not use it to list every current package.
+- Keep planning and research separate from normative current behaviour.
+- New design documents must state whether they are normative, draft, research, or historical.
+- Use `MUST`, `MUST NOT`, and `NEVER` only for genuine validity, security, data, or external-contract requirements.
+- Prefer links to one authority over duplicated rules, command lists, package trees, or test counts.
+- Describe the system as it is meant to operate now. Remove superseded guidance instead of preserving a chronology inside normative documents.
+
+## Security and benchmark integrity
+
+- Keep real credentials in `.env`; commit only placeholders in `.env.example`.
+- Never print, copy, commit, or expose tokens, private keys, provider secrets, or secret environment values.
+- Treat task packages, provider responses, imported jobs, archives, and external API data as untrusted input at their ingestion boundaries.
+- Do not inspect, expose, or copy holdout or sealed evaluation content unless the task explicitly authorises that access.
+- Preserve provenance needed to reproduce reported benchmark results.
+- Do not claim a run, evaluation, build, or integration works when only a stub, dry run, or disabled path was exercised.
+
+## Git and delivery
+
+- Do not commit, push, publish, release, deploy, or run hosted evaluations unless Theo asks for that action.
+- Never bypass configured checks or hooks with `--no-verify` or an equivalent mechanism.
+- Do not include unrelated working-tree changes in a commit.
+- Before a requested commit, run the relevant targeted checks and the broader repository checks appropriate to the changed files.
+- Release and dependency-publishing actions always require explicit approval.
+
+## Handoff
+
+Report:
+
+- the behaviour changed;
+- the important files changed;
+- obsolete paths removed;
+- checks run and their results;
+- any approved public contract, persisted format, or dependency change;
+- material assumptions, limitations, and unresolved failures.
+
+Do not claim a check passed unless you ran it and observed a passing result.
+
+## Nested instructions
+
+- `docs/AGENTS.md` applies only to work inside `docs/` and must stay documentation-specific.
+- Add another nested `AGENTS.md` only when a subsystem has materially different commands, generated-file rules, security boundaries, or conventions.
+- Do not copy the repository guide into nested files. State only the local differences.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,301 +1,43 @@
-# ABOUTME: Practical agent guide for working in the aec-bench codebase.
-# ABOUTME: Reflects established conventions, shared utilities, and domain boundaries from the working implementation.
+# ABOUTME: Local instructions for maintaining repository-owned AEC-Bench documentation.
+# ABOUTME: Keeps normative contracts current without duplicating implementation inventories or historical layers.
 
-# AEC-Bench: Agent Guide
+# Documentation Guide
 
-This guide is for coding agents working in the **implemented** aec-bench codebase. It reflects conventions established through the working code, not aspirational planning docs.
+The root `AGENTS.md` also applies. This file adds rules only for work inside `docs/`.
 
-For architectural context, start with [ARCHITECTURE.md](ARCHITECTURE.md) and
-[INVARIANTS.md](INVARIANTS.md). Public installation, usage, integration, and
-domain guides live at [aecbench.com/docs](https://aecbench.com/docs); this
-repository keeps only the normative architecture, contracts, invariants, project
-structure, and agent instructions.
+## Document authority
 
----
+- `INVARIANTS.md` defines non-negotiable benchmark guarantees.
+- `CONTRACTS.md` defines logical shapes and semantics at real domain boundaries.
+- `ARCHITECTURE.md` defines durable domain ownership and dependency direction.
+- `PROJECT_STRUCTURE.md` gives stable navigation and layout guidance. It is not an inventory of every package.
+- Files marked draft, plan, work item, research, or historical do not become implementation requirements unless the task explicitly selects them.
 
-## Package Overview
+State the status of a new design document near its title: `Normative`, `Draft`, `Research`, or `Historical`.
 
-```text
-src/aec_bench/
-├── contracts/       # Boundary models (Pydantic). Depends on nothing.
-├── tasks/           # Task loading, lifecycle, selection. Depends on contracts.
-├── task_world_templates/ # Composite worlds and deterministic task-owned world runtimes.
-│   └── hydraulics/  # Source-bound public hydraulic screening worlds. Depends on contracts.
-├── templates/       # Built-in generation templates (ground, electrical). Depends on nothing.
-├── generation/      # Template engine, scaffolder, dataset composer. Depends on contracts, templates.
-├── agents/          # Agent utility functions (scripts, env, tools, results, providers). Depends on contracts.
-├── adapters/        # Provider-neutral model integrations. Depends on contracts.
-│   └── tools/       # Tool executors (bash, codes_search).
-├── harness/         # Trial orchestration, compute backends. Depends on contracts, tasks, adapters, ledger.
-├── ledger/          # Append-only trial persistence. Cross-cutting, depends on contracts only.
-├── evaluation/      # Scoring, trace analysis, behavioral classification. Depends on contracts.
-│   └── adaptation/  # Task-family variation and acceptance policy.
-├── communication/   # Reports, exports, dashboards. Depends on contracts, ledger, evaluation, tasks.
-├── feedback/        # Structured human review workflows. Depends on contracts, ledger, tasks.
-├── cli/             # Typer CLI commands (generate, evaluate). Depends on generation, evaluation, tasks.
-├── tui/             # Textual TUI screens. Depends on tasks, evaluation, communication.
-├── web/             # FastAPI routes and templates. Depends on communication, feedback.
-│   └── routes/      # Endpoint modules (dashboard, leaderboard, experiment, review, export).
-├── providers/       # Vendor integrations (Anthropic LLM client). No internal dependencies.
-└── config.py        # Minimal project configuration.
-```
+## Editing policy
 
-**767 tests** across 10 domains. Run with `uv run pytest tests/ -q`.
+- Verify technical claims against the current implementation, tests, and configuration before editing.
+- Change the smallest authoritative document set. Link to an existing authority instead of repeating it.
+- Remove superseded normative text. Do not preserve obsolete guidance as a compatibility layer or change log.
+- Do not copy package trees, test counts, dependency versions, CLI output, or other volatile inventories when a source file or live command is the better authority.
+- Use examples to explain a contract, not to create a second contract.
+- Keep code identifiers, paths, commands, and schema fields exact.
+- Use `MUST`, `MUST NOT`, and `NEVER` only for genuine benchmark, security, data, or public-contract requirements.
+- Do not expand architecture while documenting a local behaviour change. Record only the durable decision the change actually makes.
 
----
+## Update routing
 
-## Dependency Rule
+- Public installation, commands, and user-visible behaviour: update `../README.md` and the public documentation source when it is part of the task.
+- Boundary semantics: update `CONTRACTS.md`.
+- Benchmark guarantees: update `INVARIANTS.md` only with deliberate approval.
+- Domain ownership or dependency direction: update `ARCHITECTURE.md`.
+- Stable repository layout: update `PROJECT_STRUCTURE.md`.
 
-Dependencies flow downward. Never import upward.
+When code and documentation disagree, do not document both. Determine the intended behaviour, then update code, tests, and the authoritative document as one coherent change.
 
-```text
-contracts
-  ├── tasks
-  ├── adapters
-  │     └── harness
-  │           ├── evaluation
-  │           │     ├── communication
-  │           │     └── feedback
-  │           └── ledger (cross-cutting)
-  └── web (delivery surface over communication + feedback)
-```
+## Validation
 
-**Verified violations to avoid:**
-- Feedback must NOT import from communication (use `tasks.loader.load_task_catalog` instead).
-- Ledger must NOT import from evaluation (compose query + summarize at the script layer).
-- Adapters must NOT import from tasks (they receive `ToolSpec` from contracts).
-
----
-
-## Model Conventions
-
-### StrictModel — internal contract boundaries
-
-All Pydantic models within the platform use `StrictModel` (from `contracts/validators.py`). It sets `extra="forbid"` to reject unknown fields at construction.
-
-```python
-from aec_bench.contracts.validators import StrictModel
-
-class MyBoundaryModel(StrictModel):
-    field_a: str
-    field_b: int
-```
-
-### LenientModel — external data ingestion
-
-Models that parse data from external systems (e.g., Harbor trial results) use `LenientModel`, which sets `extra="allow"` so new upstream fields don't break ingestion.
-
-```python
-from aec_bench.contracts.validators import LenientModel
-
-class HarborSomething(LenientModel):
-    known_field: str
-```
-
-### Frozen dataclasses — internal data structures
-
-Non-boundary data structures (adapter results, report records, trace signals) use `@dataclass(frozen=True)`. These don't need Pydantic validation but benefit from immutability.
-
----
-
-## Shared Utilities
-
-These live in established locations. Use them instead of writing local copies.
-
-### `contracts/validators.py`
-
-| Function | Purpose |
-|---|---|
-| `ensure_non_empty_string(value)` | Rejects blank strings |
-| `ensure_optional_non_empty_string(value)` | Same but accepts None |
-| `ensure_relative_path(value)` | Rejects absolute paths |
-| `ensure_optional_relative_path(value)` | Same but accepts None |
-| `normalize_workspace_path(path)` | Ensures leading `/` on workspace paths |
-| `infer_output_format(output_path)` | Returns format label from file suffix |
-
-### `contracts/jsonl.py`
-
-| Function | Purpose |
-|---|---|
-| `write_jsonl(path, records)` | Deterministic JSONL write (sort_keys=True) |
-| `read_jsonl(path)` | Read JSONL, skip blank lines |
-
-### `evaluation/stats.py`
-
-| Function | Purpose |
-|---|---|
-| `mean(values)` | None-filtering mean, returns 0.0 for empty |
-| `wilson_confidence_interval(successes, trials)` | Wilson score interval |
-| `cohen_kappa(left, right)` | Inter-rater agreement |
-
-### `communication/metrics.py`
-
-| Function | Purpose |
-|---|---|
-| `coerce_int(value, fallback=0)` | Safe int coercion from Any |
-| `resolve_agent_name(record)` | Extract display name from TrialRecord |
-| `split_task_id(task_id)` | Returns `(task_type, task_name)` from slash-delimited ID |
-
-### `tasks/loader.py`
-
-| Constant/Function | Purpose |
-|---|---|
-| `WORKSPACE_OUTPUT_PATH_RE` | Regex for `/workspace/...` paths in instructions |
-| `extract_workspace_output_paths(instruction)` | Extract + strip punctuation from instruction text |
-| `load_task_catalog(tasks_root)` | Build `dict[str, TaskDefinition]` from disk |
-
-### `harness/trial.py`
-
-| Function | Purpose |
-|---|---|
-| `build_trial_id(experiment_id, task_id, agent_name, repetition)` | Deterministic trial ID |
-
-### `adapters/transcript.py`
-
-| Function | Purpose |
-|---|---|
-| `initialize_transcript(request)` | Build system+user opening entries from AdapterRequest |
-
-### `adapters/tools/__init__.py`
-
-| Function | Purpose |
-|---|---|
-| `coerce_timeout(value, default)` | Safe timeout coercion |
-| `join_subprocess_output(stdout, stderr)` | Combine and strip subprocess output |
-| `run_subprocess_tool(command, cwd, timeout, label)` | Full subprocess execution with error handling |
-
----
-
-## File Conventions
-
-- Every `.py` file starts with a 2-line `# ABOUTME:` comment explaining what the file does.
-- Every file uses type hints on all function signatures (parameters + return).
-- Tests mirror the source package structure in `tests/`.
-- Test factories live in `tests/support/` (`trial_record_factories.py`, `task_factories.py`, `feedback_factories.py`).
-
----
-
-## Delivery Ownership
-
-Before completing a pull request, classify every delivered artifact and place it under its permanent owner:
-
-| Artifact | Permanent owner |
-|---|---|
-| Shared library or runtime behaviour | `src/aec_bench/` |
-| Task-template-specific behaviour or data | `src/aec_bench/task_world_templates/<family>/` |
-| Maintained repository command | `scripts/` when it is not part of the installed API; otherwise `src/aec_bench/` |
-| Permanent tests and test support | `tests/` |
-| Normative architecture and operating guidance | `docs/` |
-| Notes, experiments, generated evidence, and temporary outputs | Local ignored research or output storage |
-
-Do not deliver maintained code from a research, planning, output, or phase directory. A rarely run generator or certifier is still maintained code when the current system needs it.
-
-Final check: would the feature still build, package, test, and run if local research and phase directories were absent?
-
----
-
-## Adapter Rules
-
-Adapters translate protocol only. They do NOT:
-- Branch on task type
-- Rewrite instructions
-- Choose tools
-- Score outputs
-
-Tool errors are surfaced back to the model (not swallowed), logged via `logger.warning`, and the conversation loop continues.
-
----
-
-## Harness Rules
-
-- `build_trial_plan` expects pre-filtered tasks. Callers use `select_manifest_tasks` first.
-- Harbor contract models use `LenientModel` (external data).
-- `TaskRegistry.reload()` is failure-tolerant — malformed tasks are logged and tracked in `load_errors`.
-- Trial completeness is `PARTIAL` unless all provenance fields (adapter_revision, tool_versions, input_files) are present.
-
-## Continual-World Boundary Rules
-
-- Read [CONTINUAL_WORLD_RUNTIME.md](CONTINUAL_WORLD_RUNTIME.md) before changing
-  a persistent, replayable, branchable, or controllable task world.
-- Do not add a profile-specific run, repository, session, rollout, Harbor,
-  replay, or evaluation stack when the world type already has one.
-- Keep actor actions and host controls in separate validated envelopes.
-- Keep state, action semantics, events, projections, and verifier rules with
-  the task world. The runtime may store and route them but must not interpret
-  their task fields.
-- Do not add task-stage branches to agents, adapters, CLI dispatch, Harbor, or
-  evaluation. Register the world definition at the composition boundary.
-- Do not promote code to the shared runtime from one apparent use. First record
-  ownership and migration, then prove one stable contract with two real task
-  consumers.
-- A mock, duplicate wrapper, or second profile does not count as the second
-  consumer.
-- Stop for architecture review if a change needs a second durable repository,
-  run type, replay path, combined actor/control interface, or transport bridge.
-- Move useful coverage before retiring an old path. Preserve accepted artifact
-  bytes and replay results throughout the migration.
-
----
-
-## Ledger Rules
-
-- Append-only. No update or delete operations.
-- `query_trial_records` scopes to experiment directory when `experiment_id` is provided.
-- The ledger API layer owns persistence operations only — evaluation logic stays in the evaluation domain.
-
----
-
-## Testing Conventions
-
-- Use `make_trial_record(**overrides)` and `make_task_definition(**overrides)` from `tests/support/`.
-- Real Harbor data tests use `_archive/jobs/2026-03-04__17-57-43` (60 trials, skipped on fresh clones).
-- Adapter tests use replay clients (`ReplayDirectClient`, `ReplayToolLoopClient`).
-- Property-based tests (Hypothesis) are used for validators and stats primitives.
-- Test modules, classes, and functions describe stable behaviour, contracts, boundaries, or failure modes. Do not name them after delivery sequence, milestones, or temporary work items.
-- Run the full suite: `uv run pytest tests/ -q`
-- Lint: `uv run ruff check src/ tests/`
-- Type check: `uv run mypy src/aec_bench/contracts/`
-
----
-
-## Available Skills
-
-Agent skills automate common workflows. Invoke them with `/skill-name` when your
-agent environment supports slash commands, or translate each row into that
-environment's native skill/prompt mechanism.
-
-| Skill | Purpose | When to Use |
-|---|---|---|
-| `/add-task` | Interview an expert to create a task seed | When a domain expert wants to add a new benchmark task |
-| `/create-template` | Build a generation template from a seed file | Converting a `source_task.json` into a parameterisable template |
-| `/hardening-pass` | Quality-gate a template or task instance | Before using a template or task in real benchmarks |
-| `/domain-check` | Verify architectural invariants and dependency directions | Before committing cross-domain changes |
-| `/meta-harness` | Create or compare a harness candidate against a baseline | When a task needs world design, reviewer evidence, governance, or candidate-vs-baseline comparison |
-
----
-
-## Invariants (Quick Reference)
-
-| # | Rule | One-line test |
-|---|---|---|
-| 1 | Single source of truth | Can this trial be replayed from its TrialRecord alone? |
-| 2 | Contracts at boundaries | Does every cross-domain boundary validate its payload? |
-| 3 | No hidden state | Is every outcome-relevant input persisted? |
-| 4 | Task-adapter independence | Would this still work with any task or any adapter? |
-| 5 | Evaluation is a pipeline | Does this metric come from evaluation outputs, not invented state? |
-| 6 | Public/holdout separation | Could this leak holdout content? |
-| 7 | Validate before commit | Has this been smoke-tested on a representative subset? |
-| 8 | Provider isolation | Can this code be described without naming a vendor? |
-| 9 | Human judgment is structured | Is expert feedback captured as machine-readable data? |
-| 10 | Continuous quality | Does this reduce drift instead of adding to it? |
-| 11 | Staged evidence is host-controlled | Does the host own evidence release and immutable submissions? |
-| 12 | Continual-world runtime ownership | Are lifetime mechanics separate from task meaning and profile data? |
-| 13 | Maintained code has a permanent owner | Would this work without local research and phase directories? |
-
-## Objective Stack
-
-When invariants or requirements conflict, higher priority wins.
-
-```
-validity > reproducibility > coverage > cost > throughput
-```
+- Check every changed path, command, identifier, and relative link.
+- Run focused tests when documentation contains executable examples or describes changed runtime behaviour.
+- Documentation-only edits do not require unrelated unit, integration, and end-to-end test runs.

--- a/tests/test_public_repo_surface.py
+++ b/tests/test_public_repo_surface.py
@@ -7,16 +7,16 @@ import subprocess
 from pathlib import Path
 
 
-def test_root_does_not_publish_local_agent_or_node_scaffolding() -> None:
-    root_only_files = {
-        "AGENTS.md",
+def test_root_publishes_portable_agent_guidance_without_local_scaffolding() -> None:
+    prohibited_root_files = {
         "CLAUDE.md",
         "CONTEXT.md",
         "package.json",
         "package-lock.json",
     }
 
-    assert all(not Path(path).exists() for path in root_only_files)
+    assert all(not Path(path).exists() for path in prohibited_root_files)
+    assert Path("AGENTS.md").is_file()
     assert Path("src/aec_bench/web/frontend/package.json").is_file()
 
 


### PR DESCRIPTION
## Summary

- add a root `AGENTS.md` with repository-wide agent guidance
- replace `docs/AGENTS.md` with concise documentation-specific rules
- update the public repository surface test to require the portable root guide while continuing to reject local scaffolding

## Validation

- `uv run pytest tests/test_public_repo_surface.py -q` — 2 passed
- `uv run ruff check tests/test_public_repo_surface.py` — passed
- `uv run ruff format --check tests/test_public_repo_surface.py` — passed
- `git diff --check origin/main...HEAD` — passed