### PR TITLE
feat(prime-agent): continue pump journeys across host controls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,3 +135,62 @@ jobs:
           uv run mypy
           src/aec_bench/task_world_templates/hydraulics/
           src/aec_bench/task_world_templates/lifecycles/
+
+  prime-world-journey:
+    name: Prime world journey
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.13.2
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13.2"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Install locked Prime Agent dependencies
+        run: uv sync --frozen --extra prime-agent
+
+      - name: Run Prime world journey tests
+        run: >-
+          uv run pytest -q
+          tests/prime_agent/test_acp.py
+          tests/prime_agent/test_world.py
+          tests/prime_agent/test_world_journey.py
+          tests/task_world_templates/stewardship/wastewater_pump_station/test_bound_root_control_interface_envelope.py
+          tests/task_world_templates/stewardship/wastewater_pump_station/test_host_continuation.py
+          tests/task_world_templates/stewardship/wastewater_pump_station/test_reference_controller.py
+          tests/task_world_templates/stewardship/wastewater_pump_station/test_reference_system_journey.py
+          tests/task_world_templates/stewardship/wastewater_pump_station/test_root_control_capability_authority.py
+
+      - name: Check Prime world journey formatting
+        run: >-
+          uv run ruff format --check
+          src/aec_bench/prime_agent/acp.py
+          src/aec_bench/prime_agent/pump_journey_evidence.py
+          src/aec_bench/prime_agent/world.py
+          src/aec_bench/prime_agent/world_journey.py
+          src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/host_continuation.py
+          tests/prime_agent/test_acp.py
+          tests/prime_agent/test_world.py
+          tests/prime_agent/test_world_journey.py
+          tests/task_world_templates/stewardship/wastewater_pump_station/test_host_continuation.py
+
+      - name: Check Prime world journey strict types
+        run: >-
+          uv run mypy
+          src/aec_bench/prime_agent/acp.py
+          src/aec_bench/prime_agent/pump_journey_evidence.py
+          src/aec_bench/prime_agent/world.py
+          src/aec_bench/prime_agent/world_journey.py
+          src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/host_continuation.py
+          tests/prime_agent/test_acp.py
+          tests/prime_agent/test_world.py
+          tests/prime_agent/test_world_journey.py
+          tests/task_world_templates/stewardship/wastewater_pump_station/test_host_continuation.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
   prime-world-journey:
     name: Prime world journey
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Check out repository
         uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -194,6 +194,24 @@ await run_prime_pump_world_session(
 )
 ```
 
+The complete pump journey entry point is
+`aec_bench.prime_agent.world_journey.run_prime_pump_world_journey`. It reuses
+the bounded session runner. When Prime reaches an Operations boundary, the host
+closes Prime, applies at most one deterministic task-owned control, and starts a
+fresh ACP session at the exact new snapshot. All sessions use the same actor
+workspace and actor tenure, so Prime can continue from its own ledger and files.
+Prime runtime state is new for each session. World files, host-control details,
+and verifier data do not enter the actor workspace. An LLM does not choose or
+apply the host control.
+
+`PrimeJourneyLimits` applies one set of emergency limits to the complete
+journey. Each fresh session receives only the remaining world-action,
+model-call, token, cost, and wall-time allowance. A host control can follow only
+a clean Prime `end_turn` with no reached limit. The host writes a private atomic
+checkpoint before it applies a control. If the process stops after the world
+records that control, call the same entry point with `resume=True`; the world
+repository returns the exact durable result instead of applying it twice.
+
 Guided installs `aec-world` followed by `pump-station-guidance` and tells Prime
 to load the second skill before its first world action. The guidance teaches
 compact state, exact action accounting, rejection interpretation, and
@@ -202,9 +220,9 @@ world action, ledger append, compact-state update, and selected output in one
 notebook cell. It does not expose or coach Prime against host-side execution
 limits, and it does not contain a fixed plan, action sequence, or current
 instance solution. It is validated only against the current registered profile
-until a second profile supplies cross-profile evidence. Callers must also
-supply a `PrimeWorldSessionLimits` value with positive world-action, model-call,
-token, cost, and wall-clock emergency limits.
+until a second profile supplies cross-profile evidence. Bounded-session callers
+supply `PrimeWorldSessionLimits`. Journey callers supply `PrimeJourneyLimits`,
+which also limits session and host-control counts.
 
 Inside Prime, the available world calls are:
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -188,9 +188,13 @@ explicit failures. A transport cannot turn them into successful trials.
 The separate `prime_agent` integration runs the upstream Prime Agent executable
 directly. JSON mode adapts staged artifact tasks on the existing local path;
 ACP mode owns one persistent Prime process and a capability-scoped actor proxy
-for one interactive episode. The proxy translates only the current actor
-request and result models. Task-world persistence, verification, evaluation,
-and Harbor paths remain owned by their existing layers.
+for one bounded interactive segment. The pump journey composition can alternate
+these segments with exact, task-owned host controls. The proxy translates only
+the current actor request and result models. The pump world owns host-control
+eligibility and completion. A private journey checkpoint records coordination
+phase and canonical references for process recovery; it is not a second causal
+record. Task-world persistence, verification, evaluation, and Harbor paths
+remain owned by their existing layers.
 
 Local execution selects from one fixed set of adapter builders at the harness
 composition edge. Tests inject a builder callable directly; production does

--- a/docs/protocols/interactive-world-runtime.md
+++ b/docs/protocols/interactive-world-runtime.md
@@ -164,21 +164,58 @@ records malformed, unauthorized, and transport-level attempts using only a
 safe operation label. It excludes the capability secret, endpoint and
 repository paths, arbitrary malformed payload content, and hidden state.
 
-Prime HOME and XDG paths are trial-local under the actor workspace. The
-normalized Prime run evidence records configured limits, aggregate usage and
-cost, root/child session counts, refinement status counts, and any limit that
-ended the prompt. Unknown ACP metadata remains in the raw ACP evidence.
+Prime HOME and XDG paths are trial-local under the actor workspace. A bounded
+session has one Prime runtime. A pump journey uses the same actor workspace for
+all actor-owned files, but gives every segment a fresh Prime runtime and ACP
+connection. The normalized Prime evidence records configured safeguards,
+aggregate usage and cost, root/child session counts, refinement status counts,
+and any safeguard that ended the prompt. Unknown ACP metadata remains in the
+raw ACP evidence.
 
-The current Prime composition is one bounded actor continuation. It invokes the
-task-owned pump evaluator with `evaluation_scope="bounded_continuation"`
-because Operations boundary reviews remain host controls and are not available
-through the Prime actor capability. The bounded scope changes only the
-terminal-stewardship availability gate. Verification, conservation, authority,
-evidence, and liability checks remain unchanged, and closing liabilities remain
-in the result. Evaluation validity therefore does not convert an active world
-or an incomplete or interrupted Prime session into a completed one. A
-`complete_journey` Prime treatment requires explicit host-owned control
-orchestration outside the composite actor principal.
+Journey safeguards cover the whole journey: session and host-control counts,
+world actions, model calls, tokens, provider cost, and elapsed wall time. A new
+Prime session receives only the remaining allowance. Completed response
+accounting can cross a token or cost limit, but that journey stops before any
+host control or later Prime session.
+
+The bounded Prime composition still runs one actor continuation and invokes the
+task-owned pump evaluator with `evaluation_scope="bounded_continuation"`.
+Operations reviews remain outside the Prime actor capability.
+
+The pump journey composition alternates bounded actor sessions with at most one
+task-owned Operations review. Prime is closed before the host selects or applies
+a control. The pump host policy reads the current canonical state, returns one
+exact bound control or no control, and does not call evaluation. The existing
+control implementation remains responsible for authority, accepted evidence,
+stale-state, restriction matching, and exact-retry checks. After a changing
+control, the next Prime segment opens with `RESUME` at the exact result snapshot.
+All segments keep the same actor tenure and form one composite actor principal.
+Only actor-owned workspace files and the next normal actor observation carry
+information between segments; host state, control payloads, and verifier data do
+not enter the actor workspace or continuation prompt.
+
+Host continuation is permitted only after Prime returns a clean `end_turn`, no
+Prime or host limit is reached, the actor-action limit remains open, and replay
+is valid. Cancellation, `max_tokens`, `max_turn_requests`, provider failure,
+protocol failure, incomplete session evidence, and an actor-action limit stop
+the journey without a host action.
+
+Before one selected host control, the coordinator atomically records its stable
+request identity and parent snapshot in a private checkpoint. On explicit
+resume, it reproduces the request from the unchanged parent or the canonical
+committed command. The world repository then applies, recovers, or exactly
+retries that request. The checkpoint records the canonical receipt and result
+snapshot before another Prime session starts. It contains no control payload,
+authority secret, host path, or hidden world state. A checkpoint that shows an
+unclosed Prime session cannot resume automatically.
+
+The task-owned pump status is separate from Prime session state and evaluation
+validity. The journey uses `evaluation_scope="complete_journey"` only after the
+pump status reports completion and canonical replay and verification pass. If
+the world remains active and no deterministic host control is eligible, the
+journey stops incomplete. It does not ask an LLM to choose a host control or
+silently start another actor session. Private emergency safeguards can stop a
+journey, but they cannot make it complete.
 
 Same-user Prime execution is development-only and cannot produce
 benchmark-valid evidence. The current benchmark-valid local path uses a macOS
@@ -196,6 +233,12 @@ completion and failure facts; `CostRecord` owns aggregate usage and estimated
 cost. Public reports select fields from these authorities rather than exposing
 state, verifier paths, provider configuration, or recovery data.
 
+`prime-world-journey.json` records the policy digest, journey safeguards,
+ordered session evidence, exact session-to-control-to-snapshot lineage, totals,
+and final status. Per-session evidence remains separate. The private journey
+checkpoint supports restart and does not replace the final manifest or world
+repository.
+
 | Entry point | Behaviour |
 | --- | --- |
 | Python catalogue | Resolve current build and profile registration. |
@@ -203,6 +246,7 @@ state, verifier paths, provider configuration, or recovery data.
 | `control-interface` | Invoke pump controls or explicit rollout composition. |
 | Harbor agent and import | Use the concrete pump transport and evaluator. |
 | Prime ACP Python entry | Run one Open or explicitly Guided Prime session against one scoped pump actor proxy. |
+| Prime pump journey Python entry | Compose bounded Prime sessions with exact task-owned host continuation until the pump world completes or cannot advance. |
 
 The boundary fails closed for unknown build or profile identity, stale
 decisions, unavailable actions, unauthorized controls, invalid rollout
@@ -218,6 +262,8 @@ successful transition or evaluation.
 - [separate-process actor resolution](../../tests/task_world_templates/stewardship/wastewater_pump_station/test_actor_interface_transport_e2e.py)
 - [pump retry and recovery](../../tests/task_world_templates/stewardship/wastewater_pump_station/test_registered_world_run_transitions.py)
 - [Prime actor proxy and world composition](../../tests/prime_agent/test_world.py)
+- [Prime pump journey composition](../../tests/prime_agent/test_world_journey.py)
+- [pump host continuation policy](../../tests/task_world_templates/stewardship/wastewater_pump_station/test_host_continuation.py)
 - [Prime ACP lifecycle and isolation](../../tests/prime_agent/test_acp.py)
 - [Prime treatment and trajectory analysis](../../tests/prime_agent/test_trajectory.py)
 - [Harbor import](../../tests/harness/test_stewardship_harbor_import.py)

--- a/src/aec_bench/prime_agent/acp.py
+++ b/src/aec_bench/prime_agent/acp.py
@@ -279,6 +279,7 @@ async def run_prime_acp_session(
     )
     command = list(base_command)
     sandbox_profile: Path | None = None
+    benchmark_isolation = isolation is PrimeAcpIsolation.MACOS_SANDBOX
     if isolation is PrimeAcpIsolation.MACOS_SANDBOX:
         if sys.platform != "darwin" or not Path("/usr/bin/sandbox-exec").is_file():
             raise PrimeAcpIsolationError("benchmark-valid Prime execution requires macOS sandbox-exec")
@@ -496,12 +497,7 @@ async def run_prime_acp_session(
         session_state=session_state,
         stop_reason=stop_reason,
         timed_out=timed_out,
-        benchmark_valid=(
-            isolation is PrimeAcpIsolation.MACOS_SANDBOX
-            and session_state != "failed"
-            and error is None
-            and usage.complete
-        ),
+        benchmark_valid=(benchmark_isolation and session_state != "failed" and error is None and usage.complete),
         isolation=isolation,
         updates=tuple(updates),
         error=error,

--- a/src/aec_bench/prime_agent/acp.py
+++ b/src/aec_bench/prime_agent/acp.py
@@ -108,10 +108,17 @@ class PrimeAcpRun:
     error: str | None
 
 
-def prime_acp_paths(actor_workspace: Path, evidence_directory: Path) -> PrimeAcpPaths:
+def prime_acp_paths(
+    actor_workspace: Path,
+    evidence_directory: Path,
+    *,
+    runtime_directory: Path | None = None,
+) -> PrimeAcpPaths:
     actor_workspace = actor_workspace.resolve()
     evidence_directory = evidence_directory.resolve()
-    prime_directory = actor_workspace / "logs" / "prime"
+    prime_directory = (
+        actor_workspace / "logs" / "prime" if runtime_directory is None else runtime_directory.resolve() / "prime"
+    )
     return PrimeAcpPaths(
         state_dir=prime_directory / "state",
         session_dir=prime_directory / "sessions",
@@ -198,6 +205,7 @@ async def run_prime_acp_session(
     actor_environment: Mapping[str, str],
     isolation: PrimeAcpIsolation,
     limits: PrimeAcpLimits,
+    runtime_directory: Path | None = None,
     private_paths: Sequence[Path] = (),
     executable: str = "prime-agent",
     environment: Mapping[str, str] | None = None,
@@ -207,6 +215,11 @@ async def run_prime_acp_session(
     acp_schema = importlib.import_module("acp.schema")
     actor_workspace = actor_workspace.resolve()
     evidence_directory = evidence_directory.resolve()
+    selected_runtime_directory = None if runtime_directory is None else runtime_directory.resolve()
+    if selected_runtime_directory is not None and (
+        selected_runtime_directory == actor_workspace or not selected_runtime_directory.is_relative_to(actor_workspace)
+    ):
+        raise PrimeAcpIsolationError("Prime runtime directory must be a child of the actor workspace")
     if any(directory.is_symlink() for directory in skill_directories):
         raise PrimeAcpIsolationError("Prime explicit skill directories must not be symbolic links")
     resolved_skill_directories = tuple(directory.resolve() for directory in skill_directories)
@@ -227,7 +240,11 @@ async def run_prime_acp_session(
         raise PrimeAcpIsolationError("host evidence directory must be outside the actor workspace")
 
     resolved_executable = resolve_prime_executable(executable)
-    paths = prime_acp_paths(actor_workspace, evidence_directory)
+    paths = prime_acp_paths(
+        actor_workspace,
+        evidence_directory,
+        runtime_directory=selected_runtime_directory,
+    )
     paths.state_dir.mkdir(parents=True, exist_ok=False)
     paths.session_dir.mkdir(parents=True, exist_ok=False)
     evidence_directory.mkdir(parents=True, exist_ok=True)
@@ -236,7 +253,11 @@ async def run_prime_acp_session(
 
     env = dict(os.environ if environment is None else environment)
     env.update(actor_environment)
-    runtime_home = actor_workspace / ".prime-runtime"
+    runtime_home = (
+        actor_workspace / ".prime-runtime"
+        if selected_runtime_directory is None
+        else selected_runtime_directory / "runtime-home"
+    )
     env.update(
         {
             "HOME": str(runtime_home / "home"),

--- a/src/aec_bench/prime_agent/pump_journey_evidence.py
+++ b/src/aec_bench/prime_agent/pump_journey_evidence.py
@@ -1,0 +1,222 @@
+# ABOUTME: Defines safe persisted evidence and recovery state for Prime pump journeys.
+# ABOUTME: Stores only coordination and canonical references, never hidden world or host-control content.
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Literal
+
+from pydantic import ValidationError
+
+from aec_bench.contracts.validators import FrozenStrictModel, NonEmptyStr
+from aec_bench.contracts.world_session import StewardshipStateSnapshotRef, WorldSessionOpenMode, WorldSessionRequest
+from aec_bench.prime_agent.acp import PrimeAcpIsolation
+from aec_bench.prime_agent.session_evidence import PrimeAcpUsage
+from aec_bench.prime_agent.world import PrimeWorldSessionLimits
+from aec_bench.task_world_templates.continual.durability import (
+    DurableFileReplaceError,
+    replace_file_bytes_durable,
+)
+
+CHECKPOINT_NAME = "prime-world-journey-checkpoint.json"
+RUN_NAME = "prime-world-journey.json"
+type JourneyPhase = Literal["ready", "running", "segment_ended", "control_pending", "finished"]
+
+
+class PrimeJourneyRecoveryError(RuntimeError):
+    """Raised when saved journey coordination cannot be resumed safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class PrimeJourneyLimits:
+    """Private safety limits for one complete Prime journey."""
+
+    max_sessions: int
+    max_host_controls: int
+    max_world_actions: int
+    max_model_calls: int
+    max_tokens: int
+    max_cost_usd: Decimal
+    max_wall_seconds: float
+
+    def __post_init__(self) -> None:
+        if self.max_sessions < 1:
+            raise ValueError("Prime journey max_sessions must be positive")
+        if self.max_host_controls < 1:
+            raise ValueError("Prime journey max_host_controls must be positive")
+        PrimeWorldSessionLimits(
+            max_world_actions=self.max_world_actions,
+            max_model_calls=self.max_model_calls,
+            max_tokens=self.max_tokens,
+            max_cost_usd=self.max_cost_usd,
+            max_wall_seconds=self.max_wall_seconds,
+        )
+
+
+class PrimeJourneySegment(FrozenStrictModel):
+    """Safe evidence for one closed Prime session in a journey."""
+
+    index: int
+    world_session_id: NonEmptyStr
+    prime_session_id: str | None
+    open_mode: WorldSessionOpenMode
+    start_snapshot: StewardshipStateSnapshotRef
+    end_snapshot: StewardshipStateSnapshotRef
+    prime_run: NonEmptyStr
+    world_run: NonEmptyStr
+    session_state: NonEmptyStr
+    stop_reason: str | None
+    limit_reason: str | None
+    completion: NonEmptyStr
+    usage: PrimeAcpUsage
+    elapsed_seconds: float
+    world_action_attempts: int
+    world_action_limit_reached: bool
+    benchmark_valid: bool
+
+
+class PrimeJourneyControl(FrozenStrictModel):
+    """Canonical host-control lineage without hidden control content."""
+
+    index: int
+    request_id: NonEmptyStr
+    operation: NonEmptyStr
+    parent_snapshot: StewardshipStateSnapshotRef
+    result_snapshot: StewardshipStateSnapshotRef
+
+
+class JourneyCheckpoint(FrozenStrictModel):
+    """Private current coordination state; the world repository remains causal authority."""
+
+    config_id: NonEmptyStr
+    journey_id: NonEmptyStr
+    host_policy_sha256: NonEmptyStr
+    started_at: datetime
+    phase: JourneyPhase
+    next_session: WorldSessionRequest | None
+    finished_at: datetime | None = None
+    pending_request_id: str | None = None
+    pending_parent: StewardshipStateSnapshotRef | None = None
+    segments: tuple[PrimeJourneySegment, ...] = ()
+    host_controls: tuple[PrimeJourneyControl, ...] = ()
+    completion: str | None = None
+    world_state: str | None = None
+    stop_reason: str | None = None
+
+
+def journey_config_id(
+    *,
+    session_request: WorldSessionRequest,
+    instruction: str,
+    model: str,
+    isolation: PrimeAcpIsolation,
+    limits: PrimeJourneyLimits,
+    guided: bool,
+    executable: str,
+    host_policy_sha256: str,
+) -> str:
+    payload = {
+        "session": session_request.model_dump(mode="json"),
+        "instruction_sha256": hashlib.sha256(instruction.encode("utf-8")).hexdigest(),
+        "model": model,
+        "isolation": isolation,
+        "limits": limit_payload(limits),
+        "guided": guided,
+        "executable": executable,
+        "host_policy_sha256": host_policy_sha256,
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def aggregate_usage(segments: tuple[PrimeJourneySegment, ...]) -> PrimeAcpUsage:
+    return PrimeAcpUsage(
+        complete=bool(segments) and all(segment.usage.complete for segment in segments),
+        model_calls=sum(segment.usage.model_calls for segment in segments),
+        input_tokens=sum(segment.usage.input_tokens for segment in segments),
+        output_tokens=sum(segment.usage.output_tokens for segment in segments),
+        cache_read_tokens=sum(segment.usage.cache_read_tokens for segment in segments),
+        cache_write_tokens=sum(segment.usage.cache_write_tokens for segment in segments),
+        total_tokens=sum(segment.usage.total_tokens for segment in segments),
+        cost_usd=sum((segment.usage.cost_usd for segment in segments), start=Decimal(0)),
+    )
+
+
+def elapsed_seconds(checkpoint: JourneyCheckpoint) -> float:
+    end = checkpoint.finished_at or datetime.now(UTC)
+    return max(0.0, (end - checkpoint.started_at).total_seconds())
+
+
+def limit_payload(limits: PrimeJourneyLimits) -> dict[str, int | float | str]:
+    return {
+        "max_sessions": limits.max_sessions,
+        "max_host_controls": limits.max_host_controls,
+        "max_world_actions": limits.max_world_actions,
+        "max_model_calls": limits.max_model_calls,
+        "max_tokens": limits.max_tokens,
+        "max_cost_usd": str(limits.max_cost_usd),
+        "max_wall_seconds": limits.max_wall_seconds,
+    }
+
+
+def usage_payload(usage: PrimeAcpUsage) -> dict[str, bool | int | str]:
+    return {
+        "complete": usage.complete,
+        "model_calls": usage.model_calls,
+        "input_tokens": usage.input_tokens,
+        "output_tokens": usage.output_tokens,
+        "cache_read_tokens": usage.cache_read_tokens,
+        "cache_write_tokens": usage.cache_write_tokens,
+        "total_tokens": usage.total_tokens,
+        "cost_usd": str(usage.cost_usd),
+    }
+
+
+def read_checkpoint(path: Path, config_id: str) -> JourneyCheckpoint:
+    if not path.is_file():
+        raise PrimeJourneyRecoveryError("Prime journey checkpoint does not exist")
+    try:
+        checkpoint = JourneyCheckpoint.model_validate_json(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, ValidationError) as error:
+        raise PrimeJourneyRecoveryError("Prime journey checkpoint is invalid") from error
+    if checkpoint.config_id != config_id:
+        raise PrimeJourneyRecoveryError("Prime journey resume configuration differs from its checkpoint")
+    if [segment.index for segment in checkpoint.segments] != list(range(len(checkpoint.segments))):
+        raise PrimeJourneyRecoveryError("Prime journey segment order is invalid")
+    if [control.index for control in checkpoint.host_controls] != list(range(len(checkpoint.host_controls))):
+        raise PrimeJourneyRecoveryError("Prime journey host-control order is invalid")
+    if checkpoint.phase in {"ready", "running"} and checkpoint.next_session is None:
+        raise PrimeJourneyRecoveryError("Prime journey checkpoint has no next session")
+    if checkpoint.phase == "control_pending" and (
+        checkpoint.pending_request_id is None or checkpoint.pending_parent is None
+    ):
+        raise PrimeJourneyRecoveryError("Prime journey checkpoint has no pending host control")
+    if checkpoint.phase != "control_pending" and (
+        checkpoint.pending_request_id is not None or checkpoint.pending_parent is not None
+    ):
+        raise PrimeJourneyRecoveryError("Prime journey checkpoint has an unexpected pending host control")
+    if checkpoint.phase == "finished" and None in (
+        checkpoint.finished_at,
+        checkpoint.completion,
+        checkpoint.world_state,
+        checkpoint.stop_reason,
+    ):
+        raise PrimeJourneyRecoveryError("Prime journey finished checkpoint is incomplete")
+    return checkpoint
+
+
+def write_checkpoint(path: Path, checkpoint: JourneyCheckpoint) -> None:
+    atomic_write_json(path, checkpoint.model_dump(mode="json"))
+
+
+def atomic_write_json(path: Path, payload: object) -> None:
+    encoded = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    try:
+        replace_file_bytes_durable(path.parent, path.name, encoded, host_private=True)
+    except DurableFileReplaceError as error:
+        raise PrimeJourneyRecoveryError("Prime journey evidence could not be written durably") from error

--- a/src/aec_bench/prime_agent/world.py
+++ b/src/aec_bench/prime_agent/world.py
@@ -11,7 +11,7 @@ import shutil
 import socketserver
 import tempfile
 import threading
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from decimal import Decimal
@@ -415,7 +415,10 @@ def install_aec_world_skill(actor_workspace: Path) -> Path:
     actor_workspace = actor_workspace.resolve()
     package_directory = actor_workspace / "aec_world"
     if package_directory.exists():
-        raise PrimeWorldActorProxyError("aec-world package destination already exists")
+        package_source = _packaged_skill_source("aec-world") / "src" / "aec_world"
+        if not _installed_tree_matches(package_source, package_directory):
+            raise PrimeWorldActorProxyError("aec-world package destination already exists with different content")
+        return _install_packaged_skill(actor_workspace, "aec-world")
     skill_directory = _install_packaged_skill(actor_workspace, "aec-world")
     source = _packaged_skill_source("aec-world")
     shutil.copytree(source / "src" / "aec_world", package_directory)
@@ -437,6 +440,8 @@ async def run_prime_pump_world_session(
     model: str,
     isolation: PrimeAcpIsolation,
     limits: PrimeWorldSessionLimits,
+    prime_runtime_directory: Path | None = None,
+    additional_private_paths: Sequence[Path] = (),
     pump_station_guidance: bool = False,
     executable: str = "prime-agent",
     environment: Mapping[str, str] | None = None,
@@ -472,7 +477,8 @@ async def run_prime_pump_world_session(
             actor_environment=proxy.connection_environment(),
             isolation=isolation,
             limits=limits.acp_limits(),
-            private_paths=(world_run_directory, evidence_directory),
+            runtime_directory=prime_runtime_directory,
+            private_paths=(world_run_directory, evidence_directory, *additional_private_paths),
             executable=executable,
             environment=environment,
         )
@@ -569,10 +575,30 @@ def _install_packaged_skill(actor_workspace: Path, name: str) -> Path:
     source = _packaged_skill_source(name)
     skill_directory = actor_workspace / ".prime-skills" / name
     if skill_directory.exists():
-        raise PrimeWorldActorProxyError(f"Prime skill destination already exists: {name}")
+        if not _installed_tree_matches(source, skill_directory):
+            raise PrimeWorldActorProxyError(f"Prime skill destination already exists with different content: {name}")
+        return skill_directory
     skill_directory.parent.mkdir(parents=True, exist_ok=True)
     shutil.copytree(source, skill_directory)
     return skill_directory
+
+
+def _installed_tree_matches(source: Path, destination: Path) -> bool:
+    if not destination.is_dir() or destination.is_symlink():
+        return False
+    if any(path.is_symlink() for path in destination.rglob("*")):
+        return False
+    expected = {
+        path.relative_to(source): path.read_bytes()
+        for path in source.rglob("*")
+        if path.is_file() and not path.is_symlink()
+    }
+    installed = {path.relative_to(destination): path for path in destination.rglob("*") if path.is_file()}
+    if any(relative not in expected and "__pycache__" not in relative.parts for relative in installed):
+        return False
+    return all(
+        relative in installed and installed[relative].read_bytes() == content for relative, content in expected.items()
+    )
 
 
 def _safe_operation(value: Any) -> str | None:

--- a/src/aec_bench/prime_agent/world_journey.py
+++ b/src/aec_bench/prime_agent/world_journey.py
@@ -1,0 +1,596 @@
+# ABOUTME: Composes bounded Prime pump sessions with deterministic host-owned continuation.
+# ABOUTME: Enforces journey-wide safeguards and recovers exact host controls from canonical world evidence.
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Literal
+
+from aec_bench.contracts.evaluation_result import StewardshipEvaluation
+from aec_bench.contracts.world_session import (
+    StewardshipStateSnapshotRef,
+    WorldSessionOpenMode,
+    WorldSessionRequest,
+)
+from aec_bench.prime_agent import pump_journey_evidence as journey_evidence
+from aec_bench.prime_agent.acp import PrimeAcpIsolation
+from aec_bench.prime_agent.session_evidence import PrimeAcpUsage
+from aec_bench.prime_agent.world import PrimePumpWorldRun, PrimeWorldSessionLimits, run_prime_pump_world_session
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station import host_continuation as pump_host
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.evaluation import (
+    evaluate_pump_station_reference_run,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_models import (
+    PumpStationBoundControlRequest,
+    PumpStationOperationsBoundaryReviewRequest,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_verifier import (
+    PumpStationCoupledVerificationReport,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_control import (
+    PumpStationRootControlResult,
+    PumpStationWorldControl,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run import (
+    PumpStationWorldRun,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_models import (
+    PumpStationStateSnapshotRef,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_repository import (
+    PumpStationWorldRunRepository,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_serialization import (
+    pump_station_artifact_id,
+)
+
+PrimeJourneyLimits = journey_evidence.PrimeJourneyLimits
+PrimeJourneyRecoveryError = journey_evidence.PrimeJourneyRecoveryError
+
+
+@dataclass(frozen=True, slots=True)
+class PrimePumpWorldJourneyRun:
+    """One complete or stopped pump journey with separate actor and world outcomes."""
+
+    segments: tuple[journey_evidence.PrimeJourneySegment, ...]
+    host_controls: tuple[journey_evidence.PrimeJourneyControl, ...]
+    final_snapshot: StewardshipStateSnapshotRef
+    world_state: str
+    completion: str
+    stop_reason: str
+    verification: PumpStationCoupledVerificationReport
+    evaluation: StewardshipEvaluation
+    usage: PrimeAcpUsage
+    elapsed_seconds: float
+    world_action_attempts: int
+    run_file: Path
+    benchmark_valid: bool
+
+
+async def run_prime_pump_world_journey(
+    *,
+    actor_workspace: Path,
+    world_run_directory: Path,
+    evidence_directory: Path,
+    session_request: WorldSessionRequest,
+    instruction: str,
+    model: str,
+    isolation: PrimeAcpIsolation,
+    limits: PrimeJourneyLimits,
+    pump_station_guidance: bool = False,
+    resume: bool = False,
+    executable: str = "prime-agent",
+    environment: Mapping[str, str] | None = None,
+) -> PrimePumpWorldJourneyRun:
+    """Run clean Prime sessions and exact pump-owned host continuation."""
+    actor_workspace = actor_workspace.resolve()
+    world_run_directory = world_run_directory.resolve()
+    evidence_directory = evidence_directory.resolve()
+    if any(_paths_overlap(actor_workspace, path) for path in (world_run_directory, evidence_directory)):
+        raise ValueError("actor workspace must be separate from host world and journey evidence paths")
+    if _paths_overlap(world_run_directory, evidence_directory):
+        raise ValueError("world run and journey evidence paths must be separate")
+    policy_sha256 = _host_policy_sha256()
+    config_id = journey_evidence.journey_config_id(
+        session_request=session_request,
+        instruction=instruction,
+        model=model,
+        isolation=isolation,
+        limits=limits,
+        guided=pump_station_guidance,
+        executable=executable,
+        host_policy_sha256=policy_sha256,
+    )
+    checkpoint_file = evidence_directory / journey_evidence.CHECKPOINT_NAME
+    if resume:
+        if not actor_workspace.is_dir() or not evidence_directory.is_dir():
+            raise PrimeJourneyRecoveryError("Prime journey resume paths do not exist")
+        checkpoint = journey_evidence.read_checkpoint(checkpoint_file, config_id)
+        if checkpoint.phase == "running":
+            raise PrimeJourneyRecoveryError("cannot resume a Prime session without a terminal checkpoint")
+    else:
+        actor_workspace.mkdir(parents=True, exist_ok=False)
+        evidence_directory.mkdir(parents=True, exist_ok=False)
+        checkpoint = journey_evidence.JourneyCheckpoint(
+            config_id=config_id,
+            journey_id=session_request.session_id,
+            host_policy_sha256=policy_sha256,
+            started_at=datetime.now(UTC),
+            phase="ready",
+            next_session=session_request,
+        )
+        journey_evidence.write_checkpoint(checkpoint_file, checkpoint)
+
+    control = PumpStationWorldControl(
+        world_run_directory,
+        authorised_principal_ids=(pump_host.PUMP_STATION_OPERATIONS_AUTHORITY_ID,),
+    )
+
+    def finish(
+        current: journey_evidence.JourneyCheckpoint,
+        completion: str,
+        world_state: str,
+        stop_reason: str,
+    ) -> PrimePumpWorldJourneyRun:
+        return _finish(
+            current,
+            completion=completion,
+            world_state=world_state,
+            stop_reason=stop_reason,
+            limits=limits,
+            instruction=instruction,
+            model=model,
+            isolation=isolation,
+            pump_station_guidance=pump_station_guidance,
+            world_run_directory=world_run_directory,
+            evidence_directory=evidence_directory,
+            checkpoint_file=checkpoint_file,
+        )
+
+    while True:
+        if checkpoint.phase == "finished":
+            return _result(
+                checkpoint,
+                world_run_directory=world_run_directory,
+                evidence_directory=evidence_directory,
+            )
+        if checkpoint.phase == "control_pending":
+            checkpoint, completed = _apply_pending_control(
+                checkpoint,
+                control=control,
+                world_run_directory=world_run_directory,
+                initial_session=session_request,
+            )
+            if completed:
+                return finish(checkpoint, "completed", "completed", "declared-terminal-state")
+            journey_evidence.write_checkpoint(checkpoint_file, checkpoint)
+            continue
+        if checkpoint.phase == "ready":
+            limit_reason = _journey_limit_reason(checkpoint, limits)
+            if limit_reason is not None:
+                return finish(checkpoint, "interrupted", "active", limit_reason)
+            current_request = checkpoint.next_session
+            if current_request is None:
+                raise PrimeJourneyRecoveryError("ready journey checkpoint has no next session")
+            running = checkpoint.model_copy(update={"phase": "running"})
+            journey_evidence.write_checkpoint(checkpoint_file, running)
+            index = len(checkpoint.segments)
+            runtime_directory = actor_workspace / ".prime-runtimes" / f"segment-{index:03d}"
+            segment = await run_prime_pump_world_session(
+                actor_workspace=actor_workspace,
+                world_run_directory=world_run_directory,
+                evidence_directory=evidence_directory / "segments" / f"segment-{index:03d}",
+                prime_runtime_directory=runtime_directory,
+                additional_private_paths=(evidence_directory,),
+                session_request=current_request,
+                instruction=_segment_instruction(instruction, index),
+                model=model,
+                isolation=isolation,
+                limits=_remaining_session_limits(checkpoint, limits),
+                pump_station_guidance=pump_station_guidance,
+                executable=executable,
+                environment=environment,
+            )
+            _remove_closed_prime_runtime(actor_workspace, runtime_directory)
+            run = _resume_verified_run(world_run_directory)
+            summary = _segment_summary(segment, run, index=index, evidence_directory=evidence_directory)
+            checkpoint = running.model_copy(
+                update={
+                    "phase": "segment_ended",
+                    "next_session": None,
+                    "segments": (*checkpoint.segments, summary),
+                }
+            )
+            journey_evidence.write_checkpoint(checkpoint_file, checkpoint)
+            continue
+        if checkpoint.phase != "segment_ended" or not checkpoint.segments:
+            raise PrimeJourneyRecoveryError(f"unsupported journey checkpoint phase: {checkpoint.phase}")
+
+        run = _resume_verified_run(world_run_directory)
+        stop = _segment_stop(checkpoint.segments[-1])
+        if stop is not None:
+            completion, reason = stop
+            return finish(checkpoint, completion, "active", reason)
+        decision = pump_host.resolve_pump_station_host_continuation(run)
+        if decision.status is pump_host.PumpStationJourneyStatus.COMPLETED:
+            return finish(checkpoint, "completed", "completed", decision.reason)
+        limit_reason = _journey_limit_reason(checkpoint, limits)
+        if limit_reason is not None:
+            return finish(checkpoint, "interrupted", "active", limit_reason)
+        if decision.control_request is None:
+            return finish(checkpoint, "incomplete", "active", decision.reason)
+        if len(checkpoint.host_controls) >= limits.max_host_controls:
+            return finish(checkpoint, "interrupted", "active", "max_host_controls")
+        checkpoint = checkpoint.model_copy(
+            update={
+                "phase": "control_pending",
+                "pending_request_id": decision.control_request.request_id,
+                "pending_parent": _shared_snapshot(run.snapshot()),
+            }
+        )
+        journey_evidence.write_checkpoint(checkpoint_file, checkpoint)
+
+
+def _apply_pending_control(
+    checkpoint: journey_evidence.JourneyCheckpoint,
+    *,
+    control: PumpStationWorldControl,
+    world_run_directory: Path,
+    initial_session: WorldSessionRequest,
+) -> tuple[journey_evidence.JourneyCheckpoint, bool]:
+    request = _pending_control_request(checkpoint, world_run_directory)
+    result = control.execute(request)
+    if not isinstance(result, PumpStationRootControlResult):
+        raise PrimeJourneyRecoveryError("pump host continuation returned a non-root control result")
+    parent = checkpoint.pending_parent
+    receipt = result.receipt
+    if (
+        parent is None
+        or not receipt.state_changed
+        or receipt.prior_snapshot != parent
+        or receipt.result_snapshot is None
+        or receipt.result_snapshot == parent
+    ):
+        raise PrimeJourneyRecoveryError("pump host continuation did not advance the exact canonical snapshot")
+    run = _resume_verified_run(world_run_directory)
+    result_snapshot = _shared_snapshot(run.snapshot())
+    if receipt.result_snapshot != result_snapshot:
+        raise PrimeJourneyRecoveryError("pump host continuation result differs from the selected canonical snapshot")
+    host_control = journey_evidence.PrimeJourneyControl(
+        index=len(checkpoint.host_controls),
+        request_id=receipt.request_id,
+        operation=receipt.operation,
+        parent_snapshot=parent,
+        result_snapshot=result_snapshot,
+    )
+    checkpoint = checkpoint.model_copy(
+        update={
+            "pending_request_id": None,
+            "pending_parent": None,
+            "host_controls": (*checkpoint.host_controls, host_control),
+        }
+    )
+    if pump_host.pump_station_journey_status(run.state) is pump_host.PumpStationJourneyStatus.COMPLETED:
+        return checkpoint.model_copy(update={"phase": "segment_ended"}), True
+    next_session = WorldSessionRequest(
+        execution_kind=initial_session.execution_kind,
+        open_mode=WorldSessionOpenMode.RESUME,
+        session_id=f"{initial_session.session_id}-continuation-{len(checkpoint.segments):03d}",
+        task_world_id=initial_session.task_world_id,
+        agent_tenure_id=initial_session.agent_tenure_id,
+        run_id=initial_session.run_id,
+        episode_id=initial_session.episode_id,
+        world_branch_id=initial_session.world_branch_id,
+        start_snapshot=result_snapshot,
+    )
+    return checkpoint.model_copy(update={"phase": "ready", "next_session": next_session}), False
+
+
+def _pending_control_request(
+    checkpoint: journey_evidence.JourneyCheckpoint,
+    world_run_directory: Path,
+) -> PumpStationBoundControlRequest:
+    request_id = checkpoint.pending_request_id
+    parent = checkpoint.pending_parent
+    if request_id is None or parent is None:
+        raise PrimeJourneyRecoveryError("pending host control checkpoint is incomplete")
+    repository = PumpStationWorldRunRepository(world_run_directory)
+    committed = repository.find_committed_command(request_id)
+    if committed is None:
+        run = _resume_verified_run(world_run_directory)
+        if _shared_snapshot(run.snapshot()) != parent:
+            raise PrimeJourneyRecoveryError("pending host control parent differs from the canonical snapshot")
+        decision = pump_host.resolve_pump_station_host_continuation(run)
+        if decision.control_request is None or decision.control_request.request_id != request_id:
+            raise PrimeJourneyRecoveryError("pending host control cannot be reproduced from its parent snapshot")
+        return decision.control_request
+    matching = tuple(step.command for step in repository.command_steps() if step.command.request_id == request_id)
+    if len(matching) != 1:
+        raise PrimeJourneyRecoveryError("pending host control has no unique canonical command")
+    command = matching[0]
+    if command.kind != "operations_review" or not isinstance(
+        command.control, PumpStationOperationsBoundaryReviewRequest
+    ):
+        raise PrimeJourneyRecoveryError("pending host control differs from the pump continuation policy")
+    return PumpStationBoundControlRequest(
+        request_id=command.request_id,
+        run_id=command.run_id,
+        episode_id=command.episode_id,
+        world_branch_id=command.world_branch_id,
+        base_state_id=command.base_state_id,
+        base_commit_id=command.base_commit_id,
+        based_on_sequence=command.based_on_sequence,
+        control=command.control,
+    )
+
+
+def _segment_summary(
+    segment: PrimePumpWorldRun,
+    run: PumpStationWorldRun,
+    *,
+    index: int,
+    evidence_directory: Path,
+) -> journey_evidence.PrimeJourneySegment:
+    return journey_evidence.PrimeJourneySegment(
+        index=index,
+        world_session_id=segment.world_session.session_id,
+        prime_session_id=segment.prime.session_id,
+        open_mode=segment.world_session.open_mode,
+        start_snapshot=segment.world_session.snapshot,
+        end_snapshot=_shared_snapshot(run.snapshot()),
+        prime_run=segment.prime.paths.run_file.relative_to(evidence_directory).as_posix(),
+        world_run=segment.run_file.relative_to(evidence_directory).as_posix(),
+        session_state=segment.prime.session_state,
+        stop_reason=segment.prime.stop_reason,
+        limit_reason=segment.prime.limit_reason,
+        completion=segment.completion,
+        usage=segment.prime.usage,
+        elapsed_seconds=segment.prime.elapsed_seconds,
+        world_action_attempts=segment.world_action_attempts,
+        world_action_limit_reached=segment.world_action_limit_reached,
+        benchmark_valid=segment.benchmark_valid,
+    )
+
+
+def _segment_stop(segment: journey_evidence.PrimeJourneySegment) -> tuple[str, str] | None:
+    if segment.session_state == "failed" or segment.completion == "failed":
+        return "failed", "prime-session-failed"
+    if segment.limit_reason is not None:
+        return "interrupted", segment.limit_reason
+    if segment.world_action_limit_reached:
+        return "interrupted", "max_world_actions"
+    if segment.session_state == "cancelled" or segment.stop_reason == "cancelled":
+        return "interrupted", "cancelled"
+    if segment.stop_reason in {"max_tokens", "max_turn_requests"}:
+        return "interrupted", segment.stop_reason
+    if segment.stop_reason != "end_turn":
+        return "failed", "unsupported-prime-stop-reason"
+    if segment.completion in {"interrupted", "truncated"}:
+        return "interrupted", "prime-session-interrupted"
+    return None
+
+
+def _finish(
+    checkpoint: journey_evidence.JourneyCheckpoint,
+    *,
+    completion: str,
+    world_state: str,
+    stop_reason: str,
+    limits: PrimeJourneyLimits,
+    instruction: str,
+    model: str,
+    isolation: PrimeAcpIsolation,
+    pump_station_guidance: bool,
+    world_run_directory: Path,
+    evidence_directory: Path,
+    checkpoint_file: Path,
+) -> PrimePumpWorldJourneyRun:
+    finished = checkpoint.model_copy(
+        update={
+            "phase": "finished",
+            "finished_at": datetime.now(UTC),
+            "next_session": None,
+            "completion": completion,
+            "world_state": world_state,
+            "stop_reason": stop_reason,
+        }
+    )
+    _write_run_evidence(
+        finished,
+        limits=limits,
+        instruction=instruction,
+        model=model,
+        isolation=isolation,
+        pump_station_guidance=pump_station_guidance,
+        world_run_directory=world_run_directory,
+        evidence_directory=evidence_directory,
+    )
+    journey_evidence.write_checkpoint(checkpoint_file, finished)
+    return _result(finished, world_run_directory=world_run_directory, evidence_directory=evidence_directory)
+
+
+def _result(
+    checkpoint: journey_evidence.JourneyCheckpoint,
+    *,
+    world_run_directory: Path,
+    evidence_directory: Path,
+) -> PrimePumpWorldJourneyRun:
+    if checkpoint.phase != "finished" or None in (
+        checkpoint.completion,
+        checkpoint.world_state,
+        checkpoint.stop_reason,
+    ):
+        raise PrimeJourneyRecoveryError("journey result requires a finished checkpoint")
+    run = _resume_verified_run(world_run_directory)
+    verification = run.verify()
+    world_state = str(checkpoint.world_state)
+    evaluation = evaluate_pump_station_reference_run(
+        run,
+        evaluation_scope="complete_journey" if world_state == "completed" else "bounded_continuation",
+    )
+    usage = journey_evidence.aggregate_usage(checkpoint.segments)
+    return PrimePumpWorldJourneyRun(
+        segments=checkpoint.segments,
+        host_controls=checkpoint.host_controls,
+        final_snapshot=_shared_snapshot(run.snapshot()),
+        world_state=world_state,
+        completion=str(checkpoint.completion),
+        stop_reason=str(checkpoint.stop_reason),
+        verification=verification,
+        evaluation=evaluation,
+        usage=usage,
+        elapsed_seconds=journey_evidence.elapsed_seconds(checkpoint),
+        world_action_attempts=sum(segment.world_action_attempts for segment in checkpoint.segments),
+        run_file=evidence_directory / journey_evidence.RUN_NAME,
+        benchmark_valid=(
+            bool(checkpoint.segments)
+            and all(segment.benchmark_valid for segment in checkpoint.segments)
+            and verification.valid
+        ),
+    )
+
+
+def _write_run_evidence(
+    checkpoint: journey_evidence.JourneyCheckpoint,
+    *,
+    limits: PrimeJourneyLimits,
+    instruction: str,
+    model: str,
+    isolation: PrimeAcpIsolation,
+    pump_station_guidance: bool,
+    world_run_directory: Path,
+    evidence_directory: Path,
+) -> None:
+    run = _resume_verified_run(world_run_directory)
+    usage = journey_evidence.aggregate_usage(checkpoint.segments)
+    final_snapshot = _shared_snapshot(run.snapshot())
+    evaluation_scope: Literal["complete_journey", "bounded_continuation"] = (
+        "complete_journey" if checkpoint.world_state == "completed" else "bounded_continuation"
+    )
+    evaluation = evaluate_pump_station_reference_run(run, evaluation_scope=evaluation_scope)
+    payload = {
+        "schema": "aecbench.prime-world-journey.v1",
+        "journey_id": checkpoint.journey_id,
+        "config_id": checkpoint.config_id,
+        "instruction_sha256": hashlib.sha256(instruction.encode("utf-8")).hexdigest(),
+        "model_requested": model,
+        "treatment": "guided" if pump_station_guidance else "open",
+        "isolation": isolation,
+        "actor_principal_scope": "prime-journey-composite",
+        "actor_workspace_continuity": "shared_actor_files_fresh_prime_runtime",
+        "host_policy_sha256": checkpoint.host_policy_sha256,
+        "safeguards": journey_evidence.limit_payload(limits),
+        "world_manifest_content_id": pump_station_artifact_id(run.manifest),
+        "initial_snapshot": checkpoint.segments[0].start_snapshot.model_dump(mode="json"),
+        "segments": [segment.model_dump(mode="json") for segment in checkpoint.segments],
+        "host_controls": [control.model_dump(mode="json") for control in checkpoint.host_controls],
+        "totals": journey_evidence.usage_payload(usage),
+        "elapsed_seconds": journey_evidence.elapsed_seconds(checkpoint),
+        "world_action_attempts": sum(segment.world_action_attempts for segment in checkpoint.segments),
+        "world_state": checkpoint.world_state,
+        "completion": checkpoint.completion,
+        "stop_reason": checkpoint.stop_reason,
+        "evaluation_scope": evaluation_scope,
+        "evaluation_valid": evaluation.valid,
+        "benchmark_valid": (
+            bool(checkpoint.segments)
+            and all(segment.benchmark_valid for segment in checkpoint.segments)
+            and run.verify().valid
+        ),
+        "final_snapshot": final_snapshot.model_dump(mode="json"),
+    }
+    journey_evidence.atomic_write_json(evidence_directory / journey_evidence.RUN_NAME, payload)
+
+
+def _journey_limit_reason(
+    checkpoint: journey_evidence.JourneyCheckpoint,
+    limits: PrimeJourneyLimits,
+) -> str | None:
+    usage = journey_evidence.aggregate_usage(checkpoint.segments)
+    if len(checkpoint.segments) >= limits.max_sessions:
+        return "max_sessions"
+    if sum(segment.world_action_attempts for segment in checkpoint.segments) >= limits.max_world_actions:
+        return "max_world_actions"
+    if usage.model_calls >= limits.max_model_calls:
+        return "max_model_calls"
+    if usage.total_tokens >= limits.max_tokens:
+        return "max_tokens"
+    if usage.cost_usd >= limits.max_cost_usd:
+        return "max_cost_usd"
+    if journey_evidence.elapsed_seconds(checkpoint) >= limits.max_wall_seconds:
+        return "max_wall_seconds"
+    return None
+
+
+def _remaining_session_limits(
+    checkpoint: journey_evidence.JourneyCheckpoint,
+    limits: PrimeJourneyLimits,
+) -> PrimeWorldSessionLimits:
+    usage = journey_evidence.aggregate_usage(checkpoint.segments)
+    return PrimeWorldSessionLimits(
+        max_world_actions=limits.max_world_actions
+        - sum(segment.world_action_attempts for segment in checkpoint.segments),
+        max_model_calls=limits.max_model_calls - usage.model_calls,
+        max_tokens=limits.max_tokens - usage.total_tokens,
+        max_cost_usd=limits.max_cost_usd - usage.cost_usd,
+        max_wall_seconds=limits.max_wall_seconds - journey_evidence.elapsed_seconds(checkpoint),
+    )
+
+
+def _segment_instruction(instruction: str, segment_index: int) -> str:
+    if segment_index == 0:
+        return instruction
+    return (
+        instruction.rstrip()
+        + "\n\n"
+        + f"This is continuation segment {segment_index}. Reuse the actor-owned ledger, compact state, "
+        "calculations, and handover files already in this workspace. The host may have advanced an authorised "
+        "boundary while Prime was closed. Call observe before acting and use only the new actor-visible evidence."
+    )
+
+
+def _resume_verified_run(repository_root: Path) -> PumpStationWorldRun:
+    repository = PumpStationWorldRunRepository(repository_root)
+    run = PumpStationWorldRun.resume_reference_system(repository=repository, snapshot=repository.current_snapshot())
+    if not run.verify().valid:
+        raise PrimeJourneyRecoveryError("pump world canonical replay or verification failed")
+    return run
+
+
+def _shared_snapshot(snapshot: PumpStationStateSnapshotRef) -> StewardshipStateSnapshotRef:
+    return StewardshipStateSnapshotRef(
+        run_id=snapshot.run_id,
+        episode_id=snapshot.episode_id,
+        world_branch_id=snapshot.world_branch_id,
+        sequence=snapshot.sequence,
+        state_id=snapshot.state_id,
+        commit_id=snapshot.commit_id,
+    )
+
+
+def _host_policy_sha256() -> str:
+    source = getattr(pump_host, "__file__", None)
+    if source is None:
+        raise PrimeJourneyRecoveryError("pump host continuation source is unavailable")
+    return hashlib.sha256(Path(source).read_bytes()).hexdigest()
+
+
+def _remove_closed_prime_runtime(actor_workspace: Path, runtime_directory: Path) -> None:
+    expected_parent = actor_workspace / ".prime-runtimes"
+    if runtime_directory.parent != expected_parent or runtime_directory.is_symlink():
+        raise PrimeJourneyRecoveryError("closed Prime runtime path is unsafe to remove")
+    if not runtime_directory.exists():
+        return
+    try:
+        shutil.rmtree(runtime_directory)
+    except OSError as error:
+        raise PrimeJourneyRecoveryError("closed Prime runtime could not be removed") from error
+
+
+def _paths_overlap(first: Path, second: Path) -> bool:
+    return first == second or first in second.parents or second in first.parents

--- a/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/host_continuation.py
+++ b/src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/host_continuation.py
@@ -1,0 +1,190 @@
+# ABOUTME: Selects exact pump-station host controls and classifies journey completion.
+# ABOUTME: Keeps Operations authority and terminal-state rules outside agents and evaluation.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.coupled_work import (
+    PumpStationBacklogItem,
+    PumpStationBacklogStatus,
+    PumpStationCoupledProcessStatus,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.physical_models import (
+    PumpStationPumpMode,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_identity import (
+    stewardship_content_id,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_models import (
+    PumpStationBoundControlRequest,
+    PumpStationEvidenceKind,
+    PumpStationObligationStatus,
+    PumpStationOperationsBoundaryReviewRequest,
+    PumpStationRestriction,
+    PumpStationRestrictionKind,
+    PumpStationRestrictionStatus,
+    PumpStationStewardshipState,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run import (
+    PumpStationWorldRun,
+)
+
+PUMP_STATION_OPERATIONS_AUTHORITY_ID = "operations-controller"
+
+_TERMINAL_BACKLOG_STATUSES = {
+    PumpStationBacklogStatus.CLOSED,
+    PumpStationBacklogStatus.CANCELLED,
+    PumpStationBacklogStatus.SUPERSEDED,
+}
+_TERMINAL_PROCESS_STATUSES = {
+    PumpStationCoupledProcessStatus.COMPLETED,
+    PumpStationCoupledProcessStatus.FAILED,
+    PumpStationCoupledProcessStatus.CANCELLED,
+}
+
+
+class PumpStationJourneyStatus(StrEnum):
+    """Task-owned runtime status independent of any model session or evaluator."""
+
+    ACTIVE = "active"
+    COMPLETED = "completed"
+
+
+@dataclass(frozen=True, slots=True)
+class PumpStationHostContinuation:
+    """One current host decision without exposing raw state to the actor."""
+
+    status: PumpStationJourneyStatus
+    control_request: PumpStationBoundControlRequest | None
+    reason: str
+
+
+def pump_station_journey_status(state: PumpStationStewardshipState) -> PumpStationJourneyStatus:
+    """Return completed only when no current task work or authority boundary remains."""
+    if state.active_restriction_ids:
+        return PumpStationJourneyStatus.ACTIVE
+    if any(process.status not in _TERMINAL_PROCESS_STATUSES for process in state.processes):
+        return PumpStationJourneyStatus.ACTIVE
+    if any(obligation.status is not PumpStationObligationStatus.FULFILLED for obligation in state.obligations):
+        return PumpStationJourneyStatus.ACTIVE
+    if any(episode.status == "open" for episode in state.outage_episodes):
+        return PumpStationJourneyStatus.ACTIVE
+    if any(_is_current_unfinished_work(state, item) for item in state.backlog):
+        return PumpStationJourneyStatus.ACTIVE
+    return PumpStationJourneyStatus.COMPLETED
+
+
+def resolve_pump_station_host_continuation(
+    run: PumpStationWorldRun,
+    *,
+    authority_id: str = PUMP_STATION_OPERATIONS_AUTHORITY_ID,
+) -> PumpStationHostContinuation:
+    """Select one deterministic Operations review from the canonical current state."""
+    status = pump_station_journey_status(run.state)
+    if status is PumpStationJourneyStatus.COMPLETED:
+        return PumpStationHostContinuation(status=status, control_request=None, reason="declared-terminal-state")
+    for restriction in sorted(
+        run.state.restrictions,
+        key=lambda item: (item.created_sequence, item.restriction_id),
+    ):
+        control = _eligible_review(run, restriction, authority_id=authority_id)
+        if control is not None:
+            return PumpStationHostContinuation(
+                status=status,
+                control_request=control,
+                reason="eligible-operations-review",
+            )
+    return PumpStationHostContinuation(
+        status=status,
+        control_request=None,
+        reason="actor-or-external-progress-required",
+    )
+
+
+def _is_current_unfinished_work(state: PumpStationStewardshipState, item: PumpStationBacklogItem) -> bool:
+    if item.status in _TERMINAL_BACKLOG_STATUSES:
+        return False
+    return not (
+        item.generation_rule_id == "WG-06"
+        and item.due_calendar_seconds is not None
+        and item.due_calendar_seconds > state.disclosed_through_calendar_seconds
+    )
+
+
+def _eligible_review(
+    run: PumpStationWorldRun,
+    restriction: PumpStationRestriction,
+    *,
+    authority_id: str,
+) -> PumpStationBoundControlRequest | None:
+    state = run.state
+    if restriction.status is not PumpStationRestrictionStatus.ACTIVE:
+        return None
+    if restriction.kind is PumpStationRestrictionKind.POST_MAINTENANCE_RUN_IN:
+        review_kind = "post_verification_restriction"
+        evidence_id = f"evidence-{restriction.pump_id}-verification-pass-001"
+        evidence_kind = PumpStationEvidenceKind.POST_MAINTENANCE_VERIFICATION
+        expected_mode = PumpStationPumpMode.RUN_IN_SERVICE
+        work_types = {"post_maintenance_verification"}
+        work_status = PumpStationBacklogStatus.COMPLETED
+    elif restriction.kind is PumpStationRestrictionKind.NO_INTERVENTION and restriction.restriction_id.startswith(
+        f"isolation-{restriction.pump_id}-"
+    ):
+        review_kind = "post_inspection_isolation"
+        evidence_id = f"evidence-{restriction.pump_id.removeprefix('pump-')}-inspection-no-finding-001"
+        evidence_kind = PumpStationEvidenceKind.INSPECTION
+        expected_mode = PumpStationPumpMode.ISOLATED_FOR_WORK
+        work_types = {"inspection", "collateral_duty_inspection"}
+        work_status = PumpStationBacklogStatus.CLOSED
+    else:
+        return None
+    if state.physical.boundary(restriction.pump_id).mode is not expected_mode:
+        return None
+    evidence = tuple(
+        item
+        for item in state.evidence
+        if item.evidence_id == evidence_id
+        and item.kind is evidence_kind
+        and item.pump_id == restriction.pump_id
+        and item.accepted_by is not None
+        and item.passed is True
+        and (item.health is None or item.health.accepted)
+    )
+    matching_work = tuple(
+        item
+        for item in state.backlog
+        if item.target_id == restriction.pump_id
+        and item.work_type in work_types
+        and item.status is work_status
+        and evidence_id in item.closure_evidence_ids
+    )
+    if len(evidence) != 1 or len(matching_work) != 1:
+        return None
+    snapshot = run.snapshot()
+    review_id = (
+        "operations-review-"
+        + stewardship_content_id((review_kind, restriction.pump_id, restriction.restriction_id, evidence_id))[:16]
+    )
+    review = PumpStationOperationsBoundaryReviewRequest(
+        review_id=review_id,
+        review_kind=review_kind,
+        pump_id=restriction.pump_id,
+        restriction_or_isolation_permit_id=restriction.restriction_id,
+        accepted_evidence_id=evidence_id,
+        requested_outcome="release",
+        base_state_id=snapshot.state_id,
+        operations_authority_id=authority_id,
+        reason="Release only the matched boundary after the accepted evidence.",
+    )
+    return PumpStationBoundControlRequest(
+        request_id=review_id,
+        run_id=snapshot.run_id,
+        episode_id=snapshot.episode_id,
+        world_branch_id=snapshot.world_branch_id,
+        base_state_id=snapshot.state_id,
+        base_commit_id=snapshot.commit_id,
+        based_on_sequence=snapshot.sequence,
+        control=review,
+    )

--- a/tests/prime_agent/test_acp.py
+++ b/tests/prime_agent/test_acp.py
@@ -50,6 +50,7 @@ Path("observed-acp.json").write_text(json.dumps({{
     "xdg_cache_home": os.environ.get("XDG_CACHE_HOME"),
     "xdg_config_home": os.environ.get("XDG_CONFIG_HOME"),
     "xdg_data_home": os.environ.get("XDG_DATA_HOME"),
+    "actor_state_exists": Path("state.json").is_file(),
 }}))
 scenario = os.environ.get("FAKE_ACP_SCENARIO", "success")
 session_dir = Path(sys.argv[sys.argv.index("--session-dir") + 1])
@@ -124,7 +125,7 @@ for line in sys.stdin:
                     "continue_operation",
                     {{"reason": "Advance the current world once."}},
                     decision_id=observation["decision_id"],
-                    request_id="fake-prime-world-action",
+                    request_id=os.environ.get("FAKE_WORLD_REQUEST_ID", "fake-prime-world-action"),
                 )
             asyncio.run(act())
         print(json.dumps({{

--- a/tests/prime_agent/test_world.py
+++ b/tests/prime_agent/test_world.py
@@ -17,6 +17,7 @@ from typing import Any, cast
 import pytest
 
 from aec_bench.contracts.world_session import (
+    StewardshipStateSnapshotRef,
     WorldSessionExecutionKind,
     WorldSessionOpenMode,
     WorldSessionRequest,
@@ -27,6 +28,7 @@ from aec_bench.prime_agent.world import (
     WORLD_ACTOR_CAPABILITY_ENV,
     WORLD_ACTOR_SOCKET_ENV,
     PrimeWorldActorProxy,
+    PrimeWorldActorProxyError,
     PrimeWorldSessionLimits,
     install_aec_world_skill,
     install_pump_station_guidance_skill,
@@ -34,6 +36,9 @@ from aec_bench.prime_agent.world import (
 )
 from aec_bench.task_world_templates.stewardship.wastewater_pump_station.episode_runtime import (
     PUMP_STATION_TASK_WORLD_ID,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_repository import (
+    PumpStationWorldRunRepository,
 )
 
 
@@ -73,6 +78,20 @@ def _raw_call(socket_path: str, payload: dict[str, Any]) -> dict[str, Any]:
         client.sendall(json.dumps(payload).encode("utf-8") + b"\n")
         response = client.makefile("rb").readline()
     return cast(dict[str, Any], json.loads(response))
+
+
+def test_reused_world_skill_rejects_nested_symbolic_links(tmp_path: Path) -> None:
+    workspace = tmp_path / "actor-workspace"
+    workspace.mkdir()
+    install_aec_world_skill(workspace)
+    package_file = workspace / "aec_world" / "__init__.py"
+    matching_file = workspace / "matching.py"
+    matching_file.write_bytes(package_file.read_bytes())
+    package_file.unlink()
+    package_file.symlink_to(matching_file)
+
+    with pytest.raises(PrimeWorldActorProxyError, match="different content"):
+        install_aec_world_skill(workspace)
 
 
 @pytest.mark.asyncio
@@ -365,6 +384,74 @@ async def test_explicit_guided_treatment_adds_only_the_ordered_skill_and_instruc
     assert all(argument not in serialized_provenance for argument in skill_arguments)
     assert result.verification.valid
     assert result.evaluation.evaluation_scope == "bounded_continuation"
+
+
+@pytest.mark.asyncio
+async def test_repeated_prime_sessions_share_actor_files_but_not_prime_runtime(tmp_path: Path) -> None:
+    from tests.prime_agent.test_acp import _fake_prime_agent
+
+    actor_workspace = tmp_path / "actor"
+    world_directory = tmp_path / "private-world"
+    executable = str(_fake_prime_agent(tmp_path))
+    first_runtime = actor_workspace / ".prime-runtimes" / "segment-000"
+    first = await run_prime_pump_world_session(
+        actor_workspace=actor_workspace,
+        world_run_directory=world_directory,
+        evidence_directory=tmp_path / "host-evidence-000",
+        prime_runtime_directory=first_runtime,
+        session_request=_session_request(),
+        instruction="Advance the current world, then save your actor-owned state.",
+        model="anthropic/test",
+        isolation=PrimeAcpIsolation.DEVELOPMENT_SAME_USER,
+        limits=_limits(),
+        executable=executable,
+        environment={**os.environ, "FAKE_ACP_SCENARIO": "world", "FAKE_WORLD_REQUEST_ID": "segment-000-action"},
+    )
+    (actor_workspace / "state.json").write_text('{"retained":true}\n', encoding="utf-8")
+    first_observed = json.loads((actor_workspace / "observed-acp.json").read_text(encoding="utf-8"))
+
+    snapshot = PumpStationWorldRunRepository(world_directory).current_snapshot()
+    second_runtime = actor_workspace / ".prime-runtimes" / "segment-001"
+    second = await run_prime_pump_world_session(
+        actor_workspace=actor_workspace,
+        world_run_directory=world_directory,
+        evidence_directory=tmp_path / "host-evidence-001",
+        prime_runtime_directory=second_runtime,
+        session_request=WorldSessionRequest(
+            execution_kind=WorldSessionExecutionKind.STEWARDSHIP,
+            open_mode=WorldSessionOpenMode.RESUME,
+            session_id="prime-session-001",
+            task_world_id=PUMP_STATION_TASK_WORLD_ID,
+            agent_tenure_id="prime-composite-actor",
+            run_id=snapshot.run_id,
+            episode_id=snapshot.episode_id,
+            world_branch_id=snapshot.world_branch_id,
+            start_snapshot=StewardshipStateSnapshotRef(
+                run_id=snapshot.run_id,
+                episode_id=snapshot.episode_id,
+                world_branch_id=snapshot.world_branch_id,
+                sequence=snapshot.sequence,
+                state_id=snapshot.state_id,
+                commit_id=snapshot.commit_id,
+            ),
+        ),
+        instruction="Continue from the actor-owned files and current observation.",
+        model="anthropic/test",
+        isolation=PrimeAcpIsolation.DEVELOPMENT_SAME_USER,
+        limits=_limits(),
+        executable=executable,
+        environment={**os.environ, "FAKE_ACP_SCENARIO": "world", "FAKE_WORLD_REQUEST_ID": "segment-001-action"},
+    )
+    second_observed = json.loads((actor_workspace / "observed-acp.json").read_text(encoding="utf-8"))
+
+    assert first.prime.session_state == second.prime.session_state == "ended"
+    assert first_observed["actor_state_exists"] is False
+    assert second_observed["actor_state_exists"] is True
+    assert Path(first_observed["home"]).is_relative_to(first_runtime)
+    assert Path(second_observed["home"]).is_relative_to(second_runtime)
+    assert first.prime.paths.state_dir != second.prime.paths.state_dir
+    assert first.prime.paths.session_dir != second.prime.paths.session_dir
+    assert (actor_workspace / "state.json").read_text(encoding="utf-8") == '{"retained":true}\n'
 
 
 @pytest.mark.asyncio

--- a/tests/prime_agent/test_world_journey.py
+++ b/tests/prime_agent/test_world_journey.py
@@ -1,0 +1,609 @@
+# ABOUTME: Proves Prime pump journeys alternate isolated actor sessions with host-owned controls.
+# ABOUTME: Covers actor-workspace continuity, exact resume snapshots, replay, and final evidence.
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from pydantic import JsonValue
+
+from aec_bench.contracts.world_interface import WorldActorActionRequest
+from aec_bench.contracts.world_session import WorldSessionRequest
+from aec_bench.prime_agent import pump_journey_evidence as journey_evidence
+from aec_bench.prime_agent.acp import PrimeAcpIsolation, PrimeAcpPaths, PrimeAcpRun
+from aec_bench.prime_agent.session_evidence import PrimeAcpRefinement, PrimeAcpTopology, PrimeAcpUsage
+from aec_bench.prime_agent.world import PrimePumpWorldRun, PrimeWorldSessionLimits
+from aec_bench.prime_agent.world_journey import (
+    PrimeJourneyLimits,
+    PrimeJourneyRecoveryError,
+    run_prime_pump_world_journey,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.coupled_work import (
+    PumpStationBacklogStatus,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.episode_runtime import (
+    PumpStationEpisodeHost,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.evaluation import (
+    evaluate_pump_station_reference_run,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run import (
+    PumpStationWorldRun,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_repository import (
+    PumpStationWorldRunRepository,
+)
+from tests.prime_agent.test_world import _session_request
+
+
+def _journey_limits(**overrides: object) -> PrimeJourneyLimits:
+    values: dict[str, object] = {
+        "max_sessions": 4,
+        "max_host_controls": 4,
+        "max_world_actions": 100,
+        "max_model_calls": 10,
+        "max_tokens": 1_000,
+        "max_cost_usd": Decimal("10"),
+        "max_wall_seconds": 300.0,
+    }
+    values.update(overrides)
+    return PrimeJourneyLimits(**values)  # type: ignore[arg-type]
+
+
+def _act(host: PumpStationEpisodeHost, request_id: str, action_name: str, **arguments: object) -> None:
+    observation = host.observe()
+    result = host.invoke(
+        WorldActorActionRequest(
+            request_id=request_id,
+            decision_id=observation.decision_id,
+            action_name=action_name,
+            arguments=cast(
+                dict[str, JsonValue],
+                {"reason": f"Complete {request_id} under the visible service plan.", **arguments},
+            ),
+        )
+    )
+    assert result.status == "applied"
+
+
+def _continue_to(host: PumpStationEpisodeHost, run: PumpStationWorldRun, target: int) -> None:
+    while run.state.calendar_seconds < target:
+        _act(host, f"continue-{run.snapshot().sequence + 1}", "continue_operation")
+    assert run.state.calendar_seconds == target
+
+
+def _item_id(run: PumpStationWorldRun, rule_id: str, target_id: str) -> str:
+    matching = tuple(
+        item.item_id
+        for item in run.state.backlog
+        if item.generation_rule_id == rule_id
+        and item.target_id == target_id
+        and item.status in {PumpStationBacklogStatus.OPEN, PumpStationBacklogStatus.PLANNED}
+    )
+    assert len(matching) == 1
+    return matching[0]
+
+
+def _run_actor_segment(repository_root: Path, index: int) -> int:
+    repository = PumpStationWorldRunRepository(repository_root)
+    run = PumpStationWorldRun.resume_reference_system(repository=repository, snapshot=repository.current_snapshot())
+    host = PumpStationEpisodeHost(repository_root)
+    before = run.snapshot().sequence
+    if index == 0:
+        _act(
+            host,
+            "a-verification",
+            "request_post_maintenance_verification",
+            pump_id="pump-a",
+            backlog_item_id="backlog-a-verification-001",
+        )
+        _continue_to(host, run, 50_400)
+    elif index == 1:
+        _continue_to(host, run, 64_800)
+        _act(host, "assign-a-c", "request_duty_assignment", ordered_pump_ids=["pump-a", "pump-c"])
+        _continue_to(host, run, 108_000)
+        _act(
+            host,
+            "b-clearance",
+            "request_obstruction_clearance",
+            pump_id="pump-b",
+            backlog_item_id="backlog-b-clearance-001",
+            inspection_evidence_id="initial-b-inspection-accepted",
+        )
+        _continue_to(host, run, 122_400)
+        _act(
+            host,
+            "b-functional",
+            "request_functional_check",
+            pump_id="pump-b",
+            backlog_item_id=_item_id(run, "WG-03", "pump-b"),
+        )
+        _continue_to(host, run, 126_000)
+        _act(
+            host,
+            "b-provisional-return",
+            "request_provisional_return",
+            pump_id="pump-b",
+            functional_check_evidence_id="evidence-b-functional-check-pass-001",
+        )
+        _act(host, "b-provisional-closure", "request_provisional_closure", work_order_id="work-order-b-001")
+        _act(
+            host,
+            "b-verification",
+            "request_post_maintenance_verification",
+            pump_id="pump-b",
+            backlog_item_id=_item_id(run, "WG-04", "pump-b"),
+        )
+        _continue_to(host, run, 154_800)
+    elif index == 2:
+        _continue_to(host, run, 194_400)
+        _act(host, "assign-a-b", "request_duty_assignment", ordered_pump_ids=["pump-a", "pump-b"])
+        _act(
+            host,
+            "c-inspection",
+            "request_inspection",
+            pump_id="pump-c",
+            backlog_item_id=_item_id(run, "WG-07", "pump-c"),
+        )
+        _continue_to(host, run, 223_200)
+    else:
+        raise AssertionError(f"unexpected actor segment {index}")
+    return run.snapshot().sequence - before
+
+
+def _fake_prime_run(
+    *,
+    evidence_directory: Path,
+    runtime_directory: Path,
+    isolation: PrimeAcpIsolation,
+    limits: PrimeWorldSessionLimits,
+    index: int,
+    session_state: str = "ended",
+    stop_reason: str = "end_turn",
+    limit_reason: str | None = None,
+) -> PrimeAcpRun:
+    evidence_directory.mkdir(parents=True, exist_ok=True)
+    runtime_directory.mkdir(parents=True, exist_ok=True)
+    paths = PrimeAcpPaths(
+        state_dir=runtime_directory / "state",
+        session_dir=runtime_directory / "sessions",
+        inbound_file=evidence_directory / "prime-acp-in.jsonl",
+        outbound_file=evidence_directory / "prime-acp-out.jsonl",
+        stderr_file=evidence_directory / "prime-stderr.log",
+        run_file=evidence_directory / "prime-run.json",
+    )
+    for path in (paths.inbound_file, paths.outbound_file, paths.stderr_file):
+        path.write_text("", encoding="utf-8")
+    paths.run_file.write_text("{}\n", encoding="utf-8")
+    now = datetime.now(UTC)
+    return PrimeAcpRun(
+        command=("fake-prime",),
+        prime_version="0.7.0",
+        paths=paths,
+        started_at=now,
+        finished_at=now,
+        elapsed_seconds=1.0,
+        exit_code=0,
+        session_id=f"fake-prime-{index}",
+        protocol_version=1,
+        agent_name="prime-agent",
+        agent_version="0.7.0",
+        agent_capabilities={},
+        limits=limits.acp_limits(),
+        usage=PrimeAcpUsage(
+            complete=True,
+            model_calls=1,
+            input_tokens=10,
+            output_tokens=5,
+            cache_read_tokens=2,
+            cache_write_tokens=3,
+            total_tokens=20,
+            cost_usd=Decimal("0.25"),
+        ),
+        topology=PrimeAcpTopology(root_sessions=1, child_sessions=0),
+        refinement=PrimeAcpRefinement(events=0, completed=0, failed=0, unknown=0),
+        limit_reason=limit_reason,
+        session_state=session_state,
+        stop_reason=stop_reason,
+        timed_out=False,
+        benchmark_valid=True,
+        isolation=isolation,
+        updates=(),
+        error=None,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("world_path", "evidence_path"),
+    [
+        ("host", "host/evidence"),
+        ("host/world", "host"),
+    ],
+)
+async def test_journey_keeps_world_repository_and_evidence_separate(
+    tmp_path: Path,
+    world_path: str,
+    evidence_path: str,
+) -> None:
+    with pytest.raises(ValueError, match="world run and journey evidence paths must be separate"):
+        await run_prime_pump_world_journey(
+            actor_workspace=tmp_path / "actor",
+            world_run_directory=tmp_path / world_path,
+            evidence_directory=tmp_path / evidence_path,
+            session_request=_session_request(),
+            instruction="Complete the pump-station stewardship task.",
+            model="anthropic/test",
+            isolation=PrimeAcpIsolation.MACOS_SANDBOX,
+            limits=_journey_limits(),
+        )
+
+
+def _fake_segment_result(
+    kwargs: dict[str, Any],
+    *,
+    index: int,
+    make_progress: bool,
+    session_state: str = "ended",
+    stop_reason: str = "end_turn",
+    limit_reason: str | None = None,
+    world_action_limit_reached: bool = False,
+) -> PrimePumpWorldRun:
+    actor_workspace = Path(kwargs["actor_workspace"])
+    session_request = cast(WorldSessionRequest, kwargs["session_request"])
+    repository_root = Path(kwargs["world_run_directory"])
+    world_session = PumpStationEpisodeHost(repository_root).open(session_request)
+    action_count = _run_actor_segment(repository_root, index) if make_progress else 0
+    repository = PumpStationWorldRunRepository(repository_root)
+    run = PumpStationWorldRun.resume_reference_system(repository=repository, snapshot=repository.current_snapshot())
+    verification = run.verify()
+    evidence_directory = Path(kwargs["evidence_directory"])
+    evidence_directory.mkdir(parents=True, exist_ok=True)
+    actor_transport = evidence_directory / "world-actor-transport.jsonl"
+    actor_transport.write_text("", encoding="utf-8")
+    run_file = evidence_directory / "prime-world-run.json"
+    run_file.write_text("{}\n", encoding="utf-8")
+    prime = _fake_prime_run(
+        evidence_directory=evidence_directory,
+        runtime_directory=Path(kwargs["prime_runtime_directory"]),
+        isolation=cast(PrimeAcpIsolation, kwargs["isolation"]),
+        limits=cast(PrimeWorldSessionLimits, kwargs["limits"]),
+        index=index,
+        session_state=session_state,
+        stop_reason=stop_reason,
+        limit_reason=limit_reason,
+    )
+    assert actor_workspace.is_dir()
+    return PrimePumpWorldRun(
+        prime=prime,
+        world_session=world_session,
+        world_state="active",
+        completion="incomplete",
+        verification=verification,
+        evaluation=evaluate_pump_station_reference_run(run, evaluation_scope="bounded_continuation"),
+        actor_transport_file=actor_transport,
+        run_file=run_file,
+        world_action_attempts=action_count,
+        world_action_limit_reached=world_action_limit_reached,
+        benchmark_valid=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_complete_journey_preserves_actor_workspace_and_keeps_host_controls_outside_prime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import aec_bench.prime_agent.world_journey as journey_module
+
+    calls: list[dict[str, Any]] = []
+
+    async def fake_session_runner(**kwargs: Any) -> PrimePumpWorldRun:
+        index = len(calls)
+        calls.append(kwargs)
+        actor_workspace = Path(kwargs["actor_workspace"])
+        runtime_directory = Path(kwargs["prime_runtime_directory"])
+        if index > 0:
+            previous_runtime = actor_workspace / ".prime-runtimes" / f"segment-{index - 1:03d}"
+            assert not previous_runtime.exists()
+        runtime_directory.mkdir(parents=True)
+        runtime_target = runtime_directory / "python-runtime"
+        runtime_target.write_text("runtime\n", encoding="utf-8")
+        (runtime_directory / "python").symlink_to(runtime_target)
+        if index == 0:
+            (actor_workspace / "state.json").write_text('{"segment":0}\n', encoding="utf-8")
+        else:
+            assert (actor_workspace / "state.json").read_text(encoding="utf-8") == '{"segment":0}\n'
+            assert "continuation segment" in str(kwargs["instruction"]).lower()
+        return _fake_segment_result(kwargs, index=index, make_progress=True)
+
+    monkeypatch.setattr(journey_module, "run_prime_pump_world_session", fake_session_runner)
+    result = await run_prime_pump_world_journey(
+        actor_workspace=tmp_path / "actor",
+        world_run_directory=tmp_path / "private-world",
+        evidence_directory=tmp_path / "host-evidence",
+        session_request=_session_request(),
+        instruction="Complete the pump-station stewardship task.",
+        model="anthropic/test",
+        isolation=PrimeAcpIsolation.MACOS_SANDBOX,
+        limits=_journey_limits(),
+    )
+
+    assert result.completion == "completed"
+    assert result.world_state == "completed"
+    assert len(result.segments) == 3
+    assert len(result.host_controls) == 3
+    assert result.verification.valid
+    assert result.evaluation.valid
+    assert result.evaluation.evaluation_scope == "complete_journey"
+    assert result.usage.complete
+    assert result.usage.model_calls == 3
+    assert result.usage.total_tokens == 60
+    assert result.usage.cost_usd == Decimal("0.75")
+    assert result.benchmark_valid
+    assert all(call["actor_workspace"] == tmp_path / "actor" for call in calls)
+    assert len({call["prime_runtime_directory"] for call in calls}) == 3
+    requests = [cast(WorldSessionRequest, call["session_request"]) for call in calls]
+    assert requests[0].open_mode.value == "start"
+    assert [request.open_mode.value for request in requests[1:]] == ["resume", "resume"]
+    assert len({request.session_id for request in requests}) == 3
+    assert {request.agent_tenure_id for request in requests} == {"prime-composite-actor"}
+    assert all(request.start_snapshot is not None for request in requests[1:])
+    assert (tmp_path / "actor" / "state.json").read_text(encoding="utf-8") == '{"segment":0}\n'
+    assert not any(Path(call["prime_runtime_directory"]).exists() for call in calls)
+    session_limits = [cast(PrimeWorldSessionLimits, call["limits"]) for call in calls]
+    assert [limit.max_model_calls for limit in session_limits] == [10, 9, 8]
+    assert [limit.max_tokens for limit in session_limits] == [1_000, 980, 960]
+    assert [limit.max_cost_usd for limit in session_limits] == [Decimal("10"), Decimal("9.75"), Decimal("9.50")]
+    assert (
+        session_limits[0].max_world_actions > session_limits[1].max_world_actions > session_limits[2].max_world_actions
+    )
+
+    evidence = json.loads(result.run_file.read_text(encoding="utf-8"))
+    serialized = json.dumps(evidence)
+    assert evidence["schema"] == "aecbench.prime-world-journey.v1"
+    assert evidence["actor_principal_scope"] == "prime-journey-composite"
+    assert len(evidence["segments"]) == 3
+    assert len(evidence["host_controls"]) == 3
+    assert evidence["host_policy_sha256"]
+    assert evidence["segments"][0]["end_snapshot"]
+    assert evidence["host_controls"][0]["parent_snapshot"]
+    assert str(tmp_path) not in serialized
+    assert "operations-controller" not in serialized
+    checkpoint = (tmp_path / "host-evidence" / "prime-world-journey-checkpoint.json").read_text(encoding="utf-8")
+    assert str(tmp_path) not in checkpoint
+    assert "operations-controller" not in checkpoint
+
+
+@pytest.mark.asyncio
+async def test_journey_stops_incomplete_when_no_deterministic_host_control_exists(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import aec_bench.prime_agent.world_journey as journey_module
+
+    async def no_progress_runner(**kwargs: Any) -> PrimePumpWorldRun:
+        return _fake_segment_result(kwargs, index=0, make_progress=False)
+
+    monkeypatch.setattr(journey_module, "run_prime_pump_world_session", no_progress_runner)
+    result = await run_prime_pump_world_journey(
+        actor_workspace=tmp_path / "actor",
+        world_run_directory=tmp_path / "private-world",
+        evidence_directory=tmp_path / "host-evidence",
+        session_request=_session_request(),
+        instruction="Complete the pump-station stewardship task.",
+        model="anthropic/test",
+        isolation=PrimeAcpIsolation.MACOS_SANDBOX,
+        limits=_journey_limits(),
+    )
+
+    assert result.completion == "incomplete"
+    assert result.world_state == "active"
+    assert len(result.segments) == 1
+    assert result.host_controls == ()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("stop_reason", "limit_reason", "session_state", "world_action_limit_reached", "expected_reason"),
+    [
+        ("max_tokens", None, "ended", False, "max_tokens"),
+        ("max_turn_requests", None, "ended", False, "max_turn_requests"),
+        ("end_turn", "max_tokens", "ended", False, "max_tokens"),
+        ("end_turn", None, "ended", True, "max_world_actions"),
+        ("cancelled", None, "cancelled", False, "cancelled"),
+    ],
+)
+async def test_host_control_requires_a_clean_prime_end(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    stop_reason: str,
+    limit_reason: str | None,
+    session_state: str,
+    world_action_limit_reached: bool,
+    expected_reason: str,
+) -> None:
+    import aec_bench.prime_agent.world_journey as journey_module
+
+    async def stopped_runner(**kwargs: Any) -> PrimePumpWorldRun:
+        return _fake_segment_result(
+            kwargs,
+            index=0,
+            make_progress=True,
+            stop_reason=stop_reason,
+            limit_reason=limit_reason,
+            session_state=session_state,
+            world_action_limit_reached=world_action_limit_reached,
+        )
+
+    monkeypatch.setattr(journey_module, "run_prime_pump_world_session", stopped_runner)
+    result = await run_prime_pump_world_journey(
+        actor_workspace=tmp_path / "actor",
+        world_run_directory=tmp_path / "private-world",
+        evidence_directory=tmp_path / "host-evidence",
+        session_request=_session_request(),
+        instruction="Complete the pump-station stewardship task.",
+        model="anthropic/test",
+        isolation=PrimeAcpIsolation.MACOS_SANDBOX,
+        limits=_journey_limits(),
+    )
+
+    assert result.completion == "interrupted"
+    assert result.stop_reason == expected_reason
+    assert result.host_controls == ()
+    restrictions = PumpStationEpisodeHost(tmp_path / "private-world").observe().view["active_restriction_ids"]
+    assert isinstance(restrictions, list)
+    assert "restriction-a-run-in-001" in restrictions
+
+
+@pytest.mark.asyncio
+async def test_session_limit_stops_before_host_control(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import aec_bench.prime_agent.world_journey as journey_module
+
+    async def clean_runner(**kwargs: Any) -> PrimePumpWorldRun:
+        return _fake_segment_result(kwargs, index=0, make_progress=True)
+
+    monkeypatch.setattr(journey_module, "run_prime_pump_world_session", clean_runner)
+    result = await run_prime_pump_world_journey(
+        actor_workspace=tmp_path / "actor",
+        world_run_directory=tmp_path / "private-world",
+        evidence_directory=tmp_path / "host-evidence",
+        session_request=_session_request(),
+        instruction="Complete the pump-station stewardship task.",
+        model="anthropic/test",
+        isolation=PrimeAcpIsolation.MACOS_SANDBOX,
+        limits=_journey_limits(max_sessions=1),
+    )
+
+    assert result.completion == "interrupted"
+    assert result.stop_reason == "max_sessions"
+    assert result.host_controls == ()
+
+
+@pytest.mark.asyncio
+async def test_open_and_guided_journeys_use_the_same_host_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import aec_bench.prime_agent.world_journey as journey_module
+
+    calls: list[dict[str, Any]] = []
+
+    async def no_progress_runner(**kwargs: Any) -> PrimePumpWorldRun:
+        calls.append(kwargs)
+        return _fake_segment_result(kwargs, index=0, make_progress=False)
+
+    monkeypatch.setattr(journey_module, "run_prime_pump_world_session", no_progress_runner)
+    digests: list[str] = []
+    for guided in (False, True):
+        name = "guided" if guided else "open"
+        result = await run_prime_pump_world_journey(
+            actor_workspace=tmp_path / f"actor-{name}",
+            world_run_directory=tmp_path / f"world-{name}",
+            evidence_directory=tmp_path / f"evidence-{name}",
+            session_request=_session_request(),
+            instruction="Complete the pump-station stewardship task.",
+            model="anthropic/test",
+            isolation=PrimeAcpIsolation.MACOS_SANDBOX,
+            limits=_journey_limits(),
+            pump_station_guidance=guided,
+        )
+        evidence = json.loads(result.run_file.read_text(encoding="utf-8"))
+        assert evidence["treatment"] == name
+        digests.append(str(evidence["host_policy_sha256"]))
+
+    assert [call["pump_station_guidance"] for call in calls] == [False, True]
+    assert len(set(digests)) == 1
+
+
+@pytest.mark.asyncio
+async def test_resume_rejects_a_prime_session_without_a_terminal_checkpoint(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import aec_bench.prime_agent.world_journey as journey_module
+
+    async def crashed_runner(**kwargs: Any) -> PrimePumpWorldRun:
+        raise RuntimeError("simulated Prime process crash")
+
+    monkeypatch.setattr(journey_module, "run_prime_pump_world_session", crashed_runner)
+
+    async def run(*, resume: bool = False) -> Any:
+        return await run_prime_pump_world_journey(
+            actor_workspace=tmp_path / "actor",
+            world_run_directory=tmp_path / "private-world",
+            evidence_directory=tmp_path / "host-evidence",
+            session_request=_session_request(),
+            instruction="Complete the pump-station stewardship task.",
+            model="anthropic/test",
+            isolation=PrimeAcpIsolation.MACOS_SANDBOX,
+            limits=_journey_limits(),
+            resume=resume,
+        )
+
+    with pytest.raises(RuntimeError, match="simulated Prime process crash"):
+        await run()
+    with pytest.raises(PrimeJourneyRecoveryError, match="without a terminal checkpoint"):
+        await run(resume=True)
+
+
+@pytest.mark.asyncio
+async def test_resume_recovers_one_applied_host_control_without_repeating_it(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import aec_bench.prime_agent.world_journey as journey_module
+
+    calls: list[dict[str, Any]] = []
+
+    async def fake_session_runner(**kwargs: Any) -> PrimePumpWorldRun:
+        index = len(calls)
+        calls.append(kwargs)
+        return _fake_segment_result(kwargs, index=index, make_progress=True)
+
+    monkeypatch.setattr(journey_module, "run_prime_pump_world_session", fake_session_runner)
+    real_write = journey_evidence.write_checkpoint
+    crashed = False
+
+    def crash_after_control(path: Path, checkpoint: Any) -> None:
+        nonlocal crashed
+        if not crashed and checkpoint.phase == "ready" and len(checkpoint.host_controls) == 1:
+            crashed = True
+            raise RuntimeError("simulated process crash after durable host control")
+        real_write(path, checkpoint)
+
+    monkeypatch.setattr(journey_evidence, "write_checkpoint", crash_after_control)
+
+    async def run(*, resume: bool = False) -> Any:
+        return await run_prime_pump_world_journey(
+            actor_workspace=tmp_path / "actor",
+            world_run_directory=tmp_path / "private-world",
+            evidence_directory=tmp_path / "host-evidence",
+            session_request=_session_request(),
+            instruction="Complete the pump-station stewardship task.",
+            model="anthropic/test",
+            isolation=PrimeAcpIsolation.MACOS_SANDBOX,
+            limits=_journey_limits(),
+            resume=resume,
+        )
+
+    with pytest.raises(RuntimeError, match="simulated process crash"):
+        await run()
+
+    repository = PumpStationWorldRunRepository(tmp_path / "private-world")
+    applied_request_id = repository.command_steps()[-1].command.request_id
+    assert applied_request_id.startswith("operations-review-")
+    assert sum(step.command.request_id == applied_request_id for step in repository.command_steps()) == 1
+
+    monkeypatch.setattr(journey_evidence, "write_checkpoint", real_write)
+    result = await run(resume=True)
+
+    assert result.completion == "completed"
+    assert len(result.host_controls) == 3
+    assert result.host_controls[0].request_id == applied_request_id
+    assert sum(step.command.request_id == applied_request_id for step in repository.command_steps()) == 1

--- a/tests/task_world_templates/stewardship/wastewater_pump_station/test_host_continuation.py
+++ b/tests/task_world_templates/stewardship/wastewater_pump_station/test_host_continuation.py
@@ -1,0 +1,124 @@
+# ABOUTME: Proves pump-owned host continuation selects only exact eligible Operations reviews.
+# ABOUTME: Keeps runtime completion separate from Prime session end and task evaluation.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+from pydantic import JsonValue
+
+from aec_bench.contracts.world_interface import WorldActorActionRequest
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.episode_runtime import (
+    PumpStationEpisodeHost,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.host_continuation import (
+    PUMP_STATION_OPERATIONS_AUTHORITY_ID,
+    PumpStationJourneyStatus,
+    pump_station_journey_status,
+    resolve_pump_station_host_continuation,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.reference_controller import (
+    run_pump_station_reference_controller,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.stewardship_models import (
+    PumpStationOperationsBoundaryReviewRequest,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_control import (
+    PumpStationWorldControl,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run import (
+    PumpStationWorldRun,
+)
+from aec_bench.task_world_templates.stewardship.wastewater_pump_station.world_run_repository import (
+    PumpStationWorldRunRepository,
+)
+
+
+def _act(host: PumpStationEpisodeHost, request_id: str, action_name: str, **arguments: object) -> None:
+    observation = host.observe()
+    result = host.invoke(
+        WorldActorActionRequest(
+            request_id=request_id,
+            decision_id=observation.decision_id,
+            action_name=action_name,
+            arguments=cast(
+                dict[str, JsonValue],
+                {"reason": f"Complete {request_id} under the visible service plan.", **arguments},
+            ),
+        )
+    )
+    assert result.status == "applied"
+
+
+def _continue_to(host: PumpStationEpisodeHost, run: PumpStationWorldRun, target: int) -> None:
+    while run.state.calendar_seconds < target:
+        _act(host, f"continue-{run.snapshot().sequence + 1}", "continue_operation")
+    assert run.state.calendar_seconds == target
+
+
+def test_host_continuation_releases_only_a_matching_accepted_verification(tmp_path: Path) -> None:
+    repository_root = tmp_path / "world"
+    run = PumpStationWorldRun.create_reference_system(
+        repository=PumpStationWorldRunRepository(repository_root),
+        run_id="host-continuation-run",
+        episode_id="host-continuation-episode",
+        world_branch_id="host-continuation-branch",
+    )
+    host = PumpStationEpisodeHost(repository_root)
+
+    opening = resolve_pump_station_host_continuation(run)
+    assert opening.status is PumpStationJourneyStatus.ACTIVE
+    assert opening.control_request is None
+    assert "restriction-b-isolated-001" in run.state.active_restriction_ids
+
+    _act(
+        host,
+        "a-verification",
+        "request_post_maintenance_verification",
+        pump_id="pump-a",
+        backlog_item_id="backlog-a-verification-001",
+    )
+    assert resolve_pump_station_host_continuation(run).control_request is None
+    _continue_to(host, run, 50_400)
+
+    first = resolve_pump_station_host_continuation(run)
+    retry = resolve_pump_station_host_continuation(run)
+    assert first == retry
+    assert first.status is PumpStationJourneyStatus.ACTIVE
+    assert first.control_request is not None
+    assert first.control_request.authority_id == PUMP_STATION_OPERATIONS_AUTHORITY_ID
+    assert first.control_request.base_state_id == run.state.state_id
+    assert first.control_request.based_on_sequence == run.snapshot().sequence
+    review = first.control_request.control
+    assert isinstance(review, PumpStationOperationsBoundaryReviewRequest)
+    assert review.pump_id == "pump-a"
+    assert review.accepted_evidence_id == "evidence-pump-a-verification-pass-001"
+    assert review.restriction_or_isolation_permit_id == "restriction-a-run-in-001"
+
+    control = PumpStationWorldControl(
+        repository_root,
+        authorised_principal_ids=(PUMP_STATION_OPERATIONS_AUTHORITY_ID,),
+    )
+    result = control.execute(first.control_request)
+    exact_retry = control.execute(first.control_request)
+    assert exact_retry == result
+    assert result.receipt.state_changed
+    assert result.receipt.result_snapshot is not None
+    assert result.receipt.result_snapshot.state_id == run.state.state_id
+    assert "restriction-a-run-in-001" not in run.state.active_restriction_ids
+    assert resolve_pump_station_host_continuation(run).control_request is None
+
+
+def test_declared_reference_terminal_state_is_completed_without_using_evaluation(tmp_path: Path) -> None:
+    completed = run_pump_station_reference_controller(
+        tmp_path / "world",
+        run_id="completed-run",
+        episode_id="completed-episode",
+        world_branch_id="completed-branch",
+    )
+
+    assert pump_station_journey_status(completed.run.state) is PumpStationJourneyStatus.COMPLETED
+    decision = resolve_pump_station_host_continuation(completed.run)
+    assert decision.status is PumpStationJourneyStatus.COMPLETED
+    assert decision.control_request is None


### PR DESCRIPTION
## Summary

- compose fresh Prime ACP sessions into one pump-station journey
- apply at most one deterministic task-owned Operations review after each clean Prime end_turn
- keep actor files across sessions while replacing and removing each closed Prime runtime
- enforce journey-wide session, host-control, action, model-call, token, cost, and wall-time safeguards
- recover pending host controls through canonical world commands and exact retry
- preserve safe journey lineage, aggregate usage, replay, verification, and evaluation evidence
- add focused CI, architecture guidance, and public Python entry-point documentation

## Validity boundary

- The world repository remains the canonical replay authority.
- Prime never selects or applies host controls.
- Host continuation follows only a clean end_turn with no reached safeguard.
- World, evidence, and actor-workspace paths must be separate.
- The root Prime session and descendants remain one composite actor principal.
- Same-user execution remains development-only. Benchmark-valid evidence requires process and filesystem isolation.
- The private checkpoint uses the existing durable private-file replacement primitive.

## Review order

1. Host eligibility and completion: src/aec_bench/task_world_templates/stewardship/wastewater_pump_station/host_continuation.py
2. Journey orchestration: src/aec_bench/prime_agent/world_journey.py
3. Checkpoint and evidence models: src/aec_bench/prime_agent/pump_journey_evidence.py
4. Reusable session runtime changes: src/aec_bench/prime_agent/acp.py and src/aec_bench/prime_agent/world.py
5. Boundary tests and documentation

## Verification

- 58 focused Prime and pump-journey tests passed
- focused Ruff lint and format checks passed
- focused strict mypy passed
- source distribution and wheel built; both archives contain the new runtime modules
- git diff --check passed

## Paid Open Journey smoke

The replacement smoke crossed two real host boundaries and resumed in two fresh Prime sessions. Replay, verification, evaluation, secret checks, path checks, and benchmark-valid isolation passed. The world stopped incomplete for actor-or-external-progress-required; it did not claim false completion.

The paid smoke used the pre-commit working tree. The final review then added two narrow hardening changes: durable private checkpoint writes and rejection of overlapping world/evidence paths. Their targeted tests pass, but no second paid run was made for these non-model-facing changes.

## Scope

This is additive and pump-specific. It does not change Harbor, actor-interface, verifier, evaluator, or existing bounded-session behavior. It does not add Guided advice, refine, child-agent control, or an LLM-selected host policy.