### PR TITLE
feat(prime-agent): add guided world treatment

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,12 +180,31 @@ pip install "aec-bench[prime-agent]"
 The maintained async Python entry point is
 `aec_bench.prime_agent.world.run_prime_pump_world_session`. It receives a
 host-selected `WorldSessionRequest`, launches one Prime ACP process for one
-session, supplies the resolved objective in the initial prompt, and installs
-only the generic `aec-world` skill. This is the Open condition: Prime receives
-the objective, actor-visible starting material, and generic actor capability,
-with no task-family guidance or external plan. Callers must also supply a
-`PrimeWorldSessionLimits` value with positive world-action, model-call, token,
-cost, and wall-clock limits.
+session, and supplies the resolved objective in the initial prompt. By default,
+it installs only the generic `aec-world` skill. This is the Open treatment:
+Prime receives the objective, actor-visible starting material, and generic
+actor capability, with no task-family method or external plan.
+
+The caller can select the experimental Guided treatment explicitly:
+
+```python
+await run_prime_pump_world_session(
+    ...,
+    pump_station_guidance=True,
+)
+```
+
+Guided installs `aec-world` followed by `pump-station-guidance` and tells Prime
+to load the second skill before its first world action. The guidance teaches
+compact state, exact action accounting, rejection interpretation, and
+pump-station decision checks. Its current protocol tells Prime to combine each
+world action, ledger append, compact-state update, and selected output in one
+notebook cell. It does not expose or coach Prime against host-side execution
+limits, and it does not contain a fixed plan, action sequence, or current
+instance solution. It is validated only against the current registered profile
+until a second profile supplies cross-profile evidence. Callers must also
+supply a `PrimeWorldSessionLimits` value with positive world-action, model-call,
+token, cost, and wall-clock emergency limits.
 
 Inside Prime, the available world calls are:
 
@@ -234,14 +253,17 @@ Each run preserves `prime-acp-in.jsonl`, `prime-acp-out.jsonl`,
 `prime-stderr.log`, `prime-run.json`, `prime-world-run.json`, Prime session
 files, and a separate actor-transport log. `prime-run.json` normalizes usage,
 cost, root/child session topology, refinement counts, configured limits, and
-the limit that ended the prompt. `prime-world-run.json` records the selected
-task-owned evaluation scope and whether that evaluation passed alongside the
-separate session and world states. Unknown ACP `_meta` content stays in the raw
-evidence. The actor log timestamps every accepted, rejected, unauthorized, and
-malformed transport attempt without recording the socket capability, host
-paths, or hidden state. Trial-local Prime HOME/XDG directories, configuration,
-sessions, workspace files, and refinement artifacts are isolated and are not
-promoted to another run.
+the limit that ended the prompt. It also records the selected skills in order,
+with content digests but no host paths. Skill availability in that provenance
+and a completed skill read in the retained session are separate treatment-
+integrity facts. `prime-world-run.json` records the selected task-owned
+evaluation scope and whether that evaluation passed alongside the separate
+session and world states. Unknown ACP `_meta` content stays in the raw evidence.
+The actor log timestamps every accepted, rejected, unauthorized, and malformed
+transport attempt without recording the socket capability, host paths, or
+hidden state. Trial-local Prime HOME/XDG directories, configuration, sessions,
+workspace files, and refinement artifacts are isolated and are not promoted to
+another run.
 
 `PrimeAcpIsolation.DEVELOPMENT_SAME_USER` is explicitly non-benchmark-valid
 development evidence because Prime has the current user's OS permissions.
@@ -253,7 +275,8 @@ until an equivalent filesystem/process boundary is implemented.
 
 This integration is additive. It does not change Harbor, the installed
 `actor-interface`, task templates, world semantics, verification, or
-evaluation.
+evaluation. Guided selection also does not change actor authority, world state,
+replay, automatic continuation, verification, or evaluation.
 
 ### Meta-Harness
 

--- a/docs/protocols/interactive-world-runtime.md
+++ b/docs/protocols/interactive-world-runtime.md
@@ -81,6 +81,24 @@ The Prime root process and its descendants receive the same scoped capability,
 so they form one composite actor principal. Per-child action attribution is not
 claimed without enforceable per-child capability scoping.
 
+The composition selects explicit skills in caller order while ambient skills,
+extensions, prompt templates, themes, and context files remain disabled. Open
+installs only `aec-world`. The optional Guided pump treatment installs
+`aec-world` followed by `pump-station-guidance` and adds one instruction to load
+the guidance before the first world action. The caller selects Guided
+explicitly; task, world, profile, and model identities do not route it. Both
+skills are copied under the isolated actor workspace before Prime starts.
+Selected skill names, order, and content digests are normalized in
+`prime-run.json` without retaining their host paths. Retained session evidence
+separately shows whether Prime completed the guidance read.
+
+The `pump-station-guidance` treatment asks Prime to combine each actor
+invocation, ledger append, compact-state update, and selected output in one
+notebook cell. Host-side emergency limits are not included in the guidance or
+added instruction. The guidance does not select actions, add actor observations,
+expose verifier state, or change world and evaluation rules. Its content digest
+in `prime-run.json` identifies the exact guidance used by a retained run.
+
 The composed entry point requires positive host limits for world actions,
 model calls, aggregate tokens, aggregate provider cost, and elapsed wall time.
 The actor proxy counts distinct invoke request content while allowing an exact
@@ -184,7 +202,7 @@ state, verifier paths, provider configuration, or recovery data.
 | `actor-interface` | Invoke the pump episode host with current actor JSON. |
 | `control-interface` | Invoke pump controls or explicit rollout composition. |
 | Harbor agent and import | Use the concrete pump transport and evaluator. |
-| Prime ACP Python entry | Run one Open-mode Prime session against one scoped pump actor proxy. |
+| Prime ACP Python entry | Run one Open or explicitly Guided Prime session against one scoped pump actor proxy. |
 
 The boundary fails closed for unknown build or profile identity, stale
 decisions, unavailable actions, unauthorized controls, invalid rollout
@@ -201,4 +219,5 @@ successful transition or evaluation.
 - [pump retry and recovery](../../tests/task_world_templates/stewardship/wastewater_pump_station/test_registered_world_run_transitions.py)
 - [Prime actor proxy and world composition](../../tests/prime_agent/test_world.py)
 - [Prime ACP lifecycle and isolation](../../tests/prime_agent/test_acp.py)
+- [Prime treatment and trajectory analysis](../../tests/prime_agent/test_trajectory.py)
 - [Harbor import](../../tests/harness/test_stewardship_harbor_import.py)

