### PR TITLE
feat(init): install skills for Claude Code and Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,24 +610,25 @@ Agent skills are portable workflow contracts. They can be implemented as native
 skills, slash commands, prompts, or task recipes in Claude Code, Codex, Copilot,
 or another agent environment.
 
-| Skill | Command | Purpose |
-|-------|---------|---------|
-| **Add Task** | `/add-task` | Interview-driven seed creation from expert description |
-| **Configure Experiment** | `/configure-experiment` | Select tasks, agents, models, and execution settings for a validated experiment manifest |
-| **Create Dataset** | `/create-dataset` | Build and verify a reproducible dataset from templates or existing tasks |
-| **Create Template** | `/create-template <seed-path>` | Build a generation template from a seed file |
-| **Hardening Pass** | `/hardening-pass <path>` | Quality-gate a template or task instance before benchmarking |
-| **Domain Check** | `/domain-check` | Verify architectural invariants before publishing or committing |
-| **Meta-Harness** | `/meta-harness` | Design or compare a harness candidate from task prose and run evidence |
+| Skill | Claude Code | Codex | Purpose |
+|-------|-------------|-------|---------|
+| **Add Task** | `/add-task` | `$add-task` | Interview-driven seed creation from expert description |
+| **Configure Experiment** | `/configure-experiment` | `$configure-experiment` | Select tasks, agents, models, and execution settings for a validated experiment manifest |
+| **Create Dataset** | `/create-dataset` | `$create-dataset` | Build and verify a reproducible dataset from templates or existing tasks |
+| **Create Template** | `/create-template <seed-path>` | `$create-template <seed-path>` | Build a generation template from a seed file |
+| **Hardening Pass** | `/hardening-pass <path>` | `$hardening-pass <path>` | Quality-gate a template or task instance before benchmarking |
+| **Domain Check** | `/domain-check` | `$domain-check` | Verify architectural invariants before publishing or committing |
+| **Meta-Harness** | `/meta-harness` | `$meta-harness` | Design or compare a harness candidate from task prose and run evidence |
 
-`aec-bench init` installs the packaged skills into `.claude/skills/`. Run
-`aec-bench init --update-skills` in an existing project to refresh the packaged
-copies without replacing user-added skills.
+`aec-bench init` installs the packaged skills into `.claude/skills/` for Claude
+Code and `.agents/skills/` for Codex. Run `aec-bench init --update-skills` in an
+existing project to refresh both packaged copies without removing other skill
+directories.
 
-**Typical flow:** `/add-task` produces an expert-authored seed. For a
-parameterisable task, `/create-template` builds the generation template and
-`/hardening-pass` checks it before benchmark use. `/create-dataset` freezes a
-reproducible selection, then `/configure-experiment` prepares the run.
+**Typical flow:** Add Task produces an expert-authored seed. For a
+parameterisable task, Create Template builds the generation template and
+Hardening Pass checks it before benchmark use. Create Dataset freezes a
+reproducible selection, then Configure Experiment prepares the run.
 
 ## Harbor Agent
 
@@ -662,7 +663,7 @@ disciplines. The catalogue changes frequently, so use
 src/aec_bench/          # Library source
 tests/                  # Regression test suite
 tasks/                  # Benchmark task seeds and instances
-seeds/                  # Expert-created seed files (from /add-task)
+seeds/                  # Expert-created seed files (from Add Task)
 agents/                 # Ready-to-use default agent implementations
 scripts/                # Utility scripts for local maintenance workflows
 docs/                   # Repository-owned architecture, contracts, and invariants

