### PR TITLE
fix(prime-agent): stabilize Open world runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,9 @@ host-selected `WorldSessionRequest`, launches one Prime ACP process for one
 session, supplies the resolved objective in the initial prompt, and installs
 only the generic `aec-world` skill. This is the Open condition: Prime receives
 the objective, actor-visible starting material, and generic actor capability,
-with no task-family guidance or external plan.
+with no task-family guidance or external plan. Callers must also supply a
+`PrimeWorldSessionLimits` value with positive world-action, model-call, token,
+cost, and wall-clock limits.
 
 Inside Prime, the available world calls are:
 
@@ -202,6 +204,17 @@ only `capabilities`, `observe`, and `invoke`. Prime never receives a world run
 directory or host-control selector. The Prime root session and all descendants
 share one capability and are therefore one composite AECBench actor principal;
 this integration does not claim that only the root process can invoke actions.
+The host rejects new world actions after the configured allowance. An exact
+retry of the same request remains available and does not consume another
+allowance, so the installed actor retry contract stays authoritative.
+
+AECBench monitors all Prime session artifacts for the composite principal and
+cancels the active ACP prompt when a model-call, aggregate-token, or aggregate-
+cost threshold is reached. Token and cost limits are enforced at completed
+provider-response boundaries: the response that reaches the threshold is
+preserved and can cross it, and a provider request already in flight when the
+host cancels can also report usage. The wall-clock limit covers Prime process
+setup and the active prompt.
 
 Prime session state and world state remain separate. In particular, ACP
 `end_turn` while the world is active produces an incomplete result and does not
@@ -209,10 +222,15 @@ start another prompt automatically. World replay, verification, and evaluation
 continue to use the existing task-owned repository and evaluator.
 
 Each run preserves `prime-acp-in.jsonl`, `prime-acp-out.jsonl`,
-`prime-stderr.log`, `prime-run.json`, Prime session files, and a separate
-actor-transport log. Unknown ACP `_meta` content stays in the raw evidence.
-Trial-local Prime configuration, sessions, workspace files, and refinement
-artifacts are isolated and are not promoted to another run.
+`prime-stderr.log`, `prime-run.json`, `prime-world-run.json`, Prime session
+files, and a separate actor-transport log. `prime-run.json` normalizes usage,
+cost, root/child session topology, refinement counts, configured limits, and
+the limit that ended the prompt. Unknown ACP `_meta` content stays in the raw
+evidence. The actor log timestamps every accepted, rejected, unauthorized, and
+malformed transport attempt without recording the socket capability, host
+paths, or hidden state. Trial-local Prime HOME/XDG directories, configuration,
+sessions, workspace files, and refinement artifacts are isolated and are not
+promoted to another run.
 
 `PrimeAcpIsolation.DEVELOPMENT_SAME_USER` is explicitly non-benchmark-valid
 development evidence because Prime has the current user's OS permissions.

--- a/docs/protocols/interactive-world-runtime.md
+++ b/docs/protocols/interactive-world-runtime.md
@@ -81,6 +81,21 @@ The Prime root process and its descendants receive the same scoped capability,
 so they form one composite actor principal. Per-child action attribution is not
 claimed without enforceable per-child capability scoping.
 
+The composed entry point requires positive host limits for world actions,
+model calls, aggregate tokens, aggregate provider cost, and elapsed wall time.
+The actor proxy counts distinct invoke request content while allowing an exact
+retry of the same request without another allowance. A changed request under an
+existing request ID is not an exact retry and still reaches the existing host
+conflict semantics when an allowance remains.
+
+AECBench reads every Prime session JSONL artifact for the composite principal.
+It cancels the active ACP prompt when a completed assistant response reaches a
+model-call, token, or cost limit. Provider usage is known only after a response,
+so that final response can cross the token or cost threshold. A provider request
+already in flight when the host cancels can also report usage. The wall limit
+covers ACP startup and prompting. Malformed, incomplete, missing, or
+unsupported session accounting fails closed.
+
 ## Host controls
 
 The installed control command parses a strict discriminated union for:
@@ -126,8 +141,15 @@ calling evaluation.
 
 Prime ACP evidence and actor transport evidence are secondary execution
 evidence. The pump repository remains canonical replay authority. The actor log
-contains only actor-visible requests, results, and errors; it excludes the
-capability secret, endpoint and repository paths, and hidden state.
+contains timestamps plus actor-visible requests, results, and errors. It also
+records malformed, unauthorized, and transport-level attempts using only a
+safe operation label. It excludes the capability secret, endpoint and
+repository paths, arbitrary malformed payload content, and hidden state.
+
+Prime HOME and XDG paths are trial-local under the actor workspace. The
+normalized Prime run evidence records configured limits, aggregate usage and
+cost, root/child session counts, refinement status counts, and any limit that
+ended the prompt. Unknown ACP metadata remains in the raw ACP evidence.
 
 Same-user Prime execution is development-only and cannot produce
 benchmark-valid evidence. The current benchmark-valid local path uses a macOS

--- a/src/aec_bench/prime_agent/acp.py
+++ b/src/aec_bench/prime_agent/acp.py
@@ -25,6 +25,18 @@ from aec_bench.prime_agent.batch import (
     redact_prime_bytes,
     resolve_prime_executable,
 )
+from aec_bench.prime_agent.session_evidence import (
+    PrimeAcpLimits,
+    PrimeAcpRefinement,
+    PrimeAcpTopology,
+    PrimeAcpUsage,
+    PrimeSessionEvidenceError,
+    empty_usage,
+    read_session_evidence,
+    refinement_evidence,
+    usage_limit_reason,
+    wait_for_usage_limit,
+)
 
 _VERSION_PATTERN = re.compile(r"(?<!\d)(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)")
 _MAX_ACP_MESSAGE_BYTES = 16 * 1024 * 1024
@@ -78,6 +90,11 @@ class PrimeAcpRun:
     agent_name: str | None
     agent_version: str | None
     agent_capabilities: dict[str, Any] | None
+    limits: PrimeAcpLimits
+    usage: PrimeAcpUsage
+    topology: PrimeAcpTopology
+    refinement: PrimeAcpRefinement
+    limit_reason: str | None
     session_state: str
     stop_reason: str | None
     timed_out: bool
@@ -176,8 +193,8 @@ async def run_prime_acp_session(
     model: str,
     actor_environment: Mapping[str, str],
     isolation: PrimeAcpIsolation,
+    limits: PrimeAcpLimits,
     private_paths: Sequence[Path] = (),
-    timeout_seconds: float = 900,
     executable: str = "prime-agent",
     environment: Mapping[str, str] | None = None,
 ) -> PrimeAcpRun:
