### PR TITLE
Route continual-world execution through registered ports

### DIFF
--- a/agents/entrypoint_agent.py
+++ b/agents/entrypoint_agent.py
@@ -26,7 +26,6 @@ from aec_bench.adapters.rlm.providers import (
 )
 from aec_bench.adapters.runtime_limits import configured_positive_int, validate_runtime_limit_contract
 from aec_bench.agents.tools import inject_trajectory_writer
-from aec_bench.contracts.agent_output import AgentOutputStatus
 from aec_bench.contracts.harness_instance import AgentBindingConfig
 from aec_bench.contracts.proposal_execution import (
     ProposalSessionExecutionRef,
@@ -52,34 +51,15 @@ from aec_bench.harness.proposal_session_output import (
 from aec_bench.harness.runtime_dependencies import PYDANTIC_AI_RUNTIME_VERSION, RUNTIME_PYTHON_PACKAGES
 from aec_bench.meta_harness.evidence_lifecycle_episode import LifecycleVisibilityPolicy
 from aec_bench.meta_harness.evidence_lifecycle_local import run_local_evidence_lifecycle_session
+from aec_bench.task_world_templates.continual.definition import (
+    ContinualWorldHarborPort,
+)
+from aec_bench.task_world_templates.continual_catalogue import default_continual_world_catalogue
 from aec_bench.task_world_templates.harbor_export import (
     HARBOR_LIFECYCLE_BRIDGE_MODE,
     HarborLifecycleBridge,
     load_harbor_lifecycle_bridge,
     write_harbor_lifecycle_attestation,
-)
-from aec_bench.task_world_templates.stewardship.wastewater_pump_station.harbor_export import (
-    PUMP_STATION_HARBOR_BRIDGE_MODE,
-    PUMP_STATION_HARBOR_EXECUTION_KIND,
-    PUMP_STATION_REVIEW_HARBOR_BRIDGE_MODE,
-    PUMP_STATION_REVIEW_HARBOR_EXECUTION_KIND,
-    PumpStationHarborBridge,
-    load_pump_station_harbor_bridge,
-)
-from aec_bench.task_world_templates.stewardship.wastewater_pump_station.harbor_session import (
-    PUMP_STATION_MODEL_CONTROLLER_MODE,
-    PUMP_STATION_MODEL_MAX_TURNS,
-    PUMP_STATION_REFERENCE_CONTROLLER_ID,
-    run_pump_station_evidence_health_reference_session,
-    run_pump_station_model_session,
-    run_pump_station_reference_session,
-    run_pump_station_rich_work_reference_session,
-)
-from aec_bench.task_world_templates.stewardship.wastewater_pump_station.maintenance_review_harbor import (
-    run_pump_station_review_reference_session,
-)
-from aec_bench.task_world_templates.stewardship.wastewater_pump_station.reference_controller import (
-    PUMP_STATION_REFERENCE_SYSTEM_CONTROLLER_ID,
 )
 
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent
@@ -197,7 +177,8 @@ class EntrypointAgent(BaseAgent):
         self._params: dict[str, Any] = kwargs
         self._lifecycle_bridge: HarborLifecycleBridge | None = None
         self._proposal_inputs: LoadedProposalSessionHostInputs | None = None
-        self._world_session_bridge: PumpStationHarborBridge | None = None
+        self._world_session_port: ContinualWorldHarborPort | None = None
+        self._world_session_bridge: object | None = None
 
     @staticmethod
     def name() -> str:
@@ -209,7 +190,14 @@ class EntrypointAgent(BaseAgent):
     async def setup(self, environment: Any) -> None:
         if "world_session" in self._params:
             self._validate_world_session_configuration()
-            self._world_session_bridge = load_pump_station_harbor_bridge(Path(environment.environment_dir))
+            port = self._world_session_port
+            if port is None:
+                raise RuntimeError("continual-world Harbor port resolution failed")
+            bridge = port.load_bridge(Path(environment.environment_dir))
+            identity = port.bridge_identity(bridge)
+            if identity.execution_kind != self._params.get("execution_kind"):
+                raise ValueError("continual-world Harbor bridge execution kind differs")
+            self._world_session_bridge = bridge
             return
         if "lifecycle_bridge" in self._params:
             self._validate_lifecycle_configuration()
@@ -668,47 +656,23 @@ class EntrypointAgent(BaseAgent):
             }
 
     def _validate_world_session_configuration(self) -> None:
-        session = self._params.get("world_session")
-        if not isinstance(session, dict):
-            raise ValueError("pump-station world session bridge configuration differs")
-        bridge_mode = session.get("bridge_mode")
-        maintenance_review = bridge_mode == PUMP_STATION_REVIEW_HARBOR_BRIDGE_MODE
-        expected_execution_kind = (
-            PUMP_STATION_REVIEW_HARBOR_EXECUTION_KIND if maintenance_review else PUMP_STATION_HARBOR_EXECUTION_KIND
-        )
-        if self._params.get("execution_kind") != expected_execution_kind:
-            raise ValueError("pump-station world session requires its exact execution kind")
-        if bridge_mode not in {
-            PUMP_STATION_HARBOR_BRIDGE_MODE,
-            PUMP_STATION_REVIEW_HARBOR_BRIDGE_MODE,
-        }:
-            raise ValueError("pump-station world session bridge configuration differs")
+        execution_kind = str(self._params.get("execution_kind") or "").strip()
+        if not execution_kind:
+            raise ValueError("continual-world session requires an execution kind")
+        try:
+            _, port = default_continual_world_catalogue().resolve_harbor(execution_kind)
+        except KeyError as exc:
+            raise ValueError(str(exc)) from exc
         if self._params.get("adapter") != "tool_loop":
-            raise ValueError("pump-station world session requires the tool_loop adapter")
+            raise ValueError("continual-world session requires the tool_loop adapter")
         if self._params.get("extra_env") not in (None, {}):
-            raise ValueError("pump-station world session does not accept environment variables")
-        controller = session.get("controller")
-        reference_controller = self.model_name in {
-            PUMP_STATION_REFERENCE_CONTROLLER_ID,
-            PUMP_STATION_REFERENCE_SYSTEM_CONTROLLER_ID,
-        }
-        if maintenance_review and not reference_controller:
-            raise ValueError("pump-station review model runs require the separately approved direct host runner")
-        expected_session = {"bridge_mode": bridge_mode}
-        if not reference_controller:
-            expected_session["controller"] = PUMP_STATION_MODEL_CONTROLLER_MODE
-        if session != expected_session:
-            raise ValueError("pump-station world session bridge configuration differs")
-        if reference_controller and controller is not None:
-            raise ValueError("pump-station reference controller cannot use model mode")
-        if not reference_controller and not str(self.model_name or "").strip():
-            raise ValueError("pump-station model controller requires a model")
+            raise ValueError("continual-world session does not accept environment variables")
         if "client" in self._params:
-            raise ValueError("pump-station world session does not accept serialized clients")
+            raise ValueError("continual-world session does not accept serialized clients")
         if "tools" in self._params:
-            raise ValueError("pump-station world session owns its exact tool allowlist")
+            raise ValueError("continual-world session owns its exact tool allowlist")
         if "system_prompt" in self._params:
-            raise ValueError("pump-station world session owns its system prompt")
+            raise ValueError("continual-world session owns its system prompt")
         allowed = {
             "adapter",
             "execution_kind",
@@ -718,12 +682,17 @@ class EntrypointAgent(BaseAgent):
         }
         unknown = sorted(set(self._params) - allowed)
         if unknown:
-            raise ValueError("unsupported pump-station world session configuration: " + ", ".join(unknown))
+            raise ValueError("unsupported continual-world session configuration: " + ", ".join(unknown))
         validate_runtime_limit_contract(
             adapter_kind="tool_loop",
             configuration=self._params,
         )
         _reject_serialized_provider_secrets(self._params)
+        port.validate_configuration(
+            configuration=self._params,
+            model_name=str(self.model_name or ""),
+        )
+        self._world_session_port = port
 
     async def _run_world_session(
         self,
@@ -734,152 +703,91 @@ class EntrypointAgent(BaseAgent):
     ) -> None:
         del instruction
         self._validate_world_session_configuration()
+        port = self._world_session_port
         configured_bridge = self._world_session_bridge
-        if configured_bridge is None:
-            raise RuntimeError("pump-station world session setup has not completed")
-        current_bridge = load_pump_station_harbor_bridge(Path(environment.environment_dir))
+        if port is None or configured_bridge is None:
+            raise RuntimeError("continual-world session setup has not completed")
+        current_bridge = port.load_bridge(Path(environment.environment_dir))
         if current_bridge != configured_bridge:
-            raise ValueError("pump-station Harbor task changed after agent setup")
+            raise ValueError("continual-world Harbor task changed after agent setup")
+        bridge_identity = port.bridge_identity(current_bridge)
+        session_configuration = cast(dict[str, Any], self._params["world_session"])
         if (
-            self._params.get("execution_kind") != current_bridge.execution_kind
-            or self._params["world_session"].get("bridge_mode") != current_bridge.bridge_mode
+            self._params.get("execution_kind") != bridge_identity.execution_kind
+            or session_configuration.get("bridge_mode") != bridge_identity.bridge_mode
         ):
-            raise ValueError("pump-station Harbor bridge identity changed after setup")
+            raise ValueError("continual-world Harbor bridge identity changed after setup")
         session_identity = str(getattr(environment, "session_id", "")).strip()
         if not session_identity:
-            raise RuntimeError("pump-station Harbor environment has no session identity")
+            raise RuntimeError("continual-world Harbor environment has no session identity")
 
-        with tempfile.TemporaryDirectory(prefix="aec-bench-pump-station-harbor-") as raw_run:
+        model = str(self.model_name or "")
+        uses_provider = port.uses_model_controller(
+            bridge=current_bridge,
+            model_name=model,
+        )
+        provider_environment = _host_model_provider_environment(model) if uses_provider else {}
+        max_turns = configured_positive_int(self._params, "max_turns") or port.default_max_turns
+        with tempfile.TemporaryDirectory(prefix="aec-bench-continual-world-harbor-") as raw_run:
             staging = Path(raw_run)
-            run_dir = staging / "world-session"
-            expected_reference_controller = (
-                PUMP_STATION_REFERENCE_SYSTEM_CONTROLLER_ID
-                if current_bridge.profile_ref is not None
-                else PUMP_STATION_REFERENCE_CONTROLLER_ID
-            )
-            reference_controller = self.model_name == expected_reference_controller
-            if (
-                self.model_name
-                in {
-                    PUMP_STATION_REFERENCE_CONTROLLER_ID,
-                    PUMP_STATION_REFERENCE_SYSTEM_CONTROLLER_ID,
-                }
-                and not reference_controller
-            ):
-                raise ValueError("pump-station reference controller differs from the exported profile")
-            if reference_controller:
-                if current_bridge.maintenance_review:
-                    review_session = await asyncio.to_thread(
-                        run_pump_station_review_reference_session,
-                        bridge=current_bridge,
-                        output_dir=run_dir,
-                        session_identity=session_identity,
-                    )
-                    world_session_id = review_session.observation.session_id
-                else:
-                    reference_runner = (
-                        run_pump_station_reference_session
-                        if current_bridge.profile_ref is not None
-                        else run_pump_station_evidence_health_reference_session
-                        if current_bridge.evidence_health
-                        else run_pump_station_rich_work_reference_session
-                        if current_bridge.rich_work_processes
-                        else run_pump_station_reference_session
-                    )
-                    world_session = await asyncio.to_thread(
-                        reference_runner,
-                        bridge=current_bridge,
-                        output_dir=run_dir,
-                        session_identity=session_identity,
-                    )
-                    world_session_id = world_session.request.session_id
-                output_path = staging / "output.md"
-                output_path.write_text(
-                    (
-                        "The deterministic wastewater pump-station closeout review completed.\n"
-                        if current_bridge.maintenance_review
-                        else "The deterministic wastewater pump-station session completed.\n"
+            try:
+                completed = await asyncio.to_thread(
+                    port.run_session,
+                    bridge=current_bridge,
+                    staging_dir=staging,
+                    session_identity=session_identity,
+                    model_name=model,
+                    max_turns=max_turns,
+                    registry=self._lifecycle_registry(),
+                )
+            except Exception as exc:
+                if not uses_provider:
+                    raise
+                context.metadata = {
+                    "adapter_name": "tool_loop",
+                    "bridge_mode": bridge_identity.bridge_mode,
+                    "bridge_manifest_sha256": bridge_identity.manifest_sha256,
+                    "error": _redact_environment_values(
+                        str(exc),
+                        provider_environment,
                     ),
-                    encoding="utf-8",
-                )
-                input_tokens = 0
-                output_tokens = 0
-                resolved_model = expected_reference_controller
-                session_status = "completed"
-            else:
-                model = str(self.model_name or "")
-                provider_environment = _host_model_provider_environment(
-                    model,
-                )
-                max_turns = configured_positive_int(self._params, "max_turns") or PUMP_STATION_MODEL_MAX_TURNS
-                try:
-                    model_session = await asyncio.to_thread(
-                        run_pump_station_model_session,
-                        bridge=current_bridge,
-                        output_dir=run_dir,
-                        session_identity=session_identity,
-                        model=model,
-                        max_turns=max_turns,
-                        registry=self._lifecycle_registry(),
-                    )
-                    adapter_result = model_session.adapter_result
-                    verification_valid = model_session.verification.valid
-                    world_session_id = model_session.request.session_id
-                except Exception as exc:
-                    context.metadata = {
-                        "adapter_name": "tool_loop",
-                        "bridge_mode": current_bridge.bridge_mode,
-                        "bridge_manifest_sha256": (current_bridge.export_manifest_sha256),
-                        "error": _redact_environment_values(
-                            str(exc),
-                            provider_environment,
-                        ),
-                        "execution_kind": current_bridge.execution_kind,
-                        "model": model,
-                        "resolved_model": model,
-                        "reward_owner": "harbor_verifier",
-                        "world_session_status": "failed",
-                    }
-                    return
-                output_path = run_dir / "output.md"
-                input_tokens = adapter_result.usage_input_tokens or 0
-                output_tokens = adapter_result.usage_output_tokens or 0
-                resolved_model = adapter_result.resolved_model
-                session_status = (
-                    "completed"
-                    if (adapter_result.agent_output.status is AgentOutputStatus.COMPLETED and verification_valid)
-                    else "incomplete"
-                )
+                    "execution_kind": bridge_identity.execution_kind,
+                    "model": model,
+                    "resolved_model": model,
+                    "reward_owner": "harbor_verifier",
+                    "world_session_status": "failed",
+                }
+                return
             await environment.upload_dir(
-                str(run_dir),
-                current_bridge.output_path,
+                str(completed.output_dir),
+                bridge_identity.output_path,
             )
             permissions = await environment.exec(
-                f"chmod -R go-rwx {current_bridge.output_path}",
+                f"chmod -R go-rwx {bridge_identity.output_path}",
             )
             if permissions.return_code != 0:
                 raise RuntimeError(
-                    "pump-station Harbor could not make uploaded evidence host-private.\n"
+                    "continual-world Harbor could not make uploaded evidence host-private.\n"
                     f"stdout: {permissions.stdout}\n"
                     f"stderr: {permissions.stderr}",
                 )
             await environment.upload_file(
-                str(output_path),
+                str(completed.output_file),
                 "/workspace/output.md",
             )
 
-        context.n_input_tokens = input_tokens
-        context.n_output_tokens = output_tokens
+        context.n_input_tokens = completed.input_tokens
+        context.n_output_tokens = completed.output_tokens
         context.metadata = {
             "adapter_name": "tool_loop",
-            "bridge_mode": current_bridge.bridge_mode,
-            "bridge_manifest_sha256": (current_bridge.export_manifest_sha256),
-            "execution_kind": current_bridge.execution_kind,
-            "model": resolved_model,
-            "resolved_model": resolved_model,
+            "bridge_mode": bridge_identity.bridge_mode,
+            "bridge_manifest_sha256": bridge_identity.manifest_sha256,
+            "execution_kind": bridge_identity.execution_kind,
+            "model": completed.resolved_model,
+            "resolved_model": completed.resolved_model,
             "reward_owner": "harbor_verifier",
-            "world_session_id": world_session_id,
-            "world_session_status": session_status,
+            "world_session_id": completed.session_id,
+            "world_session_status": completed.status,
         }
 
 

--- a/src/aec_bench/cli/commands/pump_station_world.py
+++ b/src/aec_bench/cli/commands/pump_station_world.py
@@ -5,12 +5,18 @@ from __future__ import annotations
 
 import json
 import time
+from dataclasses import asdict
 from pathlib import Path
 from typing import cast
 
 import typer
+from pydantic import BaseModel
 
 from aec_bench.cli.output import emit
+from aec_bench.contracts.continual_world import (
+    ContinualWorldActorRequest,
+    ContinualWorldControlRequest,
+)
 from aec_bench.contracts.trial_record import TrialRecord
 from aec_bench.contracts.world_session import (
     StewardshipStateSnapshotRef,
@@ -24,6 +30,12 @@ from aec_bench.evaluation.stewardship import (
 from aec_bench.harness.harbor_importing.core import import_harbor_trial
 from aec_bench.harness.world_interface import invoke_world_actor, observe_world_actor
 from aec_bench.harness.world_session import open_world_session
+from aec_bench.task_world_templates.continual.interface import (
+    ContinualWorldInterfaceContext,
+    dispatch_continual_actor,
+    dispatch_continual_control,
+)
+from aec_bench.task_world_templates.continual_catalogue import default_continual_world_catalogue
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.harbor_export import (
     export_pump_station_harbor_task,
 )
@@ -48,8 +60,16 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.rollout_
     PumpStationRolloutControlRequest,
     execute_pump_station_rollout_request,
 )
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_verifier import (
+    PumpStationVerificationReport,
+    PumpStationVerificationReportV4,
+)
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_control import (
+    PumpStationEvidenceControlRequest,
     PumpStationWorldControl,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_models import (
+    PumpStationWorldRunManifestV2,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_repository import (
     PumpStationWorldRunRepository,
@@ -61,6 +81,42 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_se
 )
 
 app = typer.Typer(help="Run the synthetic wastewater pump-station stewardship world.")
+
+
+def _model_payload(value: object) -> dict[str, object]:
+    if not isinstance(value, BaseModel):
+        raise TypeError("continual-world interface result must be a validated model")
+    return cast(dict[str, object], value.model_dump(mode="json"))
+
+
+def _verification_payload(
+    report: PumpStationVerificationReport | PumpStationVerificationReportV4,
+) -> dict[str, object]:
+    if isinstance(report, PumpStationVerificationReportV4):
+        return {
+            "valid": report.valid,
+            "replay_valid": report.replay_valid,
+            "actor_proposals_valid": report.actor_proposals_valid,
+            "host_controls_valid": report.host_controls_valid,
+            "issues": list(report.issues),
+            "replayed_transition_ids": list(report.replayed_transition_ids),
+            "final_state_id": report.final_state_id,
+            "conservation": {
+                "valid": report.conservation.valid,
+                "duty": asdict(report.conservation.duty),
+                "resources": asdict(report.conservation.resources),
+                "work": asdict(report.conservation.work),
+                "liabilities": asdict(report.conservation.liabilities),
+            },
+        }
+    return {
+        "valid": report.valid,
+        "issues": list(report.issues),
+        "replayed_transition_ids": list(report.replayed_transition_ids),
+        "final_state_id": report.final_state_id,
+        "active_restriction_ids": list(report.active_restriction_ids),
+        "open_obligation_ids": list(report.open_obligation_ids),
+    }
 
 
 def _factory(
@@ -137,6 +193,11 @@ def interface_command(
 
     started = time.monotonic()
     request = PumpStationLocalInterfaceRequest.model_validate_json(request_path.read_text(encoding="utf-8"))
+    if isinstance(PumpStationWorldRunRepository(run_dir).load_manifest(), PumpStationWorldRunManifestV2):
+        raise typer.BadParameter(
+            "registered V4 runs require actor-interface or control-interface",
+            param_hint="--run-dir",
+        )
     if request.surface == "actor":
         assert request.session_request is not None
         session = _open(run_dir, request.session_request)
@@ -178,7 +239,10 @@ def interface_command(
                 authorised_principal_ids=(host_authority_id,),
                 evidence_health=(
                     request.evidence_health
-                    or request.control_request is not None
+                    or isinstance(
+                        request.control_request,
+                        PumpStationEvidenceControlRequest,
+                    )
                     and request.control_request.operation
                     in {
                         "schedule_evidence_treatment",
@@ -196,6 +260,66 @@ def interface_command(
     emit(
         "task pump-station-world interface",
         payload,
+        start_time=started,
+    )
+
+
+@app.command("actor-interface")
+def actor_interface_command(
+    run_dir: Path = typer.Option(..., "--run-dir", help="Durable world-run directory"),
+    request_path: Path = typer.Option(..., "--request-path", help="Registered actor JSON request"),
+) -> None:
+    """Execute one separate actor request through the continual-world catalogue."""
+
+    started = time.monotonic()
+    request = ContinualWorldActorRequest.model_validate_json(request_path.read_text(encoding="utf-8"))
+    result = dispatch_continual_actor(
+        context=ContinualWorldInterfaceContext(
+            catalogue=default_continual_world_catalogue(),
+            run_root=run_dir,
+            rollout_repository_root=None,
+            authorised_principal_ids=(),
+        ),
+        request=request,
+    )
+    emit(
+        "task pump-station-world actor-interface",
+        _model_payload(result),
+        start_time=started,
+    )
+
+
+@app.command("control-interface")
+def control_interface_command(
+    run_dir: Path = typer.Option(..., "--run-dir", help="Durable world-run directory"),
+    request_path: Path = typer.Option(..., "--request-path", help="Registered host-control JSON request"),
+    host_authority_id: str = typer.Option(
+        ...,
+        "--host-authority-id",
+        help="Host-only control authority identity",
+    ),
+    rollout_dir: Path | None = typer.Option(
+        None,
+        "--rollout-dir",
+        help="Host-private rollout repository directory",
+    ),
+) -> None:
+    """Execute one separate host-control request through the continual-world catalogue."""
+
+    started = time.monotonic()
+    request = ContinualWorldControlRequest.model_validate_json(request_path.read_text(encoding="utf-8"))
+    result = dispatch_continual_control(
+        context=ContinualWorldInterfaceContext(
+            catalogue=default_continual_world_catalogue(),
+            run_root=run_dir,
+            rollout_repository_root=rollout_dir,
+            authorised_principal_ids=(host_authority_id,),
+        ),
+        request=request,
+    )
+    emit(
+        "task pump-station-world control-interface",
+        _model_payload(result),
         start_time=started,
     )
 
@@ -414,14 +538,7 @@ def verify_command(
     report = session.verify()
     emit(
         "task pump-station-world verify",
-        {
-            "valid": report.valid,
-            "issues": list(report.issues),
-            "replayed_transition_ids": list(report.replayed_transition_ids),
-            "final_state_id": report.final_state_id,
-            "active_restriction_ids": list(report.active_restriction_ids),
-            "open_obligation_ids": list(report.open_obligation_ids),
-        },
+        _verification_payload(report),
         start_time=started,
     )
 

--- a/src/aec_bench/contracts/continual_world.py
+++ b/src/aec_bench/contracts/continual_world.py
@@ -6,10 +6,12 @@ from __future__ import annotations
 from enum import StrEnum
 from typing import Final, Literal, Self
 
-from pydantic import field_validator, model_validator
+from pydantic import JsonValue, field_validator, model_validator
 
 from aec_bench.contracts.harness_kernel import ContentAddressedModel, validate_sha256
 from aec_bench.contracts.validators import FrozenStrictModel, NonEmptyStr
+from aec_bench.contracts.world_interface import WorldActorActionRequest
+from aec_bench.contracts.world_session import WorldSessionOpenMode, WorldSessionRequest
 
 CONTINUAL_WORLD_DEFINITION_SCHEMA_VERSION: Final[Literal["aecbench.continual-world-definition.v1"]] = (
     "aecbench.continual-world-definition.v1"
@@ -37,6 +39,12 @@ CONTINUAL_ROLLOUT_GROUP_STATUS_SCHEMA_VERSION: Final[Literal["aecbench.continual
 )
 CONTINUAL_ROLLOUT_CHILD_RUN_REF_SCHEMA_VERSION: Final[Literal["aecbench.continual-rollout-child-run-ref.v1"]] = (
     "aecbench.continual-rollout-child-run-ref.v1"
+)
+CONTINUAL_WORLD_ACTOR_REQUEST_SCHEMA_VERSION: Final[Literal["aecbench.continual-world-actor-request.v1"]] = (
+    "aecbench.continual-world-actor-request.v1"
+)
+CONTINUAL_WORLD_CONTROL_REQUEST_SCHEMA_VERSION: Final[Literal["aecbench.continual-world-control-request.v1"]] = (
+    "aecbench.continual-world-control-request.v1"
 )
 
 
@@ -103,6 +111,144 @@ class ContinualWorldDefinitionSpec(ContentAddressedModel):
             definition_version=self.definition_version,
             content_sha256=self.content_sha256,
         )
+
+
+class ContinualWorldActorRequest(ContentAddressedModel):
+    """One exact actor call routed through a registered continual world."""
+
+    schema_version: Literal["aecbench.continual-world-actor-request.v1"] = CONTINUAL_WORLD_ACTOR_REQUEST_SCHEMA_VERSION
+    definition_ref: ContinualWorldDefinitionRef
+    profile_ref: ContinualWorldProfileRef
+    operation: Literal["capabilities", "observe", "invoke"]
+    session_request: WorldSessionRequest
+    action_request: WorldActorActionRequest | None = None
+
+    @model_validator(mode="after")
+    def validate_actor_request(self) -> Self:
+        task_world_id = self.definition_ref.task_world_id
+        if self.profile_ref.task_world_id != task_world_id:
+            raise ValueError("continual actor profile belongs to another task world")
+        if self.session_request.task_world_id != task_world_id:
+            raise ValueError("continual actor session belongs to another task world")
+        if self.session_request.open_mode is not WorldSessionOpenMode.RESUME:
+            raise ValueError("continual actor request must resume an existing session")
+        if (self.operation == "invoke") != (self.action_request is not None):
+            raise ValueError("continual actor invoke requires exactly one action request")
+        if self.action_request is None:
+            return self
+        binding = self.action_request.binding
+        start_snapshot = self.session_request.start_snapshot
+        if start_snapshot is None:
+            raise ValueError("continual actor session requires an exact start snapshot")
+        if (
+            binding.task_world_id,
+            binding.session_id,
+            binding.run_id,
+            binding.episode_id,
+            binding.world_branch_id,
+            binding.agent_tenure_id,
+            binding.sequence,
+            binding.state_id,
+            binding.commit_id,
+        ) != (
+            task_world_id,
+            self.session_request.session_id,
+            self.session_request.run_id,
+            self.session_request.episode_id,
+            self.session_request.world_branch_id,
+            self.session_request.agent_tenure_id,
+            start_snapshot.sequence,
+            start_snapshot.state_id,
+            start_snapshot.commit_id,
+        ):
+            raise ValueError("continual actor action binding differs from the resumed session")
+        return self
+
+
+class ContinualWorldControlRequest(ContentAddressedModel):
+    """One exact host-control call routed through a registered continual world."""
+
+    schema_version: Literal["aecbench.continual-world-control-request.v1"] = (
+        CONTINUAL_WORLD_CONTROL_REQUEST_SCHEMA_VERSION
+    )
+    definition_ref: ContinualWorldDefinitionRef
+    profile_ref: ContinualWorldProfileRef
+    operation: Literal[
+        "capabilities",
+        "execute",
+        "create_rollout_group",
+        "rollout_group_status",
+        "inspect_rollout_group",
+        "rollout_child_run_ref",
+    ]
+    authority_id: NonEmptyStr
+    control_request: dict[str, JsonValue] | None = None
+    rollout_group_request: ContinualRolloutGroupRequest | None = None
+    group_id: NonEmptyStr | None = None
+    child_id: NonEmptyStr | None = None
+
+    @model_validator(mode="after")
+    def validate_control_request(self) -> Self:
+        task_world_id = self.definition_ref.task_world_id
+        if self.profile_ref.task_world_id != task_world_id:
+            raise ValueError("continual control profile belongs to another task world")
+        if self.operation == "capabilities":
+            if any(
+                item is not None
+                for item in (
+                    self.control_request,
+                    self.rollout_group_request,
+                    self.group_id,
+                    self.child_id,
+                )
+            ):
+                raise ValueError("continual control capabilities accepts no operation payload")
+            return self
+        if self.operation == "execute":
+            if self.control_request is None or any(
+                item is not None
+                for item in (
+                    self.rollout_group_request,
+                    self.group_id,
+                    self.child_id,
+                )
+            ):
+                raise ValueError("continual control execute requires exactly one task control request")
+            if (
+                self.control_request.get("task_world_id") != task_world_id
+                or self.control_request.get("authority_id") != self.authority_id
+            ):
+                raise ValueError("continual task control request differs from its control envelope")
+            return self
+        if self.operation == "create_rollout_group":
+            rollout = self.rollout_group_request
+            if rollout is None or any(
+                item is not None
+                for item in (
+                    self.control_request,
+                    self.group_id,
+                    self.child_id,
+                )
+            ):
+                raise ValueError("continual rollout creation requires exactly one group request")
+            if (
+                rollout.task_world_id,
+                rollout.definition_ref,
+                rollout.profile_ref,
+                rollout.authority_id,
+            ) != (
+                task_world_id,
+                self.definition_ref,
+                self.profile_ref,
+                self.authority_id,
+            ):
+                raise ValueError("continual rollout group request differs from its control envelope")
+            return self
+        if self.rollout_group_request is not None or self.control_request is not None or self.group_id is None:
+            raise ValueError("continual rollout inspection requires exactly one group identity")
+        if (self.operation == "rollout_child_run_ref") != (self.child_id is not None):
+            raise ValueError("continual rollout child resolution requires exactly one child identity")
+        return self
 
 
 class ContinualWorldSnapshotRef(ContentAddressedModel):

--- a/src/aec_bench/harness/world_interface.py
+++ b/src/aec_bench/harness/world_interface.py
@@ -1,115 +1,16 @@
-# ABOUTME: Validates task-neutral actor calls at the provider-independent host boundary.
-# ABOUTME: Leaves action fields, projections, state changes, and verification with each task world.
+# ABOUTME: Preserves the public harness import path for continual-world actor calls.
+# ABOUTME: Re-exports the canonical session protocol and validation from its runtime owner.
 
-from __future__ import annotations
-
-from typing import Protocol
-
-from aec_bench.contracts.world_interface import (
-    WorldActorActionRequest,
-    WorldActorActionResult,
-    WorldActorCapabilityCatalogue,
-    WorldActorObservation,
-    WorldInterfaceError,
+from aec_bench.contracts.world_interface import WorldInterfaceError
+from aec_bench.task_world_templates.continual.actor_session import (
+    ActorWorldSession,
+    invoke_world_actor,
+    observe_world_actor,
 )
-from aec_bench.contracts.world_session import WorldSessionResult
 
-
-class ActorWorldSession(Protocol):
-    """Supported actor contract implemented by one task-owned live session."""
-
-    @property
-    def result(self) -> WorldSessionResult: ...
-
-    @property
-    def actor_capabilities(self) -> WorldActorCapabilityCatalogue: ...
-
-    def observe_actor(self) -> WorldActorObservation: ...
-
-    def invoke_actor_action(
-        self,
-        request: WorldActorActionRequest,
-    ) -> WorldActorActionResult: ...
-
-
-def _validate_observation(
-    session: ActorWorldSession,
-    observation: WorldActorObservation,
-) -> None:
-    result = session.result
-    binding = observation.binding
-    if (
-        binding.task_world_id,
-        binding.session_id,
-        binding.run_id,
-        binding.episode_id,
-        binding.world_branch_id,
-        binding.agent_tenure_id,
-    ) != (
-        result.task_world_id,
-        result.session_id,
-        result.snapshot.run_id,
-        result.snapshot.episode_id,
-        result.snapshot.world_branch_id,
-        result.agent_tenure_id,
-    ):
-        raise WorldInterfaceError(
-            "actor-observation-binding-invalid",
-            "actor observation belongs to another session or world",
-        )
-    if (
-        binding.sequence,
-        binding.state_id,
-        binding.commit_id,
-        binding.actor_view_id,
-        binding.information_set_id,
-    ) != (
-        result.snapshot.sequence,
-        result.snapshot.state_id,
-        result.snapshot.commit_id,
-        result.actor_view_id,
-        result.information_set_id,
-    ):
-        raise WorldInterfaceError(
-            "actor-observation-state-invalid",
-            "actor observation differs from the current public session result",
-        )
-
-
-def observe_world_actor(session: ActorWorldSession) -> WorldActorObservation:
-    """Return and validate the task-owned current actor observation."""
-
-    observation = session.observe_actor()
-    _validate_observation(session, observation)
-    return observation
-
-
-def invoke_world_actor(
-    session: ActorWorldSession,
-    request: WorldActorActionRequest,
-) -> WorldActorActionResult:
-    """Invoke one task-owned action and validate its public post-state binding."""
-
-    if request.action_name not in {item.name for item in session.actor_capabilities.actions}:
-        raise WorldInterfaceError(
-            "actor-action-unavailable",
-            request.action_name,
-        )
-    result = session.invoke_actor_action(request)
-    if result.request_content_sha256 != request.content_sha256:
-        raise WorldInterfaceError(
-            "actor-result-request-invalid",
-            "actor result does not bind the exact request",
-        )
-    if result.pre_binding != request.binding:
-        raise WorldInterfaceError(
-            "actor-result-pre-binding-invalid",
-            "actor result does not preserve the requested binding",
-        )
-    _validate_observation(session, result.next_observation)
-    if result.post_binding != result.next_observation.binding:
-        raise WorldInterfaceError(
-            "actor-result-post-binding-invalid",
-            "actor result and next observation bindings differ",
-        )
-    return result
+__all__ = (
+    "ActorWorldSession",
+    "WorldInterfaceError",
+    "invoke_world_actor",
+    "observe_world_actor",
+)

--- a/src/aec_bench/task_world_templates/continual/actor_session.py
+++ b/src/aec_bench/task_world_templates/continual/actor_session.py
@@ -1,0 +1,122 @@
+# ABOUTME: Validates task-neutral actor calls at the continual-world session boundary.
+# ABOUTME: Leaves action fields, projections, state changes, and verification with each task world.
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from aec_bench.contracts.world_interface import (
+    WorldActorActionRequest,
+    WorldActorActionResult,
+    WorldActorCapabilityCatalogue,
+    WorldActorObservation,
+    WorldInterfaceError,
+)
+from aec_bench.contracts.world_session import WorldSessionResult
+
+
+class ActorWorldSession(Protocol):
+    """Supported actor contract implemented by one task-owned live session."""
+
+    @property
+    def result(self) -> WorldSessionResult: ...
+
+    @property
+    def actor_capabilities(self) -> WorldActorCapabilityCatalogue: ...
+
+    def observe_actor(self) -> WorldActorObservation: ...
+
+    def invoke_actor_action(
+        self,
+        request: WorldActorActionRequest,
+    ) -> WorldActorActionResult: ...
+
+
+def _validate_observation(
+    session: ActorWorldSession,
+    observation: WorldActorObservation,
+) -> None:
+    result = session.result
+    binding = observation.binding
+    if (
+        binding.task_world_id,
+        binding.session_id,
+        binding.run_id,
+        binding.episode_id,
+        binding.world_branch_id,
+        binding.agent_tenure_id,
+    ) != (
+        result.task_world_id,
+        result.session_id,
+        result.snapshot.run_id,
+        result.snapshot.episode_id,
+        result.snapshot.world_branch_id,
+        result.agent_tenure_id,
+    ):
+        raise WorldInterfaceError(
+            "actor-observation-binding-invalid",
+            "actor observation belongs to another session or world",
+        )
+    if (
+        binding.sequence,
+        binding.state_id,
+        binding.commit_id,
+        binding.actor_view_id,
+        binding.information_set_id,
+    ) != (
+        result.snapshot.sequence,
+        result.snapshot.state_id,
+        result.snapshot.commit_id,
+        result.actor_view_id,
+        result.information_set_id,
+    ):
+        raise WorldInterfaceError(
+            "actor-observation-state-invalid",
+            "actor observation differs from the current public session result",
+        )
+
+
+def observe_world_actor(session: ActorWorldSession) -> WorldActorObservation:
+    """Return and validate the task-owned current actor observation."""
+
+    observation = session.observe_actor()
+    _validate_observation(session, observation)
+    return observation
+
+
+def invoke_world_actor(
+    session: ActorWorldSession,
+    request: WorldActorActionRequest,
+) -> WorldActorActionResult:
+    """Invoke one task-owned action and validate its public post-state binding."""
+
+    if request.action_name not in {item.name for item in session.actor_capabilities.actions}:
+        raise WorldInterfaceError(
+            "actor-action-unavailable",
+            request.action_name,
+        )
+    result = session.invoke_actor_action(request)
+    if result.request_content_sha256 != request.content_sha256:
+        raise WorldInterfaceError(
+            "actor-result-request-invalid",
+            "actor result does not bind the exact request",
+        )
+    if result.pre_binding != request.binding:
+        raise WorldInterfaceError(
+            "actor-result-pre-binding-invalid",
+            "actor result does not preserve the requested binding",
+        )
+    _validate_observation(session, result.next_observation)
+    if result.post_binding != result.next_observation.binding:
+        raise WorldInterfaceError(
+            "actor-result-post-binding-invalid",
+            "actor result and next observation bindings differ",
+        )
+    return result
+
+
+__all__ = (
+    "ActorWorldSession",
+    "invoke_world_actor",
+    "observe_world_actor",
+)

--- a/src/aec_bench/task_world_templates/continual/catalogue.py
+++ b/src/aec_bench/task_world_templates/continual/catalogue.py
@@ -6,7 +6,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from aec_bench.contracts.continual_world import ContinualWorldDefinitionRef
-from aec_bench.task_world_templates.continual.definition import ContinualWorldDefinition
+from aec_bench.task_world_templates.continual.definition import (
+    ContinualWorldDefinition,
+    ContinualWorldHarborPort,
+)
 
 
 @dataclass(frozen=True)
@@ -19,6 +22,16 @@ class ContinualWorldCatalogue:
         task_world_ids = tuple(definition.spec.task_world_id for definition in self.definitions)
         if len(task_world_ids) != len(set(task_world_ids)):
             raise ValueError("continual-world catalogue task world ids must be unique")
+        harbor_execution_kinds = tuple(
+            execution_kind
+            for definition in self.definitions
+            if definition.harbor_port is not None
+            for execution_kind in definition.harbor_port.execution_kinds
+        )
+        if any(not execution_kind.strip() for execution_kind in harbor_execution_kinds):
+            raise ValueError("Harbor execution kinds must not be empty")
+        if len(harbor_execution_kinds) != len(set(harbor_execution_kinds)):
+            raise ValueError("Harbor execution kinds must be unique")
         object.__setattr__(
             self,
             "definitions",
@@ -43,3 +56,15 @@ class ContinualWorldCatalogue:
         if definition.ref != reference:
             raise ValueError(f"content-pinned definition does not match: {reference.task_world_id}")
         return definition
+
+    def resolve_harbor(
+        self,
+        execution_kind: str,
+    ) -> tuple[ContinualWorldDefinition, ContinualWorldHarborPort]:
+        """Resolve one unique task-owned Harbor port by stable execution kind."""
+
+        for definition in self.definitions:
+            port = definition.harbor_port
+            if port is not None and execution_kind in port.execution_kinds:
+                return definition, port
+        raise KeyError(f"unknown continual-world Harbor execution kind: {execution_kind}")

--- a/src/aec_bench/task_world_templates/continual/definition.py
+++ b/src/aec_bench/task_world_templates/continual/definition.py
@@ -5,15 +5,21 @@ from __future__ import annotations
 
 import hashlib
 import inspect
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from typing import Any
+from pathlib import Path
+from typing import Any, Protocol
 
 from aec_bench.contracts.continual_world import (
     ContinualWorldDefinitionRef,
     ContinualWorldDefinitionSpec,
     ContinualWorldProfileRef,
 )
+from aec_bench.contracts.world_interface import (
+    WorldControlCapabilityCatalogue,
+)
+from aec_bench.contracts.world_session import WorldSessionRequest
+from aec_bench.task_world_templates.continual.actor_session import ActorWorldSession
 from aec_bench.task_world_templates.continual.branch_port import ContinualWorldBranchPort
 
 
@@ -25,6 +31,104 @@ class LoadedContinualWorldProfile:
     value: object
 
 
+class ContinualWorldExecutionPort(Protocol):
+    """Task-owned actor and host-control adapter selected by the catalogue."""
+
+    def open_actor_session(
+        self,
+        *,
+        profile: LoadedContinualWorldProfile,
+        run_root: Path,
+        package_root: Path | None,
+        request: WorldSessionRequest,
+    ) -> ActorWorldSession:
+        """Resume one actor session through the task's canonical session owner."""
+
+    def control_capabilities(
+        self,
+        *,
+        profile: LoadedContinualWorldProfile,
+        run_root: Path,
+        package_root: Path | None,
+        authorised_principal_ids: tuple[str, ...],
+        authority_id: str,
+    ) -> WorldControlCapabilityCatalogue:
+        """Return the task's closed host-control catalogue."""
+
+    def execute_control(
+        self,
+        *,
+        profile: LoadedContinualWorldProfile,
+        run_root: Path,
+        package_root: Path | None,
+        authorised_principal_ids: tuple[str, ...],
+        request_payload: Mapping[str, object],
+    ) -> object:
+        """Validate and execute one task-owned control request."""
+
+
+@dataclass(frozen=True, slots=True)
+class ContinualWorldHarborBridgeIdentity:
+    """Task-neutral facts needed by the main Harbor agent."""
+
+    execution_kind: str
+    bridge_mode: str
+    manifest_sha256: str
+    output_path: str
+
+
+@dataclass(frozen=True, slots=True)
+class ContinualWorldHarborSessionResult:
+    """Task-neutral result returned by one registered Harbor session port."""
+
+    output_dir: Path
+    output_file: Path
+    input_tokens: int
+    output_tokens: int
+    resolved_model: str
+    session_id: str
+    status: str
+
+
+class ContinualWorldHarborPort(Protocol):
+    """Task-owned Harbor adapter selected by a unique execution kind."""
+
+    @property
+    def execution_kinds(self) -> tuple[str, ...]: ...
+
+    @property
+    def default_max_turns(self) -> int: ...
+
+    def validate_configuration(
+        self,
+        *,
+        configuration: Mapping[str, Any],
+        model_name: str,
+    ) -> None:
+        """Validate task-owned bridge and controller settings."""
+
+    def load_bridge(self, environment_dir: Path) -> object:
+        """Load and independently validate one exported task bridge."""
+
+    def bridge_identity(self, bridge: object) -> ContinualWorldHarborBridgeIdentity:
+        """Project only the bridge facts needed by generic orchestration."""
+
+    def uses_model_controller(self, *, bridge: object, model_name: str) -> bool:
+        """Return whether provider preflight is required for this execution."""
+
+    def run_session(
+        self,
+        *,
+        bridge: object,
+        staging_dir: Path,
+        session_identity: str,
+        model_name: str,
+        max_turns: int,
+        registry: object | None,
+    ) -> ContinualWorldHarborSessionResult:
+        """Run one task-owned session and return generic upload metadata."""
+
+
 @dataclass(frozen=True)
 class ContinualWorldDefinition:
     """Registered world identity with a task-owned profile validation port."""
@@ -32,6 +136,8 @@ class ContinualWorldDefinition:
     spec: ContinualWorldDefinitionSpec
     profile_loader: Callable[[ContinualWorldProfileRef], LoadedContinualWorldProfile]
     branch_port: ContinualWorldBranchPort | None = None
+    execution_port: ContinualWorldExecutionPort | None = None
+    harbor_port: ContinualWorldHarborPort | None = None
 
     @property
     def ref(self) -> ContinualWorldDefinitionRef:

--- a/src/aec_bench/task_world_templates/continual/interface.py
+++ b/src/aec_bench/task_world_templates/continual/interface.py
@@ -1,0 +1,128 @@
+# ABOUTME: Dispatches separate actor and host-control requests through the continual-world catalogue.
+# ABOUTME: Keeps task state and task-specific control decoding inside each registered execution port.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from aec_bench.contracts.continual_world import (
+    ContinualWorldActorRequest,
+    ContinualWorldControlRequest,
+)
+from aec_bench.task_world_templates.continual.actor_session import (
+    invoke_world_actor,
+    observe_world_actor,
+)
+from aec_bench.task_world_templates.continual.catalogue import ContinualWorldCatalogue
+from aec_bench.task_world_templates.continual.definition import (
+    ContinualWorldDefinition,
+    LoadedContinualWorldProfile,
+)
+from aec_bench.task_world_templates.continual.rollout_control import ContinualRolloutControl
+
+
+@dataclass(frozen=True, slots=True)
+class ContinualWorldInterfaceContext:
+    """Host-owned roots, catalogue, and authorities for one installed call."""
+
+    catalogue: ContinualWorldCatalogue
+    run_root: Path
+    rollout_repository_root: Path | None
+    authorised_principal_ids: tuple[str, ...]
+    package_root: Path | None = None
+
+    def __post_init__(self) -> None:
+        if any(not principal.strip() for principal in self.authorised_principal_ids):
+            raise ValueError("continual interface host principals must not be empty")
+        if len(self.authorised_principal_ids) != len(set(self.authorised_principal_ids)):
+            raise ValueError("continual interface host principals must be distinct")
+
+
+def _resolve(
+    context: ContinualWorldInterfaceContext,
+    request: ContinualWorldActorRequest | ContinualWorldControlRequest,
+) -> tuple[ContinualWorldDefinition, LoadedContinualWorldProfile]:
+    definition = context.catalogue.resolve(request.definition_ref)
+    loaded = definition.load_profile(request.profile_ref)
+    return definition, loaded
+
+
+def dispatch_continual_actor(
+    *,
+    context: ContinualWorldInterfaceContext,
+    request: ContinualWorldActorRequest,
+) -> object:
+    """Execute one actor call after exact definition and profile resolution."""
+
+    definition, loaded = _resolve(context, request)
+    port = definition.execution_port
+    if port is None:
+        raise ValueError(f"continual world has no registered execution port: {definition.ref.task_world_id}")
+    session = port.open_actor_session(
+        profile=loaded,
+        run_root=context.run_root,
+        package_root=context.package_root,
+        request=request.session_request,
+    )
+    if request.operation == "capabilities":
+        return session.actor_capabilities
+    if request.operation == "observe":
+        return observe_world_actor(session)
+    assert request.action_request is not None
+    return invoke_world_actor(session, request.action_request)
+
+
+def dispatch_continual_control(
+    *,
+    context: ContinualWorldInterfaceContext,
+    request: ContinualWorldControlRequest,
+) -> object:
+    """Execute one host-control or rollout call through its registered owner."""
+
+    definition, loaded = _resolve(context, request)
+    if request.authority_id not in context.authorised_principal_ids:
+        raise ValueError("continual interface control authority is not authorised")
+    if request.operation == "capabilities":
+        port = definition.execution_port
+        if port is None:
+            raise ValueError(f"continual world has no registered execution port: {definition.ref.task_world_id}")
+        return port.control_capabilities(
+            profile=loaded,
+            run_root=context.run_root,
+            package_root=context.package_root,
+            authorised_principal_ids=context.authorised_principal_ids,
+            authority_id=request.authority_id,
+        )
+    if request.operation == "execute":
+        port = definition.execution_port
+        if port is None:
+            raise ValueError(f"continual world has no registered execution port: {definition.ref.task_world_id}")
+        assert request.control_request is not None
+        return port.execute_control(
+            profile=loaded,
+            run_root=context.run_root,
+            package_root=context.package_root,
+            authorised_principal_ids=context.authorised_principal_ids,
+            request_payload=request.control_request,
+        )
+    rollout_root = context.rollout_repository_root
+    if rollout_root is None:
+        raise ValueError("continual rollout control requires a host-private repository root")
+    rollout = ContinualRolloutControl(
+        definition,
+        parent_run_root=context.run_root,
+        rollout_repository_root=rollout_root,
+        authorised_principal_ids=context.authorised_principal_ids,
+        package_root=context.package_root,
+    )
+    if request.operation == "create_rollout_group":
+        assert request.rollout_group_request is not None
+        return rollout.create_group(request.rollout_group_request)
+    assert request.group_id is not None
+    if request.operation == "rollout_group_status":
+        return rollout.group_status(request.group_id)
+    if request.operation == "inspect_rollout_group":
+        return rollout.inspect_group(request.group_id)
+    assert request.child_id is not None
+    return rollout.child_run_ref(request.group_id, request.child_id)

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/continual_definition.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/continual_definition.py
@@ -8,11 +8,25 @@ import inspect
 from collections.abc import Mapping
 from dataclasses import dataclass
 from functools import cache
+from pathlib import Path
+from typing import Any, cast
 
+from pydantic import TypeAdapter
+
+from aec_bench.contracts.agent_output import AgentOutputStatus
 from aec_bench.contracts.continual_world import ContinualWorldDefinitionSpec, ContinualWorldProfileRef
 from aec_bench.contracts.harness_kernel import canonical_content_sha256
+from aec_bench.contracts.world_interface import (
+    WorldControlCapabilityCatalogue,
+    WorldControlRequest,
+)
+from aec_bench.contracts.world_session import WorldSessionRequest
+from aec_bench.harness.world_session import open_world_session
+from aec_bench.task_world_templates.continual.actor_session import ActorWorldSession
 from aec_bench.task_world_templates.continual.definition import (
     ContinualWorldDefinition,
+    ContinualWorldHarborBridgeIdentity,
+    ContinualWorldHarborSessionResult,
     LoadedContinualWorldProfile,
     python_source_sha256,
 )
@@ -53,6 +67,328 @@ class PumpStationContinualProfile:
     station_package: ReferencePackage
     model: PumpStationCoupledModel
     opening_state: PumpStationCoupledWorldState
+
+
+@dataclass(frozen=True, slots=True)
+class PumpStationContinualExecutionPort:
+    """Bind registered actor and host-control calls to the canonical pump owners."""
+
+    def open_actor_session(
+        self,
+        *,
+        profile: LoadedContinualWorldProfile,
+        run_root: Path,
+        package_root: Path | None,
+        request: WorldSessionRequest,
+    ) -> ActorWorldSession:
+        from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_session import (
+            PumpStationWorldSessionFactory,
+        )
+
+        profile_ref = _execution_profile_ref(profile)
+        return cast(
+            ActorWorldSession,
+            open_world_session(
+                request,
+                PumpStationWorldSessionFactory(
+                    run_root,
+                    profile_ref=profile_ref,
+                    package_root=package_root,
+                ),
+            ),
+        )
+
+    def control_capabilities(
+        self,
+        *,
+        profile: LoadedContinualWorldProfile,
+        run_root: Path,
+        package_root: Path | None,
+        authorised_principal_ids: tuple[str, ...],
+        authority_id: str,
+    ) -> WorldControlCapabilityCatalogue:
+        from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_control import (
+            PumpStationWorldControl,
+        )
+
+        profile_ref = _execution_profile_ref(profile)
+        return PumpStationWorldControl(
+            run_root,
+            authorised_principal_ids=authorised_principal_ids,
+            profile_ref=profile_ref,
+            package_root=package_root,
+        ).capabilities(authority_id)
+
+    def execute_control(
+        self,
+        *,
+        profile: LoadedContinualWorldProfile,
+        run_root: Path,
+        package_root: Path | None,
+        authorised_principal_ids: tuple[str, ...],
+        request_payload: Mapping[str, object],
+    ) -> object:
+        from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_models import (
+            PumpStationBoundControlRequest,
+        )
+        from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_control import (
+            PumpStationEvidenceControlRequest,
+            PumpStationWorldControl,
+        )
+
+        profile_ref = _execution_profile_ref(profile)
+        request: WorldControlRequest | PumpStationEvidenceControlRequest | PumpStationBoundControlRequest = TypeAdapter(
+            WorldControlRequest | PumpStationEvidenceControlRequest | PumpStationBoundControlRequest
+        ).validate_python(dict(request_payload))
+        return PumpStationWorldControl(
+            run_root,
+            authorised_principal_ids=authorised_principal_ids,
+            profile_ref=profile_ref,
+            package_root=package_root,
+        ).execute(request)
+
+
+@dataclass(frozen=True, slots=True)
+class PumpStationContinualHarborPort:
+    """Keep every pump Harbor stage and controller choice inside the task port."""
+
+    execution_kinds: tuple[str, ...] = (
+        "stewardship_world_session",
+        "stewardship_review_session",
+    )
+
+    @property
+    def default_max_turns(self) -> int:
+        """Return the task-owned model turn limit from its canonical session owner."""
+
+        from aec_bench.task_world_templates.stewardship.wastewater_pump_station.harbor_session import (
+            PUMP_STATION_MODEL_MAX_TURNS,
+        )
+
+        return PUMP_STATION_MODEL_MAX_TURNS
+
+    def validate_configuration(
+        self,
+        *,
+        configuration: Mapping[str, Any],
+        model_name: str,
+    ) -> None:
+        from aec_bench.task_world_templates.stewardship.wastewater_pump_station.harbor_export import (
+            PUMP_STATION_HARBOR_BRIDGE_MODE,
+            PUMP_STATION_HARBOR_EXECUTION_KIND,
+            PUMP_STATION_REVIEW_HARBOR_BRIDGE_MODE,
+            PUMP_STATION_REVIEW_HARBOR_EXECUTION_KIND,
+        )
+        from aec_bench.task_world_templates.stewardship.wastewater_pump_station.harbor_session import (
+            PUMP_STATION_MODEL_CONTROLLER_MODE,
+            PUMP_STATION_REFERENCE_CONTROLLER_ID,
+        )
+        from aec_bench.task_world_templates.stewardship.wastewater_pump_station.reference_controller import (
+            PUMP_STATION_REFERENCE_SYSTEM_CONTROLLER_ID,
+        )
+
+        session = configuration.get("world_session")
+        if not isinstance(session, dict):
+            raise ValueError("pump-station world session bridge configuration differs")
+        bridge_mode = session.get("bridge_mode")
+        maintenance_review = bridge_mode == PUMP_STATION_REVIEW_HARBOR_BRIDGE_MODE
+        expected_execution_kind = (
+            PUMP_STATION_REVIEW_HARBOR_EXECUTION_KIND if maintenance_review else PUMP_STATION_HARBOR_EXECUTION_KIND
+        )
+        if configuration.get("execution_kind") != expected_execution_kind:
+            raise ValueError("pump-station world session requires its exact execution kind")
+        if bridge_mode not in {
+            PUMP_STATION_HARBOR_BRIDGE_MODE,
+            PUMP_STATION_REVIEW_HARBOR_BRIDGE_MODE,
+        }:
+            raise ValueError("pump-station world session bridge configuration differs")
+        controller = session.get("controller")
+        reference_controller = model_name in {
+            PUMP_STATION_REFERENCE_CONTROLLER_ID,
+            PUMP_STATION_REFERENCE_SYSTEM_CONTROLLER_ID,
+        }
+        if maintenance_review and not reference_controller:
+            raise ValueError("pump-station review model runs require the separately approved direct host runner")
+        expected_session = {"bridge_mode": bridge_mode}
+        if not reference_controller:
+            expected_session["controller"] = PUMP_STATION_MODEL_CONTROLLER_MODE
+        if session != expected_session:
+            raise ValueError("pump-station world session bridge configuration differs")
+        if reference_controller and controller is not None:
+            raise ValueError("pump-station reference controller cannot use model mode")
+        if not reference_controller and not model_name.strip():
+            raise ValueError("pump-station model controller requires a model")
+
+    def load_bridge(self, environment_dir: Path) -> object:
+        from aec_bench.task_world_templates.stewardship.wastewater_pump_station.harbor_export import (
+            load_pump_station_harbor_bridge,
+        )
+
+        return load_pump_station_harbor_bridge(environment_dir)
+
+    def bridge_identity(self, bridge: object) -> ContinualWorldHarborBridgeIdentity:
+        from aec_bench.task_world_templates.stewardship.wastewater_pump_station.harbor_export import (
+            PumpStationHarborBridge,
+        )
+
+        if not isinstance(bridge, PumpStationHarborBridge):
+            raise TypeError("pump-station Harbor port received another task bridge")
+        return ContinualWorldHarborBridgeIdentity(
+            execution_kind=bridge.execution_kind,
+            bridge_mode=bridge.bridge_mode,
+            manifest_sha256=bridge.export_manifest_sha256,
+            output_path=bridge.output_path,
+        )
+
+    def uses_model_controller(self, *, bridge: object, model_name: str) -> bool:
+        from aec_bench.task_world_templates.stewardship.wastewater_pump_station.harbor_export import (
+            PumpStationHarborBridge,
+        )
+        from aec_bench.task_world_templates.stewardship.wastewater_pump_station.harbor_session import (
+            PUMP_STATION_REFERENCE_CONTROLLER_ID,
+        )
+        from aec_bench.task_world_templates.stewardship.wastewater_pump_station.reference_controller import (
+            PUMP_STATION_REFERENCE_SYSTEM_CONTROLLER_ID,
+        )
+
+        if not isinstance(bridge, PumpStationHarborBridge):
+            raise TypeError("pump-station Harbor port received another task bridge")
+        expected_reference_controller = (
+            PUMP_STATION_REFERENCE_SYSTEM_CONTROLLER_ID
+            if bridge.profile_ref is not None
+            else PUMP_STATION_REFERENCE_CONTROLLER_ID
+        )
+        if (
+            model_name
+            in {
+                PUMP_STATION_REFERENCE_CONTROLLER_ID,
+                PUMP_STATION_REFERENCE_SYSTEM_CONTROLLER_ID,
+            }
+            and model_name != expected_reference_controller
+        ):
+            raise ValueError("pump-station reference controller differs from the exported profile")
+        return model_name != expected_reference_controller
+
+    def run_session(
+        self,
+        *,
+        bridge: object,
+        staging_dir: Path,
+        session_identity: str,
+        model_name: str,
+        max_turns: int,
+        registry: object | None,
+    ) -> ContinualWorldHarborSessionResult:
+        from aec_bench.task_world_templates.stewardship.wastewater_pump_station.harbor_export import (
+            PumpStationHarborBridge,
+        )
+        from aec_bench.task_world_templates.stewardship.wastewater_pump_station.harbor_session import (
+            PUMP_STATION_REFERENCE_CONTROLLER_ID,
+            run_pump_station_evidence_health_reference_session,
+            run_pump_station_model_session,
+            run_pump_station_reference_session,
+            run_pump_station_rich_work_reference_session,
+        )
+        from aec_bench.task_world_templates.stewardship.wastewater_pump_station.maintenance_review_harbor import (
+            run_pump_station_review_reference_session,
+        )
+        from aec_bench.task_world_templates.stewardship.wastewater_pump_station.reference_controller import (
+            PUMP_STATION_REFERENCE_SYSTEM_CONTROLLER_ID,
+        )
+
+        if not isinstance(bridge, PumpStationHarborBridge):
+            raise TypeError("pump-station Harbor port received another task bridge")
+        run_dir = staging_dir / "world-session"
+        expected_reference_controller = (
+            PUMP_STATION_REFERENCE_SYSTEM_CONTROLLER_ID
+            if bridge.profile_ref is not None
+            else PUMP_STATION_REFERENCE_CONTROLLER_ID
+        )
+        model_controller = self.uses_model_controller(
+            bridge=bridge,
+            model_name=model_name,
+        )
+        if not model_controller:
+            if bridge.maintenance_review:
+                review_session = run_pump_station_review_reference_session(
+                    bridge=bridge,
+                    output_dir=run_dir,
+                    session_identity=session_identity,
+                )
+                world_session_id = review_session.observation.session_id
+            else:
+                reference_runner = (
+                    run_pump_station_reference_session
+                    if bridge.profile_ref is not None
+                    else run_pump_station_evidence_health_reference_session
+                    if bridge.evidence_health
+                    else run_pump_station_rich_work_reference_session
+                    if bridge.rich_work_processes
+                    else run_pump_station_reference_session
+                )
+                world_session = reference_runner(
+                    bridge=bridge,
+                    output_dir=run_dir,
+                    session_identity=session_identity,
+                )
+                world_session_id = world_session.request.session_id
+            output_file = staging_dir / "output.md"
+            output_file.write_text(
+                (
+                    "The deterministic wastewater pump-station closeout review completed.\n"
+                    if bridge.maintenance_review
+                    else "The deterministic wastewater pump-station session completed.\n"
+                ),
+                encoding="utf-8",
+            )
+            return ContinualWorldHarborSessionResult(
+                output_dir=run_dir,
+                output_file=output_file,
+                input_tokens=0,
+                output_tokens=0,
+                resolved_model=expected_reference_controller,
+                session_id=world_session_id,
+                status="completed",
+            )
+        model_session = run_pump_station_model_session(
+            bridge=bridge,
+            output_dir=run_dir,
+            session_identity=session_identity,
+            model=model_name,
+            max_turns=max_turns,
+            registry=registry,
+        )
+        adapter_result = model_session.adapter_result
+        session_status = (
+            "completed"
+            if adapter_result.agent_output.status is AgentOutputStatus.COMPLETED and model_session.verification.valid
+            else "incomplete"
+        )
+        return ContinualWorldHarborSessionResult(
+            output_dir=run_dir,
+            output_file=run_dir / "output.md",
+            input_tokens=adapter_result.usage_input_tokens or 0,
+            output_tokens=adapter_result.usage_output_tokens or 0,
+            resolved_model=adapter_result.resolved_model,
+            session_id=model_session.request.session_id,
+            status=session_status,
+        )
+
+
+def _execution_profile_ref(profile: LoadedContinualWorldProfile) -> ContinualWorldProfileRef:
+    profile_value = profile.value
+    if not isinstance(profile_value, PumpStationContinualProfile):
+        raise TypeError("registered pump execution port received another profile value")
+    reference = profile.reference
+    if (
+        reference.task_world_id != PUMP_STATION_TASK_WORLD_ID
+        or reference.profile_id != PUMP_STATION_REFERENCE_SYSTEM_ID
+        or reference.profile_version != PUMP_STATION_RS1_PROFILE_VERSION
+        or profile_value.reference_system.descriptor_content_id != reference.profile_content_sha256
+        or profile_value.station_package.profile_id != profile_value.reference_system.station_data_profile_id
+    ):
+        raise ValueError("registered pump execution profile content differs")
+    return reference
 
 
 def _validated_profile_data() -> tuple[PumpStationReferenceSystem, ReferencePackage]:
@@ -108,6 +444,8 @@ def _implementation_content_sha256() -> str:
             "model_factory": python_source_sha256(coupled_pump_station_model_from_package),
             "opening_state_factory": python_source_sha256(create_asw_8_world_state),
             "branch_adapter_module": adapter_source_sha256,
+            "execution_port": python_source_sha256(PumpStationContinualExecutionPort),
+            "harbor_port": python_source_sha256(PumpStationContinualHarborPort),
         }
     )
 
@@ -136,4 +474,6 @@ def pump_station_continual_world_definition() -> ContinualWorldDefinition:
         ),
         profile_loader=_load_pump_station_profile,
         branch_port=PumpStationContinualWorldBranchPort(),
+        execution_port=PumpStationContinualExecutionPort(),
+        harbor_port=PumpStationContinualHarborPort(),
     )

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/continual_rollout_adapter.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/continual_rollout_adapter.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import cast
@@ -10,7 +11,10 @@ from typing import cast
 from aec_bench.contracts.continual_world import (
     ContinualRolloutChildReceipt,
     ContinualRolloutChildRequest,
+    ContinualRolloutChildRunRef,
     ContinualRolloutGroupRequest,
+    ContinualWorldDefinitionRef,
+    ContinualWorldProfileRef,
     ContinualWorldSnapshotRef,
 )
 from aec_bench.task_world_templates.continual.branch_port import (
@@ -55,6 +59,8 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_ru
     pump_station_artifact_id,
 )
 
+_TASK_RECEIPT_PATH = "rollout-branch-receipt.json"
+
 
 @dataclass(frozen=True, slots=True)
 class _PumpStationVerifiedRolloutOrigin:
@@ -67,10 +73,166 @@ class _PumpStationVerifiedRolloutOrigin:
     remaining_schedule_sha256: str
 
 
+def validate_pump_station_rollout_child_run(
+    child_run_root: Path,
+    rollout_child_ref: ContinualRolloutChildRunRef,
+    *,
+    definition_ref: ContinualWorldDefinitionRef,
+    profile_ref: ContinualWorldProfileRef,
+    request: ContinualRolloutGroupRequest | None = None,
+    child: ContinualRolloutChildRequest | None = None,
+    shared_receipt: ContinualRolloutChildReceipt | None = None,
+) -> PumpStationRolloutBranchReceiptV2:
+    """Verify one task-owned child tree against exact registered authority."""
+
+    root = Path(child_run_root)
+    _validate_plain_directory_tree(root)
+    if (root / "session-authority").exists():
+        raise ValueError("pump-station rollout child contains active session authority")
+    if (
+        rollout_child_ref.task_world_id != definition_ref.task_world_id
+        or rollout_child_ref.task_world_id != profile_ref.task_world_id
+    ):
+        raise ValueError("pump-station rollout child belongs to another task world")
+    repository = PumpStationWorldRunRepository(root)
+    manifest = repository.load_manifest()
+    if (
+        not isinstance(manifest, PumpStationWorldRunManifestV2)
+        or PumpStationWorldRun._definition_ref(manifest) != definition_ref
+        or PumpStationWorldRun._profile_ref(manifest) != profile_ref
+        or manifest.initial_state_source.kind != "rollout_parent_snapshot"
+    ):
+        raise ValueError("pump-station rollout child manifest authority differs")
+    snapshot = repository.current_snapshot()
+    run = PumpStationWorldRun.resume_reference_system(
+        repository=repository,
+        snapshot=snapshot,
+    )
+    receipt_payload = (root / _TASK_RECEIPT_PATH).read_bytes()
+    task_receipt = load_pump_station_artifact(
+        receipt_payload,
+        PumpStationRolloutBranchReceiptV2,
+        record_profile="v4",
+    )
+    initial_state = repository.load_state(manifest.initial_state_id)
+    if initial_state.state_version != PUMP_STATION_STATE_VERSION_V4:
+        raise ValueError("registered pump child initial state is not V4")
+    remaining_schedule_sha256 = _remaining_schedule_sha256(
+        cast(PumpStationCoupledStewardshipState, initial_state),
+    )
+    expected_snapshot = (
+        rollout_child_ref.run_id,
+        rollout_child_ref.episode_id,
+        rollout_child_ref.world_branch_id,
+        rollout_child_ref.initial_snapshot.sequence,
+        rollout_child_ref.initial_snapshot.state_id,
+        rollout_child_ref.initial_snapshot.commit_id,
+    )
+    current_snapshot = (
+        snapshot.run_id,
+        snapshot.episode_id,
+        snapshot.world_branch_id,
+        snapshot.sequence,
+        snapshot.state_id,
+        snapshot.commit_id,
+    )
+    receipt_snapshot = (
+        task_receipt.initial_snapshot.run_id,
+        task_receipt.initial_snapshot.episode_id,
+        task_receipt.initial_snapshot.world_branch_id,
+        task_receipt.initial_snapshot.sequence,
+        task_receipt.initial_snapshot.state_id,
+        task_receipt.initial_snapshot.commit_id,
+    )
+    source = manifest.initial_state_source
+    receipt_provenance = (
+        task_receipt.shared_group_request_content_sha256,
+        task_receipt.shared_child_request_content_sha256,
+        task_receipt.parent_snapshot.run_id,
+        task_receipt.parent_snapshot.world_branch_id,
+        task_receipt.parent_snapshot.state_id,
+        task_receipt.parent_snapshot.commit_id,
+        task_receipt.parent_origin_remaining_schedule_sha256,
+        task_receipt.ancestor_branch_ids,
+        task_receipt.temporal_bundle_content_id,
+    )
+    manifest_provenance = (
+        source.rollout_group_request_content_id,
+        source.child_request_content_id,
+        source.parent_run_id,
+        source.parent_branch_id,
+        source.parent_state_id,
+        source.parent_commit_id,
+        source.parent_origin_remaining_schedule_sha256,
+        source.ancestor_branch_ids,
+        manifest.temporal_bundle_content_id,
+    )
+    if (
+        current_snapshot != expected_snapshot
+        or receipt_snapshot != expected_snapshot
+        or task_receipt.receipt_version != PUMP_STATION_ROLLOUT_BRANCH_RECEIPT_VERSION_V2
+        or task_receipt.group_id != rollout_child_ref.group_id
+        or task_receipt.child_id != rollout_child_ref.child_id
+        or task_receipt.child_manifest_content_id != rollout_child_ref.child_manifest_content_sha256
+        or receipt_provenance != manifest_provenance
+        or task_receipt.parent_origin_remaining_schedule_sha256 != remaining_schedule_sha256
+        or (manifest.initial_sequence, manifest.initial_state_id)
+        != (task_receipt.parent_snapshot.sequence, task_receipt.parent_snapshot.state_id)
+        or (manifest.run_id, manifest.episode_id, manifest.world_branch_id)
+        != (rollout_child_ref.run_id, rollout_child_ref.episode_id, rollout_child_ref.world_branch_id)
+        or pump_station_artifact_id(manifest, record_profile="manifest-v2")
+        != rollout_child_ref.child_manifest_content_sha256
+        or not run.verify_v4().valid
+    ):
+        raise ValueError("pump-station rollout child run identity differs")
+
+    supplied_shared_authority = (request, child, shared_receipt)
+    if any(value is not None for value in supplied_shared_authority):
+        if request is None or child is None or shared_receipt is None:
+            raise ValueError("registered pump child shared authority is incomplete")
+        expected_parent_snapshot = _pump_snapshot(
+            request.parent_snapshot,
+            snapshot_version=manifest.snapshot_version,
+        )
+        if (
+            request.definition_ref != definition_ref
+            or request.profile_ref != profile_ref
+            or request.task_world_id != rollout_child_ref.task_world_id
+            or request.group_id != rollout_child_ref.group_id
+            or child.child_id != rollout_child_ref.child_id
+            or (child.run_id, child.episode_id, child.world_branch_id)
+            != (rollout_child_ref.run_id, rollout_child_ref.episode_id, rollout_child_ref.world_branch_id)
+            or shared_receipt.group_id != request.group_id
+            or shared_receipt.child_id != child.child_id
+            or shared_receipt.child_request_content_sha256 != child.content_sha256
+            or shared_receipt.parent_snapshot != request.parent_snapshot
+            or shared_receipt.initial_snapshot != rollout_child_ref.initial_snapshot
+            or shared_receipt.child_manifest_content_sha256 != rollout_child_ref.child_manifest_content_sha256
+            or shared_receipt.ancestor_world_branch_ids != task_receipt.ancestor_branch_ids
+            or hashlib.sha256(receipt_payload).hexdigest() != shared_receipt.task_branch_receipt_content_sha256
+            or task_receipt.shared_group_request_content_sha256 != request.content_sha256
+            or task_receipt.shared_child_request_content_sha256 != child.content_sha256
+            or task_receipt.parent_snapshot != expected_parent_snapshot
+            or source.rollout_group_request_id != request.request_id
+            or source.parent_manifest_content_id != request.parent_manifest_content_sha256
+            or source.origin_verification_content_id != request.origin_verification_content_sha256
+        ):
+            raise ValueError("registered pump child rollout provenance differs")
+    return task_receipt
+
+
+def _validate_plain_directory_tree(root: Path) -> None:
+    """Reject links and special members from one child authority tree."""
+
+    if root.is_symlink() or not root.is_dir():
+        raise ValueError("pump-station rollout child must be a plain directory")
+    for candidate in root.rglob("*"):
+        if candidate.is_symlink() or not (candidate.is_file() or candidate.is_dir()):
+            raise ValueError("pump-station rollout child contains an unsafe filesystem member")
+
+
 class PumpStationContinualWorldBranchPort:
     """Materialize registered pump children through the durable V4 world run."""
-
-    _TASK_RECEIPT_PATH = "rollout-branch-receipt.json"
 
     def verify_origin(
         self,
@@ -230,7 +392,7 @@ class PumpStationContinualWorldBranchPort:
             repository.root,
             parent_run_root=parent_run_root,
         ).publish_bytes(
-            self._TASK_RECEIPT_PATH,
+            _TASK_RECEIPT_PATH,
             pump_station_artifact_bytes(task_receipt, record_profile="v4"),
         )
         return ContinualWorldBranchMaterialization(
@@ -253,113 +415,26 @@ class PumpStationContinualWorldBranchPort:
     ) -> None:
         """Verify the child, complete source provenance, and task receipt."""
 
-        del package_root
+        del package_root, parent_run_root
         self._profile(profile_value)
-        repository = PumpStationWorldRunRepository(child_run_root)
-        manifest = repository.load_manifest()
-        if not isinstance(manifest, PumpStationWorldRunManifestV2):
-            raise ValueError("registered pump child requires manifest v2")
-        run = PumpStationWorldRun.resume_reference_system(
-            repository=repository,
-            snapshot=repository.current_snapshot(),
+        validate_pump_station_rollout_child_run(
+            child_run_root,
+            ContinualRolloutChildRunRef(
+                group_id=request.group_id,
+                child_id=child.child_id,
+                task_world_id=request.task_world_id,
+                run_id=child.run_id,
+                episode_id=child.episode_id,
+                world_branch_id=child.world_branch_id,
+                initial_snapshot=receipt.initial_snapshot,
+                child_manifest_content_sha256=receipt.child_manifest_content_sha256,
+            ),
+            definition_ref=request.definition_ref,
+            profile_ref=request.profile_ref,
+            request=request,
+            child=child,
+            shared_receipt=receipt,
         )
-        if not run.verify_v4().valid:
-            raise ValueError("registered pump child replay differs")
-        initial_snapshot = _initial_snapshot(repository, manifest)
-        manifest_content_id = pump_station_artifact_id(
-            manifest,
-            record_profile="manifest-v2",
-        )
-        if (
-            receipt.initial_snapshot != _shared_snapshot(initial_snapshot)
-            or receipt.child_manifest_content_sha256 != manifest_content_id
-        ):
-            raise ValueError("registered pump shared child receipt differs")
-        payload = _task_store(
-            repository.root,
-            parent_run_root=parent_run_root,
-        ).load_bytes(
-            self._TASK_RECEIPT_PATH,
-            expected_sha256=receipt.task_branch_receipt_content_sha256,
-        )
-        task_receipt = load_pump_station_artifact(
-            payload,
-            PumpStationRolloutBranchReceiptV2,
-        )
-        parent_snapshot = _pump_snapshot(
-            request.parent_snapshot,
-            snapshot_version=manifest.snapshot_version,
-        )
-        initial_state = repository.load_state(manifest.initial_state_id)
-        if initial_state.state_version != PUMP_STATION_STATE_VERSION_V4:
-            raise ValueError("registered pump child initial state is not V4")
-        remaining_schedule_sha256 = _remaining_schedule_sha256(
-            cast(PumpStationCoupledStewardshipState, initial_state),
-        )
-        source = manifest.initial_state_source
-        expected_source_scope = (
-            "rollout_parent_snapshot",
-            request.parent_snapshot.run_id,
-            request.parent_snapshot.world_branch_id,
-            request.parent_snapshot.state_id,
-            request.parent_snapshot.commit_id,
-            request.request_id,
-            child.content_sha256,
-            request.content_sha256,
-            request.parent_manifest_content_sha256,
-            request.origin_verification_content_sha256,
-            remaining_schedule_sha256,
-            receipt.ancestor_world_branch_ids,
-        )
-        observed_source_scope = (
-            source.kind,
-            source.parent_run_id,
-            source.parent_branch_id,
-            source.parent_state_id,
-            source.parent_commit_id,
-            source.rollout_group_request_id,
-            source.child_request_content_id,
-            source.rollout_group_request_content_id,
-            source.parent_manifest_content_id,
-            source.origin_verification_content_id,
-            source.parent_origin_remaining_schedule_sha256,
-            source.ancestor_branch_ids,
-        )
-        expected_task_scope = (
-            PUMP_STATION_ROLLOUT_BRANCH_RECEIPT_VERSION_V2,
-            request.group_id,
-            child.child_id,
-            request.content_sha256,
-            child.content_sha256,
-            parent_snapshot,
-            initial_snapshot,
-            manifest_content_id,
-            manifest.temporal_bundle_content_id,
-            remaining_schedule_sha256,
-            receipt.ancestor_world_branch_ids,
-        )
-        observed_task_scope = (
-            task_receipt.receipt_version,
-            task_receipt.group_id,
-            task_receipt.child_id,
-            task_receipt.shared_group_request_content_sha256,
-            task_receipt.shared_child_request_content_sha256,
-            task_receipt.parent_snapshot,
-            task_receipt.initial_snapshot,
-            task_receipt.child_manifest_content_id,
-            task_receipt.temporal_bundle_content_id,
-            task_receipt.parent_origin_remaining_schedule_sha256,
-            task_receipt.ancestor_branch_ids,
-        )
-        if (
-            observed_source_scope != expected_source_scope
-            or observed_task_scope != expected_task_scope
-            or (manifest.initial_sequence, manifest.initial_state_id)
-            != (parent_snapshot.sequence, parent_snapshot.state_id)
-            or (manifest.run_id, manifest.episode_id, manifest.world_branch_id)
-            != (child.run_id, child.episode_id, child.world_branch_id)
-        ):
-            raise ValueError("registered pump child rollout provenance differs")
 
     @staticmethod
     def _profile(value: object) -> PumpStationContinualProfile:
@@ -451,4 +526,7 @@ def _task_store(
     )
 
 
-__all__ = ["PumpStationContinualWorldBranchPort"]
+__all__ = [
+    "PumpStationContinualWorldBranchPort",
+    "validate_pump_station_rollout_child_run",
+]

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/harbor_export.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/harbor_export.py
@@ -11,7 +11,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Final, Literal, cast
 
-from aec_bench.contracts.continual_world import ContinualWorldProfileRef
+from aec_bench.contracts.continual_world import (
+    ContinualRolloutChildRunRef,
+    ContinualWorldDefinitionRef,
+    ContinualWorldProfileRef,
+)
 from aec_bench.task_world_templates.harbor_exporting.constants import (
     BASE_IMAGE,
     RUNTIME_DEPENDENCIES,
@@ -30,6 +34,9 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.actor_in
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.continual_definition import (
     PumpStationContinualProfile,
     pump_station_continual_world_definition,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.continual_rollout_adapter import (
+    validate_pump_station_rollout_child_run,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.maintenance_review_control import (
     PUMP_STATION_REVIEW_TASK_ID,
@@ -72,6 +79,7 @@ PUMP_STATION_REVIEW_CONTROLLER_MODES = ("deterministic_reference",)
 
 _MANIFEST_NAME = "world-session-export.json"
 _PACKAGE_PATH = "tests/reference-package"
+_INITIAL_RUN_PATH = "tests/initial-world-run"
 _MAX_MANIFEST_BYTES = 1024 * 1024
 _NON_AUTHORITY_ARTIFACT_NAMES = frozenset(
     {
@@ -125,8 +133,11 @@ class PumpStationHarborBridge:
     execution_kind: str
     task_world_id: str
     bridge_mode: str
+    definition_ref: ContinualWorldDefinitionRef | None
     profile_ref: ContinualWorldProfileRef | None
     reference_system_root: Path | None
+    initial_run_root: Path | None
+    rollout_child_ref: ContinualRolloutChildRunRef | None
 
 
 def _export_authority(
@@ -152,9 +163,15 @@ def export_pump_station_harbor_task(
     temporal_evidence: bool = False,
     maintenance_review: bool = False,
     profile_ref: ContinualWorldProfileRef | None = None,
+    initial_run_root: Path | None = None,
+    rollout_child_ref: ContinualRolloutChildRunRef | None = None,
 ) -> ExportedPumpStationHarborTask:
     """Materialize one immutable task package for provider-free Harbor execution."""
 
+    if (initial_run_root is None) != (rollout_child_ref is None):
+        raise ValueError("pump-station Harbor initial run binding is incomplete")
+    if initial_run_root is not None and profile_ref is None:
+        raise ValueError("pump-station Harbor initial run requires a registered profile")
     destination = Path(task_dir)
     if destination.exists():
         raise FileExistsError(f"Harbor task output already exists: {destination}")
@@ -173,6 +190,8 @@ def export_pump_station_harbor_task(
             package=package,
             profile_ref=profile_ref,
             reference_system=reference_system,
+            initial_run_root=initial_run_root,
+            rollout_child_ref=rollout_child_ref,
             rich_work_processes=(
                 registered_profile or rich_work_processes or evidence_health or temporal_evidence or maintenance_review
             ),
@@ -217,16 +236,36 @@ def load_pump_station_harbor_bridge(
         PUMP_STATION_REGISTERED_HARBOR_EXPORT_SCHEMA_VERSION,
     }:
         raise ValueError("unsupported pump-station Harbor export version")
+    initial_run_present = "initial_run" in manifest
+    if initial_run_present and not registered_profile:
+        raise ValueError("pump-station Harbor initial run requires a registered profile")
     _require_exact_keys(
         manifest,
-        base_fields | ({"continual_profile", "reference_system"} if registered_profile else set()),
+        base_fields
+        | (
+            {
+                "continual_definition",
+                "continual_profile",
+                "reference_system",
+            }
+            if registered_profile
+            else set()
+        )
+        | ({"initial_run"} if initial_run_present else set()),
         label="pump-station Harbor export manifest",
     )
+    definition_ref: ContinualWorldDefinitionRef | None = None
     profile_ref: ContinualWorldProfileRef | None = None
     reference_system_root: Path | None = None
+    initial_run_root: Path | None = None
+    rollout_child_ref: ContinualRolloutChildRunRef | None = None
     if registered_profile:
+        definition = pump_station_continual_world_definition()
+        definition_ref = ContinualWorldDefinitionRef.model_validate(manifest["continual_definition"])
+        if definition_ref != definition.ref:
+            raise ValueError("pump-station Harbor definition is not registered")
         profile_ref = ContinualWorldProfileRef.model_validate(manifest["continual_profile"])
-        if profile_ref not in pump_station_continual_world_definition().spec.profiles:
+        if profile_ref not in definition.spec.profiles:
             raise ValueError("pump-station Harbor profile is not registered")
         reference_payload = _mapping(manifest["reference_system"], "reference_system")
         _require_exact_keys(
@@ -243,6 +282,30 @@ def load_pump_station_harbor_bridge(
             or reference_system.descriptor_content_id != profile_ref.profile_content_sha256
         ):
             raise ValueError("pump-station Harbor reference system differs from the export")
+        if initial_run_present:
+            initial_run_payload = _mapping(manifest["initial_run"], "initial run")
+            _require_exact_keys(
+                initial_run_payload,
+                {"directory_sha256", "path", "rollout_child_ref"},
+                label="pump-station Harbor initial run",
+            )
+            if initial_run_payload["path"] != _INITIAL_RUN_PATH:
+                raise ValueError("pump-station Harbor initial run path differs")
+            initial_run_root = task_root / _INITIAL_RUN_PATH
+            if directory_sha256(initial_run_root) != initial_run_payload["directory_sha256"]:
+                raise ValueError("pump-station Harbor initial run differs from the export")
+            rollout_child_ref = ContinualRolloutChildRunRef.model_validate(
+                initial_run_payload["rollout_child_ref"],
+            )
+            try:
+                validate_pump_station_rollout_child_run(
+                    initial_run_root,
+                    rollout_child_ref,
+                    definition_ref=definition_ref,
+                    profile_ref=profile_ref,
+                )
+            except (OSError, RuntimeError, ValueError) as exc:
+                raise ValueError("pump-station Harbor initial run identity differs") from exc
     bridge_payload = _mapping(manifest["bridge"], "bridge")
     maintenance_review = bool(bridge_payload.get("maintenance_review", False))
     if registered_profile and maintenance_review:
@@ -341,8 +404,11 @@ def load_pump_station_harbor_bridge(
         execution_kind=expected_execution_kind,
         task_world_id=expected_task_world_id,
         bridge_mode=expected_bridge_mode,
+        definition_ref=definition_ref,
         profile_ref=profile_ref,
         reference_system_root=reference_system_root,
+        initial_run_root=initial_run_root,
+        rollout_child_ref=rollout_child_ref,
     )
 
 
@@ -353,6 +419,8 @@ def _write_export(
     package: ReferencePackage,
     profile_ref: ContinualWorldProfileRef | None,
     reference_system: PumpStationReferenceSystem | None,
+    initial_run_root: Path | None,
+    rollout_child_ref: ContinualRolloutChildRunRef | None,
     rich_work_processes: bool,
     evidence_health: bool,
     temporal_evidence: bool,
@@ -378,6 +446,29 @@ def _write_export(
         shutil.copytree(bundled_reference_system_root(), reference_system_dir)
         if load_reference_system(root=reference_system_dir) != reference_system:
             raise ValueError("staged pump-station reference system differs from the registered profile")
+    initial_run_dir: Path | None = None
+    initial_run_sha256: str | None = None
+    if initial_run_root is not None and rollout_child_ref is not None:
+        if profile_ref is None:
+            raise ValueError("pump-station Harbor rollout child requires one exact profile")
+        definition_ref = pump_station_continual_world_definition().ref
+        validate_pump_station_rollout_child_run(
+            initial_run_root,
+            rollout_child_ref,
+            definition_ref=definition_ref,
+            profile_ref=profile_ref,
+        )
+        initial_run_dir = task_dir / _INITIAL_RUN_PATH
+        initial_run_sha256 = _copy_content_addressed_directory(
+            initial_run_root,
+            initial_run_dir,
+        )
+        validate_pump_station_rollout_child_run(
+            initial_run_dir,
+            rollout_child_ref,
+            definition_ref=definition_ref,
+            profile_ref=profile_ref,
+        )
     runtime = build_verifier_runtime_wheel(
         project_root=project_root,
         output_dir=runtime_dir,
@@ -402,6 +493,7 @@ def _write_export(
         _test_script_text(
             runtime.path.name,
             registered_profile=profile_ref is not None,
+            initial_run=initial_run_dir is not None,
         ),
         encoding="utf-8",
     )
@@ -413,6 +505,9 @@ def _write_export(
         profile_ref=profile_ref,
         reference_system=reference_system,
         reference_system_dir=reference_system_dir,
+        initial_run_dir=initial_run_dir,
+        initial_run_sha256=initial_run_sha256,
+        rollout_child_ref=rollout_child_ref,
         runtime=runtime,
         rich_work_processes=rich_work_processes,
         evidence_health=evidence_health,
@@ -438,6 +533,9 @@ def _export_manifest(
     profile_ref: ContinualWorldProfileRef | None,
     reference_system: PumpStationReferenceSystem | None,
     reference_system_dir: Path | None,
+    initial_run_dir: Path | None,
+    initial_run_sha256: str | None,
+    rollout_child_ref: ContinualRolloutChildRunRef | None,
     runtime: RuntimeWheel,
     rich_work_processes: bool,
     evidence_health: bool,
@@ -451,6 +549,10 @@ def _export_manifest(
     registered_profile = profile_ref is not None
     if registered_profile != (reference_system is not None and reference_system_dir is not None):
         raise ValueError("registered Harbor profile authority is incomplete")
+    if (initial_run_dir is None) != (initial_run_sha256 is None) or (initial_run_dir is None) != (
+        rollout_child_ref is None
+    ):
+        raise ValueError("registered Harbor initial run authority is incomplete")
     bridge = {
         "mode": (PUMP_STATION_REVIEW_HARBOR_BRIDGE_MODE if maintenance_review else PUMP_STATION_HARBOR_BRIDGE_MODE),
         "allowed_tools": list(
@@ -517,12 +619,19 @@ def _export_manifest(
         },
     }
     if profile_ref is not None and reference_system is not None and reference_system_dir is not None:
+        manifest["continual_definition"] = pump_station_continual_world_definition().ref.model_dump(mode="json")
         manifest["continual_profile"] = profile_ref.model_dump(mode="json")
         manifest["reference_system"] = {
             "path": "tests/reference-system",
             "descriptor_id": reference_system.descriptor_id,
             "descriptor_content_id": reference_system.descriptor_content_id,
             "directory_sha256": directory_sha256(reference_system_dir),
+        }
+    if initial_run_dir is not None and initial_run_sha256 is not None and rollout_child_ref is not None:
+        manifest["initial_run"] = {
+            "path": _INITIAL_RUN_PATH,
+            "directory_sha256": initial_run_sha256,
+            "rollout_child_ref": rollout_child_ref.model_dump(mode="json"),
         }
     return manifest
 
@@ -538,6 +647,17 @@ def _validate_surface(*, task_root: Path, manifest: dict[str, Any]) -> None:
         raise ValueError("pump-station Harbor task metadata differs from the export")
     if file_sha256(task_root / str(harbor["test_script"])) != harbor["test_script_sha256"]:
         raise ValueError("pump-station Harbor verifier script differs from the export")
+
+
+def _copy_content_addressed_directory(source: Path, destination: Path) -> str:
+    """Copy one plain directory and prove that its bytes stayed unchanged."""
+
+    expected_sha256 = directory_sha256(source)
+    shutil.copytree(source, destination, symlinks=True)
+    copied_sha256 = directory_sha256(destination)
+    if directory_sha256(source) != expected_sha256 or copied_sha256 != expected_sha256:
+        raise ValueError("pump-station Harbor initial run changed while it was copied")
+    return copied_sha256
 
 
 def _validated_project_root(project_root: Path) -> Path:
@@ -622,6 +742,7 @@ def _test_script_text(
     wheel_name: str,
     *,
     registered_profile: bool = False,
+    initial_run: bool = False,
 ) -> str:
     reference_system_variable = (
         'REFERENCE_SYSTEM_DIR="${AEC_BENCH_REFERENCE_SYSTEM_DIR:-/tests/reference-system}"\n'
@@ -629,6 +750,12 @@ def _test_script_text(
         else ""
     )
     reference_system_argument = '  --reference-system-dir "$REFERENCE_SYSTEM_DIR" \\\n' if registered_profile else ""
+    initial_run_variable = (
+        'INITIAL_RUN_DIR="${AEC_BENCH_INITIAL_RUN_DIR:-${EXPORT_MANIFEST%/*}/initial-world-run}"\n'
+        if initial_run
+        else ""
+    )
+    initial_run_argument = '  --initial-run-dir "$INITIAL_RUN_DIR" \\\n' if initial_run else ""
     return f"""#!/bin/sh
 # ABOUTME: Runs the hidden pump-station verifier after Harbor ends the agent phase.
 # ABOUTME: Reloads the exact exported package and immutable world-session evidence.
@@ -637,7 +764,7 @@ set -eu
 RUN_DIR="${{AEC_BENCH_WORLD_SESSION_DIR:-{PUMP_STATION_HARBOR_OUTPUT_PATH}}}"
 EXPORT_MANIFEST="${{AEC_BENCH_EXPORT_MANIFEST:-/tests/{_MANIFEST_NAME}}}"
 PACKAGE_DIR="${{AEC_BENCH_REFERENCE_PACKAGE_DIR:-/tests/reference-package}}"
-{reference_system_variable}VERIFIER_RUNTIME="${{AEC_BENCH_VERIFIER_RUNTIME:-/tests/runtime/{wheel_name}}}"
+{reference_system_variable}{initial_run_variable}VERIFIER_RUNTIME="${{AEC_BENCH_VERIFIER_RUNTIME:-/tests/runtime/{wheel_name}}}"
 REWARD_PATH="${{AEC_BENCH_REWARD_PATH:-/logs/verifier/reward.json}}"
 DETAILS_PATH="${{AEC_BENCH_DETAILS_PATH:-/logs/verifier/details.json}}"
 PYTHON_BIN="${{AEC_BENCH_PYTHON:-python3}}"
@@ -649,7 +776,7 @@ PYTHONPATH="$RUNTIME_DIR${{PYTHONPATH:+:$PYTHONPATH}}" "$PYTHON_BIN" \\
   --run-dir "$RUN_DIR" \\
   --export-manifest "$EXPORT_MANIFEST" \\
   --package-dir "$PACKAGE_DIR" \\
-{reference_system_argument}  --verifier-runtime "$VERIFIER_RUNTIME" \\
+{reference_system_argument}{initial_run_argument}  --verifier-runtime "$VERIFIER_RUNTIME" \\
   --reward-path "$REWARD_PATH" \\
   --details-path "$DETAILS_PATH"
 """

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/harbor_session.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/harbor_session.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 
 import hashlib
 import json
+import shutil
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, cast
+
+from pydantic import JsonValue
 
 from aec_bench.adapters.base import AdapterRequest, AdapterResult
 from aec_bench.contracts.world_interface import WorldActorActionRequest
@@ -19,6 +22,10 @@ from aec_bench.contracts.world_session import (
     WorldSessionResult,
 )
 from aec_bench.harness.world_session import open_world_session
+from aec_bench.task_world_templates.harbor_exporting.stable_io import directory_sha256
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.continual_rollout_adapter import (
+    validate_pump_station_rollout_child_run,
+)
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.evidence_health import (
     PUMP_STATION_EVIDENCE_TREATMENT_VERSION_V1,
     PUMP_STATION_EVIDENCE_VISIBILITY_POLICY_V1,
@@ -40,7 +47,6 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.physical
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.reference_controller import (
     PUMP_STATION_REFERENCE_SYSTEM_CONTROLLER_ID,
-    PumpStationReferenceControllerResult,
     run_pump_station_reference_controller,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.rollout_control import (
@@ -70,6 +76,9 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_co
     PumpStationEvidenceControlRequest,
     PumpStationEvidenceControlResult,
     PumpStationWorldControl,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run import (
+    PumpStationWorldRun,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_models import (
     PumpStationStateSnapshotRef,
@@ -456,6 +465,12 @@ def _run_registered_reference_session(
     profile_ref = bridge.profile_ref
     if profile_ref is None or bridge.reference_system_root is None:
         raise ValueError("registered Harbor bridge authority is incomplete")
+    if bridge.rollout_child_ref is not None:
+        return _run_registered_rollout_child_reference_session(
+            bridge=bridge,
+            output_dir=output_dir,
+            session_identity=session_identity,
+        )
     identity = session_identity.strip()
     if not identity:
         raise ValueError("pump-station Harbor session identity is required")
@@ -496,7 +511,7 @@ def _run_registered_reference_session(
     verification = terminal.verify()
     if not verification.valid:
         raise ValueError("registered pump-station reference session did not verify")
-    temporal_verification = _verify_registered_temporal_evidence(controller)
+    temporal_verification = _verify_registered_temporal_evidence(controller.run)
     if not temporal_verification.valid:
         raise ValueError("registered pump-station temporal evidence did not verify")
     _write_session_evidence(
@@ -528,6 +543,83 @@ def _run_registered_reference_session(
     )
 
 
+def _run_registered_rollout_child_reference_session(
+    *,
+    bridge: PumpStationHarborBridge,
+    output_dir: Path,
+    session_identity: str,
+) -> CompletedPumpStationReferenceSession:
+    """Resume one bound rollout child and perform one deterministic actor action."""
+
+    identity = session_identity.strip()
+    if not identity:
+        raise ValueError("pump-station Harbor session identity is required")
+    destination = Path(output_dir)
+    if destination.exists():
+        raise FileExistsError(f"world-session output already exists: {destination}")
+    destination.mkdir(parents=True)
+    repository_root = destination / "world-run"
+    _copy_rollout_child_for_execution(
+        bridge=bridge,
+        repository_root=repository_root,
+    )
+    request = _rollout_child_session_request(bridge, identity)
+    session = _open_pump_station_session(
+        request=request,
+        repository_root=repository_root,
+        bridge=bridge,
+    )
+    start_snapshot = session.result.snapshot
+    observation = session.observe_actor()
+    session.invoke_actor_action(
+        WorldActorActionRequest(
+            request_id=f"rollout-child-condition-check.{identity}",
+            action_name="request_condition_check",
+            binding=observation.binding,
+            arguments=cast(
+                dict[str, JsonValue],
+                {
+                    "reason": "Record one bounded condition check from the selected rollout point.",
+                    "pump_id": "pump-a",
+                },
+            ),
+        )
+    )
+    verification = session.verify()
+    if not verification.valid:
+        raise ValueError("registered pump-station rollout child did not verify")
+    temporal_verification = _verify_registered_temporal_evidence(session.run)
+    if not temporal_verification.valid:
+        raise ValueError("registered pump-station rollout child temporal evidence did not verify")
+    _write_session_evidence(
+        destination=destination,
+        request=request,
+        result=session.result,
+        verification=verification,
+    )
+    _write_json(
+        destination / "temporal-verification-report.json",
+        temporal_verification.model_dump(mode="json"),
+    )
+    _write_json(
+        destination / "artifact-inventory.json",
+        _artifact_inventory(
+            bridge=bridge,
+            output_dir=destination,
+            controller_id=PUMP_STATION_REFERENCE_SYSTEM_CONTROLLER_ID,
+            start_snapshot=start_snapshot.model_dump(mode="json"),
+            end_snapshot=session.result.snapshot.model_dump(mode="json"),
+            tool_names=session.result.tool_names,
+        ),
+    )
+    return CompletedPumpStationReferenceSession(
+        request=request,
+        result=session.result,
+        verification=verification,
+        output_dir=destination,
+    )
+
+
 def _session_window_start(
     repository: PumpStationWorldRunRepository,
     selected: PumpStationSessionActivationBinding,
@@ -542,19 +634,19 @@ def _session_window_start(
 
 
 def _verify_registered_temporal_evidence(
-    controller: PumpStationReferenceControllerResult,
+    run: PumpStationWorldRun[Any, Any],
 ) -> TemporalEvidenceVerificationReport:
     proposal_bindings = {
         step.proposal.context.proposal_id: (
             step.proposal.context.information_set_id,
             step.proposal.context.base_view_id,
         )
-        for step in controller.run.repository.v4_steps()
+        for step in run.repository.v4_steps()
         if step.proposal is not None
     }
     return verify_temporal_evidence_repository(
-        TemporalEvidenceRepository(controller.run.repository.root / "temporal-evidence"),
-        package=controller.run.package,
+        TemporalEvidenceRepository(run.repository.root / "temporal-evidence"),
+        package=run.package,
         proposal_bindings=proposal_bindings,
     )
 
@@ -1032,7 +1124,14 @@ def run_pump_station_model_session(
     if destination.exists():
         raise FileExistsError(f"world-session output already exists: {destination}")
     destination.mkdir(parents=True)
-    request = _world_session_request(identity)
+    if bridge.rollout_child_ref is not None:
+        _copy_rollout_child_for_execution(
+            bridge=bridge,
+            repository_root=destination / "world-run",
+        )
+        request = _rollout_child_session_request(bridge, identity)
+    else:
+        request = _world_session_request(identity)
     session = _open_pump_station_session(
         request=request,
         repository_root=destination / "world-run",
@@ -1232,6 +1331,62 @@ def _world_session_request(identity: str) -> WorldSessionRequest:
         run_id=f"run.{identity}",
         episode_id=f"episode.{identity}",
         world_branch_id=f"branch.{identity}",
+    )
+
+
+def _rollout_child_session_request(
+    bridge: PumpStationHarborBridge,
+    identity: str,
+) -> WorldSessionRequest:
+    child_ref = bridge.rollout_child_ref
+    if child_ref is None or bridge.initial_run_root is None:
+        raise ValueError("pump-station Harbor rollout child authority is incomplete")
+    return WorldSessionRequest(
+        execution_kind=WorldSessionExecutionKind.STEWARDSHIP,
+        open_mode=WorldSessionOpenMode.RESUME,
+        session_id=f"session.{identity}",
+        task_world_id=PUMP_STATION_TASK_WORLD_ID,
+        agent_tenure_id=f"tenure.{identity}",
+        run_id=child_ref.run_id,
+        episode_id=child_ref.episode_id,
+        world_branch_id=child_ref.world_branch_id,
+        start_snapshot=StewardshipStateSnapshotRef(
+            run_id=child_ref.initial_snapshot.run_id,
+            episode_id=child_ref.initial_snapshot.episode_id,
+            world_branch_id=child_ref.initial_snapshot.world_branch_id,
+            sequence=child_ref.initial_snapshot.sequence,
+            state_id=child_ref.initial_snapshot.state_id,
+            commit_id=child_ref.initial_snapshot.commit_id,
+        ),
+    )
+
+
+def _copy_rollout_child_for_execution(
+    *,
+    bridge: PumpStationHarborBridge,
+    repository_root: Path,
+) -> None:
+    source = bridge.initial_run_root
+    child_ref = bridge.rollout_child_ref
+    definition_ref = bridge.definition_ref
+    profile_ref = bridge.profile_ref
+    if source is None or child_ref is None or definition_ref is None or profile_ref is None:
+        raise ValueError("pump-station Harbor rollout child authority is incomplete")
+    validate_pump_station_rollout_child_run(
+        source,
+        child_ref,
+        definition_ref=definition_ref,
+        profile_ref=profile_ref,
+    )
+    expected_sha256 = directory_sha256(source)
+    shutil.copytree(source, repository_root, symlinks=True)
+    if directory_sha256(source) != expected_sha256 or directory_sha256(repository_root) != expected_sha256:
+        raise ValueError("pump-station Harbor rollout child changed while it was copied")
+    validate_pump_station_rollout_child_run(
+        repository_root,
+        child_ref,
+        definition_ref=definition_ref,
+        profile_ref=profile_ref,
     )
 
 

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/harbor_verifier.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/harbor_verifier.py
@@ -11,7 +11,11 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import Any, cast
 
-from aec_bench.contracts.continual_world import ContinualWorldProfileRef
+from aec_bench.contracts.continual_world import (
+    ContinualRolloutChildRunRef,
+    ContinualWorldDefinitionRef,
+    ContinualWorldProfileRef,
+)
 from aec_bench.contracts.world_session import (
     StewardshipStateSnapshotRef,
     WorldSessionExecutionKind,
@@ -29,6 +33,9 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.actor_in
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.continual_definition import (
     pump_station_continual_world_definition,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.continual_rollout_adapter import (
+    validate_pump_station_rollout_child_run,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.harbor_export import (
     PUMP_STATION_HARBOR_EXECUTION_KIND,
@@ -63,6 +70,9 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_ru
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_repository import (
     PumpStationWorldRunRepository,
 )
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_serialization import (
+    pump_station_artifact_id,
+)
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_session import (
     PUMP_STATION_EVIDENCE_HEALTH_TOOL_NAMES,
     PUMP_STATION_RICH_WORK_TOOL_NAMES,
@@ -79,6 +89,7 @@ def verify_pump_station_harbor_run(
     export_manifest_path: Path,
     package_dir: Path,
     reference_system_dir: Path | None = None,
+    initial_run_dir: Path | None = None,
     verifier_runtime_path: Path | None = None,
 ) -> dict[str, Any]:
     """Verify one completed Harbor world session without trusting agent claims."""
@@ -110,9 +121,14 @@ def verify_pump_station_harbor_run(
     ):
         raise ValueError("pump-station Harbor export identity differs")
     profile_ref: ContinualWorldProfileRef | None = None
+    rollout_child_ref: ContinualRolloutChildRunRef | None = None
     if registered_profile:
+        definition = pump_station_continual_world_definition()
+        definition_ref = ContinualWorldDefinitionRef.model_validate(manifest.get("continual_definition"))
+        if definition_ref != definition.ref:
+            raise ValueError("pump-station Harbor definition is not registered")
         profile_ref = ContinualWorldProfileRef.model_validate(manifest.get("continual_profile"))
-        if profile_ref not in pump_station_continual_world_definition().spec.profiles:
+        if profile_ref not in definition.spec.profiles:
             raise ValueError("pump-station Harbor profile is not registered")
         if reference_system_dir is None:
             raise ValueError("registered pump-station Harbor verifier lacks its reference system")
@@ -125,6 +141,31 @@ def verify_pump_station_harbor_run(
             or reference_system.descriptor_content_id != profile_ref.profile_content_sha256
         ):
             raise ValueError("pump-station Harbor reference system evidence differs")
+        if "initial_run" in manifest:
+            initial_run_payload = _mapping(manifest.get("initial_run"), "initial run")
+            if (
+                set(initial_run_payload)
+                != {
+                    "directory_sha256",
+                    "path",
+                    "rollout_child_ref",
+                }
+                or initial_run_payload.get("path") != "tests/initial-world-run"
+            ):
+                raise ValueError("pump-station Harbor initial run fields differ")
+            if initial_run_dir is None:
+                raise ValueError("pump-station Harbor verifier lacks its initial run")
+            if directory_sha256(initial_run_dir) != initial_run_payload.get("directory_sha256"):
+                raise ValueError("pump-station Harbor initial run evidence differs")
+            rollout_child_ref = ContinualRolloutChildRunRef.model_validate(
+                initial_run_payload.get("rollout_child_ref"),
+            )
+            validate_pump_station_rollout_child_run(
+                initial_run_dir,
+                rollout_child_ref,
+                definition_ref=definition_ref,
+                profile_ref=profile_ref,
+            )
     package_payload = _mapping(manifest.get("package"), "package")
     rich_work_processes = bool(bridge_payload.get("rich_work_processes", False))
     evidence_health = bool(bridge_payload.get("evidence_health", False))
@@ -216,9 +257,19 @@ def verify_pump_station_harbor_run(
             snapshot=current_snapshot,
         )
         report = registered_run.verify_v4()
-        registered_evaluation = evaluate_pump_station_reference_run(registered_run)
-        if not registered_evaluation.valid:
-            raise ValueError("registered pump-station Harbor evaluation failed")
+        if rollout_child_ref is not None:
+            _verify_rollout_child_execution(
+                repository=repository,
+                request=request,
+                result=result,
+                child_ref=rollout_child_ref,
+                controller_id=inventory.get("controller_id"),
+                inventory_start=start_snapshot,
+            )
+        else:
+            registered_evaluation = evaluate_pump_station_reference_run(registered_run)
+            if not registered_evaluation.valid:
+                raise ValueError("registered pump-station Harbor evaluation failed")
     else:
         resumed = PumpStationWorldSessionFactory(
             root / "world-run",
@@ -305,6 +356,88 @@ def verify_pump_station_harbor_run(
     if registered_evaluation is not None:
         details["evaluation"] = registered_evaluation.model_dump(mode="json")
     return details
+
+
+def _verify_rollout_child_execution(
+    *,
+    repository: PumpStationWorldRunRepository,
+    request: WorldSessionRequest,
+    result: WorldSessionResult,
+    child_ref: ContinualRolloutChildRunRef,
+    controller_id: object,
+    inventory_start: StewardshipStateSnapshotRef,
+) -> None:
+    """Prove one completed session is a one-action continuation of the bound child."""
+
+    start_snapshot = request.start_snapshot
+    if start_snapshot is None:
+        raise ValueError("pump-station Harbor rollout child has no start snapshot")
+    expected_identity = (
+        child_ref.run_id,
+        child_ref.episode_id,
+        child_ref.world_branch_id,
+        child_ref.initial_snapshot.sequence,
+        child_ref.initial_snapshot.state_id,
+        child_ref.initial_snapshot.commit_id,
+    )
+    request_identity = (
+        request.run_id,
+        request.episode_id,
+        request.world_branch_id,
+        start_snapshot.sequence,
+        start_snapshot.state_id,
+        start_snapshot.commit_id,
+    )
+    inventory_identity = (
+        inventory_start.run_id,
+        inventory_start.episode_id,
+        inventory_start.world_branch_id,
+        inventory_start.sequence,
+        inventory_start.state_id,
+        inventory_start.commit_id,
+    )
+    result_identity = (
+        result.snapshot.run_id,
+        result.snapshot.episode_id,
+        result.snapshot.world_branch_id,
+    )
+    manifest = repository.load_manifest()
+    manifest_identity = (
+        manifest.run_id,
+        manifest.episode_id,
+        manifest.world_branch_id,
+    )
+    steps = repository.v4_steps()
+    command = steps[0].command if len(steps) == 1 else None
+    action_name = getattr(command, "action_name", None)
+    command_base = (
+        getattr(command, "run_id", None),
+        getattr(command, "episode_id", None),
+        getattr(command, "world_branch_id", None),
+        getattr(command, "based_on_sequence", None),
+        getattr(command, "base_state_id", None),
+        getattr(command, "base_commit_id", None),
+    )
+    expected_action = (
+        "request_condition_check" if controller_id == PUMP_STATION_REFERENCE_SYSTEM_CONTROLLER_ID else None
+    )
+    if (
+        request.open_mode is not WorldSessionOpenMode.RESUME
+        or request_identity != expected_identity
+        or inventory_identity != expected_identity
+        or result_identity != expected_identity[:3]
+        or manifest_identity != expected_identity[:3]
+        or pump_station_artifact_id(manifest, record_profile="manifest-v2") != child_ref.child_manifest_content_sha256
+        or result.snapshot.sequence != child_ref.initial_snapshot.sequence + 1
+        or len(steps) != 1
+        or getattr(command, "kind", None) != "actor"
+        or getattr(command, "session_id", None) != request.session_id
+        or getattr(command, "agent_tenure_id", None) != request.agent_tenure_id
+        or command_base != expected_identity
+        or action_name not in PUMP_STATION_ACTOR_ACTION_NAMES_V2
+        or (expected_action is not None and action_name != expected_action)
+    ):
+        raise ValueError("pump-station Harbor rollout child execution differs")
 
 
 def _verify_controller_completion(
@@ -443,6 +576,7 @@ def _main(argv: list[str] | None = None) -> int:
     parser.add_argument("--export-manifest", type=Path, required=True)
     parser.add_argument("--package-dir", type=Path, required=True)
     parser.add_argument("--reference-system-dir", type=Path)
+    parser.add_argument("--initial-run-dir", type=Path)
     parser.add_argument("--verifier-runtime", type=Path, required=True)
     parser.add_argument("--reward-path", type=Path, required=True)
     parser.add_argument("--details-path", type=Path, required=True)
@@ -453,6 +587,7 @@ def _main(argv: list[str] | None = None) -> int:
             export_manifest_path=args.export_manifest,
             package_dir=args.package_dir,
             reference_system_dir=args.reference_system_dir,
+            initial_run_dir=args.initial_run_dir,
             verifier_runtime_path=args.verifier_runtime,
         )
     except Exception as error:

--- a/tests/agents/test_entrypoint_agent.py
+++ b/tests/agents/test_entrypoint_agent.py
@@ -1,6 +1,7 @@
 # ABOUTME: Tests for EntrypointAgent — the universal Harbor agent
 # ABOUTME: that dispatches to library adapters via execution_entrypoint.
 
+import ast
 import asyncio
 import hashlib
 import json
@@ -34,6 +35,8 @@ from agents.entrypoint_agent import (
     _host_model_provider_environment,
 )
 from tests.support.output_completion import make_output_commit_attestation
+
+ENTRYPOINT_AGENT_PATH = Path(__file__).resolve().parents[2] / "agents" / "entrypoint_agent.py"
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -75,6 +78,70 @@ def test_entrypoint_agent_version() -> None:
 
 def test_entrypoint_result_path_matches_harbor_artifact_contract() -> None:
     assert _RESULT_REMOTE_PATH == "/workspace/agent_result.json"
+
+
+def test_entrypoint_agent_does_not_import_a_concrete_continual_task() -> None:
+    tree = ast.parse(
+        ENTRYPOINT_AGENT_PATH.read_text(encoding="utf-8"),
+        filename=str(ENTRYPOINT_AGENT_PATH),
+    )
+    imported_modules: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            imported_modules.append(node.module)
+
+    pump_imports = tuple(
+        module
+        for module in imported_modules
+        if module.startswith(
+            "aec_bench.task_world_templates.stewardship.wastewater_pump_station",
+        )
+    )
+
+    assert pump_imports == ()
+
+
+def test_entrypoint_agent_does_not_branch_on_continual_task_stage_profile_or_controller() -> None:
+    tree = ast.parse(
+        ENTRYPOINT_AGENT_PATH.read_text(encoding="utf-8"),
+        filename=str(ENTRYPOINT_AGENT_PATH),
+    )
+    forbidden_branch_tokens = {
+        "controller",
+        "evidence_health",
+        "expected_reference_controller",
+        "maintenance_review",
+        "profile_ref",
+        "reference_controller",
+        "reference_runner",
+        "rich_work_processes",
+        "temporal_evidence",
+    }
+    violations: list[tuple[int, tuple[str, ...]]] = []
+    for node in ast.walk(tree):
+        branch_expressions: tuple[ast.AST, ...] = ()
+        if isinstance(node, ast.If | ast.IfExp):
+            branch_expressions = (node.test,)
+        elif isinstance(node, ast.Match):
+            branch_expressions = (node.subject, *(case.pattern for case in node.cases))
+        for expression in branch_expressions:
+            tokens = {
+                child.id
+                if isinstance(child, ast.Name)
+                else child.attr
+                if isinstance(child, ast.Attribute)
+                else child.value
+                for child in ast.walk(expression)
+                if isinstance(child, ast.Name | ast.Attribute)
+                or (isinstance(child, ast.Constant) and isinstance(child.value, str))
+            }
+            forbidden = tuple(sorted(tokens & forbidden_branch_tokens))
+            if forbidden:
+                violations.append((node.lineno, forbidden))
+
+    assert violations == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/task_world_templates/continual/test_catalogue.py
+++ b/tests/task_world_templates/continual/test_catalogue.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import ast
 import json
-from dataclasses import FrozenInstanceError
+from dataclasses import FrozenInstanceError, replace
 from pathlib import Path
 
 import pytest
@@ -25,6 +25,9 @@ from aec_bench.task_world_templates.lifecycles.ssc03_hydraulic_continual_definit
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.continual_definition import (
     PumpStationContinualProfile,
     pump_station_continual_world_definition,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.harbor_export import (
+    PUMP_STATION_HARBOR_EXECUTION_KIND,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.physical_models import (
     PumpStationCoupledModel,
@@ -48,6 +51,30 @@ def test_catalogue_rejects_duplicate_world_id() -> None:
 
     with pytest.raises(ValueError, match="task world ids must be unique"):
         ContinualWorldCatalogue(definitions=(definition, definition))
+
+
+def test_catalogue_resolves_unique_harbor_execution_kind() -> None:
+    catalogue = default_continual_world_catalogue()
+
+    definition, port = catalogue.resolve_harbor(PUMP_STATION_HARBOR_EXECUTION_KIND)
+
+    assert definition is catalogue.get(PUMP_STATION_TASK_WORLD_ID)
+    assert port is definition.harbor_port
+    assert PUMP_STATION_HARBOR_EXECUTION_KIND in port.execution_kinds
+
+
+def test_catalogue_rejects_duplicate_harbor_execution_kind() -> None:
+    pump_definition = pump_station_continual_world_definition()
+    assert pump_definition.harbor_port is not None
+    hydraulic_with_pump_port = replace(
+        ssc03_hydraulic_continual_world_definition(),
+        harbor_port=pump_definition.harbor_port,
+    )
+
+    with pytest.raises(ValueError, match="Harbor execution kinds must be unique"):
+        ContinualWorldCatalogue(
+            definitions=(pump_definition, hydraulic_with_pump_port),
+        )
 
 
 def test_catalogue_resolves_exact_content_pinned_definition() -> None:

--- a/tests/task_world_templates/continual/test_catalogue_driven_interface.py
+++ b/tests/task_world_templates/continual/test_catalogue_driven_interface.py
@@ -1,0 +1,612 @@
+# ABOUTME: Tests catalogue-driven actor and host-control dispatch for one real continual world.
+# ABOUTME: Proves exact profile binding, separate envelopes, and shared rollout operations.
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from aec_bench.contracts.continual_world import (
+    ContinualRolloutChildRequest,
+    ContinualRolloutChildRunRef,
+    ContinualRolloutGroupRequest,
+    ContinualRolloutGroupState,
+    ContinualRolloutGroupStatus,
+    ContinualRolloutLineage,
+    ContinualWorldActorRequest,
+    ContinualWorldControlRequest,
+    ContinualWorldDefinitionRef,
+    ContinualWorldProfileRef,
+    ContinualWorldSnapshotRef,
+)
+from aec_bench.contracts.world_interface import (
+    WorldActorActionRequest,
+    WorldActorActionResult,
+    WorldActorObservation,
+    WorldControlRequest,
+    WorldControlResult,
+)
+from aec_bench.contracts.world_session import (
+    StewardshipStateSnapshotRef,
+    WorldSessionExecutionKind,
+    WorldSessionOpenMode,
+    WorldSessionRequest,
+)
+from aec_bench.meta_harness.evidence_lifecycle import run_evidence_lifecycle
+from aec_bench.task_world_templates.continual.interface import (
+    ContinualWorldInterfaceContext,
+    dispatch_continual_actor,
+    dispatch_continual_control,
+)
+from aec_bench.task_world_templates.continual.rollout_control import ContinualRolloutControl
+from aec_bench.task_world_templates.continual_catalogue import default_continual_world_catalogue
+from aec_bench.task_world_templates.lifecycles.ssc03_hydraulic_continual_definition import (
+    Ssc03HydraulicContinualProfile,
+    ssc03_hydraulic_continual_world_definition,
+)
+from aec_bench.task_world_templates.lifecycles.ssc03_hydraulic_rollout_adapter import (
+    ssc03_hydraulic_rollout_origin,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run import (
+    PumpStationWorldRun,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_models import (
+    PumpStationWorldRunManifestV2,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_repository import (
+    PumpStationWorldRunRepository,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_serialization import (
+    pump_station_artifact_id,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_session import (
+    PUMP_STATION_TASK_WORLD_ID,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _registered_run(root: Path, *, identity: str) -> PumpStationWorldRun[Any, Any]:
+    return PumpStationWorldRun.create_reference_system(
+        repository=PumpStationWorldRunRepository(root),
+        run_id=f"{identity}-run",
+        episode_id=f"{identity}-episode",
+        world_branch_id=f"{identity}-branch",
+    )
+
+
+def _shared_snapshot(run: PumpStationWorldRun[Any, Any]) -> StewardshipStateSnapshotRef:
+    snapshot = run.snapshot()
+    return StewardshipStateSnapshotRef(
+        run_id=snapshot.run_id,
+        episode_id=snapshot.episode_id,
+        world_branch_id=snapshot.world_branch_id,
+        sequence=snapshot.sequence,
+        state_id=snapshot.state_id,
+        commit_id=snapshot.commit_id,
+    )
+
+
+def _continual_snapshot(run: PumpStationWorldRun[Any, Any]) -> ContinualWorldSnapshotRef:
+    snapshot = run.snapshot()
+    return ContinualWorldSnapshotRef(
+        run_id=snapshot.run_id,
+        episode_id=snapshot.episode_id,
+        world_branch_id=snapshot.world_branch_id,
+        sequence=snapshot.sequence,
+        state_id=snapshot.state_id,
+        commit_id=snapshot.commit_id,
+    )
+
+
+def _resume_request(run: PumpStationWorldRun[Any, Any]) -> WorldSessionRequest:
+    snapshot = _shared_snapshot(run)
+    return WorldSessionRequest(
+        execution_kind=WorldSessionExecutionKind.STEWARDSHIP,
+        open_mode=WorldSessionOpenMode.RESUME,
+        session_id="catalogue-interface-session",
+        task_world_id=PUMP_STATION_TASK_WORLD_ID,
+        agent_tenure_id="catalogue-interface-tenure",
+        run_id=snapshot.run_id,
+        episode_id=snapshot.episode_id,
+        world_branch_id=snapshot.world_branch_id,
+        start_snapshot=snapshot,
+    )
+
+
+def _context(tmp_path: Path, *, run_root: Path) -> ContinualWorldInterfaceContext:
+    return ContinualWorldInterfaceContext(
+        catalogue=default_continual_world_catalogue(),
+        run_root=run_root,
+        rollout_repository_root=tmp_path / "rollouts",
+        authorised_principal_ids=("catalogue-interface-host",),
+    )
+
+
+def _exact_refs() -> tuple[ContinualWorldDefinitionRef, ContinualWorldProfileRef]:
+    definition = default_continual_world_catalogue().get(PUMP_STATION_TASK_WORLD_ID)
+    return definition.ref, definition.spec.profiles[0]
+
+
+def _actor_request(
+    run: PumpStationWorldRun[Any, Any],
+    *,
+    definition_ref: ContinualWorldDefinitionRef,
+    profile_ref: ContinualWorldProfileRef,
+    operation: str = "observe",
+    action_request: WorldActorActionRequest | None = None,
+) -> ContinualWorldActorRequest:
+    return ContinualWorldActorRequest.model_validate_json(
+        json.dumps(
+            {
+                "definition_ref": definition_ref.model_dump(mode="json"),
+                "profile_ref": profile_ref.model_dump(mode="json"),
+                "operation": operation,
+                "session_request": _resume_request(run).model_dump(mode="json"),
+                "action_request": action_request.model_dump(mode="json") if action_request is not None else None,
+            }
+        )
+    )
+
+
+def _control_request(
+    *,
+    operation: str,
+    definition_ref: ContinualWorldDefinitionRef,
+    profile_ref: ContinualWorldProfileRef,
+    control_request: WorldControlRequest | None = None,
+    rollout_group_request: ContinualRolloutGroupRequest | None = None,
+    group_id: str | None = None,
+    child_id: str | None = None,
+    authority_id: str = "catalogue-interface-host",
+) -> ContinualWorldControlRequest:
+    return ContinualWorldControlRequest.model_validate_json(
+        json.dumps(
+            {
+                "definition_ref": definition_ref.model_dump(mode="json"),
+                "profile_ref": profile_ref.model_dump(mode="json"),
+                "operation": operation,
+                "authority_id": authority_id,
+                "control_request": control_request.model_dump(mode="json") if control_request is not None else None,
+                "rollout_group_request": (
+                    rollout_group_request.model_dump(mode="json") if rollout_group_request is not None else None
+                ),
+                "group_id": group_id,
+                "child_id": child_id,
+            }
+        )
+    )
+
+
+def _group_request(run: PumpStationWorldRun[Any, Any]) -> ContinualRolloutGroupRequest:
+    definition_ref, profile_ref = _exact_refs()
+    manifest = run.manifest
+    assert isinstance(manifest, PumpStationWorldRunManifestV2)
+    return ContinualRolloutGroupRequest(
+        request_id="catalogue-rollout-request",
+        group_id="catalogue-rollout-group",
+        task_world_id=PUMP_STATION_TASK_WORLD_ID,
+        authority_id="catalogue-interface-host",
+        definition_ref=definition_ref,
+        profile_ref=profile_ref,
+        parent_manifest_content_sha256=pump_station_artifact_id(
+            manifest,
+            record_profile="manifest-v2",
+        ),
+        parent_snapshot=_continual_snapshot(run),
+        origin_verification_content_sha256=pump_station_artifact_id(
+            run.verify_v4(),
+            record_profile="v4",
+        ),
+        reason="Create two isolated continuations through the registered world port.",
+        children=tuple(
+            ContinualRolloutChildRequest(
+                child_id=child_id,
+                run_id=f"catalogue-{child_id}-run",
+                episode_id=f"catalogue-{child_id}-episode",
+                world_branch_id=f"catalogue-{child_id}-branch",
+            )
+            for child_id in ("control", "candidate")
+        ),
+    )
+
+
+def _ready_ssc03_rollout(
+    tmp_path: Path,
+) -> tuple[ContinualWorldInterfaceContext, ContinualRolloutGroupRequest]:
+    definition = ssc03_hydraulic_continual_world_definition()
+    profile_ref = definition.profile_ref("major_idf_revision", "1")
+    loaded = definition.load_profile(profile_ref)
+    assert isinstance(loaded.value, Ssc03HydraulicContinualProfile)
+    compiled = loaded.value.compile(tmp_path / "ssc03-package")
+    environment = loaded.value.build_smoke_environment(compiled.package_dir)
+    assert environment is not None
+    parent_run = tmp_path / "ssc03-parent-run"
+    run_evidence_lifecycle(
+        compiled.package_dir,
+        parent_run,
+        episode_environment=environment,
+    )
+    origin = ssc03_hydraulic_rollout_origin(
+        compiled.package_dir,
+        parent_run,
+        checkpoint_id="revision_analysis",
+    )
+    request = ContinualRolloutGroupRequest(
+        request_id="catalogue-ssc03-request",
+        group_id="catalogue-ssc03-group",
+        task_world_id=definition.ref.task_world_id,
+        authority_id="catalogue-ssc03-host",
+        definition_ref=definition.ref,
+        profile_ref=profile_ref,
+        parent_manifest_content_sha256=origin.parent_manifest_content_sha256,
+        parent_snapshot=origin.parent_snapshot,
+        origin_verification_content_sha256=origin.origin_verification_content_sha256,
+        reason="Read one ready SSC-03 rollout through the catalogue control route.",
+        children=(
+            ContinualRolloutChildRequest(
+                child_id="catalogue-ssc03-child",
+                run_id="catalogue-ssc03-child-run",
+                episode_id="catalogue-ssc03-child-episode",
+                world_branch_id="catalogue-ssc03-child-branch",
+            ),
+        ),
+    )
+    rollout_root = tmp_path / "ssc03-rollouts"
+    ContinualRolloutControl(
+        definition,
+        parent_run_root=parent_run,
+        rollout_repository_root=rollout_root,
+        authorised_principal_ids=("catalogue-ssc03-host",),
+        package_root=compiled.package_dir,
+    ).create_group(request)
+    return (
+        ContinualWorldInterfaceContext(
+            catalogue=default_continual_world_catalogue(),
+            run_root=parent_run,
+            rollout_repository_root=rollout_root,
+            authorised_principal_ids=("catalogue-ssc03-host",),
+            package_root=compiled.package_dir,
+        ),
+        request,
+    )
+
+
+def _run_installed_interface(
+    *,
+    command: str,
+    run_root: Path,
+    request_path: Path,
+    host_authority_id: str | None = None,
+) -> dict[str, Any]:
+    executable = Path(sys.executable).parent / "aec-bench"
+    arguments = [
+        str(executable),
+        "--json",
+        "task",
+        "pump-station-world",
+        command,
+        "--run-dir",
+        str(run_root),
+        "--request-path",
+        str(request_path),
+    ]
+    if host_authority_id is not None:
+        arguments.extend(("--host-authority-id", host_authority_id))
+    environment = dict(os.environ)
+    source_root = str(PROJECT_ROOT / "src")
+    current_pythonpath = environment.get("PYTHONPATH", "")
+    environment["PYTHONPATH"] = (
+        source_root if not current_pythonpath else f"{source_root}{os.pathsep}{current_pythonpath}"
+    )
+    completed = subprocess.run(
+        arguments,
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+        env=environment,
+    )
+    assert completed.returncode == 0, completed.stderr or completed.stdout
+    return json.loads(completed.stdout)["data"]
+
+
+def test_actor_and_control_json_requests_are_separate_exact_envelopes(tmp_path: Path) -> None:
+    run = _registered_run(tmp_path / "world", identity="catalogue-envelope")
+    definition_ref, profile_ref = _exact_refs()
+    actor = _actor_request(
+        run,
+        definition_ref=definition_ref,
+        profile_ref=profile_ref,
+    )
+    control = _control_request(
+        operation="execute",
+        definition_ref=definition_ref,
+        profile_ref=profile_ref,
+        control_request=WorldControlRequest(
+            request_id="catalogue-envelope-verify",
+            operation="verify",
+            task_world_id=PUMP_STATION_TASK_WORLD_ID,
+            authority_id="catalogue-interface-host",
+        ),
+    )
+
+    assert type(actor) is not type(control)
+    assert actor.definition_ref == control.definition_ref == definition_ref
+    assert actor.profile_ref == control.profile_ref == profile_ref
+    assert "surface" not in type(actor).model_fields
+    assert "surface" not in type(control).model_fields
+    assert "control_request" not in type(actor).model_fields
+    assert "session_request" not in type(control).model_fields
+
+    with pytest.raises(ValidationError):
+        ContinualWorldActorRequest.model_validate(
+            {
+                **actor.model_dump(mode="json"),
+                "authority_id": "catalogue-interface-host",
+            }
+        )
+    with pytest.raises(ValidationError):
+        ContinualWorldControlRequest.model_validate(
+            {
+                **control.model_dump(mode="json"),
+                "session_request": _resume_request(run).model_dump(mode="json"),
+            }
+        )
+
+
+def test_control_execute_rejects_a_nested_authority_when_both_principals_are_authorised(
+    tmp_path: Path,
+) -> None:
+    run_root = tmp_path / "world"
+    run = _registered_run(run_root, identity="catalogue-authority")
+    definition_ref, profile_ref = _exact_refs()
+    context = ContinualWorldInterfaceContext(
+        catalogue=default_continual_world_catalogue(),
+        run_root=run_root,
+        rollout_repository_root=None,
+        authorised_principal_ids=("envelope-host", "payload-host"),
+    )
+
+    with pytest.raises(ValidationError, match="task control request differs from its control envelope"):
+        dispatch_continual_control(
+            context=context,
+            request=_control_request(
+                operation="execute",
+                definition_ref=definition_ref,
+                profile_ref=profile_ref,
+                authority_id="envelope-host",
+                control_request=WorldControlRequest(
+                    request_id="catalogue-authority-verify",
+                    operation="verify",
+                    task_world_id=PUMP_STATION_TASK_WORLD_ID,
+                    authority_id="payload-host",
+                ),
+            ),
+        )
+
+    assert run.snapshot().sequence == 0
+
+
+def test_control_execute_rejects_a_nested_task_world_before_dispatch() -> None:
+    definition_ref, profile_ref = _exact_refs()
+
+    with pytest.raises(ValidationError, match="task control request differs from its control envelope"):
+        _control_request(
+            operation="execute",
+            definition_ref=definition_ref,
+            profile_ref=profile_ref,
+            control_request=WorldControlRequest(
+                request_id="catalogue-foreign-world-verify",
+                operation="verify",
+                task_world_id="foreign-task-world",
+                authority_id="catalogue-interface-host",
+            ),
+        )
+
+
+def test_catalogue_dispatch_resolves_exact_profile_for_actor_and_generic_verify(tmp_path: Path) -> None:
+    run_root = tmp_path / "world"
+    run = _registered_run(run_root, identity="catalogue-actor")
+    context = _context(tmp_path, run_root=run_root)
+    definition_ref, profile_ref = _exact_refs()
+    stale_definition = definition_ref.model_copy(update={"content_sha256": "f" * 64})
+    stale_profile = profile_ref.model_copy(update={"profile_content_sha256": "f" * 64})
+
+    with pytest.raises(ValueError, match="content-pinned definition does not match"):
+        dispatch_continual_actor(
+            context=context,
+            request=_actor_request(
+                run,
+                definition_ref=stale_definition,
+                profile_ref=profile_ref,
+            ),
+        )
+    with pytest.raises(ValueError, match="content-pinned profile does not match"):
+        dispatch_continual_actor(
+            context=context,
+            request=_actor_request(
+                run,
+                definition_ref=definition_ref,
+                profile_ref=stale_profile,
+            ),
+        )
+
+    observed = dispatch_continual_actor(
+        context=context,
+        request=_actor_request(
+            run,
+            definition_ref=definition_ref,
+            profile_ref=profile_ref,
+        ),
+    )
+    assert isinstance(observed, WorldActorObservation)
+    action = WorldActorActionRequest(
+        request_id="catalogue-condition-check",
+        action_name="request_condition_check",
+        binding=observed.binding,
+        arguments={
+            "pump_id": "pump-a",
+            "reason": "Record the current condition through the registered actor port.",
+        },
+    )
+
+    invoked = dispatch_continual_actor(
+        context=context,
+        request=_actor_request(
+            run,
+            definition_ref=definition_ref,
+            profile_ref=profile_ref,
+            operation="invoke",
+            action_request=action,
+        ),
+    )
+    verified = dispatch_continual_control(
+        context=context,
+        request=_control_request(
+            operation="execute",
+            definition_ref=definition_ref,
+            profile_ref=profile_ref,
+            control_request=WorldControlRequest(
+                request_id="catalogue-verify",
+                operation="verify",
+                task_world_id=PUMP_STATION_TASK_WORLD_ID,
+                authority_id="catalogue-interface-host",
+            ),
+        ),
+    )
+
+    assert isinstance(invoked, WorldActorActionResult)
+    assert invoked.request_content_sha256 == action.content_sha256
+    assert invoked.post_binding.sequence == observed.binding.sequence + 1
+    assert isinstance(verified, WorldControlResult)
+    assert verified.verification is not None
+    assert verified.verification.valid is True
+    assert verified.verification.final_state_id == invoked.post_binding.state_id
+
+
+def test_installed_json_uses_the_catalogue_actor_and_control_routes(tmp_path: Path) -> None:
+    run_root = tmp_path / "world"
+    run = _registered_run(run_root, identity="catalogue-installed")
+    definition_ref, profile_ref = _exact_refs()
+    actor_request = _actor_request(
+        run,
+        definition_ref=definition_ref,
+        profile_ref=profile_ref,
+    )
+    actor_path = tmp_path / "actor-request.json"
+    actor_path.write_text(actor_request.model_dump_json(), encoding="utf-8")
+    observed = _run_installed_interface(
+        command="actor-interface",
+        run_root=run_root,
+        request_path=actor_path,
+    )
+    control_request = _control_request(
+        operation="execute",
+        definition_ref=definition_ref,
+        profile_ref=profile_ref,
+        control_request=WorldControlRequest(
+            request_id="catalogue-installed-verify",
+            operation="verify",
+            task_world_id=PUMP_STATION_TASK_WORLD_ID,
+            authority_id="catalogue-interface-host",
+        ),
+    )
+    control_path = tmp_path / "control-request.json"
+    control_path.write_text(control_request.model_dump_json(), encoding="utf-8")
+    verified = _run_installed_interface(
+        command="control-interface",
+        run_root=run_root,
+        request_path=control_path,
+        host_authority_id="catalogue-interface-host",
+    )
+
+    assert observed["binding"]["state_id"] == run.snapshot().state_id
+    assert verified["verification"]["valid"] is True
+    assert verified["verification"]["final_state_id"] == run.snapshot().state_id
+
+
+def test_catalogue_control_dispatch_runs_every_shared_rollout_operation(tmp_path: Path) -> None:
+    run_root = tmp_path / "world"
+    run = _registered_run(run_root, identity="catalogue-rollout")
+    context = _context(tmp_path, run_root=run_root)
+    definition_ref, profile_ref = _exact_refs()
+    group_request = _group_request(run)
+
+    created = dispatch_continual_control(
+        context=context,
+        request=_control_request(
+            operation="create_rollout_group",
+            definition_ref=definition_ref,
+            profile_ref=profile_ref,
+            rollout_group_request=group_request,
+        ),
+    )
+    status = dispatch_continual_control(
+        context=context,
+        request=_control_request(
+            operation="rollout_group_status",
+            definition_ref=definition_ref,
+            profile_ref=profile_ref,
+            group_id=group_request.group_id,
+        ),
+    )
+    inspected = dispatch_continual_control(
+        context=context,
+        request=_control_request(
+            operation="inspect_rollout_group",
+            definition_ref=definition_ref,
+            profile_ref=profile_ref,
+            group_id=group_request.group_id,
+        ),
+    )
+    child_ref = dispatch_continual_control(
+        context=context,
+        request=_control_request(
+            operation="rollout_child_run_ref",
+            definition_ref=definition_ref,
+            profile_ref=profile_ref,
+            group_id=group_request.group_id,
+            child_id="candidate",
+        ),
+    )
+
+    assert isinstance(created, ContinualRolloutLineage)
+    assert created.request_content_sha256 == group_request.content_sha256
+    assert isinstance(status, ContinualRolloutGroupStatus)
+    assert status.state is ContinualRolloutGroupState.READY
+    assert status.created_child_ids == ("control", "candidate")
+    assert isinstance(inspected, ContinualRolloutLineage)
+    assert inspected == created
+    assert isinstance(child_ref, ContinualRolloutChildRunRef)
+    assert child_ref.group_id == group_request.group_id
+    assert child_ref.child_id == "candidate"
+    assert child_ref.initial_snapshot.sequence == group_request.parent_snapshot.sequence
+    assert _continual_snapshot(run) == group_request.parent_snapshot
+
+
+def test_catalogue_rollout_status_does_not_require_an_actor_execution_port(tmp_path: Path) -> None:
+    context, group_request = _ready_ssc03_rollout(tmp_path)
+
+    status = dispatch_continual_control(
+        context=context,
+        request=_control_request(
+            operation="rollout_group_status",
+            definition_ref=group_request.definition_ref,
+            profile_ref=group_request.profile_ref,
+            group_id=group_request.group_id,
+            authority_id="catalogue-ssc03-host",
+        ),
+    )
+
+    assert isinstance(status, ContinualRolloutGroupStatus)
+    assert status.state is ContinualRolloutGroupState.READY
+    assert status.created_child_ids == ("catalogue-ssc03-child",)

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_registered_rollout_child_harbor.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_registered_rollout_child_harbor.py
@@ -1,0 +1,400 @@
+# ABOUTME: Proves Harbor can resume one exact registered continual-rollout child.
+# ABOUTME: Binds immutable child bytes and runs one bounded actor action without leaks.
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+from harbor.models.trial.config import TrialConfig  # type: ignore[import-untyped]
+from harbor.trial.trial import Trial  # type: ignore[import-untyped]
+
+from aec_bench.contracts.continual_world import (
+    ContinualRolloutChildRequest,
+    ContinualRolloutChildRunRef,
+    ContinualRolloutGroupRequest,
+    ContinualWorldSnapshotRef,
+)
+from aec_bench.contracts.world_interface import WorldActorActionRequest
+from aec_bench.contracts.world_session import (
+    StewardshipStateSnapshotRef,
+    WorldSessionExecutionKind,
+    WorldSessionOpenMode,
+    WorldSessionRequest,
+    WorldSessionResult,
+)
+from aec_bench.harness.world_interface import invoke_world_actor, observe_world_actor
+from aec_bench.task_world_templates.continual.rollout_control import ContinualRolloutControl
+from aec_bench.task_world_templates.continual.rollout_repository import ContinualRolloutRepository
+from aec_bench.task_world_templates.harbor_exporting.stable_io import directory_sha256
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.continual_definition import (
+    pump_station_continual_world_definition,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.harbor_export import (
+    PUMP_STATION_HARBOR_BRIDGE_MODE,
+    PUMP_STATION_HARBOR_EXECUTION_KIND,
+    export_pump_station_harbor_task,
+    is_pump_station_harbor_inventory_artifact,
+    load_pump_station_harbor_bridge,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.harbor_verifier import (
+    verify_pump_station_harbor_run,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.reference_controller import (
+    PUMP_STATION_REFERENCE_SYSTEM_CONTROLLER_ID,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run import (
+    PumpStationWorldRun,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_models import (
+    PumpStationStateSnapshotRef,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_repository import (
+    PumpStationWorldRunRepository,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_serialization import (
+    pump_station_artifact_id,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_session import (
+    PumpStationWorldSessionFactory,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[4]
+_INITIAL_RUN_PATH = "tests/initial-world-run"
+
+
+def _tree_bytes(root: Path) -> tuple[tuple[str, bytes], ...]:
+    return tuple(
+        sorted((path.relative_to(root).as_posix(), path.read_bytes()) for path in root.rglob("*") if path.is_file())
+    )
+
+
+def _continual_snapshot(snapshot: PumpStationStateSnapshotRef) -> ContinualWorldSnapshotRef:
+    return ContinualWorldSnapshotRef(
+        run_id=snapshot.run_id,
+        episode_id=snapshot.episode_id,
+        world_branch_id=snapshot.world_branch_id,
+        sequence=snapshot.sequence,
+        state_id=snapshot.state_id,
+        commit_id=snapshot.commit_id,
+    )
+
+
+def _session_snapshot(snapshot: PumpStationStateSnapshotRef) -> StewardshipStateSnapshotRef:
+    return StewardshipStateSnapshotRef(
+        run_id=snapshot.run_id,
+        episode_id=snapshot.episode_id,
+        world_branch_id=snapshot.world_branch_id,
+        sequence=snapshot.sequence,
+        state_id=snapshot.state_id,
+        commit_id=snapshot.commit_id,
+    )
+
+
+def _create_registered_rollout(
+    tmp_path: Path,
+) -> tuple[
+    Path,
+    Path,
+    Path,
+    ContinualRolloutChildRunRef,
+    ContinualRolloutChildRunRef,
+]:
+    definition = pump_station_continual_world_definition()
+    profile_ref = definition.spec.profiles[0]
+    parent_root = tmp_path / "parent-world"
+    parent = PumpStationWorldRun.create_reference_system(
+        repository=PumpStationWorldRunRepository(parent_root),
+        run_id="harbor-rollout-parent-run",
+        episode_id="harbor-rollout-parent-episode",
+        world_branch_id="harbor-rollout-parent-branch",
+    )
+    parent_session = PumpStationWorldSessionFactory(parent_root).open(
+        WorldSessionRequest(
+            execution_kind=WorldSessionExecutionKind.STEWARDSHIP,
+            open_mode=WorldSessionOpenMode.RESUME,
+            session_id="harbor-rollout-parent-session",
+            task_world_id=definition.ref.task_world_id,
+            agent_tenure_id="harbor-rollout-parent-tenure",
+            run_id=parent.manifest.run_id,
+            episode_id=parent.manifest.episode_id,
+            world_branch_id=parent.manifest.world_branch_id,
+            start_snapshot=_session_snapshot(parent.snapshot()),
+        )
+    )
+    invoke_world_actor(
+        parent_session,
+        WorldActorActionRequest(
+            request_id="harbor-rollout-parent-condition-check",
+            action_name="request_condition_check",
+            binding=observe_world_actor(parent_session).binding,
+            arguments={
+                "pump_id": "pump-b",
+                "reason": "Select one later verified world position for the rollout.",
+            },
+        ),
+    )
+    parent = parent_session.run
+    parent_snapshot = parent.snapshot()
+    request = ContinualRolloutGroupRequest(
+        request_id="harbor-rollout-request",
+        group_id="harbor-rollout-group",
+        task_world_id=definition.ref.task_world_id,
+        authority_id="harbor-rollout-host",
+        definition_ref=definition.ref,
+        profile_ref=profile_ref,
+        parent_manifest_content_sha256=pump_station_artifact_id(
+            parent.manifest,
+            record_profile="manifest-v2",
+        ),
+        parent_snapshot=_continual_snapshot(parent_snapshot),
+        origin_verification_content_sha256=pump_station_artifact_id(
+            parent.verify_v4(),
+            record_profile="v4",
+        ),
+        reason="Run two isolated checks from this selected world position.",
+        children=(
+            ContinualRolloutChildRequest(
+                child_id="selected",
+                run_id="harbor-rollout-selected-run",
+                episode_id="harbor-rollout-selected-episode",
+                world_branch_id="harbor-rollout-selected-branch",
+            ),
+            ContinualRolloutChildRequest(
+                child_id="sibling",
+                run_id="harbor-rollout-sibling-run",
+                episode_id="harbor-rollout-sibling-episode",
+                world_branch_id="harbor-rollout-sibling-branch",
+            ),
+        ),
+    )
+    rollout_root = tmp_path / "rollouts"
+    control = ContinualRolloutControl(
+        definition,
+        parent_run_root=parent_root,
+        rollout_repository_root=rollout_root,
+        authorised_principal_ids=("harbor-rollout-host",),
+    )
+    control.create_group(request)
+    selected_ref = control.child_run_ref(request.group_id, "selected")
+    sibling_ref = control.child_run_ref(request.group_id, "sibling")
+    repository = ContinualRolloutRepository(
+        rollout_root,
+        disjoint_roots=(parent_root,),
+    )
+    selected_root = repository.child_world_root(request.group_id, "selected")
+    sibling_root = repository.child_world_root(request.group_id, "sibling")
+    return parent_root, selected_root, sibling_root, selected_ref, sibling_ref
+
+
+def _world_session_dir(trial_dir: Path) -> Path:
+    return next(
+        candidate
+        for candidate in (
+            trial_dir / "agent" / "world-session",
+            trial_dir / "artifacts" / "agent" / "world-session",
+        )
+        if candidate.is_dir()
+    )
+
+
+def _refresh_artifact_inventory(root: Path) -> None:
+    inventory_path = root / "artifact-inventory.json"
+    inventory = json.loads(inventory_path.read_text(encoding="utf-8"))
+    inventory["artifacts"] = [
+        {
+            "path": path.relative_to(root).as_posix(),
+            "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+            "size_bytes": path.stat().st_size,
+        }
+        for path in sorted(root.rglob("*"))
+        if path.is_file() and is_pump_station_harbor_inventory_artifact(root, path)
+    ]
+    inventory_path.write_text(
+        json.dumps(inventory, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_registered_rollout_child_export_binds_the_exact_immutable_initial_run(
+    tmp_path: Path,
+) -> None:
+    parent_root, selected_root, sibling_root, selected_ref, sibling_ref = _create_registered_rollout(tmp_path)
+    parent_before = _tree_bytes(parent_root)
+    selected_before = _tree_bytes(selected_root)
+    sibling_before = _tree_bytes(sibling_root)
+    profile_ref = pump_station_continual_world_definition().spec.profiles[0]
+    assert selected_ref.initial_snapshot.sequence > 0
+
+    exported = export_pump_station_harbor_task(
+        tmp_path / "task",
+        project_root=PROJECT_ROOT,
+        profile_ref=profile_ref,
+        initial_run_root=selected_root,
+        rollout_child_ref=selected_ref,
+    )
+
+    manifest = json.loads(exported.manifest_path.read_text(encoding="utf-8"))
+    assert manifest["initial_run"] == {
+        "path": _INITIAL_RUN_PATH,
+        "directory_sha256": directory_sha256(selected_root),
+        "rollout_child_ref": selected_ref.model_dump(mode="json"),
+    }
+    bridge = load_pump_station_harbor_bridge(exported.task_dir / "environment")
+    assert bridge.initial_run_root == exported.task_dir / _INITIAL_RUN_PATH
+    assert bridge.rollout_child_ref == selected_ref
+    assert directory_sha256(bridge.initial_run_root) == manifest["initial_run"]["directory_sha256"]
+    assert _tree_bytes(parent_root) == parent_before
+    assert _tree_bytes(selected_root) == selected_before
+    assert _tree_bytes(sibling_root) == sibling_before
+
+    manifest_bytes = exported.manifest_path.read_bytes()
+    manifest["initial_run"]["rollout_child_ref"] = sibling_ref.model_dump(mode="json")
+    exported.manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="initial run identity differs"):
+        load_pump_station_harbor_bridge(exported.task_dir / "environment")
+    exported.manifest_path.write_bytes(manifest_bytes)
+
+    initial_manifest = bridge.initial_run_root / "manifest.json"
+    initial_manifest.write_bytes(initial_manifest.read_bytes() + b" ")
+    with pytest.raises(ValueError, match="initial run differs from the export"):
+        load_pump_station_harbor_bridge(exported.task_dir / "environment")
+
+
+def test_local_harbor_trial_resumes_one_rollout_child_for_one_bounded_actor_action(
+    tmp_path: Path,
+) -> None:
+    parent_root, selected_root, sibling_root, selected_ref, sibling_ref = _create_registered_rollout(tmp_path)
+    parent_before = _tree_bytes(parent_root)
+    selected_before = _tree_bytes(selected_root)
+    sibling_before = _tree_bytes(sibling_root)
+    profile_ref = pump_station_continual_world_definition().spec.profiles[0]
+    exported = export_pump_station_harbor_task(
+        tmp_path / "task",
+        project_root=PROJECT_ROOT,
+        profile_ref=profile_ref,
+        initial_run_root=selected_root,
+        rollout_child_ref=selected_ref,
+    )
+    trial_name = "registered-rollout-child"
+    config = TrialConfig.model_validate(
+        {
+            "task": {"path": str(exported.task_dir)},
+            "trial_name": trial_name,
+            "trials_dir": str(tmp_path / "trials"),
+            "job_id": "b3276871-7c09-4554-9459-785354c94bc9",
+            "agent": {
+                "name": "pump-station-rollout-child-reference-controller",
+                "import_path": "agents.entrypoint_agent:EntrypointAgent",
+                "model_name": PUMP_STATION_REFERENCE_SYSTEM_CONTROLLER_ID,
+                "kwargs": {
+                    "adapter": "tool_loop",
+                    "execution_kind": PUMP_STATION_HARBOR_EXECUTION_KIND,
+                    "world_session": {"bridge_mode": PUMP_STATION_HARBOR_BRIDGE_MODE},
+                },
+            },
+            "environment": {
+                "import_path": "tests.support.harbor_local_environment:LocalFilesystemHarborEnvironment",
+                "delete": False,
+                "kwargs": {"compute_backend": "local"},
+            },
+            "artifacts": [
+                {
+                    "source": "/workspace/world-session",
+                    "destination": "agent/world-session",
+                },
+                {
+                    "source": "/workspace/output.md",
+                    "destination": "agent/output.md",
+                },
+            ],
+        }
+    )
+
+    result = asyncio.run(Trial(config).run())
+
+    assert result.exception_info is None
+    assert result.agent_result is not None
+    assert result.agent_result.metadata["world_session_status"] == "completed"
+    assert result.verifier_result is not None
+    assert result.verifier_result.rewards == {"reward": 1.0}
+    trial_dir = config.trials_dir / trial_name
+    world_session_dir = _world_session_dir(trial_dir)
+    request = WorldSessionRequest.model_validate_json((world_session_dir / "world-session-request.json").read_bytes())
+    session_result = WorldSessionResult.model_validate_json(
+        (world_session_dir / "world-session-result.json").read_bytes()
+    )
+    inventory = json.loads((world_session_dir / "artifact-inventory.json").read_text(encoding="utf-8"))
+    assert request.open_mode.value == "resume"
+    assert (
+        request.run_id,
+        request.episode_id,
+        request.world_branch_id,
+    ) == (
+        selected_ref.run_id,
+        selected_ref.episode_id,
+        selected_ref.world_branch_id,
+    )
+    assert request.start_snapshot is not None
+    assert (
+        request.start_snapshot.sequence,
+        request.start_snapshot.state_id,
+        request.start_snapshot.commit_id,
+    ) == (
+        selected_ref.initial_snapshot.sequence,
+        selected_ref.initial_snapshot.state_id,
+        selected_ref.initial_snapshot.commit_id,
+    )
+    assert (
+        session_result.snapshot.run_id,
+        session_result.snapshot.episode_id,
+        session_result.snapshot.world_branch_id,
+    ) == (
+        selected_ref.run_id,
+        selected_ref.episode_id,
+        selected_ref.world_branch_id,
+    )
+    assert session_result.snapshot.sequence == selected_ref.initial_snapshot.sequence + 1
+    assert inventory["transition_count"] == 1
+    completed = PumpStationWorldRun.resume_reference_system(
+        repository=PumpStationWorldRunRepository(world_session_dir / "world-run"),
+        snapshot=PumpStationWorldRunRepository(world_session_dir / "world-run").current_snapshot(),
+    )
+    steps = completed.repository.v4_steps()
+    assert len(steps) == 1
+    assert steps[0].command.kind == "actor"
+    assert steps[0].command.action_name == "request_condition_check"
+    assert steps[0].command.session_id == request.session_id
+    assert completed.verify_v4().valid is True
+    assert (
+        pump_station_artifact_id(completed.manifest, record_profile="manifest-v2")
+        == selected_ref.child_manifest_content_sha256
+    )
+    assert _tree_bytes(parent_root) == parent_before
+    assert _tree_bytes(selected_root) == selected_before
+    assert _tree_bytes(sibling_root) == sibling_before
+    assert sibling_ref.initial_snapshot.sequence == selected_ref.initial_snapshot.sequence
+
+    request_path = world_session_dir / "world-session-request.json"
+    result_path = world_session_dir / "world-session-result.json"
+    forged_tenure_id = "forged-rollout-child-tenure"
+    forged_request = request.model_copy(update={"agent_tenure_id": forged_tenure_id})
+    forged_result = session_result.model_copy(update={"agent_tenure_id": forged_tenure_id})
+    request_path.write_text(forged_request.model_dump_json(indent=2) + "\n", encoding="utf-8")
+    result_path.write_text(forged_result.model_dump_json(indent=2) + "\n", encoding="utf-8")
+    _refresh_artifact_inventory(world_session_dir)
+    with pytest.raises(ValueError, match="rollout child execution differs"):
+        verify_pump_station_harbor_run(
+            run_dir=world_session_dir,
+            export_manifest_path=exported.manifest_path,
+            package_dir=exported.package_dir,
+            reference_system_dir=exported.task_dir / "tests" / "reference-system",
+            initial_run_dir=exported.task_dir / _INITIAL_RUN_PATH,
+            verifier_runtime_path=exported.verifier_runtime_wheel_path,
+        )

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_registered_world_harbor.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_registered_world_harbor.py
@@ -11,6 +11,7 @@ import pytest
 from harbor.models.trial.config import TrialConfig  # type: ignore[import-untyped]
 from harbor.trial.trial import Trial  # type: ignore[import-untyped]
 
+from aec_bench.task_world_templates.continual_catalogue import default_continual_world_catalogue
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.actor_interface import (
     PUMP_STATION_ACTOR_ACTION_NAMES_V2,
 )
@@ -36,6 +37,9 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.harbor_v
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.reference_controller import (
     PUMP_STATION_REFERENCE_SYSTEM_CONTROLLER_ID,
 )
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_session import (
+    PUMP_STATION_TASK_WORLD_ID,
+)
 
 PROJECT_ROOT = Path(__file__).resolve().parents[4]
 
@@ -43,7 +47,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[4]
 def test_registered_profile_export_uses_the_canonical_harbor_bridge(
     tmp_path: Path,
 ) -> None:
-    profile_ref = pump_station_continual_world_definition().spec.profiles[0]
+    definition = pump_station_continual_world_definition()
+    profile_ref = definition.spec.profiles[0]
     exported = export_pump_station_harbor_task(
         tmp_path / "task",
         project_root=PROJECT_ROOT,
@@ -60,6 +65,8 @@ def test_registered_profile_export_uses_the_canonical_harbor_bridge(
     )
 
     assert manifest["schema_version"] == PUMP_STATION_REGISTERED_HARBOR_EXPORT_SCHEMA_VERSION
+    assert manifest["continual_definition"] == definition.ref.model_dump(mode="json")
+    assert manifest["continual_profile"] == profile_ref.model_dump(mode="json")
     assert bridge.profile_ref == profile_ref
     assert bridge.reference_system_root == exported.task_dir / "tests" / "reference-system"
     assert bridge.allowed_tools == PUMP_STATION_ACTOR_ACTION_NAMES_V2
@@ -125,7 +132,11 @@ def test_registered_reference_session_uses_standard_evidence_and_replays_offline
 def test_registered_profile_runs_through_the_real_local_harbor_entrypoint(
     tmp_path: Path,
 ) -> None:
-    profile_ref = pump_station_continual_world_definition().spec.profiles[0]
+    catalogue = default_continual_world_catalogue()
+    definition, harbor_port = catalogue.resolve_harbor(PUMP_STATION_HARBOR_EXECUTION_KIND)
+    assert definition is catalogue.get(PUMP_STATION_TASK_WORLD_ID)
+    assert PUMP_STATION_HARBOR_EXECUTION_KIND in harbor_port.execution_kinds
+    profile_ref = definition.spec.profiles[0]
     exported = export_pump_station_harbor_task(
         tmp_path / "task",
         project_root=PROJECT_ROOT,

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_world_session_cli_e2e.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_world_session_cli_e2e.py
@@ -6,13 +6,33 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+from dataclasses import asdict
 from pathlib import Path
 from typing import Any, cast
 
+from aec_bench.contracts.world_session import (
+    StewardshipStateSnapshotRef,
+    WorldSessionExecutionKind,
+    WorldSessionOpenMode,
+    WorldSessionRequest,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.local_interface import (
+    PumpStationLocalInterfaceRequest,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run import (
+    PumpStationWorldRun,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_repository import (
+    PumpStationWorldRunRepository,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_session import (
+    PUMP_STATION_TASK_WORLD_ID,
+)
 
-def _run_cli(*args: str, cwd: Path) -> dict[str, Any]:
+
+def _run_cli_process(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
     executable = Path(sys.executable).parent / "aec-bench"
-    completed = subprocess.run(
+    return subprocess.run(
         [str(executable), "--json", "task", "pump-station-world", *args],
         cwd=cwd,
         capture_output=True,
@@ -20,8 +40,21 @@ def _run_cli(*args: str, cwd: Path) -> dict[str, Any]:
         timeout=30,
         check=False,
     )
+
+
+def _run_cli(*args: str, cwd: Path) -> dict[str, Any]:
+    completed = _run_cli_process(*args, cwd=cwd)
     assert completed.returncode == 0, completed.stderr or completed.stdout
     return cast(dict[str, Any], json.loads(completed.stdout))
+
+
+def _create_registered_run(root: Path, *, identity: str) -> PumpStationWorldRun[Any, Any]:
+    return PumpStationWorldRun.create_reference_system(
+        repository=PumpStationWorldRunRepository(root),
+        run_id=f"{identity}-run",
+        episode_id=f"{identity}-episode",
+        world_branch_id=f"{identity}-branch",
+    )
 
 
 def test_installed_cli_starts_advances_resumes_and_verifies_world(tmp_path: Path) -> None:
@@ -90,6 +123,14 @@ def test_installed_cli_starts_advances_resumes_and_verifies_world(tmp_path: Path
     assert resumed["data"]["agent_tenure_id"] == "tenure-cli-2"
     assert advanced_after_handover["data"]["snapshot"]["sequence"] == 2
     assert verified["data"]["valid"] is True
+    assert set(verified["data"]) == {
+        "active_restriction_ids",
+        "final_state_id",
+        "issues",
+        "open_obligation_ids",
+        "replayed_transition_ids",
+        "valid",
+    }
     assert verified["data"]["replayed_transition_ids"] == [
         "transition-0001",
         "transition-0002",
@@ -164,3 +205,81 @@ def test_installed_cli_searches_fetches_and_verifies_temporal_evidence(
     assert fetched["data"]["receipt"]["public_status"] == "OK"
     assert verified["data"]["valid"] is True
     assert verified["data"]["access_count"] == 2
+
+
+def test_legacy_combined_interface_rejects_a_registered_v4_run(tmp_path: Path) -> None:
+    run_root = tmp_path / "registered-world"
+    run = _create_registered_run(run_root, identity="legacy-interface-v4")
+    snapshot = run.snapshot()
+    request = PumpStationLocalInterfaceRequest(
+        surface="actor",
+        operation="capabilities",
+        session_request=WorldSessionRequest(
+            execution_kind=WorldSessionExecutionKind.STEWARDSHIP,
+            open_mode=WorldSessionOpenMode.RESUME,
+            session_id="legacy-interface-v4-session",
+            task_world_id=PUMP_STATION_TASK_WORLD_ID,
+            agent_tenure_id="legacy-interface-v4-tenure",
+            run_id=snapshot.run_id,
+            episode_id=snapshot.episode_id,
+            world_branch_id=snapshot.world_branch_id,
+            start_snapshot=StewardshipStateSnapshotRef(
+                run_id=snapshot.run_id,
+                episode_id=snapshot.episode_id,
+                world_branch_id=snapshot.world_branch_id,
+                sequence=snapshot.sequence,
+                state_id=snapshot.state_id,
+                commit_id=snapshot.commit_id,
+            ),
+        ),
+    )
+    request_path = tmp_path / "legacy-interface-request.json"
+    request_path.write_text(request.model_dump_json(), encoding="utf-8")
+
+    completed = _run_cli_process(
+        "interface",
+        "--run-dir",
+        str(run_root),
+        "--request-path",
+        str(request_path),
+        cwd=tmp_path,
+    )
+
+    assert completed.returncode != 0
+    error_text = " ".join((completed.stderr + completed.stdout).split())
+    assert "registered V4 runs require" in error_text
+    assert "actor-interface" in error_text
+    assert "control-interface" in error_text
+
+
+def test_installed_verify_projects_registered_v4_replay_control_and_conservation(
+    tmp_path: Path,
+) -> None:
+    run_root = tmp_path / "registered-world"
+    run = _create_registered_run(run_root, identity="verify-v4")
+    report = run.verify_v4()
+
+    verified = _run_cli("verify", "--run-dir", str(run_root), cwd=tmp_path)["data"]
+
+    assert set(verified) == {
+        "actor_proposals_valid",
+        "conservation",
+        "final_state_id",
+        "host_controls_valid",
+        "issues",
+        "replay_valid",
+        "replayed_transition_ids",
+        "valid",
+    }
+    assert verified["valid"] is report.valid
+    assert verified["replay_valid"] is report.replay_valid
+    assert verified["actor_proposals_valid"] is report.actor_proposals_valid
+    assert verified["host_controls_valid"] is report.host_controls_valid
+    assert verified["replayed_transition_ids"] == list(report.replayed_transition_ids)
+    assert verified["final_state_id"] == report.final_state_id
+    conservation = verified["conservation"]
+    assert conservation["valid"] is report.conservation.valid
+    assert conservation["duty"] == json.loads(json.dumps(asdict(report.conservation.duty)))
+    assert conservation["resources"] == json.loads(json.dumps(asdict(report.conservation.resources)))
+    assert conservation["work"] == json.loads(json.dumps(asdict(report.conservation.work)))
+    assert conservation["liabilities"] == json.loads(json.dumps(asdict(report.conservation.liabilities)))


### PR DESCRIPTION
## Summary

- add separate catalogue-routed actor and host-control interfaces
- keep task-specific execution and Harbor behavior behind registered ports
- resume immutable rollout children in Harbor from an exact non-zero snapshot
- reject registered V4 runs from the legacy combined CLI route
- preserve task-neutral main-agent orchestration and the old harness import path

## Focused validation

- 81 targeted tests passed
- Ruff check passed
- Ruff format check passed
- Mypy passed on 13 changed source files

## Review scope

This correction targets the open ASW-8 feature branch. It does not merge PR 74 into main.