--- a/src/aec_bench/cli/commands/init.py
+++ b/src/aec_bench/cli/commands/init.py
@@ -48,7 +48,7 @@ def init_project(
         return ScaffoldResult(
             created=True,
             project_root=target,
-            messages=("Skills updated.",),
+            messages=("Skills updated in .claude/skills/ and .agents/skills/.",),
         )
 
     # Full scaffold: directories, config files, skills.
@@ -65,7 +65,7 @@ def init_project(
     messages.append("Wrote .gitignore")
 
     copy_skills(target)
-    messages.append("Copied skills to .claude/skills/")
+    messages.append("Copied skills to .claude/skills/ and .agents/skills/")
 
     # Optionally generate one example task instance.
     if generate_example:
@@ -107,7 +107,7 @@ def init_project(
 
 def init_command(
     directory: Path = typer.Argument(Path("."), help="Target directory"),
-    update_skills: bool = typer.Option(False, "--update-skills", help="Refresh skills only"),
+    update_skills: bool = typer.Option(False, "--update-skills", help="Refresh skills in supported locations"),
     force: bool = typer.Option(False, "--force", help="Overwrite config files"),
     no_example: bool = typer.Option(False, "--no-example", help="Skip example generation"),
 ) -> None:

--- a/src/aec_bench/init/scaffold.py
+++ b/src/aec_bench/init/scaffold.py
@@ -18,6 +18,11 @@ _PACKAGED_SKILLS: tuple[str, ...] = (
     "meta-harness",
 )
 
+_SKILL_INSTALL_ROOTS: tuple[Path, ...] = (
+    Path(".claude/skills"),
+    Path(".agents/skills"),
+)
+
 _SCAFFOLD_DIRS: tuple[str, ...] = (
     "tasks",
     "seeds",
@@ -195,21 +200,22 @@ def _locate_bundled_source(package_name: str, fallback_dir: str) -> Path | None:
 
 
 def copy_skills(target: Path) -> None:
-    """Copy packaged skills into ``<target>/.claude/skills/``.
+    """Copy packaged skills into each supported project skill directory.
 
-    Only the packaged skill directories are written. User-added skill
-    directories are left untouched.
+    Only the packaged skill directories are written. Skill directories with
+    other names are left untouched.
     """
-    source = _locate_bundled_source("aec_bench.init.skill_data", ".claude/skills")
+    source = _locate_bundled_source("aec_bench.init.skill_data", "src/aec_bench/init/skill_data")
     if source is None:
         return
 
-    dest_root = target / ".claude" / "skills"
-    dest_root.mkdir(parents=True, exist_ok=True)
+    for relative_root in _SKILL_INSTALL_ROOTS:
+        dest_root = target / relative_root
+        dest_root.mkdir(parents=True, exist_ok=True)
 
-    for skill_name in _PACKAGED_SKILLS:
-        src_dir = source / skill_name
-        if not src_dir.is_dir():
-            continue
-        dest_dir = dest_root / skill_name
-        shutil.copytree(src_dir, dest_dir, dirs_exist_ok=True)
+        for skill_name in _PACKAGED_SKILLS:
+            src_dir = source / skill_name
+            if not src_dir.is_dir():
+                continue
+            dest_dir = dest_root / skill_name
+            shutil.copytree(src_dir, dest_dir, dirs_exist_ok=True)

--- a/src/aec_bench/init/skill_data/__init__.py
+++ b/src/aec_bench/init/skill_data/__init__.py
@@ -1,2 +1,2 @@
 # ABOUTME: Bundled agent skill source files for the aec-bench init command.
-# ABOUTME: Currently copied to .claude/skills/ for Claude-compatible project setup.
+# ABOUTME: Copied to the supported Claude Code and Codex project skill directories.

--- a/src/aec_bench/init/skill_data/add-task/SKILL.md
+++ b/src/aec_bench/init/skill_data/add-task/SKILL.md
@@ -9,7 +9,7 @@ Create a structured benchmark task seed (`source_task.json`) from an expert's de
 
 ## When to Use
 
-- User runs `/add-task` or `/add-task <description>`
+- User explicitly invokes Add Task, with or without a description
 - User asks to "add a task", "create a task", "define a new benchmark task"
 - User describes an engineering calculation they want to benchmark
 
@@ -107,9 +107,9 @@ If ALL 5 criteria pass:
    - `source`: all collected fields using structured format for inputs/outputs
    - `feasibility`: the assessment results (parameterisable: true, all 5 criteria: true)
 3. Tell the expert: "Seed saved to `seeds/<discipline>/<task-id>/source_task.json`"
-4. Offer: "This task is parameterisable — I can create a generation template from it right now using `/create-template`. Want me to proceed?"
-5. If the expert accepts, run: `/create-template seeds/<discipline>/<task-id>/source_task.json`
-6. If declined, say: "No worries — you can run `/create-template seeds/<discipline>/<task-id>/source_task.json` any time."
+4. Offer: "This task is parameterisable — I can create a generation template from it right now using Create Template. Want me to proceed?"
+5. If the expert accepts, invoke Create Template with `seeds/<discipline>/<task-id>/source_task.json`.
+6. If declined, say: "No worries — you can invoke Create Template with `seeds/<discipline>/<task-id>/source_task.json` any time."
 
 ### Step 5b — Non-Parameterisable Path
 

--- a/src/aec_bench/init/skill_data/add-task/references/feasibility-criteria.md
+++ b/src/aec_bench/init/skill_data/add-task/references/feasibility-criteria.md
@@ -2,7 +2,7 @@
 
 A task is **parameterisable** when it can be turned into a reusable generation
 template -- a `compute()` function that accepts typed inputs, runs a closed-form
-calculation, and returns numeric outputs. The `/create-template` skill builds
+calculation, and returns numeric outputs. The Create Template skill builds
 these templates automatically.
 
 Five criteria must ALL pass. If any single criterion fails, the task requires
@@ -111,7 +111,7 @@ intermediate human decisions.
 
 | All 5 pass? | Path |
 |-------------|------|
-| **Yes** | Task is **parameterisable**. Hand the seed to `/create-template` to generate `engine.py`, `params.toml`, and `instruction.md`. |
+| **Yes** | Task is **parameterisable**. Hand the seed to Create Template to generate `engine.py`, `params.toml`, and `instruction.md`. |
 | **No** | Task needs **manual authoring**. See `manual-task-guidance.md` for the required file structure. |
 
 Record the assessment in the seed file's `feasibility` block so downstream

--- a/src/aec_bench/init/skill_data/add-task/references/seed-schema.md
+++ b/src/aec_bench/init/skill_data/add-task/references/seed-schema.md
@@ -1,7 +1,7 @@
 # Seed File Schema Reference
 
 The seed file is a JSON document that captures a benchmark task idea in enough
-detail for downstream tooling (`/create-template` for parameterisable tasks, or
+detail for downstream tooling (Create Template for parameterisable tasks, or
 manual authoring for everything else). Two origin styles exist: **expert** seeds
 (rich, structured inputs/outputs) and **ngnbench** seeds (flat string lists
 imported from legacy inventories). Both are valid.

--- a/src/aec_bench/init/skill_data/configure-experiment/SKILL.md
+++ b/src/aec_bench/init/skill_data/configure-experiment/SKILL.md
@@ -9,7 +9,7 @@ Build a valid `experiment.yaml` by discovering what's in your project, guiding y
 
 ## When to Use
 
-- User runs `/configure-experiment`
+- User explicitly invokes Configure Experiment
 - User asks to "set up an experiment", "configure a run", "plan a benchmark"
 - User wants to create or modify an experiment.yaml
 
@@ -91,7 +91,7 @@ After selection, show the count:
 
 If zero tasks match, warn and let them re-select.
 
-> **Tip:** Consider creating a dataset with `/create-dataset` to make this selection reproducible.
+> **Tip:** Consider creating a dataset with Create Dataset to make this selection reproducible.
 
 ### Step 3 — Agent Configuration
 

--- a/src/aec_bench/init/skill_data/create-dataset/SKILL.md
+++ b/src/aec_bench/init/skill_data/create-dataset/SKILL.md
@@ -9,7 +9,7 @@ Create a versioned, immutable benchmark dataset through guided discovery and con
 
 ## When to Use
 
-- User runs `/create-dataset`
+- User explicitly invokes Create Dataset
 - User asks to "create a dataset", "build a benchmark", "freeze tasks into a dataset"
 - User wants to publish a benchmark or create a reproducible evaluation set
 
@@ -140,7 +140,7 @@ After successful creation, suggest:
 >
 > - **Run an experiment:** `aec-bench run --config experiment.yaml` (reference this dataset in the tasks section)
 > - **Export for sharing:** `aec-bench dataset export <name> --output <name>.tar.gz`
-> - **Configure an experiment:** `/configure-experiment` (will discover this dataset)
+> - **Configure an experiment:** invoke Configure Experiment, which will discover this dataset
 
 Show how to reference the dataset in an experiment config:
 
@@ -161,5 +161,5 @@ compute:
 - Always verify integrity after creation with `aec-bench dataset validate`
 - Suggest meaningful names — avoid generic names like "test" or "dataset1"
 - Default seed to 42 for reproducibility unless the user specifies otherwise
-- If the user has no templates, suggest running `/create-template` first
-- If the user has no tasks and no templates, suggest `/add-task` first
+- If the user has no templates, suggest Create Template first
+- If the user has no tasks and no templates, suggest Add Task first

--- a/src/aec_bench/init/skill_data/create-template/SKILL.md
+++ b/src/aec_bench/init/skill_data/create-template/SKILL.md
@@ -11,13 +11,13 @@ This skill is part of the aec-bench task generation framework. It automates the 
 
 ## When to Use
 
-- User runs `/create-template <path_to_source_task.json>`
+- User explicitly invokes Create Template with a `source_task.json` path
 - User asks to "create a template from this seed" or "convert this seed to a template"
 - User wants to add a new benchmark task type to the generation framework
 
 ## Input
 
-The skill accepts a path to a `source_task.json` file. These seed files are found under `tasks/` (old-style, from ngnbench imports) or `seeds/` (enhanced, produced by `/add-task`) and contain:
+The skill accepts a path to a `source_task.json` file. These seed files are found under `tasks/` (old-style, from ngnbench imports) or `seeds/` (enhanced, produced by Add Task) and contain:
 
 ```json
 {
@@ -36,7 +36,7 @@ The skill accepts a path to a `source_task.json` file. These seed files are foun
 }
 ```
 
-Enhanced seeds (produced by `/add-task`) may include structured inputs/outputs and additional context:
+Enhanced seeds (produced by Add Task) may include structured inputs/outputs and additional context:
 
 ```json
 {

--- a/src/aec_bench/init/skill_data/create-template/references/example-engine.md
+++ b/src/aec_bench/init/skill_data/create-template/references/example-engine.md
@@ -18,7 +18,7 @@ Source: `templates/builtin/ground/terzaghi_bearing_capacity/engine.py`
 <!-- PATTERN: ABOUTME HEADER
 Every code file in this repo MUST start with exactly two comment lines beginning with
 "# ABOUTME: ". The first line states what the module IS. The second line states what it
-DOES. This is a hard rule from CLAUDE.md — grep relies on it.
+DOES. `AGENTS.md` defines this repository rule.
 -->
 
 ```python

--- a/src/aec_bench/init/skill_data/hardening-pass/SKILL.md
+++ b/src/aec_bench/init/skill_data/hardening-pass/SKILL.md
@@ -11,7 +11,7 @@ A template hardening catches formula and parameter issues before you generate in
 
 ## When to Use
 
-- After creating a template with `/create-template`
+- After creating a template with Create Template
 - After manually authoring a task instance
 - Before running a template's generated instances through Harbor for the first time
 - When reviewing someone else's template or task
@@ -25,8 +25,8 @@ The skill accepts a path to either:
 - **A task instance directory** (detected by presence of `task.toml`)
 
 ```
-/hardening-pass src/aec_bench/templates/builtin/ground/terzaghi_bearing_capacity/
-/hardening-pass tasks/mechanical/heat-load/audit-office-building/brisbane-8rm/
+src/aec_bench/templates/builtin/ground/terzaghi_bearing_capacity/
+tasks/mechanical/heat-load/audit-office-building/brisbane-8rm/
 ```
 
 If no path is provided, ask the user what they want to harden.

--- a/src/aec_bench/init/skill_data/meta-harness/SKILL.md
+++ b/src/aec_bench/init/skill_data/meta-harness/SKILL.md
@@ -28,7 +28,7 @@ harness was learned or that an agent generalised.
 
 ## When to Use
 
-- User runs `/meta-harness` or asks to create a harness from task prose.
+- User explicitly invokes Meta-Harness or asks to create a harness from task prose.
 - User wants to compare a candidate harness against an existing task, world, or experiment.
 - User suspects the verifier, schema, artifacts, or review language is missing a real edge case.
 

--- a/src/aec_bench/init/skill_data/meta-harness/references/experiment-workflows.md
+++ b/src/aec_bench/init/skill_data/meta-harness/references/experiment-workflows.md
@@ -16,7 +16,16 @@ This is deterministic and makes no model, Harbor, Morph, Modal, or cloud call.
 
 ## 2. Evidence-lifecycle ablation
 
-After `aec-bench init`, copy the installed example:
+After `aec-bench init`, copy the example from the installed `meta-harness`
+skill directory. Choose the command for your agent harness.
+
+For Codex:
+
+```bash
+cp .agents/skills/meta-harness/examples/lifecycle-ablation.yaml experiment.yaml
+```
+
+For Claude Code:
 
 ```bash
 cp .claude/skills/meta-harness/examples/lifecycle-ablation.yaml experiment.yaml

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -16,6 +16,15 @@ from aec_bench.init.scaffold import (
 )
 
 
+def _packaged_skill_tree(root: Path) -> dict[Path, bytes]:
+    return {
+        path.relative_to(root): path.read_bytes()
+        for skill_name in _PACKAGED_SKILLS
+        for path in (root / skill_name).rglob("*")
+        if path.is_file()
+    }
+
+
 def test_create_scaffold_creates_directories(tmp_path: Path) -> None:
     result = create_scaffold(tmp_path)
 
@@ -87,23 +96,34 @@ def test_write_gitignore_creates_file(tmp_path: Path) -> None:
 def test_copy_skills_creates_skill_dirs(tmp_path: Path) -> None:
     copy_skills(tmp_path)
 
-    skills_dir = tmp_path / ".claude" / "skills"
-    assert skills_dir.is_dir()
-    assert {path.name for path in skills_dir.iterdir() if path.is_dir()} == set(_PACKAGED_SKILLS)
-    assert all((skills_dir / skill_name / "SKILL.md").is_file() for skill_name in _PACKAGED_SKILLS)
-    assert (skills_dir / "meta-harness" / "references" / "experiment-workflows.md").exists()
-    assert (skills_dir / "meta-harness" / "examples" / "lifecycle-ablation.yaml").exists()
+    source_root = Path(__file__).resolve().parents[2] / "src" / "aec_bench" / "init" / "skill_data"
+    expected_tree = _packaged_skill_tree(source_root)
+    installed_trees: list[dict[Path, bytes]] = []
+    for relative_root in (Path(".claude/skills"), Path(".agents/skills")):
+        skills_dir = tmp_path / relative_root
+        assert skills_dir.is_dir()
+        assert {path.name for path in skills_dir.iterdir() if path.is_dir()} == set(_PACKAGED_SKILLS)
+        assert all((skills_dir / skill_name / "SKILL.md").is_file() for skill_name in _PACKAGED_SKILLS)
+        assert (skills_dir / "meta-harness" / "references" / "experiment-workflows.md").exists()
+        assert (skills_dir / "meta-harness" / "examples" / "lifecycle-ablation.yaml").exists()
+        installed_trees.append(_packaged_skill_tree(skills_dir))
+    assert installed_trees == [expected_tree, expected_tree]
 
 
-def test_copy_skills_preserves_user_added_skills(tmp_path: Path) -> None:
-    user_skill = tmp_path / ".claude" / "skills" / "my-custom-skill"
-    user_skill.mkdir(parents=True)
-    (user_skill / "SKILL.md").write_text("custom", encoding="utf-8")
+def test_copy_skills_preserves_skill_directories_with_other_names(tmp_path: Path) -> None:
+    user_skills = [
+        tmp_path / relative_root / "my-custom-skill"
+        for relative_root in (Path(".claude/skills"), Path(".agents/skills"))
+    ]
+    for user_skill in user_skills:
+        user_skill.mkdir(parents=True)
+        (user_skill / "SKILL.md").write_text("custom", encoding="utf-8")
 
     copy_skills(tmp_path)
 
-    assert (user_skill / "SKILL.md").read_text(encoding="utf-8") == "custom"
-    assert (tmp_path / ".claude" / "skills" / "add-task" / "SKILL.md").exists()
+    for user_skill in user_skills:
+        assert (user_skill / "SKILL.md").read_text(encoding="utf-8") == "custom"
+        assert (user_skill.parent / "add-task" / "SKILL.md").exists()
 
 
 # ---------------------------------------------------------------------------
@@ -121,6 +141,8 @@ def test_init_project_creates_full_scaffold(tmp_path: Path) -> None:
     assert (tmp_path / "tasks").is_dir()
     assert (tmp_path / "seeds").is_dir()
     assert (tmp_path / ".claude" / "skills" / "add-task" / "SKILL.md").exists()
+    assert (tmp_path / ".agents" / "skills" / "add-task" / "SKILL.md").exists()
+    assert "Copied skills to .claude/skills/ and .agents/skills/" in result.messages
 
 
 def test_init_project_detects_existing(tmp_path: Path) -> None:
@@ -141,11 +163,29 @@ def test_init_project_force_recreates_config(tmp_path: Path) -> None:
 def test_init_project_update_skills_only(tmp_path: Path) -> None:
     # First init
     init_project(target=tmp_path, generate_example=False)
-    # Modify a skill
-    skill_path = tmp_path / ".claude" / "skills" / "add-task" / "SKILL.md"
-    skill_path.write_text("modified", encoding="utf-8")
+    # Modify both installed copies of one packaged skill.
+    skill_paths = [
+        tmp_path / relative_root / "add-task" / "SKILL.md"
+        for relative_root in (Path(".claude/skills"), Path(".agents/skills"))
+    ]
+    for skill_path in skill_paths:
+        skill_path.write_text("modified", encoding="utf-8")
 
     # Update skills
     result = init_project(target=tmp_path, update_skills=True)
     assert result.created
-    assert skill_path.read_text(encoding="utf-8") != "modified"
+    assert all(skill_path.read_text(encoding="utf-8") != "modified" for skill_path in skill_paths)
+
+
+def test_init_project_update_skills_adds_codex_skills_to_existing_project(tmp_path: Path) -> None:
+    (tmp_path / "aec-bench.toml").write_text("[project]\n", encoding="utf-8")
+    old_claude_skill = tmp_path / ".claude" / "skills" / "add-task" / "SKILL.md"
+    old_claude_skill.parent.mkdir(parents=True)
+    old_claude_skill.write_text("old packaged copy", encoding="utf-8")
+
+    result = init_project(target=tmp_path, update_skills=True)
+
+    assert result.created
+    assert old_claude_skill.read_text(encoding="utf-8") != "old packaged copy"
+    assert (tmp_path / ".agents" / "skills" / "add-task" / "SKILL.md").is_file()
+    assert result.messages == ("Skills updated in .claude/skills/ and .agents/skills/.",)

--- a/tests/test_public_repo_surface.py
+++ b/tests/test_public_repo_surface.py
@@ -42,6 +42,20 @@ def test_readme_lists_every_packaged_skill() -> None:
     readme = Path("README.md").read_text(encoding="utf-8")
 
     assert all(f"/{skill_name}`" in readme or f"/{skill_name} " in readme for skill_name in _PACKAGED_SKILLS)
+    assert all(f"${skill_name}`" in readme or f"${skill_name} " in readme for skill_name in _PACKAGED_SKILLS)
+
+
+def test_packaged_skills_use_harness_neutral_invocation_text() -> None:
+    slash_invocation = re.compile(
+        rf"(?<![A-Za-z0-9_.-])/(?:{'|'.join(re.escape(name) for name in _PACKAGED_SKILLS)})\b"
+    )
+    offenders = {
+        str(path): slash_invocation.findall(path.read_text(encoding="utf-8"))
+        for path in SKILL_ROOT.rglob("*.md")
+        if slash_invocation.search(path.read_text(encoding="utf-8"))
+    }
+
+    assert offenders == {}
 
 
 def test_configure_experiment_skill_lists_every_harbor_backend() -> None:


### PR DESCRIPTION
## Summary

- install all packaged agent skills into both .claude/skills and .agents/skills
- keep one canonical packaged skill source and preserve other skill directories during updates
- make packaged cross-skill guidance harness-neutral and document Claude Code and Codex invocation syntax
- add dual-tree, migration, package-surface, and portability regression coverage

## Verification

- 192 focused CLI, documentation, and release tests passed
- Ruff lint and format checks passed
- targeted mypy passed
- uv build passed
- unpacked-wheel smoke test confirmed seven skills and 24 byte-identical files in both targets
- git diff check passed