### PR TITLE
feat(prime-agent): qualify refinement guidance

### DIFF
--- a/src/aec_bench/harness/pump_station_prime/session.py
+++ b/src/aec_bench/harness/pump_station_prime/session.py
@@ -15,7 +15,7 @@ from aec_bench.harness.pump_station_prime.actor_proxy import PumpStationPrimeAct
 from aec_bench.prime_agent.acp import PrimeAcpIsolation, PrimeAcpRun, run_prime_acp_session
 from aec_bench.prime_agent.refinement import PrimeRefinementCandidate, PrimeRefinementMode
 from aec_bench.prime_agent.session_evidence import PrimeAcpLimits
-from aec_bench.prime_agent.skills import install_aec_world_skill, install_prime_skill
+from aec_bench.prime_agent.skills import install_aec_world_skill, install_prime_refine_skill, install_prime_skill
 from aec_bench.worlds.stewardship.wastewater_pump_station.evaluation import (
     evaluate_pump_station_reference_run,
 )
@@ -117,6 +117,8 @@ async def run_pump_station_prime_session(
     actor_workspace.mkdir(parents=True, exist_ok=True)
     evidence_directory.mkdir(parents=True, exist_ok=False)
     skill_directories = [install_aec_world_skill(actor_workspace)]
+    if refinement_mode is PrimeRefinementMode.DISCOVER:
+        skill_directories.append(install_prime_refine_skill(actor_workspace))
     prime_instruction = instruction
     if pump_station_guidance:
         skill_directories.append(install_pump_station_guidance_skill(actor_workspace))

--- a/src/aec_bench/harness/pump_station_prime/skills/pump-station-guidance/SKILL.md
+++ b/src/aec_bench/harness/pump_station_prime/skills/pump-station-guidance/SKILL.md
@@ -3,14 +3,15 @@ name: pump-station-guidance
 description: Use compact state, exact action accounting, and pump-station stewardship checks in an AECBench world.
 metadata:
   status: experimental
-  validation: current-profile-only
+  validation: two-reference-profiles
 ---
 
 # Pump-station guidance
 
 guidance_id: aecbench.pump-station-guidance
 
-This skill is experimental. It has evidence from one registered profile only. It does not supply a solution plan.
+This skill is experimental. It has qualification evidence from two registered reference profiles. It does not supply a
+solution plan.
 
 The task objective and actor authority remain in the initial prompt and the `aec-world` skill. Use only the available actor operations.
 
@@ -50,6 +51,9 @@ evidence.
 - Distinguish process conflict, resource window, outage capacity, backlog binding, evidence binding, stale decision, and action-argument errors.
 - Check required service through the full duration of field work.
 - Distinguish run eligibility from assurance for outage planning.
+- Qualified `/refine` lesson: after a `planned-outage-capacity` rejection, do not repeat the same inspection until the
+  current actor-visible state shows new non-target assurance or other relevant world evidence. Run eligibility alone is
+  not assurance for outage planning.
 - Search documentary evidence only when the current decision needs documentary content.
 - After `NO_ACCESSIBLE_RESULT`, do not make an equivalent search unless the information set or query scope changes.
 - Identify work that depends on a host-owned decision. Do not seek another control path.

--- a/src/aec_bench/harness/pump_station_prime/skills/pump-station-guidance/references/decision-method.md
+++ b/src/aec_bench/harness/pump_station_prime/skills/pump-station-guidance/references/decision-method.md
@@ -37,6 +37,10 @@ An applied result advances the causal state. A rejected result normally leaves t
 
 Do not repeat a rejected request until a relevant state fact, decision ID, argument, or evidence binding changes.
 
+After a `planned-outage-capacity` rejection, do not repeat the same inspection until the current actor-visible state
+shows new non-target assurance through the full work duration or other relevant world evidence. A non-target pump that
+is only run eligible does not provide assurance for outage planning.
+
 ## 5. Limit documentary search
 
 Search only for content needed by the current decision. After `NO_ACCESSIBLE_RESULT`, stop the equivalent search. Search again only when the query scope or available information changes.

--- a/src/aec_bench/prime_agent/acp.py
+++ b/src/aec_bench/prime_agent/acp.py
@@ -260,6 +260,11 @@ async def run_prime_acp_session(
     )
     paths.state_dir.mkdir(parents=True, exist_ok=False)
     paths.session_dir.mkdir(parents=True, exist_ok=False)
+    if refinement_mode is PrimeRefinementMode.CANDIDATE:
+        (paths.state_dir / "settings.json").write_text(
+            json.dumps({"autoRefine": {"enabled": False}}, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
     if refinement_candidate is not None:
         install_refinement_candidate(paths.state_dir, refinement_candidate)
     evidence_directory.mkdir(parents=True, exist_ok=True)

--- a/src/aec_bench/prime_agent/skills.py
+++ b/src/aec_bench/prime_agent/skills.py
@@ -29,6 +29,12 @@ def install_aec_world_skill(actor_workspace: Path) -> Path:
     return skill_directory
 
 
+def install_prime_refine_skill(actor_workspace: Path) -> Path:
+    """Install Prime's agent-callable refinement bridge for a discovery run."""
+    source = Path(__file__).with_name("skills") / "refine"
+    return install_prime_skill(actor_workspace, source)
+
+
 def install_prime_skill(actor_workspace: Path, source: Path) -> Path:
     """Install one explicit packaged skill without using ambient discovery."""
     actor_workspace = actor_workspace.resolve()

--- a/src/aec_bench/prime_agent/skills/refine/SKILL.md
+++ b/src/aec_bench/prime_agent/skills/refine/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: refine
+description: Ask Prime Agent to make a small evidence-backed change to its continual harness.
+---
+
+# Refine
+
+This skill gives Prime access to its host-owned continual harness refinement.
+It does not implement refinement in AECBench.
+
+Use it from IPython:
+
+```python
+await refine.status()
+await refine.run()
+await refine.run("Keep the smallest stable lesson from this trajectory.", global_=True)
+```
+
+`await refine.run(instructions=None, global_=False)` schedules refinement at the
+end of the current turn. Use `global_=True` only for stable lessons that can be
+tested in a separate run. Do not save current-run facts, identifiers, paths,
+hidden state, or temporary blockers as global entries.

--- a/src/aec_bench/prime_agent/skills/refine/pyproject.toml
+++ b/src/aec_bench/prime_agent/skills/refine/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "refine"
+version = "0.1.0"
+description = "Prime Agent continual harness refinement bridge"
+requires-python = ">=3.10"
+dependencies = []
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/refine"]

--- a/src/aec_bench/prime_agent/skills/refine/src/refine/__init__.py
+++ b/src/aec_bench/prime_agent/skills/refine/src/refine/__init__.py
@@ -1,0 +1,30 @@
+# ABOUTME: Exposes Prime Agent's host-owned continual refinement to its isolated Python kernel.
+# ABOUTME: Keeps refinement policy and application inside Prime Agent through the existing host bridge.
+
+from __future__ import annotations
+
+from typing import Any
+
+from rlm import host_request
+
+
+async def status() -> dict[str, Any]:
+    """Return whether a refinement is pending or in progress."""
+    return await host_request("refine.status")
+
+
+async def run(
+    instructions: str | None = None,
+    global_: bool = False,
+) -> dict[str, Any]:
+    """Schedule one host-owned refinement at the end of the current turn."""
+    if instructions is not None and not isinstance(instructions, str):
+        raise TypeError(f"instructions must be str or None, got {type(instructions).__name__}")
+    if not isinstance(global_, bool):
+        raise TypeError(f"global_ must be bool, got {type(global_).__name__}")
+    payload: dict[str, Any] = {}
+    if instructions is not None:
+        payload["instructions"] = instructions
+    if global_:
+        payload["global"] = True
+    return await host_request("refine.run", payload)

--- a/tests/harness/pump_station_prime/test_session.py
+++ b/tests/harness/pump_station_prime/test_session.py
@@ -30,6 +30,7 @@ from aec_bench.harness.pump_station_prime.session import (
     run_pump_station_prime_session,
 )
 from aec_bench.prime_agent.acp import PrimeAcpIsolation
+from aec_bench.prime_agent.refinement import PrimeRefinementMode
 from aec_bench.prime_agent.skills import (
     WORLD_ACTOR_CAPABILITY_ENV,
     WORLD_ACTOR_SOCKET_ENV,
@@ -282,8 +283,10 @@ def test_packaged_pump_guidance_is_markdown_only_and_contains_no_instance_plan(t
 
     assert files == ["SKILL.md", "references/compact-state.md", "references/decision-method.md"]
     assert "guidance_id: aecbench.pump-station-guidance" in text
-    assert "current-profile-only" in text
+    assert "two-reference-profiles" in text
     assert "NO_ACCESSIBLE_RESULT" in text
+    assert "after a `planned-outage-capacity` rejection" in text
+    assert "Run eligibility alone is" in text
     assert "exact ledger" in text
     assert "one IPython cell for each `invoke` attempt" in text
     assert "not an action-selection rule" in text
@@ -386,6 +389,33 @@ async def test_explicit_guided_treatment_adds_only_the_ordered_skill_and_instruc
     assert all(argument not in serialized_provenance for argument in skill_arguments)
     assert result.verification.valid
     assert result.evaluation.evaluation_scope == "bounded_continuation"
+
+
+@pytest.mark.asyncio
+async def test_discovery_mode_adds_prime_refine_skill(tmp_path: Path) -> None:
+    from tests.prime_agent.test_acp import _fake_prime_agent
+
+    result = await run_pump_station_prime_session(
+        actor_workspace=tmp_path / "actor",
+        world_run_directory=tmp_path / "private-world",
+        evidence_directory=tmp_path / "host-evidence",
+        session_request=_session_request(),
+        instruction="Advance the current world and refine only an evidence-backed lesson.",
+        model="anthropic/test",
+        isolation=PrimeAcpIsolation.DEVELOPMENT_SAME_USER,
+        limits=_limits(),
+        refinement_mode=PrimeRefinementMode.DISCOVER,
+        executable=str(_fake_prime_agent(tmp_path)),
+        environment={**os.environ, "FAKE_ACP_SCENARIO": "world"},
+    )
+
+    observed = json.loads((tmp_path / "actor" / "observed-acp.json").read_text(encoding="utf-8"))
+    skill_arguments = [
+        observed["argv"][index + 1] for index, argument in enumerate(observed["argv"]) if argument == "--skill"
+    ]
+    assert [Path(argument).name for argument in skill_arguments] == ["aec-world", "refine"]
+    provenance = json.loads(result.prime.paths.run_file.read_text(encoding="utf-8"))
+    assert [skill["name"] for skill in provenance["skills"]] == ["aec-world", "refine"]
 
 
 @pytest.mark.asyncio

--- a/tests/prime_agent/test_acp.py
+++ b/tests/prime_agent/test_acp.py
@@ -57,6 +57,11 @@ Path("observed-acp.json").write_text(json.dumps({{
         if (Path(os.environ["PRIME_AGENT_CODING_AGENT_DIR"]) / "harness" / "harness_state.json").is_file()
         else None
     ),
+    "settings": (
+        json.loads((Path(os.environ["PRIME_AGENT_CODING_AGENT_DIR"]) / "settings.json").read_text())
+        if (Path(os.environ["PRIME_AGENT_CODING_AGENT_DIR"]) / "settings.json").is_file()
+        else None
+    ),
 }}))
 scenario = os.environ.get("FAKE_ACP_SCENARIO", "success")
 session_dir = Path(sys.argv[sys.argv.index("--session-dir") + 1])
@@ -539,6 +544,7 @@ async def test_loads_one_fixed_refinement_candidate_before_prime_starts(tmp_path
     observed = json.loads((actor_workspace / "observed-acp.json").read_text(encoding="utf-8"))
     installed = observed["refinement_candidate"]["entries"]
     assert sum(len(entries) for entries in installed.values()) == 4
+    assert observed["settings"] == {"autoRefine": {"enabled": False}}
     assert result.session_state == "ended"
     assert not result.refinement_harness.changed
     assert not result.refinement_harness.drifted
@@ -570,6 +576,31 @@ async def test_fixed_candidate_fails_when_prime_refines_during_comparison(tmp_pa
     assert result.refinement_harness.drifted
     assert "fixed_candidate_changed" in result.refinement_harness.issues
     assert result.error == "Prime refinement candidate changed during a fixed candidate run"
+
+
+@pytest.mark.asyncio
+async def test_discovery_keeps_prime_automatic_refinement_enabled(tmp_path: Path) -> None:
+    actor_workspace, skill, evidence = _workspace(tmp_path)
+    result = await run_prime_acp_session(
+        actor_workspace=actor_workspace,
+        evidence_directory=evidence,
+        skill_directories=(skill,),
+        instruction="Discover a useful candidate.",
+        model="anthropic/test",
+        actor_environment={
+            WORLD_ACTOR_SOCKET_ENV: "/private/tmp/scoped-actor.sock",
+            WORLD_ACTOR_CAPABILITY_ENV: "scoped-capability-secret",
+        },
+        isolation=PrimeAcpIsolation.DEVELOPMENT_SAME_USER,
+        limits=_limits(),
+        refinement_mode=PrimeRefinementMode.DISCOVER,
+        executable=str(_fake_prime_agent(tmp_path)),
+        environment=os.environ,
+    )
+
+    observed = json.loads((actor_workspace / "observed-acp.json").read_text(encoding="utf-8"))
+    assert observed["settings"] is None
+    assert result.session_state == "ended"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- expose Prime's host-owned refinement bridge only during discovery runs
- disable automatic refinement during fixed-candidate comparisons
- materialise the qualified inspection-retry lesson in pump-station guidance

## Validation

- targeted Prime ACP, refinement, journey, session, and qualification tests passed
- focused guidance tests passed
- Ruff and diff checks passed
- wheel and source archive contain the refine skill

## Live evidence

A benchmark-valid GPT-5.4 discovery produced one portable lesson. A four-cell qualification on RS1 and RS2 preserved validity in every cell. The candidate completed both profiles and removed the repeated RS1 inspection loop.