### PR TITLE
fix(prime-agent): evaluate bounded world sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,11 @@ AEC-Bench is a Python platform for creating, running, and evaluating Architectur
 
 Do not preserve obsolete code, package structure, or documentation only because it already exists. The task is to leave the current system coherent, not to preserve its full history.
 
+## Communication and language
+
+- Use ASD-STE100 Simplified Technical English for all AEC-Bench work. This rule applies to progress updates, reviews, handoffs, documentation, issues, and pull requests.
+- Keep code identifiers, commands, paths, schemas, error messages, and quoted source text exact. Do not rewrite these technical literals to follow ASD-STE100.
+
 ## Start with the relevant authority
 
 Read the implementation and tests for the area you will change. Then read only the documents that govern that change:

--- a/README.md
+++ b/README.md
@@ -221,11 +221,22 @@ Prime session state and world state remain separate. In particular, ACP
 start another prompt automatically. World replay, verification, and evaluation
 continue to use the existing task-owned repository and evaluator.
 
+One Prime ACP session is evaluated as a task-owned `bounded_continuation`.
+Prime has no host-control capability, so the bounded scope does not require it
+to perform Operations reviews that belong to the host boundary. This changes
+only the terminal-stewardship availability gate: active restrictions, deferred
+work, unavailable assets, and other closing liabilities remain explicit in the
+evaluation. A valid bounded evaluation does not mark an active world or an
+incomplete or interrupted Prime session as completed. A `complete_journey`
+treatment requires separately designed host-owned control orchestration.
+
 Each run preserves `prime-acp-in.jsonl`, `prime-acp-out.jsonl`,
 `prime-stderr.log`, `prime-run.json`, `prime-world-run.json`, Prime session
 files, and a separate actor-transport log. `prime-run.json` normalizes usage,
 cost, root/child session topology, refinement counts, configured limits, and
-the limit that ended the prompt. Unknown ACP `_meta` content stays in the raw
+the limit that ended the prompt. `prime-world-run.json` records the selected
+task-owned evaluation scope and whether that evaluation passed alongside the
+separate session and world states. Unknown ACP `_meta` content stays in the raw
 evidence. The actor log timestamps every accepted, rejected, unauthorized, and
 malformed transport attempt without recording the socket capability, host
 paths, or hidden state. Trial-local Prime HOME/XDG directories, configuration,

--- a/docs/protocols/interactive-world-runtime.md
+++ b/docs/protocols/interactive-world-runtime.md
@@ -151,6 +151,17 @@ normalized Prime run evidence records configured limits, aggregate usage and
 cost, root/child session counts, refinement status counts, and any limit that
 ended the prompt. Unknown ACP metadata remains in the raw ACP evidence.
 
+The current Prime composition is one bounded actor continuation. It invokes the
+task-owned pump evaluator with `evaluation_scope="bounded_continuation"`
+because Operations boundary reviews remain host controls and are not available
+through the Prime actor capability. The bounded scope changes only the
+terminal-stewardship availability gate. Verification, conservation, authority,
+evidence, and liability checks remain unchanged, and closing liabilities remain
+in the result. Evaluation validity therefore does not convert an active world
+or an incomplete or interrupted Prime session into a completed one. A
+`complete_journey` Prime treatment requires explicit host-owned control
+orchestration outside the composite actor principal.
+
 Same-user Prime execution is development-only and cannot produce
 benchmark-valid evidence. The current benchmark-valid local path uses a macOS
 Seatbelt profile applied to Prime and its descendants. It denies the AECBench

--- a/src/aec_bench/prime_agent/world.py
+++ b/src/aec_bench/prime_agent/world.py
@@ -473,7 +473,10 @@ async def run_prime_pump_world_session(
         snapshot=repository.current_snapshot(),
     )
     verification = run.verify()
-    evaluation = evaluate_pump_station_reference_run(run)
+    # One Prime ACP session can make only actor-authorised progress. Host-owned
+    # Operations reviews remain outside its capability, so this composition is
+    # a bounded continuation rather than the task's complete reference journey.
+    evaluation = evaluate_pump_station_reference_run(run, evaluation_scope="bounded_continuation")
     if not verification.valid:
         world_state = "failed"
     elif last_action is not None and last_action.terminated:
@@ -511,6 +514,8 @@ async def run_prime_pump_world_session(
                 "prime_limit_reason": prime.limit_reason,
                 "world_state": world_state,
                 "completion": completion,
+                "evaluation_scope": evaluation.evaluation_scope,
+                "evaluation_valid": evaluation.valid,
                 "benchmark_valid": benchmark_valid,
             },
             indent=2,

--- a/tests/prime_agent/test_world.py
+++ b/tests/prime_agent/test_world.py
@@ -269,11 +269,18 @@ async def test_prime_end_turn_while_world_is_live_is_recorded_incomplete(tmp_pat
     assert result.world_state == "active"
     assert result.completion == "incomplete"
     assert result.verification.valid
-    assert result.evaluation.valid is False
+    assert result.evaluation.evaluation_scope == "bounded_continuation"
+    assert result.evaluation.valid
+    assert result.evaluation.metrics.terminal_liability.active_restriction_count == 2
     assert result.actor_transport_file.exists()
     assert result.run_file.exists()
     assert result.world_action_attempts == 1
     assert not result.prime.benchmark_valid
+    run_evidence = json.loads(result.run_file.read_text(encoding="utf-8"))
+    assert run_evidence["evaluation_scope"] == "bounded_continuation"
+    assert run_evidence["evaluation_valid"] is True
+    assert run_evidence["world_state"] == "active"
+    assert run_evidence["completion"] == "incomplete"
 
 
 @pytest.mark.asyncio
@@ -298,5 +305,7 @@ async def test_sandboxed_prime_reaches_world_only_through_the_scoped_proxy(tmp_p
     assert result.world_state == "active"
     assert result.completion == "incomplete"
     assert result.verification.valid
+    assert result.evaluation.evaluation_scope == "bounded_continuation"
+    assert result.evaluation.valid
     assert result.prime.benchmark_valid
     assert result.benchmark_valid


### PR DESCRIPTION
## Summary

- evaluate one Prime pump session as a task-owned `bounded_continuation`;
- preserve active world, incomplete session, and closing liability states;
- record the evaluation scope and result in `prime-world-run.json`;
- document the host-control boundary;
- require ASD-STE100 Simplified Technical English for AEC-Bench work.

## Reason

The complete pump journey requires host-owned Operations reviews. Prime cannot use host controls through its scoped actor capability. The bounded scope evaluates only the actor continuation that Prime can control. It does not mark an active world as completed.

## Checks

- `.venv/bin/pytest tests/prime_agent/test_world.py -q` — 5 passed
- `.venv/bin/ruff check src/aec_bench/prime_agent/world.py tests/prime_agent/test_world.py`
- `.venv/bin/ruff format --check src/aec_bench/prime_agent/world.py tests/prime_agent/test_world.py`
- `.venv/bin/mypy src/aec_bench/prime_agent/world.py tests/prime_agent/test_world.py`
- `git diff --check`