--- a/scripts/analyze_prime_world_study.py
+++ b/scripts/analyze_prime_world_study.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# ABOUTME: Produces read-only trajectory metrics for retained Prime interactive-world trials.
+# ABOUTME: Keeps study analysis outside task-owned evaluation and world state.
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from aec_bench.prime_agent.trajectory import analyze_prime_world_trial
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Analyse retained Prime interactive-world trial evidence.")
+    parser.add_argument("trial_directories", nargs="+", type=Path)
+    parser.add_argument(
+        "--large-output-threshold-chars",
+        type=int,
+        default=10_000,
+        help="Minimum retained tool-result characters counted as a large output.",
+    )
+    parser.add_argument("--output", type=Path, help="Write JSON to this file instead of stdout.")
+    args = parser.parse_args()
+
+    analyses = [
+        analyze_prime_world_trial(
+            directory,
+            large_output_threshold_chars=args.large_output_threshold_chars,
+        ).model_dump(mode="json")
+        for directory in args.trial_directories
+    ]
+    payload = {
+        "schema_id": "aecbench.prime-world-study-analysis.v1",
+        "trials": analyses,
+    }
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if args.output is None:
+        print(text, end="")
+        return
+    args.output.write_text(text, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aec_bench/prime_agent/acp.py
+++ b/src/aec_bench/prime_agent/acp.py
@@ -7,9 +7,11 @@ import asyncio
 import contextlib
 import hashlib
 import importlib
+import importlib.metadata
 import json
 import os
 import re
+import shutil
 import signal
 import sys
 import time
@@ -19,6 +21,8 @@ from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
 from typing import Any, NoReturn
+
+import yaml
 
 from aec_bench.prime_agent.batch import (
     PRIME_AGENT_TESTED_VERSION,
@@ -124,9 +128,10 @@ def build_prime_acp_command(
     model: str,
     actor_workspace: Path,
     session_dir: Path,
-    skill_directory: Path,
+    skill_directories: Sequence[Path],
 ) -> list[str]:
     """Build Prime's one-session ACP command without using a shell."""
+    skill_arguments = [argument for directory in skill_directories for argument in ("--skill", str(directory))]
     return [
         str(executable),
         "--mode",
@@ -138,8 +143,7 @@ def build_prime_acp_command(
         "--session-dir",
         str(session_dir),
         "--no-skills",
-        "--skill",
-        str(skill_directory),
+        *skill_arguments,
         "--no-extensions",
         "--no-prompt-templates",
         "--no-themes",
@@ -188,7 +192,7 @@ async def run_prime_acp_session(
     *,
     actor_workspace: Path,
     evidence_directory: Path,
-    skill_directory: Path,
+    skill_directories: Sequence[Path],
     instruction: str,
     model: str,
     actor_environment: Mapping[str, str],
@@ -203,11 +207,22 @@ async def run_prime_acp_session(
     acp_schema = importlib.import_module("acp.schema")
     actor_workspace = actor_workspace.resolve()
     evidence_directory = evidence_directory.resolve()
-    skill_directory = skill_directory.resolve()
+    if any(directory.is_symlink() for directory in skill_directories):
+        raise PrimeAcpIsolationError("Prime explicit skill directories must not be symbolic links")
+    resolved_skill_directories = tuple(directory.resolve() for directory in skill_directories)
     if not instruction.strip():
         raise ValueError("Prime ACP instruction must be non-empty")
-    if not actor_workspace.is_dir() or not skill_directory.is_dir():
-        raise FileNotFoundError("Prime actor workspace and explicit skill must exist")
+    if not actor_workspace.is_dir():
+        raise FileNotFoundError("Prime actor workspace must exist")
+    _validate_skill_directories(actor_workspace, resolved_skill_directories)
+    selected_skills = [
+        {
+            "order": order,
+            "name": _skill_name(directory),
+            "sha256": _directory_digest(directory),
+        }
+        for order, directory in enumerate(resolved_skill_directories)
+    ]
     if _paths_overlap(actor_workspace, evidence_directory):
         raise PrimeAcpIsolationError("host evidence directory must be outside the actor workspace")
 
@@ -239,7 +254,7 @@ async def run_prime_acp_session(
         model=model,
         actor_workspace=actor_workspace,
         session_dir=paths.session_dir,
-        skill_directory=skill_directory,
+        skill_directories=resolved_skill_directories,
     )
     command = list(base_command)
     sandbox_profile: Path | None = None
@@ -407,6 +422,7 @@ async def run_prime_acp_session(
             with contextlib.suppress(Exception):
                 await stderr_task
         _redact_session_artifacts(paths.session_dir, env, redact_values)
+        _preserve_session_artifacts(paths.session_dir, evidence_directory)
         if sandbox_profile is not None:
             sandbox_profile.unlink(missing_ok=True)
 
@@ -474,7 +490,8 @@ async def run_prime_acp_session(
         model=model,
         instruction=instruction,
         actor_workspace=actor_workspace,
-        skill_directory=skill_directory,
+        skill_directories=resolved_skill_directories,
+        selected_skills=selected_skills,
         sandbox_profile=sandbox_profile,
     )
     return run
@@ -724,14 +741,20 @@ def _write_run_provenance(
     model: str,
     instruction: str,
     actor_workspace: Path,
-    skill_directory: Path,
+    skill_directories: Sequence[Path],
+    selected_skills: Sequence[Mapping[str, Any]],
     sandbox_profile: Path | None,
 ) -> None:
     replacements = {
         str(actor_workspace): "<actor-workspace>",
         str(run.paths.session_dir): "<prime-session-dir>",
-        str(skill_directory): "<aec-world-skill>",
     }
+    replacements.update(
+        {
+            str(directory): f"<skill:{skill['name']}>"
+            for directory, skill in zip(skill_directories, selected_skills, strict=True)
+        }
+    )
     if sandbox_profile is not None:
         replacements[str(sandbox_profile)] = "<sandbox-profile>"
     sanitized_command = [replacements.get(argument, argument) for argument in run.command]
@@ -748,6 +771,7 @@ def _write_run_provenance(
         "exit_code": run.exit_code,
         "session_id": run.session_id,
         "protocol_version": run.protocol_version,
+        "acp_sdk_version": _installed_distribution_version("agent-client-protocol"),
         "agent_name": run.agent_name,
         "agent_version": run.agent_version,
         "agent_capabilities": run.agent_capabilities,
@@ -785,7 +809,8 @@ def _write_run_provenance(
         "benchmark_valid": run.benchmark_valid,
         "actor_principal_scope": "prime-session-composite",
         "runtime_home_scope": "actor-workspace",
-        "skill_sha256": _directory_digest(skill_directory),
+        "skill_sha256": selected_skills[0]["sha256"],
+        "skills": selected_skills,
         "update_count": len(run.updates),
         "error": run.error,
     }
@@ -826,6 +851,16 @@ def _redact_session_artifacts(
             continue
 
 
+def _preserve_session_artifacts(session_directory: Path, evidence_directory: Path) -> None:
+    session_files = sorted(path for path in session_directory.rglob("*.jsonl") if path.is_file())
+    for index, session_file in enumerate(session_files):
+        suffix = "" if index == 0 else f"-{index + 1}"
+        destination = evidence_directory / f"prime-session{suffix}.jsonl"
+        if destination.exists():
+            raise FileExistsError(f"Prime session evidence destination already exists: {destination.name}")
+        shutil.copyfile(session_file, destination)
+
+
 def _directory_digest(directory: Path) -> str:
     digest = hashlib.sha256()
     for path in sorted(item for item in directory.rglob("*") if item.is_file()):
@@ -834,3 +869,59 @@ def _directory_digest(directory: Path) -> str:
         digest.update(path.read_bytes())
         digest.update(b"\0")
     return digest.hexdigest()
+
+
+def _validate_skill_directories(actor_workspace: Path, skill_directories: Sequence[Path]) -> None:
+    if not skill_directories:
+        raise ValueError("Prime ACP requires at least one explicit skill")
+    if any(path.is_symlink() for path in actor_workspace.rglob("*")):
+        raise PrimeAcpIsolationError("actor workspace must not contain symbolic links")
+    names: set[str] = set()
+    for index, directory in enumerate(skill_directories):
+        if not directory.is_dir():
+            raise FileNotFoundError(f"Prime explicit skill directory does not exist: {index}")
+        if directory == actor_workspace or not directory.is_relative_to(actor_workspace):
+            raise PrimeAcpIsolationError("Prime explicit skills must be installed under the actor workspace")
+        name = _skill_name(directory)
+        if name in names:
+            raise ValueError(f"Prime explicit skill name is duplicated: {name}")
+        names.add(name)
+    for index, directory in enumerate(skill_directories):
+        for other in skill_directories[index + 1 :]:
+            if _paths_overlap(directory, other):
+                raise PrimeAcpIsolationError("Prime explicit skill directories must not overlap")
+
+
+def _skill_name(directory: Path) -> str:
+    skill_file = directory / "SKILL.md"
+    if not skill_file.is_file():
+        raise FileNotFoundError("Prime explicit skill has no SKILL.md")
+    try:
+        text = skill_file.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError("Prime explicit SKILL.md must be UTF-8") from exc
+    if not text.startswith("---\n") or "\n---\n" not in text[4:]:
+        raise ValueError("Prime explicit SKILL.md must contain YAML frontmatter")
+    frontmatter, _body = text[4:].split("\n---\n", 1)
+    try:
+        metadata = yaml.safe_load(frontmatter)
+    except yaml.YAMLError as exc:
+        raise ValueError("Prime explicit SKILL.md frontmatter must be valid YAML") from exc
+    if not isinstance(metadata, dict):
+        raise ValueError("Prime explicit SKILL.md frontmatter must be a mapping")
+    name = metadata.get("name")
+    description = metadata.get("description")
+    if not isinstance(name, str) or not re.fullmatch(r"[a-z0-9]+(?:-[a-z0-9]+)*", name):
+        raise ValueError("Prime explicit skill name is invalid")
+    if name != directory.name:
+        raise ValueError("Prime explicit skill name must match its directory")
+    if not isinstance(description, str) or not description.strip():
+        raise ValueError("Prime explicit skill description is required")
+    return name
+
+
+def _installed_distribution_version(distribution: str) -> str:
+    try:
+        return importlib.metadata.version(distribution)
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown"

--- a/src/aec_bench/prime_agent/skills/pump-station-guidance/SKILL.md
+++ b/src/aec_bench/prime_agent/skills/pump-station-guidance/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: pump-station-guidance
+description: Use compact state, exact action accounting, and pump-station stewardship checks in an AECBench world.
+metadata:
+  status: experimental
+  validation: current-profile-only
+---
+
+# Pump-station guidance
+
+guidance_id: aecbench.pump-station-guidance
+
+This skill is experimental. It has evidence from one registered profile only. It does not supply a solution plan.
+
+The task objective and actor authority remain in the initial prompt and the `aec-world` skill. Use only the available actor operations.
+
+## Keep compact computational state
+
+- Keep full observations and action results in Python variables. Do not print the full objects.
+- Print only the named fields required for the next decision.
+- Keep one compact state with current time, newest decision ID, service need, running pumps, assurance, active process, resource window, restrictions, and highest-priority work.
+- Update the compact state after every action result.
+- Use the next observation in an action result. Do not call `observe()` again when that observation is current.
+- Record every `invoke` in an exact ledger. Include applied, rejected, and failed calls.
+- Build the final action account from the ledger. Do not reconstruct it from memory.
+
+See [compact-state.md](references/compact-state.md) for a generic notebook pattern.
+
+## Use one notebook cell per action attempt
+
+After initial setup, normally use one IPython cell for each `invoke` attempt. In that cell:
+
+1. Record the expected actor-visible result.
+2. Invoke the selected action.
+3. Append the actual applied, rejected, or failed outcome to the ledger.
+4. Update compact state from the returned next observation when one is available.
+5. Print only the small projection needed for the next decision.
+
+Do not use separate model turns only to append the ledger, update compact state, or reprint an unchanged result. This is
+a working method, not an action-selection rule. You must still choose the action and arguments from current actor-visible
+evidence.
+
+## Make one evidence-based decision at a time
+
+- Inspect an action input schema before the first use of that action.
+- Before an intervention, record the expected observable result.
+- After the intervention, compare the next observation with that expectation.
+- Treat a rejection as evidence about the current causal state.
+- Do not repeat the same request while its decision state and relevant facts are unchanged.
+- Distinguish process conflict, resource window, outage capacity, backlog binding, evidence binding, stale decision, and action-argument errors.
+- Check required service through the full duration of field work.
+- Distinguish run eligibility from assurance for outage planning.
+- Search documentary evidence only when the current decision needs documentary content.
+- After `NO_ACCESSIBLE_RESULT`, do not make an equivalent search unless the information set or query scope changes.
+- Identify work that depends on a host-owned decision. Do not seek another control path.
+- When supported actor progress ends, inspect the actor-visible final state and write the final report from the ledger.
+  If the world remains live, report it as incomplete.
+
+See [decision-method.md](references/decision-method.md) for the decision checks.
+
+## Stay within scope
+
+Do not infer hidden state, verifier expectations, rewards, host controls, or world files. Do not modify the supplied skills or harness. Do not use this guidance as evidence that the world is complete.

--- a/src/aec_bench/prime_agent/skills/pump-station-guidance/references/compact-state.md
+++ b/src/aec_bench/prime_agent/skills/pump-station-guidance/references/compact-state.md
@@ -1,0 +1,85 @@
+# Compact state and action ledger
+
+Keep rich results in the kernel and expose only the fields required for the next decision.
+
+## State shape
+
+Use one mapping with these concepts:
+
+```python
+compact_state = {
+    "time": None,
+    "decision_id": None,
+    "required_service": None,
+    "running_pumps": [],
+    "assurance": {},
+    "active_process": None,
+    "resource_window": None,
+    "restrictions": [],
+    "priority_work": [],
+}
+```
+
+Update it from the latest observation. Print a small projection, not the source object.
+
+```python
+print({
+    "time": compact_state["time"],
+    "required_service": compact_state["required_service"],
+    "active_process": compact_state["active_process"],
+    "priority_work": compact_state["priority_work"],
+})
+```
+
+## Ledger shape
+
+Append one entry for every `invoke` attempt:
+
+```python
+action_ledger.append({
+    "request_id": request_id,
+    "decision_id": decision_id,
+    "action": action_name,
+    "expected_result": expected_result,
+    "status": result_status,
+    "reason_code": reason_code,
+    "next_decision_id": next_decision_id,
+})
+```
+
+Include rejected and failed attempts. Use this ledger for the final action count and outcome account.
+
+## One-cell action pattern
+
+Use this schematic shape after setup. Replace the placeholders with the action, arguments, state fields, and output fields
+justified by the current actor-visible evidence. It is not a task solution or a fixed action sequence.
+
+```python
+expected_result = ...
+result = await aec_world.invoke(action_name, arguments, decision_id=decision_id)
+action_ledger.append({
+    "action": action_name,
+    "expected_result": expected_result,
+    "status": result["status"],
+    "next_decision_id": result["next_observation"]["decision_id"],
+})
+compact_state.update({
+    "decision_id": result["next_observation"]["decision_id"],
+    # Add only state fields needed for the next decision.
+})
+print({
+    "status": result["status"],
+    # Add only changed fields needed for the next decision.
+})
+```
+
+Handle an actor error in the same action cell when practical and record its code in the ledger. Do not fabricate a next
+observation when the actor did not return one.
+
+## Output discipline
+
+- Assign the full result to a variable.
+- Select the current fields in Python.
+- Print one small mapping or short table.
+- Do not use an indented JSON dump for a complete capability, observation, or action result.
+- Do not repeat a printed field when its value did not change.

--- a/src/aec_bench/prime_agent/skills/pump-station-guidance/references/decision-method.md
+++ b/src/aec_bench/prime_agent/skills/pump-station-guidance/references/decision-method.md
@@ -1,0 +1,46 @@
+# Pump-station decision method
+
+Use this method for each decision. It does not define an action sequence.
+
+## 1. Protect service
+
+Check the required service over the full proposed work duration. Identify which pumps can run now and which pumps are assured for outage planning. These are different conditions.
+
+Do not make an operating or maintenance change that creates an avoidable service deficit.
+
+## 2. Check work feasibility
+
+For the highest-priority actor-addressable work, check:
+
+- the action input schema;
+- the bound backlog and evidence identifiers;
+- active or conflicting processes;
+- required resource capacity;
+- the complete remaining resource window;
+- outage capacity during the work;
+- the newest decision ID.
+
+## 3. Predict, act, and compare
+
+Record the expected observable change. Make one action. Compare the returned next observation with the prediction before choosing another action.
+
+An applied result advances the causal state. A rejected result normally leaves the state unchanged and supplies a reason. A failed call can indicate an action argument, decision, or transport problem. Keep these outcomes separate in the ledger.
+
+## 4. Use rejection codes
+
+- A process conflict means another process owns the required work lane or dependency.
+- A resource-window rejection means the work cannot fit the current declared window.
+- An outage-capacity rejection means the proposed work would leave insufficient permitted service.
+- A backlog or evidence binding rejection means the request does not match the current actor-visible record.
+- A stale decision requires a new observation.
+- An action-argument error requires correction against the action schema.
+
+Do not repeat a rejected request until a relevant state fact, decision ID, argument, or evidence binding changes.
+
+## 5. Limit documentary search
+
+Search only for content needed by the current decision. After `NO_ACCESSIBLE_RESULT`, stop the equivalent search. Search again only when the query scope or available information changes.
+
+## 6. Stop at the authority boundary
+
+Complete supported actor work while service and evidence remain valid. When further progress depends on a host-owned decision, record that dependency and stop. Do not claim the world is complete only because the Prime turn ends.

--- a/src/aec_bench/prime_agent/trajectory.py
+++ b/src/aec_bench/prime_agent/trajectory.py
@@ -1,0 +1,623 @@
+# ABOUTME: Derives read-only Prime world trajectory metrics from retained execution evidence.
+# ABOUTME: Keeps treatment and process analysis separate from canonical world evaluation.
+
+from __future__ import annotations
+
+import json
+import math
+import re
+import statistics
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import Field, JsonValue, model_validator
+
+from aec_bench.contracts.validators import StrictModel
+
+GUIDANCE_ID = "aecbench.pump-station-guidance"
+_GUIDANCE_MARKER_PATTERN = re.compile(r"aecbench\.pump-station-guidance(?:\.v\d+)?")
+_GUIDANCE_SKILL_NAME = "pump-station-guidance"
+_GUIDANCE_REFERENCES = ("compact-state.md", "decision-method.md")
+
+
+class PrimeTrajectoryEvidenceError(ValueError):
+    """Raised when retained trial evidence cannot support trajectory analysis."""
+
+
+class PrimeHumanReportReview(StrictModel):
+    """Attributable human comparison of one final report with canonical evidence."""
+
+    rubric_id: Literal["aecbench.prime-world-report-review.v1"] = "aecbench.prime-world-report-review.v1"
+    reviewer: str = Field(min_length=1)
+    reviewed_at: datetime
+    canonical_invoke_count: int = Field(ge=0)
+    reported_invoke_count: int = Field(ge=0)
+    matched_invoke_count: int = Field(ge=0)
+    correctly_classified_invoke_count: int = Field(ge=0)
+    pending_liability_claim_count: int = Field(ge=0)
+    correct_pending_liability_claim_count: int = Field(ge=0)
+    unsupported_claim_count: int = Field(ge=0)
+    evidence_references: tuple[str, ...] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def validate_counts(self) -> PrimeHumanReportReview:
+        if self.matched_invoke_count > min(self.canonical_invoke_count, self.reported_invoke_count):
+            raise ValueError("matched invoke count exceeds the canonical or reported count")
+        if self.correctly_classified_invoke_count > self.matched_invoke_count:
+            raise ValueError("classified invoke count exceeds the matched count")
+        if self.correct_pending_liability_claim_count > self.pending_liability_claim_count:
+            raise ValueError("correct pending-liability count exceeds the claimed count")
+        if any(not reference.strip() for reference in self.evidence_references):
+            raise ValueError("report review evidence references must be non-empty")
+        return self
+
+
+class PrimeWorldTrajectoryAnalysis(StrictModel):
+    """One deterministic study projection that does not alter benchmark evaluation."""
+
+    schema_id: Literal["aecbench.prime-world-trajectory.v1"] = "aecbench.prime-world-trajectory.v1"
+    trial_id: str
+    condition: str
+    treatment: Literal["open", "guided"]
+    large_output_threshold_chars: int = Field(gt=0)
+    usage_by_call: tuple[dict[str, JsonValue], ...]
+    model_context: dict[str, JsonValue]
+    notebook: dict[str, JsonValue]
+    actor_transport: dict[str, JsonValue]
+    efficiency: dict[str, JsonValue]
+    prime_features: dict[str, JsonValue]
+    treatment_integrity: dict[str, JsonValue]
+    world_progress: dict[str, JsonValue]
+    report_quality: dict[str, JsonValue]
+
+
+def analyze_prime_world_trial(
+    trial_directory: Path,
+    *,
+    large_output_threshold_chars: int = 10_000,
+    human_review_file: Path | None = None,
+) -> PrimeWorldTrajectoryAnalysis:
+    """Read one retained trial without invoking or re-evaluating its world."""
+    if large_output_threshold_chars < 1:
+        raise ValueError("large output threshold must be positive")
+    trial_directory = trial_directory.resolve()
+    evidence_directory = trial_directory / "evidence"
+    summary = _read_json_object(trial_directory / "trial-summary.json")
+    prime_run = _read_json_object(evidence_directory / "prime-run.json")
+    session_events = _read_session_events(evidence_directory)
+    actor_events = _read_jsonl(evidence_directory / "world-actor-transport.jsonl")
+
+    messages = [
+        _required_mapping(event.get("message"), "Prime message")
+        for event in session_events
+        if event.get("type") == "message"
+    ]
+    assistant_messages = [message for message in messages if message.get("role") == "assistant"]
+    tool_result_messages = [message for message in messages if message.get("role") == "toolResult"]
+    usage_by_call = _usage_by_call(assistant_messages)
+    tool_calls, code_cells = _tool_calls(assistant_messages)
+    invoke_cells = [code for code in code_cells if "aec_world.invoke(" in code]
+    tool_results = _tool_results(tool_result_messages, tool_calls)
+    actor = _actor_metrics(actor_events)
+    treatment_integrity = _treatment_integrity(prime_run, tool_calls, tool_results)
+
+    condition = _required_string(summary.get("condition"), "trial condition")
+    treatment: Literal["open", "guided"] = (
+        "guided" if treatment_integrity["guidance_available"] or "guided" in condition.lower() else "open"
+    )
+    prime_summary = _required_mapping(summary.get("prime"), "trial Prime summary")
+    total_tokens = _required_int(
+        _required_mapping(prime_summary.get("usage"), "trial Prime usage").get("total_tokens"),
+        "total_tokens",
+    )
+    model_calls = _required_int(
+        _required_mapping(prime_summary.get("usage"), "trial Prime usage").get("model_calls"),
+        "model_calls",
+    )
+    elapsed_seconds = _required_float(prime_summary.get("elapsed_seconds"), "elapsed_seconds")
+    cost_usd = _required_float(
+        _required_mapping(prime_summary.get("usage"), "trial Prime usage").get("cost_usd"),
+        "cost_usd",
+    )
+    applied = int(actor["invoke_statuses"].get("applied", 0))
+    invoke_attempts = int(actor["operations"].get("invoke", 0))
+    session_state = _required_string(prime_summary.get("session_state"), "Prime session state")
+    stop_reason = _optional_string(prime_summary.get("stop_reason"), "Prime stop reason")
+    limit_reason = _optional_string(prime_summary.get("limit_reason"), "Prime limit reason")
+
+    input_values = [int(item["input_tokens"]) for item in usage_by_call]
+    tool_lengths = [int(result["chars"]) for result in tool_results]
+    final_text = (
+        _final_assistant_text(assistant_messages) if session_state == "ended" and stop_reason == "end_turn" else ""
+    )
+    first_invoke_call = min(
+        (
+            int(call["ordinal"])
+            for call in tool_calls
+            if call["name"] == "ipython" and "aec_world.invoke(" in str(call["code"])
+        ),
+        default=None,
+    )
+    last_invoke_call = max(
+        (
+            int(call["ordinal"])
+            for call in tool_calls
+            if call["name"] == "ipython" and "aec_world.invoke(" in str(call["code"])
+        ),
+        default=None,
+    )
+    review_path = human_review_file or trial_directory / "report-review.json"
+    report_quality = _report_quality(review_path, canonical_invoke_count=invoke_attempts, final_text=final_text)
+
+    return PrimeWorldTrajectoryAnalysis(
+        trial_id=_required_string(summary.get("trial_id"), "trial ID"),
+        condition=condition,
+        treatment=treatment,
+        large_output_threshold_chars=large_output_threshold_chars,
+        usage_by_call=tuple(usage_by_call),
+        model_context={
+            "reported_input_tokens_sum": sum(input_values),
+            "input_tokens_median": _median(input_values),
+            "input_tokens_p90": _percentile(input_values, 0.9),
+            "input_tokens_max": max(input_values, default=0),
+            "output_tokens_sum": sum(int(item["output_tokens"]) for item in usage_by_call),
+            "cache_read_tokens_sum": sum(int(item["cache_read_tokens"]) for item in usage_by_call),
+            "cache_write_tokens_sum": sum(int(item["cache_write_tokens"]) for item in usage_by_call),
+            "reported_total_tokens_sum": sum(int(item["total_tokens"]) for item in usage_by_call),
+        },
+        notebook={
+            "tool_calls": len(tool_calls),
+            "tool_call_names": dict(Counter(str(call["name"]) for call in tool_calls)),
+            "ipython_cells": len(code_cells),
+            "full_object_output_cells": sum(1 for code in code_cells if _prints_full_object(code)),
+            "compact_state_cells": sum(1 for code in code_cells if _uses_compact_state(code)),
+            "compact_state_update_cells": sum(1 for code in code_cells if _updates_compact_state(code)),
+            "action_ledger_cells": sum(1 for code in code_cells if _uses_action_ledger(code)),
+            "action_ledger_append_cells": sum(1 for code in code_cells if _appends_action_ledger(code)),
+            "invoke_cells": len(invoke_cells),
+            "invoke_and_ledger_append_cells": sum(1 for code in invoke_cells if _appends_action_ledger(code)),
+            "invoke_and_compact_state_update_cells": sum(1 for code in invoke_cells if _updates_compact_state(code)),
+            "invoke_and_print_cells": sum(1 for code in invoke_cells if "print(" in code),
+            "invoke_ledger_colocation_rate": _ratio(
+                sum(1 for code in invoke_cells if _appends_action_ledger(code)), len(invoke_cells)
+            ),
+            "invoke_compact_state_colocation_rate": _ratio(
+                sum(1 for code in invoke_cells if _updates_compact_state(code)), len(invoke_cells)
+            ),
+            "first_invoke_model_call": first_invoke_call,
+            "last_invoke_model_call": last_invoke_call,
+            "model_calls_before_first_invoke": None if first_invoke_call is None else first_invoke_call - 1,
+            "tool_result_count": len(tool_results),
+            "tool_result_error_count": sum(1 for result in tool_results if result["is_error"]),
+            "tool_result_chars_total": sum(tool_lengths),
+            "tool_result_chars_median": _median(tool_lengths),
+            "tool_result_chars_p90": _percentile(tool_lengths, 0.9),
+            "tool_result_chars_max": max(tool_lengths, default=0),
+            "large_tool_result_count": sum(1 for length in tool_lengths if length >= large_output_threshold_chars),
+            "largest_tool_result": max(tool_results, key=lambda result: int(result["chars"]), default=None),
+            "final_assistant_text_chars": len(final_text),
+        },
+        actor_transport=actor,
+        efficiency={
+            "total_tokens": total_tokens,
+            "model_calls": model_calls,
+            "cost_usd": cost_usd,
+            "elapsed_seconds": elapsed_seconds,
+            "applied_transitions": applied,
+            "tokens_per_applied_transition": _ratio(total_tokens, applied),
+            "model_calls_per_applied_transition": _ratio(model_calls, applied),
+            "cost_per_applied_transition": _ratio(cost_usd, applied),
+            "actions_per_model_call": _ratio(invoke_attempts, model_calls),
+            "applied_invoke_rate": _ratio(applied, invoke_attempts),
+        },
+        prime_features={
+            "child_sessions": _nested_int(prime_summary, "topology", "child_sessions"),
+            "refinement_events": _nested_int(prime_summary, "refinement", "events"),
+            "explicit_compaction_events": _compaction_event_count(evidence_directory, session_events),
+            "session_state": session_state,
+            "stop_reason": stop_reason,
+            "limit_reason": limit_reason,
+        },
+        treatment_integrity=treatment_integrity,
+        world_progress=_world_progress(summary),
+        report_quality=report_quality,
+    )
+
+
+def _read_session_events(evidence_directory: Path) -> list[dict[str, Any]]:
+    paths = sorted(evidence_directory.glob("prime-session*.jsonl"))
+    if not paths:
+        raise PrimeTrajectoryEvidenceError("trial has no retained Prime session JSONL")
+    return [event for path in paths for event in _read_jsonl(path)]
+
+
+def _read_json_object(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise PrimeTrajectoryEvidenceError(f"cannot read JSON evidence: {path.name}") from exc
+    if not isinstance(value, dict):
+        raise PrimeTrajectoryEvidenceError(f"JSON evidence must be an object: {path.name}")
+    return value
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        raise PrimeTrajectoryEvidenceError(f"cannot read JSONL evidence: {path.name}") from exc
+    if text and not text.endswith("\n"):
+        raise PrimeTrajectoryEvidenceError(f"JSONL evidence has an incomplete final frame: {path.name}")
+    events: list[dict[str, Any]] = []
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        if not line.strip():
+            raise PrimeTrajectoryEvidenceError(f"JSONL evidence has a blank frame: {path.name}:{line_number}")
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise PrimeTrajectoryEvidenceError(f"JSONL evidence is malformed: {path.name}:{line_number}") from exc
+        if not isinstance(value, dict):
+            raise PrimeTrajectoryEvidenceError(f"JSONL evidence frame must be an object: {path.name}:{line_number}")
+        events.append(value)
+    return events
+
+
+def _usage_by_call(assistant_messages: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for message in assistant_messages:
+        usage = message.get("usage")
+        if not isinstance(usage, dict):
+            raise PrimeTrajectoryEvidenceError("Prime assistant message has no usage evidence")
+        result.append(
+            {
+                "call": len(result) + 1,
+                "input_tokens": _required_int(usage.get("input"), "usage.input"),
+                "output_tokens": _required_int(usage.get("output"), "usage.output"),
+                "cache_read_tokens": _required_int(usage.get("cacheRead"), "usage.cacheRead"),
+                "cache_write_tokens": _required_int(usage.get("cacheWrite"), "usage.cacheWrite"),
+                "total_tokens": _required_int(usage.get("totalTokens"), "usage.totalTokens"),
+            }
+        )
+    return result
+
+
+def _tool_calls(
+    assistant_messages: Sequence[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[str]]:
+    calls: list[dict[str, Any]] = []
+    code_cells: list[str] = []
+    ordinal = 0
+    for message in assistant_messages:
+        ordinal += 1
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for item in content:
+            if not isinstance(item, dict) or item.get("type") != "toolCall":
+                continue
+            call_id = item.get("id")
+            name = item.get("name")
+            if not isinstance(call_id, str) or not isinstance(name, str):
+                raise PrimeTrajectoryEvidenceError("Prime tool call has no identity or name")
+            arguments = item.get("arguments")
+            code = arguments.get("code", "") if isinstance(arguments, dict) else ""
+            if not isinstance(code, str):
+                code = ""
+            calls.append({"id": call_id, "name": name, "code": code, "ordinal": ordinal})
+            if name == "ipython":
+                code_cells.append(code)
+    return calls, code_cells
+
+
+def _tool_results(
+    tool_result_messages: Sequence[dict[str, Any]],
+    tool_calls: Sequence[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    calls = {str(call["id"]): call for call in tool_calls}
+    results: list[dict[str, Any]] = []
+    for ordinal, message in enumerate(tool_result_messages, start=1):
+        call_id = message.get("toolCallId")
+        if not isinstance(call_id, str):
+            raise PrimeTrajectoryEvidenceError("Prime tool result has no tool call identity")
+        call = calls.get(call_id)
+        text = _content_text(message.get("content"))
+        results.append(
+            {
+                "tool_call_id": call_id,
+                "name": str(message.get("toolName", "")),
+                "chars": len(text),
+                "is_error": bool(message.get("isError")),
+                "guidance_marker_present": _guidance_marker_present(text),
+                "code_preview": " ".join(str(call["code"]).split())[:240] if call is not None else "",
+                "result_ordinal": ordinal,
+            }
+        )
+    return results
+
+
+def _actor_metrics(events: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    operations = Counter(str(event.get("operation")) for event in events if event.get("operation") is not None)
+    invokes = [event for event in events if event.get("operation") == "invoke"]
+    statuses: Counter[str] = Counter()
+    repeated = 0
+    seen: dict[tuple[str, str, str], str] = {}
+    for event in invokes:
+        result = event.get("result")
+        error = event.get("error")
+        status = result.get("status") if isinstance(result, dict) else None
+        if not isinstance(status, str) and isinstance(error, dict):
+            status = error.get("code")
+        statuses[str(status or "unknown")] += 1
+        request = event.get("request")
+        if not isinstance(request, dict):
+            continue
+        decision_id = request.get("decision_id")
+        action_name = request.get("action_name")
+        request_id = request.get("request_id")
+        arguments = request.get("arguments")
+        if not isinstance(decision_id, str) or not isinstance(action_name, str) or not isinstance(request_id, str):
+            continue
+        key = (decision_id, action_name, json.dumps(arguments, sort_keys=True, separators=(",", ":")))
+        previous_request_id = seen.setdefault(key, request_id)
+        if previous_request_id != request_id:
+            repeated += 1
+    invalid_codes = {"actor-request-invalid", "actor-action-arguments"}
+    return {
+        "operations": dict(operations),
+        "invoke_statuses": dict(statuses),
+        "repeated_equivalent_requests_in_unchanged_state": repeated,
+        "invalid_invoke_count": sum(statuses[code] for code in invalid_codes),
+        "stale_decision_count": statuses["decision-stale"],
+        "no_accessible_result_count": statuses["NO_ACCESSIBLE_RESULT"],
+    }
+
+
+def _treatment_integrity(
+    prime_run: Mapping[str, Any],
+    tool_calls: Sequence[dict[str, Any]],
+    tool_results: Sequence[dict[str, Any]],
+) -> dict[str, Any]:
+    raw_skills = prime_run.get("skills")
+    selected_skills = [skill for skill in raw_skills if isinstance(skill, dict)] if isinstance(raw_skills, list) else []
+    guidance_available = any(
+        skill.get("name") == _GUIDANCE_SKILL_NAME and isinstance(skill.get("sha256"), str) and bool(skill["sha256"])
+        for skill in selected_skills
+    )
+    calls = {str(call["id"]): call for call in tool_calls}
+    load_calls: dict[str, int] = {}
+    reference_loads: list[str] = []
+    for result in tool_results:
+        if result["is_error"]:
+            continue
+        call = calls.get(str(result["tool_call_id"]))
+        if call is None:
+            continue
+        code = str(call["code"])
+        if _GUIDANCE_SKILL_NAME in code and "SKILL.md" in code:
+            load_calls[str(call["id"])] = int(call["ordinal"])
+        for reference in _GUIDANCE_REFERENCES:
+            if reference in code and reference not in reference_loads:
+                reference_loads.append(reference)
+    completed_load_call_ids = {
+        str(result["tool_call_id"])
+        for result in tool_results
+        if not result["is_error"] and result["guidance_marker_present"]
+    }.intersection(load_calls)
+    guidance_loaded = bool(completed_load_call_ids)
+    first_invoke_ordinal = min(
+        (
+            int(call["ordinal"])
+            for call in tool_calls
+            if call["name"] == "ipython" and "aec_world.invoke(" in str(call["code"])
+        ),
+        default=None,
+    )
+    loaded_before_first_invoke = bool(
+        guidance_loaded
+        and first_invoke_ordinal is not None
+        and min(load_calls[call_id] for call_id in completed_load_call_ids) < first_invoke_ordinal
+    )
+    return {
+        "guidance_available": guidance_available,
+        "guidance_loaded": guidance_loaded,
+        "guidance_loaded_before_first_invoke": loaded_before_first_invoke,
+        "guidance_id": GUIDANCE_ID if guidance_loaded else None,
+        "reference_loads": reference_loads,
+    }
+
+
+def _guidance_marker_present(text: str) -> bool:
+    return _GUIDANCE_MARKER_PATTERN.search(text) is not None
+
+
+def _report_quality(path: Path, *, canonical_invoke_count: int, final_text: str) -> dict[str, Any]:
+    if not path.is_file():
+        return {
+            "status": "incomplete",
+            "reason": "human report review is missing",
+            "final_report_present": bool(final_text.strip()),
+            "action_ledger_recall": None,
+            "action_outcome_classification_accuracy": None,
+            "pending_liability_accuracy": None,
+            "unsupported_claim_count": None,
+        }
+    try:
+        review = PrimeHumanReportReview.model_validate_json(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, ValueError) as exc:
+        raise PrimeTrajectoryEvidenceError("human report review is invalid") from exc
+    if review.canonical_invoke_count != canonical_invoke_count:
+        raise PrimeTrajectoryEvidenceError("human report review canonical invoke count does not match transport")
+    return {
+        "status": "complete",
+        "rubric_id": review.rubric_id,
+        "reviewer": review.reviewer,
+        "reviewed_at": review.reviewed_at.isoformat(),
+        "evidence_references": list(review.evidence_references),
+        "final_report_present": bool(final_text.strip()),
+        "reported_invoke_count": review.reported_invoke_count,
+        "action_ledger_recall": _ratio(review.matched_invoke_count, canonical_invoke_count),
+        "action_outcome_classification_accuracy": _ratio(
+            review.correctly_classified_invoke_count, canonical_invoke_count
+        ),
+        "pending_liability_accuracy": _ratio(
+            review.correct_pending_liability_claim_count, review.pending_liability_claim_count
+        ),
+        "unsupported_claim_count": review.unsupported_claim_count,
+    }
+
+
+def _world_progress(summary: Mapping[str, Any]) -> dict[str, Any]:
+    world = _required_mapping(summary.get("world"), "trial world summary")
+    verification = _required_mapping(world.get("verification"), "world verification")
+    conservation = _required_mapping(verification.get("conservation"), "world conservation")
+    duty = _required_mapping(conservation.get("duty"), "world duty conservation")
+    work = _required_mapping(conservation.get("work"), "world work conservation")
+    evaluation = _required_mapping(world.get("evaluation"), "world evaluation")
+    return {
+        "benchmark_valid": _required_bool(world.get("benchmark_valid"), "world benchmark_valid"),
+        "verification_valid": _required_bool(verification.get("valid"), "world verification valid"),
+        "replay_valid": _required_bool(verification.get("replay_valid"), "world replay valid"),
+        "evaluation_valid": _required_bool(evaluation.get("valid"), "world evaluation valid"),
+        "unserved_capacity_seconds": _required_int(duty.get("unserved_capacity_seconds"), "unserved_capacity_seconds"),
+        "terminal_work_count": len(_required_list(work.get("terminal_ids"), "terminal work IDs")),
+        "closing_work_count": len(_required_list(work.get("closing_ids"), "closing work IDs")),
+        "world_state": _required_string(world.get("state"), "world state"),
+        "completion": _required_string(world.get("completion"), "world completion"),
+    }
+
+
+def _compaction_event_count(evidence_directory: Path, session_events: Sequence[dict[str, Any]]) -> int:
+    acp_file = evidence_directory / "prime-acp-out.jsonl"
+    events = _read_jsonl(acp_file) if acp_file.is_file() else list(session_events)
+    return sum(_contains_structured_key(event, "compaction") for event in events)
+
+
+def _contains_structured_key(value: object, key: str) -> bool:
+    if isinstance(value, dict):
+        return key in value or any(
+            _contains_structured_key(item, key) for item in value.values() if not isinstance(item, str)
+        )
+    if isinstance(value, list):
+        return any(_contains_structured_key(item, key) for item in value)
+    return False
+
+
+def _prints_full_object(code: str) -> bool:
+    normalized = re.sub(r"\s+", " ", code)
+    return ("json.dumps(" in code and re.search(r"indent\s*=", code) is not None) or bool(
+        re.search(r"print\([^)]*\b(observation|catalogue|caps|result(?:_?[A-Za-z0-9]+)?)\s*\)", normalized)
+    )
+
+
+def _uses_compact_state(code: str) -> bool:
+    return "state.json" in code or bool(re.search(r"\bcompact(?:_state)?\s*(?:=|\[|\.)", code))
+
+
+def _updates_compact_state(code: str) -> bool:
+    return bool(re.search(r"\bcompact(?:_state)?\.update\(", code)) or bool(
+        re.search(r"\bcompact(?:_state)?\[[^]]+\]\s*=", code)
+    )
+
+
+def _uses_action_ledger(code: str) -> bool:
+    return "action_ledger" in code or bool(re.search(r"\bledger\s*=|\bledger\.append\(", code))
+
+
+def _appends_action_ledger(code: str) -> bool:
+    return "action_ledger.append(" in code or "ledger.append(" in code
+
+
+def _final_assistant_text(assistant_messages: Sequence[dict[str, Any]]) -> str:
+    final = ""
+    for message in assistant_messages:
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        text = "".join(
+            str(item.get("text", "")) for item in content if isinstance(item, dict) and item.get("type") == "text"
+        )
+        if text:
+            final = text
+    return final
+
+
+def _content_text(content: object) -> str:
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    return "".join(str(item.get(key, "")) for item in content if isinstance(item, dict) for key in ("text", "thinking"))
+
+
+def _median(values: Sequence[int]) -> float:
+    return float(statistics.median(values)) if values else 0.0
+
+
+def _percentile(values: Sequence[int], fraction: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * fraction
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    weight = position - lower
+    return float(ordered[lower] * (1 - weight) + ordered[upper] * weight)
+
+
+def _ratio(numerator: int | float, denominator: int) -> float | None:
+    return None if denominator == 0 else float(numerator / denominator)
+
+
+def _required_mapping(value: object, name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise PrimeTrajectoryEvidenceError(f"{name} must be an object")
+    return value
+
+
+def _required_list(value: object, name: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise PrimeTrajectoryEvidenceError(f"{name} must be a list")
+    return value
+
+
+def _required_string(value: object, name: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise PrimeTrajectoryEvidenceError(f"{name} must be a non-empty string")
+    return value
+
+
+def _optional_string(value: object, name: str) -> str | None:
+    if value is None:
+        return None
+    return _required_string(value, name)
+
+
+def _required_int(value: object, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise PrimeTrajectoryEvidenceError(f"{name} must be a non-negative integer")
+    return value
+
+
+def _required_float(value: object, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, int | float | str):
+        raise PrimeTrajectoryEvidenceError(f"{name} must be numeric")
+    try:
+        result = float(value)
+    except ValueError as exc:
+        raise PrimeTrajectoryEvidenceError(f"{name} must be numeric") from exc
+    if not math.isfinite(result) or result < 0:
+        raise PrimeTrajectoryEvidenceError(f"{name} must be non-negative")
+    return result
+
+
+def _required_bool(value: object, name: str) -> bool:
+    if not isinstance(value, bool):
+        raise PrimeTrajectoryEvidenceError(f"{name} must be a boolean")
+    return value
+
+
+def _nested_int(value: Mapping[str, Any], parent: str, child: str) -> int:
+    return _required_int(_required_mapping(value.get(parent), parent).get(child), f"{parent}.{child}")

--- a/src/aec_bench/prime_agent/world.py
+++ b/src/aec_bench/prime_agent/world.py
@@ -56,6 +56,11 @@ if TYPE_CHECKING:
 WORLD_ACTOR_SOCKET_ENV = "AEC_BENCH_WORLD_ACTOR_SOCKET"
 WORLD_ACTOR_CAPABILITY_ENV = "AEC_BENCH_WORLD_ACTOR_CAPABILITY_TOKEN"
 _MAX_MESSAGE_BYTES = 1024 * 1024
+PUMP_STATION_GUIDANCE_INSTRUCTION = (
+    "Before your first world action, load and follow the full `pump-station-guidance` skill. "
+    "Keep its compact state and exact action ledger throughout the episode. "
+    "Use its references when they help the current decision."
+)
 
 
 class PrimeWorldActorProxyError(RuntimeError):
@@ -408,15 +413,18 @@ class PrimeWorldActorProxy:
 def install_aec_world_skill(actor_workspace: Path) -> Path:
     """Install the packaged skill and importable client into one isolated actor workspace."""
     actor_workspace = actor_workspace.resolve()
-    source = Path(__file__).with_name("skills") / "aec-world"
-    skill_directory = actor_workspace / ".prime-skills" / "aec-world"
     package_directory = actor_workspace / "aec_world"
-    if skill_directory.exists() or package_directory.exists():
-        raise PrimeWorldActorProxyError("aec-world skill destination already exists")
-    skill_directory.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copytree(source, skill_directory)
+    if package_directory.exists():
+        raise PrimeWorldActorProxyError("aec-world package destination already exists")
+    skill_directory = _install_packaged_skill(actor_workspace, "aec-world")
+    source = _packaged_skill_source("aec-world")
     shutil.copytree(source / "src" / "aec_world", package_directory)
     return skill_directory
+
+
+def install_pump_station_guidance_skill(actor_workspace: Path) -> Path:
+    """Install the packaged Markdown guidance into one isolated actor workspace."""
+    return _install_packaged_skill(actor_workspace.resolve(), "pump-station-guidance")
 
 
 async def run_prime_pump_world_session(
@@ -429,6 +437,7 @@ async def run_prime_pump_world_session(
     model: str,
     isolation: PrimeAcpIsolation,
     limits: PrimeWorldSessionLimits,
+    pump_station_guidance: bool = False,
     executable: str = "prime-agent",
     environment: Mapping[str, str] | None = None,
 ) -> PrimePumpWorldRun:
@@ -440,7 +449,11 @@ async def run_prime_pump_world_session(
         raise PrimeWorldActorProxyError("actor workspace must be separate from host world and evidence paths")
     actor_workspace.mkdir(parents=True, exist_ok=True)
     evidence_directory.mkdir(parents=True, exist_ok=False)
-    skill_directory = install_aec_world_skill(actor_workspace)
+    skill_directories = [install_aec_world_skill(actor_workspace)]
+    prime_instruction = instruction
+    if pump_station_guidance:
+        skill_directories.append(install_pump_station_guidance_skill(actor_workspace))
+        prime_instruction = instruction.rstrip() + "\n\n" + PUMP_STATION_GUIDANCE_INSTRUCTION + "\n"
     actor_transport_file = evidence_directory / "world-actor-transport.jsonl"
     proxy = PrimeWorldActorProxy(
         world_run_directory=world_run_directory,
@@ -453,8 +466,8 @@ async def run_prime_pump_world_session(
         prime = await run_prime_acp_session(
             actor_workspace=actor_workspace,
             evidence_directory=evidence_directory,
-            skill_directory=skill_directory,
-            instruction=instruction,
+            skill_directories=tuple(skill_directories),
+            instruction=prime_instruction,
             model=model,
             actor_environment=proxy.connection_environment(),
             isolation=isolation,
@@ -543,6 +556,23 @@ def _paths_overlap(first: Path, second: Path) -> bool:
     first = first.resolve()
     second = second.resolve()
     return first == second or first in second.parents or second in first.parents
+
+
+def _packaged_skill_source(name: str) -> Path:
+    source = Path(__file__).with_name("skills") / name
+    if not source.is_dir():
+        raise PrimeWorldActorProxyError(f"packaged Prime skill is missing: {name}")
+    return source
+
+
+def _install_packaged_skill(actor_workspace: Path, name: str) -> Path:
+    source = _packaged_skill_source(name)
+    skill_directory = actor_workspace / ".prime-skills" / name
+    if skill_directory.exists():
+        raise PrimeWorldActorProxyError(f"Prime skill destination already exists: {name}")
+    skill_directory.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(source, skill_directory)
+    return skill_directory
 
 
 def _safe_operation(value: Any) -> str | None:

--- a/tests/prime_agent/test_acp.py
+++ b/tests/prime_agent/test_acp.py
@@ -14,6 +14,7 @@ import pytest
 
 from aec_bench.prime_agent.acp import (
     PrimeAcpIsolation,
+    PrimeAcpIsolationError,
     build_macos_sandbox_profile,
     build_prime_acp_command,
     run_prime_acp_session,
@@ -24,6 +25,7 @@ from aec_bench.prime_agent.world import (
     WORLD_ACTOR_CAPABILITY_ENV,
     WORLD_ACTOR_SOCKET_ENV,
     install_aec_world_skill,
+    install_pump_station_guidance_skill,
 )
 
 
@@ -185,7 +187,7 @@ def test_builds_acp_command_with_only_the_explicit_skill(tmp_path: Path) -> None
         model="anthropic/test",
         actor_workspace=actor_workspace,
         session_dir=actor_workspace / "sessions",
-        skill_directory=skill,
+        skill_directories=(skill,),
     )
 
     assert command == [
@@ -209,6 +211,25 @@ def test_builds_acp_command_with_only_the_explicit_skill(tmp_path: Path) -> None
     ]
 
 
+def test_builds_acp_command_with_ordered_explicit_skills(tmp_path: Path) -> None:
+    actor_workspace, skill, _ = _workspace(tmp_path)
+    guidance = install_pump_station_guidance_skill(actor_workspace)
+
+    command = build_prime_acp_command(
+        executable=Path("/opt/prime/bin/prime-agent"),
+        model="anthropic/test",
+        actor_workspace=actor_workspace,
+        session_dir=actor_workspace / "sessions",
+        skill_directories=(skill, guidance),
+    )
+
+    first_skill = command.index("--skill")
+    second_skill = command.index("--skill", first_skill + 1)
+    assert command[first_skill + 1] == str(skill)
+    assert command[second_skill + 1] == str(guidance)
+    assert command.count("--no-skills") == 1
+
+
 @pytest.mark.asyncio
 async def test_runs_one_acp_session_and_preserves_unknown_metadata(tmp_path: Path) -> None:
     actor_workspace, skill, evidence = _workspace(tmp_path)
@@ -216,7 +237,7 @@ async def test_runs_one_acp_session_and_preserves_unknown_metadata(tmp_path: Pat
     result = await run_prime_acp_session(
         actor_workspace=actor_workspace,
         evidence_directory=evidence,
-        skill_directory=skill,
+        skill_directories=(skill,),
         instruction="Use the current world actor until the task is complete.",
         model="anthropic/test",
         actor_environment={
@@ -260,7 +281,19 @@ async def test_runs_one_acp_session_and_preserves_unknown_metadata(tmp_path: Pat
     assert provenance["benchmark_valid"] is False
     assert provenance["runtime_home_scope"] == "actor-workspace"
     assert provenance["usage"]["cost_usd"] == "0.25"
+    assert provenance["acp_sdk_version"]
+    assert provenance["skills"] == [
+        {
+            "name": "aec-world",
+            "order": 0,
+            "sha256": provenance["skill_sha256"],
+        }
+    ]
+    assert str(skill) not in json.dumps(provenance)
+    assert "<skill:aec-world>" in provenance["command"]
     assert "environment" not in provenance
+    assert (evidence / "prime-session.jsonl").is_file()
+    assert "fake-assistant-1" in (evidence / "prime-session.jsonl").read_text(encoding="utf-8")
     observed = json.loads((actor_workspace / "observed-acp.json").read_text(encoding="utf-8"))
     runtime_root = actor_workspace / ".prime-runtime"
     assert observed["home"] == str(runtime_root / "home")
@@ -270,12 +303,68 @@ async def test_runs_one_acp_session_and_preserves_unknown_metadata(tmp_path: Pat
 
 
 @pytest.mark.asyncio
+async def test_rejects_missing_duplicate_external_and_overlapping_skills(tmp_path: Path) -> None:
+    actor_workspace, skill, evidence = _workspace(tmp_path)
+    duplicate = actor_workspace / ".alternate" / "aec-world"
+    duplicate.mkdir(parents=True)
+    (duplicate / "SKILL.md").write_text(
+        "---\nname: aec-world\ndescription: Duplicate test skill.\n---\n",
+        encoding="utf-8",
+    )
+    outer = actor_workspace / ".overlap" / "outer"
+    inner = outer / "inner"
+    inner.mkdir(parents=True)
+    (outer / "SKILL.md").write_text(
+        "---\nname: outer\ndescription: Outer test skill.\n---\n",
+        encoding="utf-8",
+    )
+    (inner / "SKILL.md").write_text(
+        "---\nname: inner\ndescription: Inner test skill.\n---\n",
+        encoding="utf-8",
+    )
+    external = tmp_path / "external"
+    external.mkdir()
+    (external / "SKILL.md").write_text(
+        "---\nname: external\ndescription: External test skill.\n---\n",
+        encoding="utf-8",
+    )
+    executable = str(_fake_prime_agent(tmp_path))
+
+    async def run_with(skills: tuple[Path, ...], evidence_name: str) -> None:
+        await run_prime_acp_session(
+            actor_workspace=actor_workspace,
+            evidence_directory=evidence / evidence_name,
+            skill_directories=skills,
+            instruction="Act once.",
+            model="anthropic/test",
+            actor_environment={
+                WORLD_ACTOR_SOCKET_ENV: "/private/tmp/scoped-actor.sock",
+                WORLD_ACTOR_CAPABILITY_ENV: "scoped-capability-secret",
+            },
+            isolation=PrimeAcpIsolation.DEVELOPMENT_SAME_USER,
+            limits=_limits(),
+            executable=executable,
+            environment=os.environ,
+        )
+
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        await run_with((skill, actor_workspace / "missing"), "missing")
+    with pytest.raises(ValueError, match="duplicated"):
+        await run_with((skill, duplicate), "duplicate")
+    with pytest.raises(PrimeAcpIsolationError, match="under the actor workspace"):
+        await run_with((skill, external), "external")
+    with pytest.raises(PrimeAcpIsolationError, match="must not overlap"):
+        await run_with((outer, inner), "overlap")
+    assert not (actor_workspace / "observed-acp.json").exists()
+
+
+@pytest.mark.asyncio
 async def test_normalizes_child_topology_and_refinement_metadata(tmp_path: Path) -> None:
     actor_workspace, skill, evidence = _workspace(tmp_path)
     result = await run_prime_acp_session(
         actor_workspace=actor_workspace,
         evidence_directory=evidence,
-        skill_directory=skill,
+        skill_directories=(skill,),
         instruction="Record evidence.",
         model="anthropic/test",
         actor_environment={
@@ -294,6 +383,10 @@ async def test_normalizes_child_topology_and_refinement_metadata(tmp_path: Path)
     assert result.refinement.completed == 1
     assert result.refinement.failed == 0
     assert "kept raw" in result.paths.outbound_file.read_text(encoding="utf-8")
+    assert sorted(path.name for path in evidence.glob("prime-session*.jsonl")) == [
+        "prime-session-2.jsonl",
+        "prime-session.jsonl",
+    ]
 
 
 @pytest.mark.asyncio
@@ -314,7 +407,7 @@ async def test_usage_limit_cancels_the_active_prime_prompt(
     result = await run_prime_acp_session(
         actor_workspace=actor_workspace,
         evidence_directory=evidence,
-        skill_directory=skill,
+        skill_directories=(skill,),
         instruction="Keep working.",
         model="anthropic/test",
         actor_environment={
@@ -338,7 +431,7 @@ async def test_fails_closed_when_prime_session_accounting_is_malformed(tmp_path:
     result = await run_prime_acp_session(
         actor_workspace=actor_workspace,
         evidence_directory=evidence,
-        skill_directory=skill,
+        skill_directories=(skill,),
         instruction="Act once.",
         model="anthropic/test",
         actor_environment={
@@ -363,7 +456,7 @@ async def test_fails_closed_on_malformed_or_unsupported_acp(tmp_path: Path, scen
     result = await run_prime_acp_session(
         actor_workspace=actor_workspace,
         evidence_directory=evidence,
-        skill_directory=skill,
+        skill_directories=(skill,),
         instruction="Act once.",
         model="anthropic/test",
         actor_environment={
@@ -387,7 +480,7 @@ async def test_timeout_cancels_then_reaps_the_prime_process(tmp_path: Path) -> N
     result = await run_prime_acp_session(
         actor_workspace=actor_workspace,
         evidence_directory=evidence,
-        skill_directory=skill,
+        skill_directories=(skill,),
         instruction="Wait indefinitely.",
         model="anthropic/test",
         actor_environment={
@@ -412,7 +505,7 @@ async def test_process_exit_during_prompt_is_a_failed_session(tmp_path: Path) ->
     result = await run_prime_acp_session(
         actor_workspace=actor_workspace,
         evidence_directory=evidence,
-        skill_directory=skill,
+        skill_directories=(skill,),
         instruction="Act.",
         model="anthropic/test",
         actor_environment={
@@ -494,7 +587,7 @@ async def test_macos_sandboxed_acp_run_is_benchmark_valid(tmp_path: Path) -> Non
     result = await run_prime_acp_session(
         actor_workspace=actor_workspace,
         evidence_directory=evidence,
-        skill_directory=skill,
+        skill_directories=(skill,),
         instruction="End the turn.",
         model="anthropic/test",
         actor_environment={

--- a/tests/prime_agent/test_trajectory.py
+++ b/tests/prime_agent/test_trajectory.py
@@ -1,0 +1,345 @@
+# ABOUTME: Proves Prime world trajectory metrics come only from retained machine and attributed human evidence.
+# ABOUTME: Covers treatment delivery, actor efficiency, report review, and fail-closed evidence parsing.
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+import pytest
+
+from aec_bench.prime_agent.trajectory import (
+    GUIDANCE_ID,
+    PrimeTrajectoryEvidenceError,
+    analyze_prime_world_trial,
+)
+
+LoadState = Literal["before", "after", "failed", "absent"]
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _write_jsonl(path: Path, values: list[dict[str, Any]]) -> None:
+    path.write_text("".join(json.dumps(value) + "\n" for value in values), encoding="utf-8")
+
+
+def _assistant_message(call: int, *, tool_call: dict[str, Any] | None = None, text: str = "") -> dict[str, Any]:
+    content: list[dict[str, Any]] = []
+    if tool_call is not None:
+        content.append(tool_call)
+    if text:
+        content.append({"type": "text", "text": text})
+    return {
+        "type": "message",
+        "id": f"assistant-{call}",
+        "message": {
+            "role": "assistant",
+            "content": content,
+            "usage": {
+                "input": call * 100,
+                "output": call * 10,
+                "cacheRead": call * 2,
+                "cacheWrite": call * 3,
+                "totalTokens": call * 115,
+            },
+        },
+    }
+
+
+def _trial_fixture(tmp_path: Path, *, load_state: LoadState = "before") -> Path:
+    trial = tmp_path / f"trial-{load_state}"
+    evidence = trial / "evidence"
+    evidence.mkdir(parents=True)
+    guided = load_state != "absent"
+    skill_call = {
+        "type": "toolCall",
+        "id": "load-guidance",
+        "name": "ipython",
+        "arguments": {
+            "code": (
+                "print(open('.prime-skills/pump-station-guidance/SKILL.md').read())\n"
+                "print(open('references/compact-state.md').read())\n"
+                "print(open('references/decision-method.md').read())"
+            ),
+        },
+    }
+    invoke_call = {
+        "type": "toolCall",
+        "id": "invoke-world",
+        "name": "ipython",
+        "arguments": {
+            "code": (
+                "compact = {'decision_id': 'decision-1'}\n"
+                "action_ledger = []\n"
+                "result = await aec_world.invoke('act', {}, decision_id='decision-1')\n"
+                "action_ledger.append(result['status'])\n"
+                "compact.update({'decision_id': result['next_decision_id']})\n"
+                "print(result)"
+            ),
+        },
+    }
+    ordered_calls = [invoke_call]
+    if load_state == "before":
+        ordered_calls.insert(0, skill_call)
+    elif load_state in {"after", "failed"}:
+        ordered_calls.append(skill_call)
+    session_events: list[dict[str, Any]] = [{"type": "session", "id": "root", "rlmDepth": 0}]
+    for call_number, tool_call in enumerate(ordered_calls, start=1):
+        session_events.append(_assistant_message(call_number, tool_call=tool_call))
+        is_skill = tool_call["id"] == "load-guidance"
+        session_events.append(
+            {
+                "type": "message",
+                "id": f"result-{call_number}",
+                "message": {
+                    "role": "toolResult",
+                    "toolCallId": tool_call["id"],
+                    "toolName": "ipython",
+                    "isError": is_skill and load_state == "failed",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": (
+                                "read failed"
+                                if is_skill and load_state == "failed"
+                                else GUIDANCE_ID
+                                if is_skill
+                                else '{"status": "applied", "next_observation": {}}'
+                            ),
+                        }
+                    ],
+                },
+            }
+        )
+    final_call = len(ordered_calls) + 1
+    session_events.append(_assistant_message(final_call, text="I made five world action attempts."))
+    _write_jsonl(evidence / "prime-session.jsonl", session_events)
+    _write_jsonl(
+        evidence / "prime-acp-out.jsonl",
+        [{"jsonrpc": "2.0", "method": "session/update", "params": {"_meta": {"compaction": {"count": 1}}}}],
+    )
+    skills = [{"order": 0, "name": "aec-world", "sha256": "generic-digest"}]
+    if guided:
+        skills.append({"order": 1, "name": "pump-station-guidance", "sha256": "guidance-digest"})
+    _write_json(evidence / "prime-run.json", {"skills": skills, "skill_sha256": "generic-digest"})
+
+    actor_events = [
+        {"operation": "capabilities", "request": {"operation": "capabilities"}, "result": {}},
+        {"operation": "observe", "request": {"operation": "observe"}, "result": {}},
+        _invoke_event("request-1", "decision-1", "act", {"target": "one"}, status="applied"),
+        _invoke_event("request-2", "decision-2", "act", {"target": "two"}, status="rejected"),
+        _invoke_event(
+            "request-3",
+            "decision-2",
+            "act",
+            {"target": "bad"},
+            error="actor-action-arguments",
+        ),
+        _invoke_event("request-4", "decision-2", "search", {"query": "record"}, status="NO_ACCESSIBLE_RESULT"),
+        _invoke_event("request-5", "decision-2", "search", {"query": "record"}, status="NO_ACCESSIBLE_RESULT"),
+    ]
+    _write_jsonl(evidence / "world-actor-transport.jsonl", actor_events)
+
+    model_calls = len(ordered_calls) + 1
+    total_tokens = sum(call * 115 for call in range(1, model_calls + 1))
+    _write_json(
+        trial / "trial-summary.json",
+        {
+            "trial_id": f"trial-{load_state}",
+            "condition": "Guided" if guided else "Open",
+            "prime": {
+                "usage": {"total_tokens": total_tokens, "model_calls": model_calls, "cost_usd": "0.9"},
+                "elapsed_seconds": 12.5,
+                "topology": {"child_sessions": 0},
+                "refinement": {"events": 0},
+                "session_state": "ended",
+                "stop_reason": "end_turn",
+                "limit_reason": None,
+            },
+            "world": {
+                "benchmark_valid": True,
+                "state": "active",
+                "completion": "incomplete",
+                "verification": {
+                    "valid": True,
+                    "replay_valid": True,
+                    "conservation": {
+                        "duty": {"unserved_capacity_seconds": 0},
+                        "work": {"terminal_ids": ["work-1"], "closing_ids": ["work-1", "work-2"]},
+                    },
+                },
+                "evaluation": {"valid": True},
+            },
+        },
+    )
+    return trial
+
+
+def _invoke_event(
+    request_id: str,
+    decision_id: str,
+    action_name: str,
+    arguments: dict[str, Any],
+    *,
+    status: str | None = None,
+    error: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "operation": "invoke",
+        "request": {
+            "operation": "invoke",
+            "request_id": request_id,
+            "decision_id": decision_id,
+            "action_name": action_name,
+            "arguments": arguments,
+        },
+        "result": None if status is None else {"status": status},
+        "error": None if error is None else {"code": error, "detail": "fixture error"},
+    }
+
+
+def test_derives_guided_trajectory_and_leaves_report_quality_incomplete_without_review(tmp_path: Path) -> None:
+    trial = _trial_fixture(tmp_path)
+
+    analysis = analyze_prime_world_trial(trial, large_output_threshold_chars=20)
+
+    assert analysis.treatment == "guided"
+    assert analysis.model_context == {
+        "reported_input_tokens_sum": 600,
+        "input_tokens_median": 200.0,
+        "input_tokens_p90": 280.0,
+        "input_tokens_max": 300,
+        "output_tokens_sum": 60,
+        "cache_read_tokens_sum": 12,
+        "cache_write_tokens_sum": 18,
+        "reported_total_tokens_sum": 690,
+    }
+    assert analysis.notebook["ipython_cells"] == 2
+    assert analysis.notebook["full_object_output_cells"] == 1
+    assert analysis.notebook["compact_state_cells"] == 1
+    assert analysis.notebook["compact_state_update_cells"] == 1
+    assert analysis.notebook["action_ledger_cells"] == 1
+    assert analysis.notebook["action_ledger_append_cells"] == 1
+    assert analysis.notebook["invoke_cells"] == 1
+    assert analysis.notebook["invoke_and_ledger_append_cells"] == 1
+    assert analysis.notebook["invoke_and_compact_state_update_cells"] == 1
+    assert analysis.notebook["invoke_and_print_cells"] == 1
+    assert analysis.notebook["invoke_ledger_colocation_rate"] == 1.0
+    assert analysis.notebook["invoke_compact_state_colocation_rate"] == 1.0
+    assert analysis.notebook["first_invoke_model_call"] == 2
+    assert analysis.notebook["last_invoke_model_call"] == 2
+    assert analysis.notebook["model_calls_before_first_invoke"] == 1
+    assert analysis.actor_transport["operations"] == {"capabilities": 1, "observe": 1, "invoke": 5}
+    assert analysis.actor_transport["invoke_statuses"] == {
+        "applied": 1,
+        "rejected": 1,
+        "actor-action-arguments": 1,
+        "NO_ACCESSIBLE_RESULT": 2,
+    }
+    assert analysis.actor_transport["repeated_equivalent_requests_in_unchanged_state"] == 1
+    assert analysis.efficiency["tokens_per_applied_transition"] == 690.0
+    assert analysis.efficiency["model_calls_per_applied_transition"] == 3.0
+    assert analysis.efficiency["actions_per_model_call"] == pytest.approx(5 / 3)
+    assert analysis.efficiency["elapsed_seconds"] == 12.5
+    assert analysis.prime_features["explicit_compaction_events"] == 1
+    assert analysis.treatment_integrity == {
+        "guidance_available": True,
+        "guidance_loaded": True,
+        "guidance_loaded_before_first_invoke": True,
+        "guidance_id": GUIDANCE_ID,
+        "reference_loads": ["compact-state.md", "decision-method.md"],
+    }
+    assert analysis.world_progress["unserved_capacity_seconds"] == 0
+    assert analysis.world_progress["terminal_work_count"] == 1
+    assert analysis.report_quality["status"] == "incomplete"
+    assert analysis.report_quality["action_ledger_recall"] is None
+
+
+@pytest.mark.parametrize(
+    ("load_state", "available", "loaded", "before"),
+    [
+        ("before", True, True, True),
+        ("after", True, True, False),
+        ("failed", True, False, False),
+        ("absent", False, False, False),
+    ],
+)
+def test_distinguishes_treatment_availability_and_delivery(
+    tmp_path: Path,
+    load_state: LoadState,
+    available: bool,
+    loaded: bool,
+    before: bool,
+) -> None:
+    analysis = analyze_prime_world_trial(_trial_fixture(tmp_path, load_state=load_state))
+
+    assert analysis.treatment_integrity["guidance_available"] is available
+    assert analysis.treatment_integrity["guidance_loaded"] is loaded
+    assert analysis.treatment_integrity["guidance_loaded_before_first_invoke"] is before
+
+
+def test_recognizes_a_legacy_versioned_guidance_marker(tmp_path: Path) -> None:
+    trial = _trial_fixture(tmp_path)
+    session_file = trial / "evidence" / "prime-session.jsonl"
+    session_file.write_text(
+        session_file.read_text(encoding="utf-8").replace(
+            GUIDANCE_ID,
+            "aecbench.pump-station-guidance.v1",
+        ),
+        encoding="utf-8",
+    )
+
+    analysis = analyze_prime_world_trial(trial)
+
+    assert analysis.treatment_integrity["guidance_loaded"] is True
+    assert analysis.treatment_integrity["guidance_id"] == GUIDANCE_ID
+
+
+def test_uses_attributed_human_review_for_final_report_metrics(tmp_path: Path) -> None:
+    trial = _trial_fixture(tmp_path)
+    review = {
+        "rubric_id": "aecbench.prime-world-report-review.v1",
+        "reviewer": "reviewer@example.test",
+        "reviewed_at": datetime(2026, 8, 7, tzinfo=UTC).isoformat(),
+        "canonical_invoke_count": 5,
+        "reported_invoke_count": 4,
+        "matched_invoke_count": 4,
+        "correctly_classified_invoke_count": 4,
+        "pending_liability_claim_count": 2,
+        "correct_pending_liability_claim_count": 1,
+        "unsupported_claim_count": 1,
+        "evidence_references": ["evidence/world-actor-transport.jsonl", "evidence/prime-session.jsonl"],
+    }
+    _write_json(trial / "report-review.json", review)
+
+    report = analyze_prime_world_trial(trial).report_quality
+
+    assert report["status"] == "complete"
+    assert report["rubric_id"] == "aecbench.prime-world-report-review.v1"
+    assert report["action_ledger_recall"] == 0.8
+    assert report["action_outcome_classification_accuracy"] == 0.8
+    assert report["pending_liability_accuracy"] == 0.5
+    assert report["unsupported_claim_count"] == 1
+
+    review["canonical_invoke_count"] = 4
+    _write_json(trial / "report-review.json", review)
+    with pytest.raises(PrimeTrajectoryEvidenceError, match="canonical invoke count"):
+        analyze_prime_world_trial(trial)
+
+
+def test_cancelled_session_does_not_treat_planning_text_as_a_final_report(tmp_path: Path) -> None:
+    trial = _trial_fixture(tmp_path)
+    summary = json.loads((trial / "trial-summary.json").read_text(encoding="utf-8"))
+    summary["prime"]["session_state"] = "cancelled"
+    summary["prime"]["stop_reason"] = "cancelled"
+    summary["prime"]["limit_reason"] = "max_model_calls"
+    _write_json(trial / "trial-summary.json", summary)
+
+    analysis = analyze_prime_world_trial(trial)
+
+    assert analysis.notebook["final_assistant_text_chars"] == 0
+    assert analysis.report_quality["final_report_present"] is False

--- a/tests/prime_agent/test_world.py
+++ b/tests/prime_agent/test_world.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib
+import inspect
 import json
 import os
 import socket
@@ -22,11 +23,13 @@ from aec_bench.contracts.world_session import (
 )
 from aec_bench.prime_agent.acp import PrimeAcpIsolation
 from aec_bench.prime_agent.world import (
+    PUMP_STATION_GUIDANCE_INSTRUCTION,
     WORLD_ACTOR_CAPABILITY_ENV,
     WORLD_ACTOR_SOCKET_ENV,
     PrimeWorldActorProxy,
     PrimeWorldSessionLimits,
     install_aec_world_skill,
+    install_pump_station_guidance_skill,
     run_prime_pump_world_session,
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.episode_runtime import (
@@ -248,6 +251,42 @@ def test_packaged_skill_has_only_the_three_actor_operations(tmp_path: Path, monk
     assert not hasattr(client, "host_control")
 
 
+def test_packaged_pump_guidance_is_markdown_only_and_contains_no_instance_plan(tmp_path: Path) -> None:
+    workspace = tmp_path / "actor"
+    workspace.mkdir()
+
+    guidance = install_pump_station_guidance_skill(workspace)
+    files = sorted(path.relative_to(guidance).as_posix() for path in guidance.rglob("*") if path.is_file())
+    text = "\n".join((guidance / relative).read_text(encoding="utf-8") for relative in files)
+
+    assert files == ["SKILL.md", "references/compact-state.md", "references/decision-method.md"]
+    assert "guidance_id: aecbench.pump-station-guidance" in text
+    assert "current-profile-only" in text
+    assert "NO_ACCESSIBLE_RESULT" in text
+    assert "exact ledger" in text
+    assert "one IPython cell for each `invoke` attempt" in text
+    assert "not an action-selection rule" in text
+    assert "remaining action budget" not in text
+    assert "model-call limit" not in text
+    assert "closure threshold" not in text
+    for forbidden in (
+        "pump-a",
+        "pump-b",
+        "backlog-a",
+        "restriction-a",
+        "world_run_directory",
+        "--run-dir",
+        "host_control",
+        "expected score",
+    ):
+        assert forbidden not in text.lower()
+
+    parameters = inspect.signature(run_prime_pump_world_session).parameters
+    assert parameters["pump_station_guidance"].default is False
+    assert "skill_directory" not in parameters
+    assert "skill_directories" not in parameters
+
+
 @pytest.mark.asyncio
 async def test_prime_end_turn_while_world_is_live_is_recorded_incomplete(tmp_path: Path) -> None:
     from tests.prime_agent.test_acp import _fake_prime_agent
@@ -281,6 +320,51 @@ async def test_prime_end_turn_while_world_is_live_is_recorded_incomplete(tmp_pat
     assert run_evidence["evaluation_valid"] is True
     assert run_evidence["world_state"] == "active"
     assert run_evidence["completion"] == "incomplete"
+    assert not (tmp_path / "actor" / ".prime-skills" / "pump-station-guidance").exists()
+    inbound = result.prime.paths.inbound_file.read_text(encoding="utf-8")
+    assert PUMP_STATION_GUIDANCE_INSTRUCTION not in inbound
+    provenance = json.loads(result.prime.paths.run_file.read_text(encoding="utf-8"))
+    assert [skill["name"] for skill in provenance["skills"]] == ["aec-world"]
+
+
+@pytest.mark.asyncio
+async def test_explicit_guided_treatment_adds_only_the_ordered_skill_and_instruction(tmp_path: Path) -> None:
+    from tests.prime_agent.test_acp import _fake_prime_agent
+
+    instruction = "Advance the current world, then end the turn."
+    result = await run_prime_pump_world_session(
+        actor_workspace=tmp_path / "actor",
+        world_run_directory=tmp_path / "private-world",
+        evidence_directory=tmp_path / "host-evidence",
+        session_request=_session_request(),
+        instruction=instruction,
+        model="anthropic/test",
+        isolation=PrimeAcpIsolation.DEVELOPMENT_SAME_USER,
+        limits=_limits(),
+        pump_station_guidance=True,
+        executable=str(_fake_prime_agent(tmp_path)),
+        environment={**os.environ, "FAKE_ACP_SCENARIO": "world"},
+    )
+
+    observed = json.loads((tmp_path / "actor" / "observed-acp.json").read_text(encoding="utf-8"))
+    skill_arguments = [
+        observed["argv"][index + 1] for index, argument in enumerate(observed["argv"]) if argument == "--skill"
+    ]
+    assert [Path(argument).name for argument in skill_arguments] == ["aec-world", "pump-station-guidance"]
+    inbound = result.prime.paths.inbound_file.read_text(encoding="utf-8")
+    assert instruction in inbound
+    assert PUMP_STATION_GUIDANCE_INSTRUCTION in inbound
+    assert "host model-call limit" not in inbound
+    assert "closure no later than" not in inbound
+    provenance = json.loads(result.prime.paths.run_file.read_text(encoding="utf-8"))
+    assert [skill["name"] for skill in provenance["skills"]] == ["aec-world", "pump-station-guidance"]
+    assert [skill["order"] for skill in provenance["skills"]] == [0, 1]
+    assert provenance["skill_sha256"] == provenance["skills"][0]["sha256"]
+    serialized_provenance = json.dumps(provenance)
+    assert str(tmp_path / "actor") not in serialized_provenance
+    assert all(argument not in serialized_provenance for argument in skill_arguments)
+    assert result.verification.valid
+    assert result.evaluation.evaluation_scope == "bounded_continuation"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add one optional `pump-station-guidance` treatment after the generic `aec-world` skill
- teach compact state, exact action accounting, and one-cell action bookkeeping without providing an instance plan or exposing host limits
- preserve Prime session JSONL as trial evidence and add a read-only trajectory analyzer
- keep actor authority, world semantics, replay, verification, evaluation, and existing Open behavior unchanged

Exact guidance content is identified by the skill digest in `prime-run.json`; there are no maintained v1/v2/v3 treatment variants.

## Validation

- `uv run pytest tests/prime_agent/test_acp.py tests/prime_agent/test_world.py tests/prime_agent/test_trajectory.py -q` (32 passed)
- targeted Ruff checks passed
- targeted mypy passed
- `uv build` passed
- wheel content inspection passed
- `git diff --check` passed

No full test suite or paid model run was used for the final revision.