### PR TITLE
fix(world): preserve resource rejection codes

### DIFF
--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/episode_runtime.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/episode_runtime.py
@@ -46,6 +46,9 @@ from aec_bench.task_world_templates.stewardship.wastewater_pump_station.coupled_
     project_coupled_information_set,
     transition,
 )
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.coupled_work import (
+    PumpStationResourceError,
+)
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_identity import (
     canonical_stewardship_value,
 )
@@ -528,7 +531,7 @@ class PumpStationEpisodeHost:
                 action=action.action,
                 model=run.model,
             )
-        except (PumpStationActionError, PumpStationCoupledWorldError) as error:
+        except (PumpStationActionError, PumpStationCoupledWorldError, PumpStationResourceError) as error:
             return ActionRejected(getattr(error, "code", "domain-action-rejected"), str(error))
         return Transition(state=task_transition.state, output=task_transition)
 

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_actor_interface_transport_e2e.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_actor_interface_transport_e2e.py
@@ -184,3 +184,60 @@ def test_registered_episode_records_accepted_step_before_runtime_truncation(
     assert run.verify().valid
     with pytest.raises(EpisodeFinishedError, match="episode is truncated"):
         PumpStationEpisodeHost(run_dir, limits=EpisodeLimits(max_steps=1)).observe()
+
+
+def test_actor_receives_resource_window_rejection_without_losing_world_state(tmp_path: Path) -> None:
+    run_dir = tmp_path / "world"
+    run = PumpStationWorldRun.create_reference_system(
+        repository=PumpStationWorldRunRepository(run_dir),
+        run_id="resource-rejection-run",
+        episode_id="resource-rejection-episode",
+        world_branch_id="resource-rejection-branch",
+    )
+    host = PumpStationEpisodeHost(run_dir)
+    observation = host.observe()
+    verification = host.invoke(
+        WorldActorActionRequest(
+            request_id="resource-rejection-verification",
+            decision_id=observation.decision_id,
+            action_name="request_post_maintenance_verification",
+            arguments={
+                "reason": "Verify Pump A before other field work.",
+                "pump_id": "pump-a",
+                "backlog_item_id": "backlog-a-verification-001",
+            },
+        )
+    )
+    assert verification.next_observation is not None
+    advanced = host.invoke(
+        WorldActorActionRequest(
+            request_id="resource-rejection-continue",
+            decision_id=verification.next_observation.decision_id,
+            action_name="continue_operation",
+            arguments={"reason": "Continue until the verification process completes."},
+        )
+    )
+    assert advanced.next_observation is not None
+
+    rejected = host.invoke(
+        WorldActorActionRequest(
+            request_id="resource-rejection-clearance",
+            decision_id=advanced.next_observation.decision_id,
+            action_name="request_obstruction_clearance",
+            arguments={
+                "reason": "Request Pump B clearance before the current field window closes.",
+                "pump_id": "pump-b",
+                "inspection_evidence_id": "initial-b-inspection-accepted",
+                "backlog_item_id": "backlog-b-clearance-001",
+            },
+        )
+    )
+
+    assert rejected.status == "rejected"
+    assert rejected.task_receipt == {
+        "code": "resource-window",
+        "message": "resource-window: field-access-slot",
+    }
+    assert rejected.next_observation == advanced.next_observation
+    assert run.snapshot().sequence == 2
+    assert run.verify().valid


### PR DESCRIPTION
## Outcome

Pump-station actor calls now receive expected resource-scheduling failures as task-owned rejections. An outer transport no longer labels them as malformed actor requests.

## Evidence

A correct Pump B clearance request at 14:00 failed with `PumpStationResourceError: resource-window: field-access-slot`. The episode boundary did not convert that expected domain error into `ActionRejected`. The Prime proxy therefore returned `actor-request-invalid`.

## Change

- Convert `PumpStationResourceError` into the existing rejected-action result.
- Add a regression test for the 14:00 resource-window state.
- Confirm that the rejected call does not advance the durable world.

## Checks

- `uv run pytest tests/task_world_templates/stewardship/wastewater_pump_station/test_actor_interface_transport_e2e.py tests/prime_agent/test_world.py -q` (9 passed)
- `uv run ruff check` on both changed files
- `uv run ruff format --check` on both changed files
- `git diff --check`