@@ -189,8 +206,6 @@ async def run_prime_acp_session(
     skill_directory = skill_directory.resolve()
     if not instruction.strip():
         raise ValueError("Prime ACP instruction must be non-empty")
-    if timeout_seconds <= 0:
-        raise ValueError("Prime ACP timeout must be positive")
     if not actor_workspace.is_dir() or not skill_directory.is_dir():
         raise FileNotFoundError("Prime actor workspace and explicit skill must exist")
     if _paths_overlap(actor_workspace, evidence_directory):
@@ -206,8 +221,13 @@ async def run_prime_acp_session(
 
     env = dict(os.environ if environment is None else environment)
     env.update(actor_environment)
+    runtime_home = actor_workspace / ".prime-runtime"
     env.update(
         {
+            "HOME": str(runtime_home / "home"),
+            "XDG_CACHE_HOME": str(runtime_home / "cache"),
+            "XDG_CONFIG_HOME": str(runtime_home / "config"),
+            "XDG_DATA_HOME": str(runtime_home / "data"),
             "PRIME_AGENT_CODING_AGENT_DIR": str(paths.state_dir),
             "PRIME_AGENT_SESSION_DIR": str(paths.session_dir),
             "PI_OFFLINE": "1",
@@ -244,9 +264,12 @@ async def run_prime_acp_session(
     redact_values = tuple(value for key, value in actor_environment.items() if "CAPABILITY" in key or "SOCKET" in key)
     started_at = datetime.now(UTC)
     started = time.monotonic()
+    deadline = started + limits.max_wall_seconds
     process: asyncio.subprocess.Process | None = None
     connection: Any = None
     stderr_task: asyncio.Task[None] | None = None
+    prompt_task: asyncio.Task[Any] | None = None
+    limit_task: asyncio.Task[str] | None = None
     session_id: str | None = None
     protocol_version: int | None = None
     agent_name: str | None = None
@@ -255,11 +278,18 @@ async def run_prime_acp_session(
     stop_reason: str | None = None
     updates: list[dict[str, Any]] = []
     timed_out = False
+    limit_reason: str | None = None
     error: str | None = None
     session_state = "failed"
     prime_version = "unknown"
     try:
-        prime_version = await _prime_version(command[: -len(base_command)], resolved_executable, actor_workspace, env)
+        prime_version = await _prime_version(
+            command[: -len(base_command)],
+            resolved_executable,
+            actor_workspace,
+            env,
+            timeout_seconds=min(_remaining_seconds(deadline), 10),
+        )
         process = await asyncio.create_subprocess_exec(
             *command,
             cwd=actor_workspace,
@@ -286,12 +316,13 @@ async def run_prime_acp_session(
         )
         client = _AecBenchAcpClient(updates)
         connection = acp.connect_to_agent(client, transport)
+        initialize_timeout = min(_remaining_seconds(deadline), 30)
         initialized = await asyncio.wait_for(
             connection.initialize(
                 protocol_version=acp.PROTOCOL_VERSION,
                 client_info=acp_schema.Implementation(name="aec-bench", version="0.1.0"),
             ),
-            timeout=min(timeout_seconds, 30),
+            timeout=initialize_timeout,
         )
         _validate_raw_initialize(transport.received_messages)
         _validate_initialize(initialized, acp.PROTOCOL_VERSION)
@@ -301,9 +332,10 @@ async def run_prime_acp_session(
         agent_capabilities = initialized.agent_capabilities.model_dump(
             mode="json", by_alias=True, exclude_none=True, warnings=False
         )
+        new_session_timeout = min(_remaining_seconds(deadline), 30)
         session = await asyncio.wait_for(
             connection.new_session(cwd=str(actor_workspace), additional_directories=[], mcp_servers=[]),
-            timeout=min(timeout_seconds, 30),
+            timeout=new_session_timeout,
         )
         if not isinstance(session.session_id, str) or not session.session_id.strip():
             raise PrimeAcpProtocolError("Prime ACP returned an empty session ID")
@@ -312,10 +344,30 @@ async def run_prime_acp_session(
             connection.prompt(session_id=session_id, prompt=[acp.text_block(instruction)]),
             name="prime-acp-prompt",
         )
-        try:
-            prompt = await asyncio.wait_for(asyncio.shield(prompt_task), timeout=timeout_seconds)
-        except TimeoutError:
+        limit_task = asyncio.create_task(
+            wait_for_usage_limit(paths.session_dir, limits),
+            name="prime-acp-usage-limits",
+        )
+        done, _pending = await asyncio.wait(
+            {prompt_task, limit_task},
+            timeout=_remaining_seconds(deadline),
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if prompt_task in done:
+            prompt = prompt_task.result()
+        elif limit_task in done:
+            limit_reason = limit_task.result()
+            await connection.cancel(session_id=session_id)
+            try:
+                prompt = await asyncio.wait_for(prompt_task, timeout=_CANCEL_GRACE_SECONDS)
+            except TimeoutError:
+                prompt_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await prompt_task
+                raise PrimeAcpProtocolError("Prime ACP prompt did not stop after limit cancellation") from None
+        else:
             timed_out = True
+            limit_reason = "max_wall_seconds"
             await connection.cancel(session_id=session_id)
             try:
                 prompt = await asyncio.wait_for(prompt_task, timeout=_CANCEL_GRACE_SECONDS)
@@ -324,15 +376,28 @@ async def run_prime_acp_session(
                 with contextlib.suppress(asyncio.CancelledError):
                     await prompt_task
                 raise PrimeAcpProtocolError("Prime ACP prompt did not stop after cancellation") from None
+        limit_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await limit_task
         stop_reason = str(prompt.stop_reason)
         if client.protocol_error is not None:
             raise client.protocol_error
         session_state = "cancelled" if stop_reason == "cancelled" or timed_out else "ended"
         await asyncio.wait_for(connection.close_session(session_id=session_id), timeout=10)
+    except TimeoutError as exc:
+        timed_out = True
+        limit_reason = "max_wall_seconds"
+        error = f"{type(exc).__name__}: Prime ACP wall-clock budget expired"
+        session_state = "cancelled" if session_id is not None else "failed"
     except Exception as exc:
         error = f"{type(exc).__name__}: {exc}"
         session_state = "cancelled" if timed_out else "failed"
     finally:
+        for task in (prompt_task, limit_task):
+            if task is not None and not task.done():
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
         if connection is not None:
             with contextlib.suppress(Exception):
                 await connection.close()
@@ -344,6 +409,20 @@ async def run_prime_acp_session(
         _redact_session_artifacts(paths.session_dir, env, redact_values)
         if sandbox_profile is not None:
             sandbox_profile.unlink(missing_ok=True)
+
+    usage = empty_usage()
+    topology = PrimeAcpTopology(root_sessions=0, child_sessions=0)
+    if session_id is not None:
+        try:
+            session_evidence = read_session_evidence(paths.session_dir, allow_partial=False)
+            assert session_evidence is not None
+            usage, topology = session_evidence
+        except PrimeSessionEvidenceError as exc:
+            error = error or f"{type(exc).__name__}: {exc}"
+            session_state = "failed"
+    refinement = refinement_evidence(updates)
+    if usage.complete:
+        limit_reason = limit_reason or usage_limit_reason(usage, limits)
 
     exit_code = process.returncode if process is not None else None
     if exit_code not in (None, 0) and not timed_out:
@@ -372,10 +451,20 @@ async def run_prime_acp_session(
         agent_name=agent_name,
         agent_version=agent_version,
         agent_capabilities=agent_capabilities,
+        limits=limits,
+        usage=usage,
+        topology=topology,
+        refinement=refinement,
+        limit_reason=limit_reason,
         session_state=session_state,
         stop_reason=stop_reason,
         timed_out=timed_out,
-        benchmark_valid=isolation is PrimeAcpIsolation.MACOS_SANDBOX and session_state != "failed",
+        benchmark_valid=(
+            isolation is PrimeAcpIsolation.MACOS_SANDBOX
+            and session_state != "failed"
+            and error is None
+            and usage.complete
+        ),
         isolation=isolation,
         updates=tuple(updates),
         error=error,
@@ -575,6 +664,8 @@ async def _prime_version(
     executable: Path,
     workspace: Path,
     environment: Mapping[str, str],
+    *,
+    timeout_seconds: float,
 ) -> str:
     process: asyncio.subprocess.Process | None = None
     try:
@@ -589,7 +680,7 @@ async def _prime_version(
             stderr=asyncio.subprocess.DEVNULL,
             start_new_session=os.name == "posix",
         )
-        stdout, _ = await asyncio.wait_for(process.communicate(), timeout=10)
+        stdout, _ = await asyncio.wait_for(process.communicate(), timeout=timeout_seconds)
     except (OSError, TimeoutError):
         if process is not None:
             await _reap_process(process)
@@ -660,12 +751,40 @@ def _write_run_provenance(
         "agent_name": run.agent_name,
         "agent_version": run.agent_version,
         "agent_capabilities": run.agent_capabilities,
+        "limits": {
+            "max_model_calls": run.limits.max_model_calls,
+            "max_tokens": run.limits.max_tokens,
+            "max_cost_usd": str(run.limits.max_cost_usd),
+            "max_wall_seconds": run.limits.max_wall_seconds,
+        },
+        "usage": {
+            "complete": run.usage.complete,
+            "model_calls": run.usage.model_calls,
+            "input_tokens": run.usage.input_tokens,
+            "output_tokens": run.usage.output_tokens,
+            "cache_read_tokens": run.usage.cache_read_tokens,
+            "cache_write_tokens": run.usage.cache_write_tokens,
+            "total_tokens": run.usage.total_tokens,
+            "cost_usd": str(run.usage.cost_usd),
+        },
+        "topology": {
+            "root_sessions": run.topology.root_sessions,
+            "child_sessions": run.topology.child_sessions,
+        },
+        "refinement": {
+            "events": run.refinement.events,
+            "completed": run.refinement.completed,
+            "failed": run.refinement.failed,
+            "unknown": run.refinement.unknown,
+        },
+        "limit_reason": run.limit_reason,
         "session_state": run.session_state,
         "stop_reason": run.stop_reason,
         "timed_out": run.timed_out,
         "isolation": run.isolation,
         "benchmark_valid": run.benchmark_valid,
         "actor_principal_scope": "prime-session-composite",
+        "runtime_home_scope": "actor-workspace",
         "skill_sha256": _directory_digest(skill_directory),
         "update_count": len(run.updates),
         "error": run.error,
@@ -677,6 +796,13 @@ def _paths_overlap(first: Path, second: Path) -> bool:
     first = first.resolve()
     second = second.resolve()
     return first == second or first in second.parents or second in first.parents
+
+
+def _remaining_seconds(deadline: float) -> float:
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise TimeoutError
+    return remaining
 
 
 def _sandbox_quote(path: Path) -> str:

--- a/src/aec_bench/prime_agent/session_evidence.py
+++ b/src/aec_bench/prime_agent/session_evidence.py
@@ -1,0 +1,290 @@
+# ABOUTME: Validates Prime ACP session artifacts and derives composite-principal accounting evidence.
+# ABOUTME: Supports fail-closed model-call, token, and cost limits at completed-response boundaries.
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+
+from aec_bench.prime_agent.events import PRIME_EVENT_STREAM_VERSIONS
+
+_USAGE_POLL_SECONDS = 0.05
+_PRIME_AGENT_META_NAMESPACE = "ai.primeintellect.prime-agent"
+_COST_QUANTUM_USD = Decimal("0.000000000001")
+
+
+class PrimeSessionEvidenceError(ValueError):
+    """Raised when Prime's session artifacts cannot support safe accounting."""
+
+
+@dataclass(frozen=True, slots=True)
+class PrimeAcpLimits:
+    """Host limits for one Prime root session and its descendants."""
+
+    max_model_calls: int
+    max_tokens: int
+    max_cost_usd: Decimal
+    max_wall_seconds: float
+
+    def __post_init__(self) -> None:
+        if self.max_model_calls < 1:
+            raise ValueError("Prime ACP max_model_calls must be positive")
+        if self.max_tokens < 1:
+            raise ValueError("Prime ACP max_tokens must be positive")
+        if self.max_cost_usd <= 0:
+            raise ValueError("Prime ACP max_cost_usd must be positive")
+        if self.max_wall_seconds <= 0:
+            raise ValueError("Prime ACP max_wall_seconds must be positive")
+
+
+@dataclass(frozen=True, slots=True)
+class PrimeAcpUsage:
+    """Normalized provider accounting read from Prime's session artifacts."""
+
+    complete: bool
+    model_calls: int
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int
+    cache_write_tokens: int
+    total_tokens: int
+    cost_usd: Decimal
+
+
+@dataclass(frozen=True, slots=True)
+class PrimeAcpTopology:
+    """Composite-principal topology observed in Prime's session artifacts."""
+
+    root_sessions: int
+    child_sessions: int
+
+
+@dataclass(frozen=True, slots=True)
+class PrimeAcpRefinement:
+    """Normalized counts derived from preserved Prime ACP refinement metadata."""
+
+    events: int
+    completed: int
+    failed: int
+    unknown: int
+
+
+async def wait_for_usage_limit(session_directory: Path, limits: PrimeAcpLimits) -> str:
+    """Wait until persisted composite usage reaches one configured threshold."""
+    previous_signature: tuple[tuple[str, int, int], ...] | None = None
+    while True:
+        signature = _session_artifact_signature(session_directory)
+        if signature != previous_signature:
+            previous_signature = signature
+            evidence = read_session_evidence(session_directory, allow_partial=True, require_root=False)
+            if evidence is not None:
+                usage, _topology = evidence
+                reason = usage_limit_reason(usage, limits)
+                if reason is not None:
+                    return reason
+        await asyncio.sleep(_USAGE_POLL_SECONDS)
+
+
+def read_session_evidence(
+    session_directory: Path,
+    *,
+    allow_partial: bool,
+    require_root: bool = True,
+) -> tuple[PrimeAcpUsage, PrimeAcpTopology] | None:
+    """Validate all Prime session streams and aggregate their assistant usage."""
+    files = sorted(path for path in session_directory.rglob("*.jsonl") if path.is_file())
+    if not files:
+        if require_root:
+            raise PrimeSessionEvidenceError("Prime ACP session produced no parseable session artifacts")
+        return None
+
+    model_calls = 0
+    input_tokens = 0
+    output_tokens = 0
+    cache_read_tokens = 0
+    cache_write_tokens = 0
+    total_tokens = 0
+    cost_usd = Decimal(0)
+    root_sessions = 0
+    child_sessions = 0
+    seen_messages: set[str] = set()
+    for path in files:
+        events = _session_events(path, allow_partial=allow_partial)
+        if not events:
+            continue
+        depth = _session_depth(events[0])
+        if depth == 0:
+            root_sessions += 1
+        else:
+            child_sessions += 1
+
+        for event in events[1:]:
+            message = event.get("message")
+            if event.get("type") != "message" or not isinstance(message, dict) or message.get("role") != "assistant":
+                continue
+            message_id = event.get("id")
+            if not isinstance(message_id, str) or not message_id.strip():
+                raise PrimeSessionEvidenceError("Prime assistant session event has no identity")
+            if message_id in seen_messages:
+                continue
+            seen_messages.add(message_id)
+            usage = message.get("usage")
+            if not isinstance(usage, dict):
+                raise PrimeSessionEvidenceError("Prime assistant session event has no usage evidence")
+            values = tuple(
+                _required_non_negative_int(usage.get(name), name)
+                for name in ("input", "output", "cacheRead", "cacheWrite", "totalTokens")
+            )
+            input_value, output_value, cache_read_value, cache_write_value, total_value = values
+            if total_value != input_value + output_value + cache_read_value + cache_write_value:
+                raise PrimeSessionEvidenceError("Prime assistant token totals are inconsistent")
+            cost = usage.get("cost")
+            if not isinstance(cost, dict):
+                raise PrimeSessionEvidenceError("Prime assistant session event has no cost evidence")
+            model_calls += 1
+            input_tokens += input_value
+            output_tokens += output_value
+            cache_read_tokens += cache_read_value
+            cache_write_tokens += cache_write_value
+            total_tokens += total_value
+            cost_usd += _required_non_negative_decimal(cost.get("total"), "cost.total")
+
+    if require_root and root_sessions != 1:
+        raise PrimeSessionEvidenceError("Prime ACP session artifacts must contain exactly one root session")
+    return (
+        PrimeAcpUsage(
+            complete=True,
+            model_calls=model_calls,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_tokens=cache_read_tokens,
+            cache_write_tokens=cache_write_tokens,
+            total_tokens=total_tokens,
+            cost_usd=cost_usd,
+        ),
+        PrimeAcpTopology(root_sessions=root_sessions, child_sessions=child_sessions),
+    )
+
+
+def usage_limit_reason(usage: PrimeAcpUsage, limits: PrimeAcpLimits) -> str | None:
+    if usage.model_calls >= limits.max_model_calls:
+        return "max_model_calls"
+    if usage.total_tokens >= limits.max_tokens:
+        return "max_tokens"
+    if usage.cost_usd >= limits.max_cost_usd:
+        return "max_cost_usd"
+    return None
+
+
+def empty_usage() -> PrimeAcpUsage:
+    return PrimeAcpUsage(
+        complete=False,
+        model_calls=0,
+        input_tokens=0,
+        output_tokens=0,
+        cache_read_tokens=0,
+        cache_write_tokens=0,
+        total_tokens=0,
+        cost_usd=Decimal(0),
+    )
+
+
+def refinement_evidence(updates: Sequence[dict[str, Any]]) -> PrimeAcpRefinement:
+    statuses: list[str | None] = []
+    for event in updates:
+        update = event.get("update")
+        metadata = event.get("_meta")
+        candidates = [
+            update.get("_meta") if isinstance(update, dict) else None,
+            metadata,
+        ]
+        for candidate in candidates:
+            if not isinstance(candidate, dict):
+                continue
+            namespaced = candidate.get(_PRIME_AGENT_META_NAMESPACE)
+            if not isinstance(namespaced, dict) or "refinement" not in namespaced:
+                continue
+            refinement = namespaced["refinement"]
+            statuses.append(refinement.get("status") if isinstance(refinement, dict) else None)
+    return PrimeAcpRefinement(
+        events=len(statuses),
+        completed=statuses.count("complete"),
+        failed=statuses.count("failed"),
+        unknown=sum(status not in {"complete", "failed"} for status in statuses),
+    )
+
+
+def _session_artifact_signature(session_directory: Path) -> tuple[tuple[str, int, int], ...]:
+    signature: list[tuple[str, int, int]] = []
+    for path in sorted(session_directory.rglob("*.jsonl")):
+        if path.is_file():
+            stat = path.stat()
+            signature.append((path.relative_to(session_directory).as_posix(), stat.st_size, stat.st_mtime_ns))
+    return tuple(signature)
+
+
+def _session_events(path: Path, *, allow_partial: bool) -> list[dict[str, Any]]:
+    try:
+        text = path.read_bytes().decode("utf-8", errors="strict")
+    except UnicodeDecodeError as exc:
+        raise PrimeSessionEvidenceError("Prime session artifact is not valid UTF-8") from exc
+    if text and not text.endswith("\n"):
+        if not allow_partial:
+            raise PrimeSessionEvidenceError("Prime session artifact ended with an incomplete JSONL frame")
+        last_newline = text.rfind("\n")
+        text = "" if last_newline < 0 else text[: last_newline + 1]
+    lines = text.splitlines()
+    if not lines:
+        if allow_partial:
+            return []
+        raise PrimeSessionEvidenceError("Prime session artifact is empty")
+    events: list[dict[str, Any]] = []
+    for line in lines:
+        if not line.strip():
+            raise PrimeSessionEvidenceError("Prime session artifact contains a blank frame")
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise PrimeSessionEvidenceError("Prime session artifact contains malformed JSON") from exc
+        if not isinstance(event, dict) or not isinstance(event.get("type"), str):
+            raise PrimeSessionEvidenceError("Prime session artifact contains an unsupported event")
+        events.append(event)
+    return events
+
+
+def _session_depth(header: dict[str, Any]) -> int:
+    if header.get("type") != "session" or header.get("version") not in PRIME_EVENT_STREAM_VERSIONS:
+        raise PrimeSessionEvidenceError("Prime session artifact has an unsupported session header")
+    session_id = header.get("id")
+    depth = header.get("rlmDepth")
+    if not isinstance(session_id, str) or not session_id.strip():
+        raise PrimeSessionEvidenceError("Prime session artifact has no session identity")
+    if isinstance(depth, bool) or not isinstance(depth, int) or depth < 0:
+        raise PrimeSessionEvidenceError("Prime session artifact has invalid topology metadata")
+    return depth
+
+
+def _required_non_negative_int(value: Any, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise PrimeSessionEvidenceError(f"Prime assistant usage {name} must be a non-negative integer")
+    return int(value)
+
+
+def _required_non_negative_decimal(value: Any, name: str) -> Decimal:
+    if isinstance(value, bool) or not isinstance(value, int | float | str):
+        raise PrimeSessionEvidenceError(f"Prime assistant usage {name} must be a non-negative number")
+    try:
+        result = Decimal(str(value))
+    except InvalidOperation as exc:
+        raise PrimeSessionEvidenceError(f"Prime assistant usage {name} must be a non-negative number") from exc
+    if not result.is_finite() or result < 0:
+        raise PrimeSessionEvidenceError(f"Prime assistant usage {name} must be a non-negative number")
+    try:
+        return result.quantize(_COST_QUANTUM_USD).normalize()
+    except InvalidOperation as exc:
+        raise PrimeSessionEvidenceError(f"Prime assistant usage {name} is outside the supported range") from exc

--- a/src/aec_bench/prime_agent/world.py
+++ b/src/aec_bench/prime_agent/world.py
@@ -13,6 +13,8 @@ import tempfile
 import threading
 from collections.abc import Mapping
 from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -26,6 +28,12 @@ from aec_bench.contracts.world_interface import (
     WorldInterfaceError,
 )
 from aec_bench.contracts.world_session import WorldSessionRequest, WorldSessionResult
+from aec_bench.prime_agent.acp import (
+    PrimeAcpIsolation,
+    PrimeAcpRun,
+    run_prime_acp_session,
+)
+from aec_bench.prime_agent.session_evidence import PrimeAcpLimits
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.episode_runtime import (
     PumpStationEpisodeHost,
 )
@@ -41,7 +49,6 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_ru
 
 if TYPE_CHECKING:
     from aec_bench.contracts.evaluation_result import StewardshipEvaluation
-    from aec_bench.prime_agent.acp import PrimeAcpIsolation, PrimeAcpRun
     from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_verifier import (
         PumpStationCoupledVerificationReport,
     )
@@ -56,6 +63,30 @@ class PrimeWorldActorProxyError(RuntimeError):
 
 
 @dataclass(frozen=True, slots=True)
+class PrimeWorldSessionLimits:
+    """Host limits for one composed Prime and interactive-world run."""
+
+    max_world_actions: int
+    max_model_calls: int
+    max_tokens: int
+    max_cost_usd: Decimal
+    max_wall_seconds: float
+
+    def __post_init__(self) -> None:
+        if self.max_world_actions < 1:
+            raise ValueError("Prime world max_world_actions must be positive")
+        self.acp_limits()
+
+    def acp_limits(self) -> PrimeAcpLimits:
+        return PrimeAcpLimits(
+            max_model_calls=self.max_model_calls,
+            max_tokens=self.max_tokens,
+            max_cost_usd=self.max_cost_usd,
+            max_wall_seconds=self.max_wall_seconds,
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class PrimePumpWorldRun:
     """Separate Prime-session and canonical-world outcomes for one interactive trial."""
 
@@ -66,6 +97,9 @@ class PrimePumpWorldRun:
     verification: PumpStationCoupledVerificationReport
     evaluation: StewardshipEvaluation
     actor_transport_file: Path
+    run_file: Path
+    world_action_attempts: int
+    world_action_limit_reached: bool
     benchmark_valid: bool
 
 
@@ -93,17 +127,23 @@ class _ActorRequestHandler(socketserver.StreamRequestHandler):
     server: _ActorProxyServer
 
     def handle(self) -> None:
+        received_at = datetime.now(UTC)
         line = self.rfile.readline(_MAX_MESSAGE_BYTES + 1)
         if len(line) > _MAX_MESSAGE_BYTES:
-            self.server.owner._write_response(self.wfile, error=("request-too-large", "actor request is too large"))
+            self.server.owner._reject_transport(
+                self.wfile,
+                received_at=received_at,
+                error=("request-too-large", "actor request is too large"),
+            )
             return
         if not line or not line.endswith(b"\n"):
-            self.server.owner._write_response(
+            self.server.owner._reject_transport(
                 self.wfile,
+                received_at=received_at,
                 error=("transport-malformed", "actor request must be one line"),
             )
             return
-        self.server.owner._handle_request(line, self.wfile)
+        self.server.owner._handle_request(line, self.wfile, received_at=received_at)
 
 
 class _ActorProxyServer(_ThreadedUnixServer):
@@ -123,8 +163,11 @@ class PrimeWorldActorProxy:
         *,
         world_run_directory: Path,
         socket_directory: Path,
+        max_world_actions: int,
         evidence_file: Path | None = None,
     ) -> None:
+        if max_world_actions < 1:
+            raise ValueError("Prime world max_world_actions must be positive")
         self._world_run_directory = world_run_directory.resolve()
         requested_socket_directory = socket_directory.resolve()
         requested_socket_path = requested_socket_directory / "actor.sock"
@@ -137,6 +180,10 @@ class PrimeWorldActorProxy:
         )
         self._evidence_file = evidence_file.resolve() if evidence_file is not None else None
         self._host = PumpStationEpisodeHost(self._world_run_directory)
+        self._max_world_actions = max_world_actions
+        self._world_action_attempts = 0
+        self._world_action_limit_reached = False
+        self._world_action_requests: dict[str, str] = {}
         self._capability = secrets.token_urlsafe(32)
         self._socket_path = self._socket_directory / "actor.sock"
         self._server: _ActorProxyServer | None = None
@@ -181,6 +228,14 @@ class PrimeWorldActorProxy:
     def last_action_result(self) -> WorldActorActionResult | None:
         return self._last_action_result
 
+    @property
+    def world_action_attempts(self) -> int:
+        return self._world_action_attempts
+
+    @property
+    def world_action_limit_reached(self) -> bool:
+        return self._world_action_limit_reached
+
     def close(self) -> None:
         server, thread = self._server, self._thread
         self._server = None
@@ -201,30 +256,96 @@ class PrimeWorldActorProxy:
     def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
         self.close()
 
-    def _handle_request(self, line: bytes, writer: Any) -> None:
+    def _handle_request(self, line: bytes, writer: Any, *, received_at: datetime) -> None:
         request: ContinualWorldActorRequest | None = None
+        operation: str | None = None
         try:
             raw = json.loads(line)
+            operation = _safe_operation(raw)
             envelope = _ActorTransportRequest.model_validate(raw)
             if not hmac.compare_digest(envelope.capability, self._capability):
+                self._record(
+                    request=None,
+                    operation=operation,
+                    received_at=received_at,
+                    error={"code": "actor-unauthorized", "detail": "actor capability is invalid"},
+                )
                 self._write_response(writer, error=("actor-unauthorized", "actor capability is invalid"))
                 return
             request = envelope.request
+            operation = request.operation
+            if request.operation == "invoke" and not self._authorize_world_action(request):
+                response_error = ("world-action-budget-exhausted", "world action budget is exhausted")
+                error: dict[str, JsonValue] = {
+                    "code": response_error[0],
+                    "detail": response_error[1],
+                }
+                self._record(
+                    request=request,
+                    operation=operation,
+                    received_at=received_at,
+                    error=error,
+                )
+                self._write_response(writer, error=response_error)
+                return
             result = self._dispatch(request)
         except (UnicodeDecodeError, json.JSONDecodeError, ValidationError, TypeError, ValueError):
+            self._record(
+                request=None,
+                operation=operation,
+                received_at=received_at,
+                error={
+                    "code": "actor-request-invalid",
+                    "detail": "actor request does not match the contract",
+                },
+            )
             self._write_response(writer, error=("actor-request-invalid", "actor request does not match the contract"))
             return
         except WorldInterfaceError as exc:
-            self._record(request=request, error={"code": exc.code, "detail": exc.detail})
+            self._record(
+                request=request,
+                operation=operation,
+                received_at=received_at,
+                error={"code": exc.code, "detail": exc.detail},
+            )
             self._write_response(writer, error=(exc.code, exc.detail))
             return
         except Exception:
-            self._record(request=request, error={"code": "actor-proxy-failed", "detail": "host actor call failed"})
+            self._record(
+                request=request,
+                operation=operation,
+                received_at=received_at,
+                error={"code": "actor-proxy-failed", "detail": "host actor call failed"},
+            )
             self._write_response(writer, error=("actor-proxy-failed", "host actor call failed"))
             return
         payload = result.model_dump(mode="json")
-        self._record(request=request, result=payload)
+        self._record(request=request, operation=operation, received_at=received_at, result=payload)
         self._write_response(writer, result=payload)
+
+    def _reject_transport(self, writer: Any, *, received_at: datetime, error: tuple[str, str]) -> None:
+        self._record(
+            request=None,
+            operation=None,
+            received_at=received_at,
+            error={"code": error[0], "detail": error[1]},
+        )
+        self._write_response(writer, error=error)
+
+    def _authorize_world_action(self, request: ContinualWorldActorRequest) -> bool:
+        assert request.request_id is not None
+        fingerprint = request.model_dump_json()
+        with self._evidence_lock:
+            if self._world_action_requests.get(request.request_id) == fingerprint:
+                return True
+            self._world_action_attempts += 1
+            if self._world_action_attempts > self._max_world_actions:
+                self._world_action_limit_reached = True
+                return False
+            self._world_action_requests.setdefault(request.request_id, fingerprint)
+            if self._world_action_attempts == self._max_world_actions:
+                self._world_action_limit_reached = True
+            return True
 
     def _dispatch(self, request: ContinualWorldActorRequest) -> StrictModel:
         if request.operation == "capabilities":
@@ -249,6 +370,8 @@ class PrimeWorldActorProxy:
         self,
         *,
         request: ContinualWorldActorRequest | None,
+        operation: str | None,
+        received_at: datetime,
         result: dict[str, JsonValue] | None = None,
         error: dict[str, JsonValue] | None = None,
     ) -> None:
@@ -258,6 +381,8 @@ class PrimeWorldActorProxy:
             self._sequence += 1
             event: dict[str, JsonValue] = {
                 "sequence": self._sequence,
+                "received_at": received_at.isoformat(),
+                "operation": operation,
                 "request": request.model_dump(mode="json") if request is not None else None,
                 "result": result,
                 "error": error,
@@ -303,13 +428,11 @@ async def run_prime_pump_world_session(
     instruction: str,
     model: str,
     isolation: PrimeAcpIsolation,
-    timeout_seconds: float = 900,
+    limits: PrimeWorldSessionLimits,
     executable: str = "prime-agent",
     environment: Mapping[str, str] | None = None,
 ) -> PrimePumpWorldRun:
     """Compose Prime with the current pump world without changing task-owned runtime paths."""
-    from aec_bench.prime_agent.acp import run_prime_acp_session
-
     actor_workspace = actor_workspace.resolve()
     world_run_directory = world_run_directory.resolve()
     evidence_directory = evidence_directory.resolve()
@@ -322,6 +445,7 @@ async def run_prime_pump_world_session(
     proxy = PrimeWorldActorProxy(
         world_run_directory=world_run_directory,
         socket_directory=actor_workspace / ".actor",
+        max_world_actions=limits.max_world_actions,
         evidence_file=actor_transport_file,
     )
     world_session = proxy.open_world_session(session_request)
@@ -334,12 +458,14 @@ async def run_prime_pump_world_session(
             model=model,
             actor_environment=proxy.connection_environment(),
             isolation=isolation,
+            limits=limits.acp_limits(),
             private_paths=(world_run_directory, evidence_directory),
-            timeout_seconds=timeout_seconds,
             executable=executable,
             environment=environment,
         )
         last_action = proxy.last_action_result
+        world_action_attempts = proxy.world_action_attempts
+        world_action_limit_reached = proxy.world_action_limit_reached
 
     repository = PumpStationWorldRunRepository(world_run_directory)
     run = PumpStationWorldRun.resume_reference_system(
@@ -366,6 +492,33 @@ async def run_prime_pump_world_session(
         completion = "truncated"
     else:
         completion = "incomplete"
+    benchmark_valid = prime.benchmark_valid and verification.valid
+    run_file = evidence_directory / "prime-world-run.json"
+    run_file.write_text(
+        json.dumps(
+            {
+                "schema": "aecbench.prime-world-run.v1",
+                "limits": {
+                    "max_world_actions": limits.max_world_actions,
+                    "max_model_calls": limits.max_model_calls,
+                    "max_tokens": limits.max_tokens,
+                    "max_cost_usd": str(limits.max_cost_usd),
+                    "max_wall_seconds": limits.max_wall_seconds,
+                },
+                "world_action_attempts": world_action_attempts,
+                "world_action_limit_reached": world_action_limit_reached,
+                "prime_session_state": prime.session_state,
+                "prime_limit_reason": prime.limit_reason,
+                "world_state": world_state,
+                "completion": completion,
+                "benchmark_valid": benchmark_valid,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
     return PrimePumpWorldRun(
         prime=prime,
         world_session=world_session,
@@ -374,7 +527,10 @@ async def run_prime_pump_world_session(
         verification=verification,
         evaluation=evaluation,
         actor_transport_file=actor_transport_file,
-        benchmark_valid=prime.benchmark_valid and verification.valid,
+        run_file=run_file,
+        world_action_attempts=world_action_attempts,
+        world_action_limit_reached=world_action_limit_reached,
+        benchmark_valid=benchmark_valid,
     )
 
 
@@ -382,3 +538,15 @@ def _paths_overlap(first: Path, second: Path) -> bool:
     first = first.resolve()
     second = second.resolve()
     return first == second or first in second.parents or second in first.parents
+
+
+def _safe_operation(value: Any) -> str | None:
+    if not isinstance(value, dict):
+        return None
+    request = value.get("request")
+    if not isinstance(request, dict):
+        return None
+    operation = request.get("operation")
+    if isinstance(operation, str) and operation in {"capabilities", "observe", "invoke"}:
+        return operation
+    return None

--- a/tests/prime_agent/test_acp.py
+++ b/tests/prime_agent/test_acp.py
@@ -7,6 +7,7 @@ import json
 import os
 import subprocess
 import sys
+from decimal import Decimal
 from pathlib import Path
 
 import pytest
@@ -18,6 +19,7 @@ from aec_bench.prime_agent.acp import (
     run_prime_acp_session,
 )
 from aec_bench.prime_agent.batch import PRIME_AGENT_TESTED_VERSION
+from aec_bench.prime_agent.session_evidence import PrimeAcpLimits
 from aec_bench.prime_agent.world import (
     WORLD_ACTOR_CAPABILITY_ENV,
     WORLD_ACTOR_SOCKET_ENV,
@@ -39,8 +41,39 @@ if "--version" in sys.argv:
     print("prime-agent {PRIME_AGENT_TESTED_VERSION}")
     raise SystemExit(0)
 
-Path("observed-acp.json").write_text(json.dumps({{"argv": sys.argv[1:], "cwd": os.getcwd()}}))
+Path("observed-acp.json").write_text(json.dumps({{
+    "argv": sys.argv[1:],
+    "cwd": os.getcwd(),
+    "home": os.environ.get("HOME"),
+    "xdg_cache_home": os.environ.get("XDG_CACHE_HOME"),
+    "xdg_config_home": os.environ.get("XDG_CONFIG_HOME"),
+    "xdg_data_home": os.environ.get("XDG_DATA_HOME"),
+}}))
 scenario = os.environ.get("FAKE_ACP_SCENARIO", "success")
+session_dir = Path(sys.argv[sys.argv.index("--session-dir") + 1])
+session_file = session_dir / "root.jsonl"
+
+def append_session(event):
+    with session_file.open("a") as sink:
+        sink.write(json.dumps(event) + "\\n")
+
+def record_assistant():
+    append_session({{
+        "type": "message",
+        "id": "fake-assistant-1",
+        "message": {{
+            "role": "assistant",
+            "usage": {{
+                "input": 10,
+                "output": 5,
+                "cacheRead": 2,
+                "cacheWrite": 3,
+                "totalTokens": 20,
+                "cost": {{"total": 0.25000000000000003}},
+            }},
+        }},
+    }})
+
 sessions = 0
 for line in sys.stdin:
     request = json.loads(line)
@@ -56,6 +89,9 @@ for line in sys.stdin:
         print(json.dumps({{"jsonrpc": "2.0", "id": request["id"], "result": result}}), flush=True)
     elif method == "session/new":
         sessions += 1
+        append_session({{
+            "type": "session", "version": 3, "id": "prime-root", "rlmDepth": 0
+        }})
         print(json.dumps({{"jsonrpc": "2.0", "id": request["id"], "result": {{
             "sessionId": f"fake-session-{{sessions}}", "_meta": {{"unknownSessionKey": 7}}
         }}}}), flush=True)
@@ -67,6 +103,15 @@ for line in sys.stdin:
         if scenario == "malformed":
             print("not-json", flush=True)
             continue
+        record_assistant()
+        if scenario == "malformed-session":
+            with session_file.open("a") as sink:
+                sink.write("not-json\\n")
+        if scenario == "topology-refinement":
+            child_file = session_dir / "child.jsonl"
+            child_file.write_text(json.dumps({{
+                "type": "session", "version": 3, "id": "prime-child", "rlmDepth": 1
+            }}) + "\\n")
         if scenario == "world":
             import asyncio
             sys.path.insert(0, os.getcwd())
@@ -88,11 +133,18 @@ for line in sys.stdin:
                 "update": {{
                     "sessionUpdate": "agent_message_chunk",
                     "content": {{"type": "text", "text": "Working"}},
-                    "_meta": {{"unknownUpdateKey": "kept"}},
+                    "_meta": {{
+                        "unknownUpdateKey": "kept",
+                        **({{"ai.primeintellect.prime-agent": {{
+                            "refinement": {{"status": "complete", "summary": "kept raw"}}
+                        }}}} if scenario == "topology-refinement" else {{}}),
+                    }},
                 }},
                 "_meta": {{"unknownNotificationKey": True}},
             }},
         }}), flush=True)
+        if scenario == "budget":
+            time.sleep(0.2)
         print(json.dumps({{"jsonrpc": "2.0", "id": request["id"], "result": {{
             "stopReason": "end_turn", "_meta": {{"futurePromptMetadata": [1, 2, 3]}}
         }}}}), flush=True)
@@ -114,6 +166,15 @@ def _workspace(tmp_path: Path) -> tuple[Path, Path, Path]:
     skill = install_aec_world_skill(actor_workspace)
     evidence = tmp_path / "host-evidence"
     return actor_workspace, skill, evidence
+
+
+def _limits(*, wall_seconds: float = 5) -> PrimeAcpLimits:
+    return PrimeAcpLimits(
+        max_model_calls=10,
+        max_tokens=1_000,
+        max_cost_usd=Decimal("10"),
+        max_wall_seconds=wall_seconds,
+    )
 
 
 def test_builds_acp_command_with_only_the_explicit_skill(tmp_path: Path) -> None:
@@ -163,7 +224,7 @@ async def test_runs_one_acp_session_and_preserves_unknown_metadata(tmp_path: Pat
             WORLD_ACTOR_CAPABILITY_ENV: "scoped-capability-secret",
         },
         isolation=PrimeAcpIsolation.DEVELOPMENT_SAME_USER,
-        timeout_seconds=5,
+        limits=_limits(),
         executable=str(_fake_prime_agent(tmp_path)),
         environment={**os.environ, "FAKE_SECRET_TOKEN": secret},
     )
@@ -177,6 +238,12 @@ async def test_runs_one_acp_session_and_preserves_unknown_metadata(tmp_path: Pat
     assert result.agent_name == "prime-agent"
     assert result.agent_capabilities is not None
     assert len(result.updates) == 1
+    assert result.usage.complete
+    assert result.usage.model_calls == 1
+    assert result.usage.total_tokens == 20
+    assert result.usage.cost_usd == Decimal("0.25")
+    assert result.topology.root_sessions == 1
+    assert result.topology.child_sessions == 0
     assert not result.benchmark_valid
     inbound = result.paths.inbound_file.read_text(encoding="utf-8")
     outbound = result.paths.outbound_file.read_text(encoding="utf-8")
@@ -191,7 +258,102 @@ async def test_runs_one_acp_session_and_preserves_unknown_metadata(tmp_path: Pat
     assert provenance["actor_principal_scope"] == "prime-session-composite"
     assert provenance["isolation"] == "development_same_user"
     assert provenance["benchmark_valid"] is False
+    assert provenance["runtime_home_scope"] == "actor-workspace"
+    assert provenance["usage"]["cost_usd"] == "0.25"
     assert "environment" not in provenance
+    observed = json.loads((actor_workspace / "observed-acp.json").read_text(encoding="utf-8"))
+    runtime_root = actor_workspace / ".prime-runtime"
+    assert observed["home"] == str(runtime_root / "home")
+    assert observed["xdg_cache_home"] == str(runtime_root / "cache")
+    assert observed["xdg_config_home"] == str(runtime_root / "config")
+    assert observed["xdg_data_home"] == str(runtime_root / "data")
+
+
+@pytest.mark.asyncio
+async def test_normalizes_child_topology_and_refinement_metadata(tmp_path: Path) -> None:
+    actor_workspace, skill, evidence = _workspace(tmp_path)
+    result = await run_prime_acp_session(
+        actor_workspace=actor_workspace,
+        evidence_directory=evidence,
+        skill_directory=skill,
+        instruction="Record evidence.",
+        model="anthropic/test",
+        actor_environment={
+            WORLD_ACTOR_SOCKET_ENV: "/private/tmp/scoped-actor.sock",
+            WORLD_ACTOR_CAPABILITY_ENV: "scoped-capability-secret",
+        },
+        isolation=PrimeAcpIsolation.DEVELOPMENT_SAME_USER,
+        limits=_limits(),
+        executable=str(_fake_prime_agent(tmp_path)),
+        environment={**os.environ, "FAKE_ACP_SCENARIO": "topology-refinement"},
+    )
+
+    assert result.topology.root_sessions == 1
+    assert result.topology.child_sessions == 1
+    assert result.refinement.events == 1
+    assert result.refinement.completed == 1
+    assert result.refinement.failed == 0
+    assert "kept raw" in result.paths.outbound_file.read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("limits", "expected_reason"),
+    [
+        (PrimeAcpLimits(1, 1_000, Decimal("10"), 2), "max_model_calls"),
+        (PrimeAcpLimits(10, 20, Decimal("10"), 2), "max_tokens"),
+        (PrimeAcpLimits(10, 1_000, Decimal("0.25"), 2), "max_cost_usd"),
+    ],
+)
+async def test_usage_limit_cancels_the_active_prime_prompt(
+    tmp_path: Path,
+    limits: PrimeAcpLimits,
+    expected_reason: str,
+) -> None:
+    actor_workspace, skill, evidence = _workspace(tmp_path)
+    result = await run_prime_acp_session(
+        actor_workspace=actor_workspace,
+        evidence_directory=evidence,
+        skill_directory=skill,
+        instruction="Keep working.",
+        model="anthropic/test",
+        actor_environment={
+            WORLD_ACTOR_SOCKET_ENV: "/private/tmp/scoped-actor.sock",
+            WORLD_ACTOR_CAPABILITY_ENV: "scoped-capability-secret",
+        },
+        isolation=PrimeAcpIsolation.DEVELOPMENT_SAME_USER,
+        limits=limits,
+        executable=str(_fake_prime_agent(tmp_path)),
+        environment={**os.environ, "FAKE_ACP_SCENARIO": "budget"},
+    )
+
+    assert result.limit_reason == expected_reason
+    assert result.usage.model_calls == 1
+    assert '"method":"session/cancel"' in result.paths.inbound_file.read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_fails_closed_when_prime_session_accounting_is_malformed(tmp_path: Path) -> None:
+    actor_workspace, skill, evidence = _workspace(tmp_path)
+    result = await run_prime_acp_session(
+        actor_workspace=actor_workspace,
+        evidence_directory=evidence,
+        skill_directory=skill,
+        instruction="Act once.",
+        model="anthropic/test",
+        actor_environment={
+            WORLD_ACTOR_SOCKET_ENV: "/private/tmp/scoped-actor.sock",
+            WORLD_ACTOR_CAPABILITY_ENV: "scoped-capability-secret",
+        },
+        isolation=PrimeAcpIsolation.DEVELOPMENT_SAME_USER,
+        limits=_limits(),
+        executable=str(_fake_prime_agent(tmp_path)),
+        environment={**os.environ, "FAKE_ACP_SCENARIO": "malformed-session"},
+    )
+
+    assert result.session_state == "failed"
+    assert result.error is not None
+    assert "malformed JSON" in result.error
 
 
 @pytest.mark.asyncio
@@ -209,7 +371,7 @@ async def test_fails_closed_on_malformed_or_unsupported_acp(tmp_path: Path, scen
             WORLD_ACTOR_CAPABILITY_ENV: "scoped-capability-secret",
         },
         isolation=PrimeAcpIsolation.DEVELOPMENT_SAME_USER,
-        timeout_seconds=2,
+        limits=_limits(wall_seconds=2),
         executable=str(_fake_prime_agent(tmp_path)),
         environment={**os.environ, "FAKE_ACP_SCENARIO": scenario},
     )
@@ -233,7 +395,7 @@ async def test_timeout_cancels_then_reaps_the_prime_process(tmp_path: Path) -> N
             WORLD_ACTOR_CAPABILITY_ENV: "scoped-capability-secret",
         },
         isolation=PrimeAcpIsolation.DEVELOPMENT_SAME_USER,
-        timeout_seconds=0.1,
+        limits=_limits(wall_seconds=0.5),
         executable=str(_fake_prime_agent(tmp_path)),
         environment={**os.environ, "FAKE_ACP_SCENARIO": "timeout"},
     )
@@ -258,7 +420,7 @@ async def test_process_exit_during_prompt_is_a_failed_session(tmp_path: Path) ->
             WORLD_ACTOR_CAPABILITY_ENV: "scoped-capability-secret",
         },
         isolation=PrimeAcpIsolation.DEVELOPMENT_SAME_USER,
-        timeout_seconds=2,
+        limits=_limits(wall_seconds=2),
         executable=str(_fake_prime_agent(tmp_path)),
         environment={**os.environ, "FAKE_ACP_SCENARIO": "process-exit"},
     )
@@ -341,7 +503,7 @@ async def test_macos_sandboxed_acp_run_is_benchmark_valid(tmp_path: Path) -> Non
         },
         isolation=PrimeAcpIsolation.MACOS_SANDBOX,
         private_paths=(tmp_path / "private-world",),
-        timeout_seconds=2,
+        limits=_limits(wall_seconds=2),
         executable=str(_fake_prime_agent(tmp_path)),
         environment=os.environ,
     )

--- a/tests/prime_agent/test_world.py
+++ b/tests/prime_agent/test_world.py
@@ -8,6 +8,8 @@ import json
 import os
 import socket
 import sys
+from datetime import datetime
+from decimal import Decimal
 from pathlib import Path
 from typing import Any, cast
 
@@ -23,6 +25,7 @@ from aec_bench.prime_agent.world import (
     WORLD_ACTOR_CAPABILITY_ENV,
     WORLD_ACTOR_SOCKET_ENV,
     PrimeWorldActorProxy,
+    PrimeWorldSessionLimits,
     install_aec_world_skill,
     run_prime_pump_world_session,
 )
@@ -41,6 +44,16 @@ def _session_request() -> WorldSessionRequest:
         run_id="prime-run",
         episode_id="prime-episode",
         world_branch_id="prime-branch",
+    )
+
+
+def _limits(*, max_world_actions: int = 20) -> PrimeWorldSessionLimits:
+    return PrimeWorldSessionLimits(
+        max_world_actions=max_world_actions,
+        max_model_calls=10,
+        max_tokens=1_000,
+        max_cost_usd=Decimal("10"),
+        max_wall_seconds=5,
     )
 
 
@@ -72,6 +85,7 @@ async def test_scoped_proxy_preserves_actor_semantics_and_redacted_transport_evi
     proxy = PrimeWorldActorProxy(
         world_run_directory=world_directory,
         socket_directory=actor_workspace / ".actor",
+        max_world_actions=20,
         evidence_file=evidence_file,
     )
     proxy.open_world_session(_session_request())
@@ -139,13 +153,19 @@ async def test_scoped_proxy_preserves_actor_semantics_and_redacted_transport_evi
             },
         )
         assert forbidden_control == forbidden
+        unauthorized = _raw_call(
+            environment[WORLD_ACTOR_SOCKET_ENV],
+            {"capability": "wrong-capability-secret", "request": {"operation": "observe"}},
+        )
+        assert unauthorized == {"error": {"code": "actor-unauthorized", "detail": "actor capability is invalid"}}
 
     assert not Path(environment[WORLD_ACTOR_SOCKET_ENV]).exists()
     evidence = evidence_file.read_text(encoding="utf-8")
     assert environment[WORLD_ACTOR_CAPABILITY_ENV] not in evidence
+    assert "wrong-capability-secret" not in evidence
     assert str(world_directory) not in evidence
     events = [json.loads(line) for line in evidence.splitlines()]
-    assert [event["request"]["operation"] for event in events] == [
+    assert [event["operation"] for event in events] == [
         "capabilities",
         "observe",
         "invoke",
@@ -153,7 +173,64 @@ async def test_scoped_proxy_preserves_actor_semantics_and_redacted_transport_evi
         "invoke",
         "invoke",
         "invoke",
+        "observe",
+        None,
+        "observe",
     ]
+    assert all(datetime.fromisoformat(event["received_at"]) for event in events)
+    assert events[-3]["request"] is None
+    assert events[-2]["request"] is None
+    assert events[-1]["request"] is None
+
+
+@pytest.mark.asyncio
+async def test_world_action_budget_preserves_exact_retry_and_blocks_a_new_action(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    world_directory = tmp_path / "private-world"
+    actor_workspace = tmp_path / "actor-workspace"
+    actor_workspace.mkdir()
+    evidence_file = tmp_path / "host-evidence" / "actor-transport.jsonl"
+    client = _load_skill(actor_workspace, monkeypatch)
+    proxy = PrimeWorldActorProxy(
+        world_run_directory=world_directory,
+        socket_directory=actor_workspace / ".actor",
+        max_world_actions=1,
+        evidence_file=evidence_file,
+    )
+    proxy.open_world_session(_session_request())
+
+    with proxy:
+        environment = proxy.connection_environment()
+        monkeypatch.setenv(WORLD_ACTOR_SOCKET_ENV, environment[WORLD_ACTOR_SOCKET_ENV])
+        monkeypatch.setenv(WORLD_ACTOR_CAPABILITY_ENV, environment[WORLD_ACTOR_CAPABILITY_ENV])
+        observation = await client.observe()
+        first = await client.invoke(
+            "continue_operation",
+            {"reason": "Advance once."},
+            decision_id=observation["decision_id"],
+            request_id="action-1",
+        )
+        retry = await client.invoke(
+            "continue_operation",
+            {"reason": "Advance once."},
+            decision_id=observation["decision_id"],
+            request_id="action-1",
+        )
+        assert retry == first
+        with pytest.raises(client.ActorError, match="world-action-budget-exhausted"):
+            await client.invoke(
+                "continue_operation",
+                {"reason": "Try another action."},
+                decision_id=first["next_observation"]["decision_id"],
+                request_id="action-2",
+            )
+
+    assert proxy.world_action_attempts == 2
+    assert proxy.world_action_limit_reached
+    events = [json.loads(line) for line in evidence_file.read_text(encoding="utf-8").splitlines()]
+    assert events[-1]["error"]["code"] == "world-action-budget-exhausted"
 
 
 def test_packaged_skill_has_only_the_three_actor_operations(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -183,7 +260,7 @@ async def test_prime_end_turn_while_world_is_live_is_recorded_incomplete(tmp_pat
         instruction="Advance the current world, then end the turn.",
         model="anthropic/test",
         isolation=PrimeAcpIsolation.DEVELOPMENT_SAME_USER,
-        timeout_seconds=5,
+        limits=_limits(),
         executable=str(_fake_prime_agent(tmp_path)),
         environment={**os.environ, "FAKE_ACP_SCENARIO": "world"},
     )
@@ -194,6 +271,8 @@ async def test_prime_end_turn_while_world_is_live_is_recorded_incomplete(tmp_pat
     assert result.verification.valid
     assert result.evaluation.valid is False
     assert result.actor_transport_file.exists()
+    assert result.run_file.exists()
+    assert result.world_action_attempts == 1
     assert not result.prime.benchmark_valid
 
 
@@ -210,7 +289,7 @@ async def test_sandboxed_prime_reaches_world_only_through_the_scoped_proxy(tmp_p
         instruction="Advance the current world, then end the turn.",
         model="anthropic/test",
         isolation=PrimeAcpIsolation.MACOS_SANDBOX,
-        timeout_seconds=5,
+        limits=_limits(),
         executable=str(_fake_prime_agent(tmp_path)),
         environment={**os.environ, "FAKE_ACP_SCENARIO": "world"},
     )


### PR DESCRIPTION
## Summary

- isolate Prime HOME and XDG state inside each actor workspace so the Seatbelt boundary supports the real IPython runtime
- require positive world-action, model-call, token, cost, and wall limits; keep exact actor retries available while rejecting new actions after the allowance
- observe all Prime v3 session artifacts, cancel ACP at completed-response thresholds, and normalize usage, cost, root/child topology, and refinement evidence
- timestamp every actor proxy attempt, including malformed, unauthorized, and transport-level failures, without retaining capabilities, host paths, or arbitrary invalid payloads
- preserve the world repository as replay authority and add only secondary `prime-run.json` and `prime-world-run.json` summaries

## Validation

- `uv run pytest tests/prime_agent/test_acp.py tests/prime_agent/test_world.py -q` — 20 passed, including macOS Seatbelt and Unix-socket boundary coverage
- targeted Ruff format and lint checks passed
- targeted mypy passed
- `git diff --check` passed
- the new parser reproduced the retained smoke-04 evidence: 33 model calls, 821617 tokens, USD 2.38132335, one root session, no children

## Limit semantics

Provider token and cost evidence exists only after a completed response. The response that reaches a limit can cross it, and a provider request already in flight when cancellation arrives can also report usage. The wall limit remains host timed. No new paid provider run was made for this PR.

The upstream Prime 0.7.0 Bedrock bundle issue is intentionally unchanged and remains an upstream compatibility finding.