### PR TITLE
Fix DeepSeek native tool gateway semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,14 @@ The baseline, native-tool, and explicit-commit modes are separate treatments:
 | Native tools | `@aec-bench/dsh-tools` with the exact AEC-owned tool manifest | The owning lifecycle or world runtime decides completion |
 | Explicit commit | `aec_commit_output` only | The task contract accepts and binds the exact output bytes |
 
+Native-tool availability does not create candidate output. The adapter needs a
+nonempty declared artifact, a nonempty assistant response, or an accepted and
+revalidated output commit. A lifecycle or world can still record its own valid
+episode outcome when the adapter remains partial because it has no candidate
+output. The native gateway derives request identity from the DeepSeek session
+and tool call, keeps that identity out of the model schema, and records an
+explicit quiescent or unsettled close result.
+
 Explicit commit is capability-gated. Set `output_completion_commit: true` only
 with a matching task-owned `output_completion_contract`. The current supported
 contract format is `markdown_final_fenced_json`, and its output path must be

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -196,9 +196,12 @@ provider evidence. It binds the single manifest digest into the existing AEC
 runtime execution attestation.
 
 The optional `@aec-bench/dsh-tools` Cordis plugin is a transport gateway, not a
-tool authority. The AEC host supplies one exact per-run manifest from typed
-Python callables. The plugin registers those JSON schemas and forwards calls to
-an authenticated trial-local Unix socket. Lifecycle state, world state,
+tool authority. The AEC host supplies one exact per-run manifest from explicit
+`NativeToolDefinition` values. The plugin registers those JSON schemas and
+forwards calls to an authenticated trial-local Unix socket. The endpoint owns
+trusted invocation identity, cancellation propagation, generic turn
+disposition, generation finalization, and bounded close reporting. It does not
+infer candidate output from tool availability. Lifecycle state, world state,
 effects, host controls, verification, and reward stay with their existing AEC
 owners. The pump-station Harbor journey can alternate fresh DeepSeek model
 segments with the same deterministic task-owned Operations controls used by

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -279,7 +279,7 @@ The qualified DeepSeek compatibility conditions are:
 | Treatment | AEC identity | DeepSeek identity | Optional plugin | Qualification proof |
 | --- | --- | --- | --- | --- |
 | Baseline | Installed AEC package version in the manifest | Exact SDK pin from `pyproject.toml`; worker requires the runtime distribution to match | None | Keyless real-composition suite |
-| Native tool gateway | Same | Same | `@aec-bench/dsh-tools` with the exact per-run callable names and JSON schemas | Authenticated endpoint tests plus lifecycle and pump-world boundary tests |
+| Native tool gateway | Same | Same | `@aec-bench/dsh-tools` protocol v2 with exact `NativeToolDefinition` names and JSON schemas | Authenticated endpoint tests plus lifecycle and pump-world boundary tests |
 | Explicit output commit | Same | Same | Named, versioned build copied into the trial evidence | Keyless rejection, repair, acceptance, and stability suite |
 
 The manifest states that resolved composition and resolved tool-surface dumps
@@ -287,10 +287,22 @@ are unavailable. The pinned SDK path does not expose them. The adapter retains
 the exact Cordis input and does not claim stronger evidence.
 
 For native-tool runs, the manifest records the exact tool names and copied
-plugin artifact. The AEC endpoint derives parameter schemas from fully
-annotated callables, validates each JSON request with those annotations, and
-executes only the per-run mapping. The provider plugin cannot add shell access,
-world host controls, verification, or reward authority.
+plugin artifact. The AEC host supplies each model-facing parameter schema
+explicitly through `NativeToolDefinition`. The endpoint validates requests
+against that schema and gives the handler a hidden `NativeToolInvocation` with
+the DeepSeek session, tool-call, turn, generation, cancellation, and trusted
+request identity. A world action uses that trusted identity; the model-facing
+schema cannot supply or replace it.
+
+The handler returns `NativeToolResponse`. Only its generic `conclude-turn`
+disposition can conclude the current model turn; the plugin does not inspect a
+tool name or task result field. Cancellation crosses the socket into a
+cooperative handler token. Endpoint close has a deadline and records either a
+quiescent close or the unsettled and unknown request identities. A
+non-quiescent close cannot produce a completed adapter result. The sealed close
+record prevents late handler output from changing finalized evidence. The
+provider plugin cannot add shell access, world host controls, verification, or
+reward authority.
 
 ## Output completion and explicit commit
 

--- a/docs/protocols/interactive-world-runtime.md
+++ b/docs/protocols/interactive-world-runtime.md
@@ -62,6 +62,12 @@ is not content-addressed:
 | Request ID, action, and arguments | Repository lock, selected pointer, and persistence transaction |
 | Receipt and next observation | Verifier-only and recovery data |
 
+The DeepSeek native-tool facade does not expose the installed request ID as a
+model argument. Its authenticated gateway derives one stable ID from the
+DeepSeek session and tool-call identity, then supplies that ID when the pump
+wrapper creates `WorldActorActionRequest`. This changes transport presentation,
+not the task-owned retry, conflict, state-transition, or evidence semantics.
+
 The pump actor command resolves the selected run from `--run-dir` on every
 call. The repository lock and selected pointer support concurrent and
 separate-process calls without a public binding or in-memory session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,10 @@ dev = [
 
 [project.optional-dependencies]
 execution = ["harbor[modal]>=0.15,<0.16"]
-deepseek-harness = ["deepseek-harness-sdk==0.1.0rc6"]
+deepseek-harness = [
+    "deepseek-harness-sdk==0.1.0rc6",
+    "jsonschema>=4.26,<5",
+]
 morph = ["morphcloud>=0.1.111"]
 local-agents = [
     "boto3>=1.42,<2",

--- a/src/aec_bench/adapters/deepseek_harness/__init__.py
+++ b/src/aec_bench/adapters/deepseek_harness/__init__.py
@@ -1,6 +1,20 @@
 # ABOUTME: Exposes the DeepSeek Harness adapter from its provider-integration package.
 # ABOUTME: Keeps runtime, event, worker, and profile details behind one adapter owner.
 
-from aec_bench.adapters.deepseek_harness.adapter import DeepSeekHarnessAdapter
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from aec_bench.adapters.deepseek_harness.adapter import DeepSeekHarnessAdapter
 
 __all__ = ["DeepSeekHarnessAdapter"]
+
+
+def __getattr__(name: str) -> Any:
+    """Load the optional adapter only when a caller selects it."""
+    if name != "DeepSeekHarnessAdapter":
+        raise AttributeError(name)
+    from aec_bench.adapters.deepseek_harness.adapter import DeepSeekHarnessAdapter
+
+    return DeepSeekHarnessAdapter

--- a/src/aec_bench/adapters/deepseek_harness/adapter.py
+++ b/src/aec_bench/adapters/deepseek_harness/adapter.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import hashlib
-from collections.abc import Mapping
+from collections.abc import Sequence
 from dataclasses import replace
 from pathlib import Path
 
@@ -32,7 +32,7 @@ from aec_bench.adapters.deepseek_harness.runtime import (
     DeepSeekHarnessRuntimeTimeout,
     DeepSeekRuntime,
 )
-from aec_bench.adapters.deepseek_harness.tool_gateway import NativeTool
+from aec_bench.adapters.deepseek_harness.tool_gateway import NativeToolDefinition
 from aec_bench.contracts.agent_output import AgentOutput, AgentOutputStatus
 
 
@@ -45,12 +45,12 @@ class DeepSeekHarnessAdapter:
         settings: DeepSeekHarnessSettings,
         workspace: str | Path,
         runtime: DeepSeekRuntime | None = None,
-        native_tools: Mapping[str, NativeTool] | None = None,
+        native_tools: Sequence[NativeToolDefinition] | None = None,
         adapter_name: str = "deepseek_harness",
     ) -> None:
         self._settings = settings
         self._workspace = Path(workspace).resolve()
-        self._native_tool_names = frozenset((native_tools or {}).keys())
+        self._native_tool_names = frozenset(tool.name for tool in native_tools or ())
         self._runtime = runtime or DeepSeekHarnessProcessRuntime(
             settings=settings,
             workspace=self._workspace,
@@ -81,7 +81,10 @@ class DeepSeekHarnessAdapter:
         direct_output = _has_direct_output(self._workspace, resolved_request.output_path)
         status, failure_kind, stop_reason, error = _outcome(
             run,
-            candidate_available=bool(self._native_tool_names) or direct_output or bool(run.final_response),
+            candidate_available=(
+                direct_output or bool(run.final_response.strip()) or run.completion_commit is not None
+            ),
+            native_tool_activity=bool(self._native_tool_names) and run.projection.tool_calls_completed > 0,
         )
         raw_output_text = None if direct_output else run.final_response
         completion_commit = run.completion_commit if status is AgentOutputStatus.COMPLETED else None
@@ -170,12 +173,13 @@ def _outcome(
     run: DeepSeekHarnessRun,
     *,
     candidate_available: bool,
+    native_tool_activity: bool,
 ) -> tuple[AgentOutputStatus, AdapterFailureKind | None, AdapterStopReason | None, str | None]:
     finish_reason = run.finish_reason or run.projection.last_turn_end_reason
     if finish_reason == "completed" and run.projection.idle_seen:
         if not candidate_available:
             return (
-                AgentOutputStatus.EMPTY,
+                AgentOutputStatus.PARTIAL if native_tool_activity else AgentOutputStatus.EMPTY,
                 AdapterFailureKind.MISSING_OUTPUT,
                 None,
                 "DeepSeek Harness completed without a candidate output",
@@ -229,6 +233,13 @@ def _configuration_record(settings: DeepSeekHarnessSettings, run: DeepSeekHarnes
     }
     if run.evidence_manifest_sha256 is not None:
         record["evidence_manifest_sha256"] = run.evidence_manifest_sha256
+    if run.tool_gateway_close_report is not None:
+        record["tool_gateway_close"] = {
+            "quiescent": run.tool_gateway_close_report.quiescent,
+            "unsettled_request_ids": list(run.tool_gateway_close_report.unsettled_request_ids),
+            "unknown_outcome_request_ids": list(run.tool_gateway_close_report.unknown_outcome_request_ids),
+            "closed_at": run.tool_gateway_close_report.closed_at.isoformat(),
+        }
     for field_name in (
         "root_events_path",
         "sessions_path",

--- a/src/aec_bench/adapters/deepseek_harness/config.py
+++ b/src/aec_bench/adapters/deepseek_harness/config.py
@@ -23,7 +23,7 @@ DEEPSEEK_HARNESS_VERSION = "0.1.0rc6"
 OUTPUT_COMMIT_PLUGIN_ID = "@aec-bench/dsh-output-commit"
 OUTPUT_COMMIT_PLUGIN_VERSION = "0.1.0"
 TOOL_GATEWAY_PLUGIN_ID = "@aec-bench/dsh-tools"
-TOOL_GATEWAY_PLUGIN_VERSION = "0.1.0"
+TOOL_GATEWAY_PLUGIN_VERSION = "0.2.0"
 _MAX_SAFE_INTEGER = 2**53 - 1
 _HARNESS_PROVIDER_ROUTES: dict[str, HarnessProviderRoute] = {
     "azure": "azure",

--- a/src/aec_bench/adapters/deepseek_harness/plugin/dist/tools.js
+++ b/src/aec_bench/adapters/deepseek_harness/plugin/dist/tools.js
@@ -1,7 +1,7 @@
 import { createConnection } from 'node:net';
 export const name = '@aec-bench/dsh-tools';
 export const inject = ['tools'];
-export const TOOL_GATEWAY_PROTOCOL = 'aec-bench/deepseek-tools/1';
+export const TOOL_GATEWAY_PROTOCOL = 'aec-bench/deepseek-tools/2';
 const SOCKET_ENV = 'DSH_TOOLS_SOCKET';
 const TOKEN_ENV = 'DSH_TOOLS_TOKEN';
 const MANIFEST_ENV = 'DSH_TOOLS';
@@ -46,7 +46,7 @@ export function createGatewayTool(config, tool) {
         description: tool.description,
         parameters: tool.parameters,
         output: {
-            schema: { type: 'object', additionalProperties: true },
+            schema: {},
             render: (_args, value) => [{ type: 'text', text: JSON.stringify(value) }],
         },
         async execute(args, exec) {
@@ -60,8 +60,11 @@ export function createGatewayTool(config, tool) {
             }, exec.signal);
             if (response.status === 'error')
                 return { status: 'error', error: response.error };
+            if (response.disposition !== 'continue' && response.disposition !== 'conclude-turn') {
+                throw new Error('tool response disposition is invalid');
+            }
             const result = response.result ?? { status: 'error', error: { code: 'missing_result' } };
-            if (tool.name === 'submit_checkpoint' && result['status'] === 'complete')
+            if (response.disposition === 'conclude-turn')
                 exec.concludeTurn();
             return result;
         },
@@ -79,12 +82,14 @@ export function currentModelTurn(events) {
     throw new Error('tool gateway could not resolve the current model turn');
 }
 export async function requestGatewayTool(config, toolName, argumentsValue, identity, signal) {
-    if (signal.aborted)
+    if (signal.aborted) {
+        await requestGatewayCancellation(config, identity).catch(() => undefined);
         throw new Error('tool request cancelled');
+    }
     const payload = JSON.stringify({
         protocol: TOOL_GATEWAY_PROTOCOL,
         capability: config.capability,
-        request_id: `dsh:${identity.sessionId}:${identity.toolCallId}`,
+        operation: 'invoke',
         tool: toolName,
         arguments: argumentsValue,
         metadata: {
@@ -108,7 +113,14 @@ export async function requestGatewayTool(config, toolName, argumentsValue, ident
             else if (response !== undefined)
                 resolve(response);
         };
-        const cancel = () => finish(new Error('tool request cancelled'));
+        const cancel = () => {
+            if (settled)
+                return;
+            settled = true;
+            signal.removeEventListener('abort', cancel);
+            socket.destroy();
+            void requestGatewayCancellation(config, identity).then(() => reject(new Error('tool request cancelled')), () => reject(new Error('tool request cancelled')));
+        };
         signal.addEventListener('abort', cancel, { once: true });
         if (signal.aborted) {
             cancel();
@@ -139,6 +151,56 @@ export async function requestGatewayTool(config, toolName, argumentsValue, ident
         });
     });
 }
+export async function requestGatewayCancellation(config, identity) {
+    const payload = JSON.stringify({
+        protocol: TOOL_GATEWAY_PROTOCOL,
+        capability: config.capability,
+        operation: 'cancel',
+        metadata: {
+            deepseek_session_id: identity.sessionId,
+            deepseek_tool_call_id: identity.toolCallId,
+            aec_model_turn: identity.modelTurn,
+        },
+    }) + '\n';
+    return new Promise((resolve, reject) => {
+        const socket = createConnection(config.socketPath);
+        let settled = false;
+        let received = Buffer.alloc(0);
+        const finish = (error, response) => {
+            if (settled)
+                return;
+            settled = true;
+            socket.destroy();
+            if (error !== null)
+                reject(error);
+            else if (response !== undefined)
+                resolve(response);
+        };
+        socket.setTimeout(REQUEST_TIMEOUT_MS, () => finish(new Error('tool cancellation request timed out')));
+        socket.once('connect', () => socket.write(payload));
+        socket.on('data', chunk => {
+            received = Buffer.concat([received, chunk]);
+            if (received.length > MAX_RESPONSE_BYTES) {
+                finish(new Error('tool cancellation response is too large'));
+                return;
+            }
+            const newline = received.indexOf(0x0a);
+            if (newline < 0)
+                return;
+            try {
+                finish(null, parseResponse(received.subarray(0, newline).toString('utf8')));
+            }
+            catch (error) {
+                finish(error instanceof Error ? error : new Error('invalid tool cancellation response'));
+            }
+        });
+        socket.once('error', error => finish(error));
+        socket.once('end', () => {
+            if (!settled)
+                finish(new Error('tool authority closed without a cancellation response'));
+        });
+    });
+}
 function parseResponse(value) {
     const parsed = JSON.parse(value);
     if (typeof parsed !== 'object' || parsed === null)
@@ -146,6 +208,11 @@ function parseResponse(value) {
     const response = parsed;
     if (response.protocol !== TOOL_GATEWAY_PROTOCOL || (response.status !== 'ok' && response.status !== 'error')) {
         throw new Error('tool response protocol is invalid');
+    }
+    if (response.disposition !== undefined
+        && response.disposition !== 'continue'
+        && response.disposition !== 'conclude-turn') {
+        throw new Error('tool response disposition is invalid');
     }
     return response;
 }

--- a/src/aec_bench/adapters/deepseek_harness/plugin/src/tools.ts
+++ b/src/aec_bench/adapters/deepseek_harness/plugin/src/tools.ts
@@ -2,7 +2,7 @@ import { createConnection } from 'node:net'
 
 export const name = '@aec-bench/dsh-tools'
 export const inject = ['tools']
-export const TOOL_GATEWAY_PROTOCOL = 'aec-bench/deepseek-tools/1'
+export const TOOL_GATEWAY_PROTOCOL = 'aec-bench/deepseek-tools/2'
 
 const SOCKET_ENV = 'DSH_TOOLS_SOCKET'
 const TOKEN_ENV = 'DSH_TOOLS_TOKEN'
@@ -64,10 +64,11 @@ interface ToolGatewayResponse {
   readonly protocol: typeof TOOL_GATEWAY_PROTOCOL
   readonly status: 'ok' | 'error'
   readonly result?: ToolResult
+  readonly disposition?: 'continue' | 'conclude-turn'
   readonly error?: { readonly code: string; readonly message: string }
 }
 
-export type ToolResult = Readonly<Record<string, unknown>>
+export type ToolResult = unknown
 
 export function apply(ctx: CordisContext): void {
   const config = readConfig(process.env)
@@ -104,7 +105,7 @@ export function createGatewayTool(config: ToolGatewayConfig, tool: ToolManifest)
     description: tool.description,
     parameters: tool.parameters,
     output: {
-      schema: { type: 'object', additionalProperties: true },
+      schema: {},
       render: (_args, value) => [{ type: 'text', text: JSON.stringify(value) }],
     },
     async execute(args, exec) {
@@ -122,8 +123,11 @@ export function createGatewayTool(config: ToolGatewayConfig, tool: ToolManifest)
         exec.signal,
       )
       if (response.status === 'error') return { status: 'error', error: response.error }
+      if (response.disposition !== 'continue' && response.disposition !== 'conclude-turn') {
+        throw new Error('tool response disposition is invalid')
+      }
       const result = response.result ?? { status: 'error', error: { code: 'missing_result' } }
-      if (tool.name === 'submit_checkpoint' && result['status'] === 'complete') exec.concludeTurn()
+      if (response.disposition === 'conclude-turn') exec.concludeTurn()
       return result
     },
   }
@@ -146,11 +150,14 @@ export async function requestGatewayTool(
   identity: ToolIdentity,
   signal: AbortSignal,
 ): Promise<ToolGatewayResponse> {
-  if (signal.aborted) throw new Error('tool request cancelled')
+  if (signal.aborted) {
+    await requestGatewayCancellation(config, identity).catch(() => undefined)
+    throw new Error('tool request cancelled')
+  }
   const payload = JSON.stringify({
     protocol: TOOL_GATEWAY_PROTOCOL,
     capability: config.capability,
-    request_id: `dsh:${identity.sessionId}:${identity.toolCallId}`,
+    operation: 'invoke',
     tool: toolName,
     arguments: argumentsValue,
     metadata: {
@@ -172,7 +179,16 @@ export async function requestGatewayTool(
       if (error !== null) reject(error)
       else if (response !== undefined) resolve(response)
     }
-    const cancel = (): void => finish(new Error('tool request cancelled'))
+    const cancel = (): void => {
+      if (settled) return
+      settled = true
+      signal.removeEventListener('abort', cancel)
+      socket.destroy()
+      void requestGatewayCancellation(config, identity).then(
+        () => reject(new Error('tool request cancelled')),
+        () => reject(new Error('tool request cancelled')),
+      )
+    }
     signal.addEventListener('abort', cancel, { once: true })
     if (signal.aborted) {
       cancel()
@@ -201,12 +217,66 @@ export async function requestGatewayTool(
   })
 }
 
+export async function requestGatewayCancellation(
+  config: ToolGatewayConfig,
+  identity: ToolIdentity,
+): Promise<ToolGatewayResponse> {
+  const payload = JSON.stringify({
+    protocol: TOOL_GATEWAY_PROTOCOL,
+    capability: config.capability,
+    operation: 'cancel',
+    metadata: {
+      deepseek_session_id: identity.sessionId,
+      deepseek_tool_call_id: identity.toolCallId,
+      aec_model_turn: identity.modelTurn,
+    },
+  }) + '\n'
+
+  return new Promise<ToolGatewayResponse>((resolve, reject) => {
+    const socket = createConnection(config.socketPath)
+    let settled = false
+    let received = Buffer.alloc(0)
+    const finish = (error: Error | null, response?: ToolGatewayResponse): void => {
+      if (settled) return
+      settled = true
+      socket.destroy()
+      if (error !== null) reject(error)
+      else if (response !== undefined) resolve(response)
+    }
+    socket.setTimeout(REQUEST_TIMEOUT_MS, () => finish(new Error('tool cancellation request timed out')))
+    socket.once('connect', () => socket.write(payload))
+    socket.on('data', chunk => {
+      received = Buffer.concat([received, chunk])
+      if (received.length > MAX_RESPONSE_BYTES) {
+        finish(new Error('tool cancellation response is too large'))
+        return
+      }
+      const newline = received.indexOf(0x0a)
+      if (newline < 0) return
+      try {
+        finish(null, parseResponse(received.subarray(0, newline).toString('utf8')))
+      } catch (error: unknown) {
+        finish(error instanceof Error ? error : new Error('invalid tool cancellation response'))
+      }
+    })
+    socket.once('error', error => finish(error))
+    socket.once('end', () => {
+      if (!settled) finish(new Error('tool authority closed without a cancellation response'))
+    })
+  })
+}
+
 function parseResponse(value: string): ToolGatewayResponse {
   const parsed: unknown = JSON.parse(value)
   if (typeof parsed !== 'object' || parsed === null) throw new Error('tool response must be an object')
   const response = parsed as Partial<ToolGatewayResponse>
   if (response.protocol !== TOOL_GATEWAY_PROTOCOL || (response.status !== 'ok' && response.status !== 'error')) {
     throw new Error('tool response protocol is invalid')
+  }
+  if (response.disposition !== undefined
+    && response.disposition !== 'continue'
+    && response.disposition !== 'conclude-turn') {
+    throw new Error('tool response disposition is invalid')
   }
   return response as ToolGatewayResponse
 }

--- a/src/aec_bench/adapters/deepseek_harness/plugin/test/tools.test.mjs
+++ b/src/aec_bench/adapters/deepseek_harness/plugin/test/tools.test.mjs
@@ -52,6 +52,7 @@ async function withEndpoint(response, action) {
   const directory = await mkdtemp(join(tmpdir(), 'aec-dsh-tools-test-'))
   const socketPath = join(directory, 'tools.sock')
   let request
+  const requests = []
   const server = createServer(client => {
     let payload = ''
     client.setEncoding('utf8')
@@ -59,7 +60,14 @@ async function withEndpoint(response, action) {
       payload += chunk
       if (!payload.includes('\n')) return
       request = JSON.parse(payload.slice(0, payload.indexOf('\n')))
-      if (response !== undefined) client.end(`${JSON.stringify(response)}\n`)
+      requests.push(request)
+      if (request.operation === 'cancel') {
+        client.end(`${JSON.stringify({
+          protocol: TOOL_GATEWAY_PROTOCOL,
+          status: 'ok',
+          result: { outcome: 'unknown' },
+        })}\n`)
+      } else if (response !== undefined) client.end(`${JSON.stringify(response)}\n`)
     })
   })
   await new Promise((resolve, reject) => {
@@ -67,7 +75,7 @@ async function withEndpoint(response, action) {
     server.listen(socketPath, resolve)
   })
   try {
-    await action({ socketPath, request: () => request })
+    await action({ socketPath, request: () => request, requests: () => requests })
   } finally {
     await new Promise(resolve => server.close(resolve))
     await rm(directory, { recursive: true, force: true })
@@ -86,22 +94,28 @@ function execution(concludeTurn) {
   }
 }
 
-test('terminal checkpoint submission concludes the DeepSeek turn', async () => {
-  const completed = { protocol: TOOL_GATEWAY_PROTOCOL, status: 'ok', result: { status: 'complete' } }
+test('generic conclude-turn disposition concludes for any tool name', async () => {
+  const completed = {
+    protocol: TOOL_GATEWAY_PROTOCOL,
+    status: 'ok',
+    result: { status: 'observed' },
+    disposition: 'conclude-turn',
+  }
   await withEndpoint(completed, async endpoint => {
     let conclusions = 0
     const tool = createGatewayTool(
-      { socketPath: endpoint.socketPath, capability: 'secret', tools: [submitTool] },
-      submitTool,
+      { socketPath: endpoint.socketPath, capability: 'secret', tools: [readTool] },
+      readTool,
     )
 
-    const result = await tool.execute({ checkpoint_id: 'decision' }, execution(() => { conclusions += 1 }))
+    const result = await tool.execute({ path: 'instruction.md' }, execution(() => { conclusions += 1 }))
 
-    assert.deepEqual(result, { status: 'complete' })
+    assert.deepEqual(result, { status: 'observed' })
     assert.equal(conclusions, 1)
-    assert.equal(endpoint.request().tool, 'submit_checkpoint')
-    assert.deepEqual(endpoint.request().arguments, { checkpoint_id: 'decision' })
-    assert.equal(endpoint.request().request_id, 'dsh:root-session:tool-2')
+    assert.equal(endpoint.request().tool, 'read_workspace_file')
+    assert.deepEqual(endpoint.request().arguments, { path: 'instruction.md' })
+    assert.equal(endpoint.request().operation, 'invoke')
+    assert.equal('request_id' in endpoint.request(), false)
   })
 })
 
@@ -116,7 +130,12 @@ test('world tool uses the supplied tuple schema and keeps the turn active', asyn
       additionalProperties: false,
     },
   }
-  const accepted = { protocol: TOOL_GATEWAY_PROTOCOL, status: 'ok', result: { status: 'accepted' } }
+  const accepted = {
+    protocol: TOOL_GATEWAY_PROTOCOL,
+    status: 'ok',
+    result: { status: 'accepted' },
+    disposition: 'continue',
+  }
   await withEndpoint(accepted, async endpoint => {
     let conclusions = 0
     const tool = createGatewayTool(
@@ -135,6 +154,26 @@ test('world tool uses the supplied tuple schema and keeps the turn active', asyn
   })
 })
 
+test('generic JSON result can be a scalar', async () => {
+  const completed = {
+    protocol: TOOL_GATEWAY_PROTOCOL,
+    status: 'ok',
+    result: 'observed',
+    disposition: 'continue',
+  }
+  await withEndpoint(completed, async endpoint => {
+    const tool = createGatewayTool(
+      { socketPath: endpoint.socketPath, capability: 'secret', tools: [readTool] },
+      readTool,
+    )
+
+    const result = await tool.execute({ path: 'instruction.md' }, execution(() => assert.fail('unexpected conclusion')))
+
+    assert.equal(result, 'observed')
+    assert.deepEqual(tool.output.schema, {})
+  })
+})
+
 test('cancellation closes an in-flight tool request', async () => {
   await withEndpoint(undefined, async endpoint => {
     const controller = new AbortController()
@@ -148,5 +187,6 @@ test('cancellation closes an in-flight tool request', async () => {
     controller.abort()
 
     await assert.rejects(pending, /cancelled/)
+    assert.equal(endpoint.requests().some(request => request.operation === 'cancel'), true)
   })
 })

--- a/src/aec_bench/adapters/deepseek_harness/runtime.py
+++ b/src/aec_bench/adapters/deepseek_harness/runtime.py
@@ -13,7 +13,7 @@ import subprocess
 import sys
 import time
 import uuid
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -66,7 +66,8 @@ from aec_bench.adapters.deepseek_harness.tool_gateway import (
     TOOL_GATEWAY_MANIFEST_ENV,
     TOOL_GATEWAY_SOCKET_ENV,
     TOOL_GATEWAY_TOKEN_ENV,
-    NativeTool,
+    EndpointCloseReport,
+    NativeToolDefinition,
     ToolGatewayEndpoint,
 )
 from aec_bench.adapters.output_commit import read_output_completion_content, validate_stable_output_commit
@@ -160,6 +161,7 @@ class DeepSeekHarnessRun:
     cordis_path: Path | None = None
     commit_evidence_path: Path | None = None
     tool_gateway_evidence_path: Path | None = None
+    tool_gateway_close_report: EndpointCloseReport | None = None
 
 
 class DeepSeekHarnessProcessRuntime:
@@ -171,7 +173,8 @@ class DeepSeekHarnessProcessRuntime:
         settings: DeepSeekHarnessSettings,
         workspace: Path,
         worker_command: tuple[str, ...] | None = None,
-        native_tools: Mapping[str, NativeTool] | None = None,
+        native_tools: Sequence[NativeToolDefinition] | None = None,
+        tool_gateway_close_timeout_seconds: float = 5.0,
     ) -> None:
         self.settings = settings
         self.workspace = workspace.resolve()
@@ -180,7 +183,9 @@ class DeepSeekHarnessProcessRuntime:
             "-m",
             "aec_bench.adapters.deepseek_harness.worker",
         )
-        self.native_tools = dict(native_tools or {})
+        self.native_tools = tuple(native_tools or ())
+        self.native_tool_names = tuple(sorted(tool.name for tool in self.native_tools))
+        self.tool_gateway_close_timeout_seconds = tool_gateway_close_timeout_seconds
         self.paths = _deepseek_paths(self.workspace, trial_id=f"run-{uuid.uuid4().hex}")
         self._has_run = False
 
@@ -188,7 +193,7 @@ class DeepSeekHarnessProcessRuntime:
         if self._has_run:
             raise DeepSeekHarnessRuntimeError("one DeepSeek Harness runtime instance can execute only one trial")
         self._has_run = True
-        native_tool_names = frozenset(self.native_tools)
+        native_tool_names = frozenset(self.native_tool_names)
         validate_deepseek_request(request, native_tool_names=native_tool_names)
         contract, commit_required = deepseek_output_commit_configuration(request)
         timeout_seconds = request_timeout_seconds(request)
@@ -221,10 +226,24 @@ class DeepSeekHarnessProcessRuntime:
 
         commit_endpoint = self._commit_endpoint(contract, commit_required=commit_required)
         tool_gateway = self._tool_gateway()
-        for endpoint in (commit_endpoint, tool_gateway):
-            if endpoint is not None:
-                endpoint.start()
-                environment.update(endpoint.connection_environment())
+        commit_endpoint_started = False
+        tool_gateway_started = False
+        try:
+            if commit_endpoint is not None:
+                commit_endpoint.start()
+                commit_endpoint_started = True
+                environment.update(commit_endpoint.connection_environment())
+            if tool_gateway is not None:
+                tool_gateway.start()
+                tool_gateway_started = True
+                environment.update(tool_gateway.connection_environment())
+        except BaseException:
+            if tool_gateway_started and tool_gateway is not None:
+                tool_gateway.close()
+            if commit_endpoint_started and commit_endpoint is not None:
+                commit_endpoint.close()
+            self._retire_transient_directories()
+            raise
         command = (
             *self.worker_command,
             str(self.paths.request),
@@ -233,6 +252,7 @@ class DeepSeekHarnessProcessRuntime:
         )
         started_at = datetime.now(UTC)
         timed_out = False
+        tool_gateway_close_report: EndpointCloseReport | None = None
         try:
             with self.paths.stderr.open("w", encoding="utf-8") as stderr:
                 process = subprocess.Popen(
@@ -253,13 +273,33 @@ class DeepSeekHarnessProcessRuntime:
                 else:
                     _stop_process_group(process)
         finally:
-            for endpoint in (commit_endpoint, tool_gateway):
-                if endpoint is not None:
-                    endpoint.close()
-            self._retire_transient_directories()
+            try:
+                if commit_endpoint_started and commit_endpoint is not None:
+                    commit_endpoint.close()
+            finally:
+                try:
+                    if tool_gateway_started and tool_gateway is not None:
+                        tool_gateway_close_report = tool_gateway.close()
+                finally:
+                    self._retire_transient_directories()
 
         finished_at = datetime.now(UTC)
         self._redact_secret_values(environment)
+        if tool_gateway_close_report is not None and not tool_gateway_close_report.quiescent:
+            unsettled = ", ".join(tool_gateway_close_report.unsettled_request_ids)
+            error = f"DeepSeek native tool endpoint closed with unsettled requests: {unsettled}"
+            self._write_failure_evidence(
+                error=error,
+                exit_code=process.returncode,
+                timeout_seconds=timeout_seconds,
+                max_tokens=max_tokens,
+                commit_required=commit_required,
+                plugins=plugins,
+                started_at=started_at,
+                finished_at=finished_at,
+                tool_gateway_close_report=tool_gateway_close_report,
+            )
+            raise DeepSeekHarnessRuntimeError(error)
         if timed_out:
             error = f"DeepSeek Harness exceeded timeout_sec={timeout_seconds}"
             self._write_failure_evidence(
@@ -350,6 +390,7 @@ class DeepSeekHarnessProcessRuntime:
             projection=projection,
             started_at=started_at,
             finished_at=finished_at,
+            tool_gateway_close_report=tool_gateway_close_report,
         )
         return DeepSeekHarnessRun(
             session_id=worker_result.session_id,
@@ -368,7 +409,7 @@ class DeepSeekHarnessProcessRuntime:
             stderr_path=self.paths.stderr,
             evidence_manifest_sha256=_file_sha256(self.paths.manifest),
             optional_plugins=plugins,
-            native_tools=tuple(sorted(self.native_tools)),
+            native_tools=self.native_tool_names,
             root_events_path=self.paths.root_events,
             sessions_path=self.paths.sessions,
             manifest_path=self.paths.manifest,
@@ -377,6 +418,7 @@ class DeepSeekHarnessProcessRuntime:
             cordis_path=self.paths.cordis_input,
             commit_evidence_path=self.paths.commit_evidence if commit_required else None,
             tool_gateway_evidence_path=(self.paths.tool_gateway_evidence if self.native_tools else None),
+            tool_gateway_close_report=tool_gateway_close_report,
         )
 
     def _tool_gateway(self) -> ToolGatewayEndpoint | None:
@@ -385,6 +427,7 @@ class DeepSeekHarnessProcessRuntime:
         return ToolGatewayEndpoint(
             tools=self.native_tools,
             evidence_path=self.paths.tool_gateway_evidence,
+            close_timeout_seconds=self.tool_gateway_close_timeout_seconds,
         )
 
     def _commit_endpoint(
@@ -538,7 +581,7 @@ class DeepSeekHarnessProcessRuntime:
                     timeout_seconds=request_timeout_seconds(request),
                     max_tokens=request_max_tokens(request),
                     output_commit_required=commit_required,
-                    native_tools=tuple(sorted(self.native_tools)),
+                    native_tools=self.native_tool_names,
                 ),
                 "environment": {
                     "owned_names": sorted(owned_names),
@@ -614,6 +657,7 @@ class DeepSeekHarnessProcessRuntime:
         projection: DeepSeekRunProjection,
         started_at: datetime,
         finished_at: datetime,
+        tool_gateway_close_report: EndpointCloseReport | None,
     ) -> None:
         _write_root_events(self.paths.root_events, worker_result.session_id, notifications)
         _write_json(
@@ -633,6 +677,7 @@ class DeepSeekHarnessProcessRuntime:
                 "output_commit_mode": "required" if commit_required else "disabled",
                 "output_commit_accepted": completion_commit is not None,
                 "output_commit_error": commit_error,
+                "tool_gateway_close": _close_report_payload(tool_gateway_close_report),
             },
         )
         _write_evidence_manifest(
@@ -645,7 +690,7 @@ class DeepSeekHarnessProcessRuntime:
             timeout_seconds=timeout_seconds,
             max_tokens=max_tokens,
             commit_required=commit_required,
-            native_tools=tuple(sorted(self.native_tools)),
+            native_tools=self.native_tool_names,
             plugins=plugins,
             started_at=started_at,
             finished_at=finished_at,
@@ -662,6 +707,7 @@ class DeepSeekHarnessProcessRuntime:
         plugins: tuple[DeepSeekPluginIdentity, ...],
         started_at: datetime,
         finished_at: datetime,
+        tool_gateway_close_report: EndpointCloseReport | None = None,
     ) -> None:
         try:
             notifications = _read_notifications(self.paths.notifications) if self.paths.notifications.is_file() else []
@@ -681,6 +727,7 @@ class DeepSeekHarnessProcessRuntime:
                 "process_group_retired": True,
                 "timeout_sec": timeout_seconds,
                 "max_tokens": max_tokens,
+                "tool_gateway_close": _close_report_payload(tool_gateway_close_report),
             },
         )
         _write_evidence_manifest(
@@ -693,7 +740,7 @@ class DeepSeekHarnessProcessRuntime:
             timeout_seconds=timeout_seconds,
             max_tokens=max_tokens,
             commit_required=commit_required,
-            native_tools=tuple(sorted(self.native_tools)),
+            native_tools=self.native_tool_names,
             plugins=plugins,
             started_at=started_at,
             finished_at=finished_at,
@@ -734,6 +781,17 @@ def build_deepseek_worker_environment(
     if commit_environment is not None:
         environment.update(commit_environment)
     return environment
+
+
+def _close_report_payload(report: EndpointCloseReport | None) -> dict[str, Any] | None:
+    if report is None:
+        return None
+    return {
+        "quiescent": report.quiescent,
+        "unsettled_request_ids": list(report.unsettled_request_ids),
+        "unknown_outcome_request_ids": list(report.unknown_outcome_request_ids),
+        "closed_at": report.closed_at.isoformat(),
+    }
 
 
 def _worker_request_payload(

--- a/src/aec_bench/adapters/deepseek_harness/tool_gateway.py
+++ b/src/aec_bench/adapters/deepseek_harness/tool_gateway.py
@@ -1,41 +1,154 @@
 # ABOUTME: Exposes one exact AEC-owned native tool surface on an authenticated Unix socket.
-# ABOUTME: Keeps tool state and effects in AEC while DeepSeek presents model-facing JSON schemas.
+# ABOUTME: Supplies trusted invocation identity, cancellation, dispositions, and bounded close evidence.
 
 from __future__ import annotations
 
 import hashlib
 import hmac
-import inspect
 import json
 import os
+import re
 import secrets
 import socketserver
 import tempfile
 import threading
-from collections.abc import Callable, Mapping
-from dataclasses import dataclass
+import time
+import uuid
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from enum import StrEnum
 from pathlib import Path
-from typing import Any, Literal, cast, get_type_hints
+from typing import Any, Literal
 
-from pydantic import BaseModel, Field, create_model
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError, ValidationError
+from pydantic import Field, JsonValue
 
 from aec_bench.contracts.validators import NonEmptyStr, StrictModel
 
-TOOL_GATEWAY_PROTOCOL = "aec-bench/deepseek-tools/1"
+TOOL_GATEWAY_PROTOCOL = "aec-bench/deepseek-tools/2"
 TOOL_GATEWAY_SOCKET_ENV = "DSH_TOOLS_SOCKET"
 TOOL_GATEWAY_TOKEN_ENV = "DSH_TOOLS_TOKEN"
 TOOL_GATEWAY_MANIFEST_ENV = "DSH_TOOLS"
 _MAX_REQUEST_BYTES = 1024 * 1024
 _MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+_TOOL_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,127}$")
 
-NativeTool = Callable[..., str]
+
+class NativeToolDisposition(StrEnum):
+    """Tell the provider loop whether the current model turn can continue."""
+
+    CONTINUE = "continue"
+    CONCLUDE_TURN = "conclude-turn"
+
+
+class NativeCancellation:
+    """Expose cooperative cancellation to one synchronous AEC handler."""
+
+    def __init__(self) -> None:
+        self._event = threading.Event()
+        self._lock = threading.Lock()
+        self._requested_at: datetime | None = None
+
+    @property
+    def cancelled(self) -> bool:
+        return self._event.is_set()
+
+    @property
+    def requested_at(self) -> datetime | None:
+        with self._lock:
+            return self._requested_at
+
+    def wait(self, timeout: float | None = None) -> bool:
+        """Wait until cancellation or the optional timeout."""
+        return self._event.wait(timeout)
+
+    def _cancel(self) -> datetime:
+        with self._lock:
+            if self._requested_at is None:
+                self._requested_at = datetime.now(UTC)
+            requested_at = self._requested_at
+        self._event.set()
+        return requested_at
+
+
+@dataclass(frozen=True)
+class NativeToolInvocation:
+    """AEC-created identity and lifecycle state hidden from the model schema."""
+
+    request_id: str
+    deepseek_session_id: str
+    deepseek_tool_call_id: str
+    model_turn: int
+    tool_name: str
+    generation_id: str
+    admitted_at: datetime
+    cancellation: NativeCancellation
+
+
+@dataclass(frozen=True)
+class NativeToolResponse:
+    """Return one JSON result and generic provider-loop disposition."""
+
+    result: JsonValue
+    disposition: NativeToolDisposition = NativeToolDisposition.CONTINUE
+
+
+NativeToolHandler = Callable[[NativeToolInvocation, Mapping[str, JsonValue]], NativeToolResponse]
+
+
+@dataclass(frozen=True)
+class NativeToolDefinition:
+    """Define the exact model-facing schema and its AEC-owned handler."""
+
+    name: str
+    description: str
+    parameters_schema: dict[str, Any]
+    handler: NativeToolHandler
+
+
+def json_native_tool_definition(
+    *,
+    name: str,
+    description: str,
+    parameters_schema: dict[str, Any],
+    function: Callable[..., str],
+    trusted_request_argument: str | None = None,
+    disposition: Callable[[JsonValue], NativeToolDisposition] | None = None,
+) -> NativeToolDefinition:
+    """Bind an existing JSON-returning AEC method to one explicit model schema."""
+
+    def handle(invocation: NativeToolInvocation, arguments: Mapping[str, JsonValue]) -> NativeToolResponse:
+        call_arguments = dict(arguments)
+        if trusted_request_argument is not None:
+            call_arguments[trusted_request_argument] = invocation.request_id
+        result = json.loads(function(**call_arguments))
+        resolved_disposition = disposition(result) if disposition is not None else NativeToolDisposition.CONTINUE
+        return NativeToolResponse(result=result, disposition=resolved_disposition)
+
+    return NativeToolDefinition(
+        name=name,
+        description=description,
+        parameters_schema=parameters_schema,
+        handler=handle,
+    )
+
+
+@dataclass(frozen=True)
+class EndpointCloseReport:
+    """State whether every admitted operation settled before the close deadline."""
+
+    quiescent: bool
+    unsettled_request_ids: tuple[str, ...]
+    unknown_outcome_request_ids: tuple[str, ...]
+    closed_at: datetime
 
 
 @dataclass(frozen=True)
 class _ToolBinding:
-    function: NativeTool
-    arguments_model: type[BaseModel]
+    definition: NativeToolDefinition
+    validator: Draft202012Validator
     manifest: dict[str, Any]
 
 
@@ -45,18 +158,36 @@ class _ToolMetadata(StrictModel):
     aec_model_turn: int = Field(ge=1)
 
 
-class _ToolRequest(StrictModel):
-    protocol: Literal["aec-bench/deepseek-tools/1"]
+class _ToolInvocationRequest(StrictModel):
+    protocol: Literal["aec-bench/deepseek-tools/2"]
     capability: NonEmptyStr
-    request_id: NonEmptyStr
+    operation: Literal["invoke"]
     tool: NonEmptyStr
-    arguments: dict[str, Any]
+    arguments: dict[str, JsonValue]
     metadata: _ToolMetadata
 
 
+class _ToolCancellationRequest(StrictModel):
+    protocol: Literal["aec-bench/deepseek-tools/2"]
+    capability: NonEmptyStr
+    operation: Literal["cancel"]
+    metadata: _ToolMetadata
+
+
+@dataclass
+class _AdmittedInvocation:
+    fingerprint: str
+    invocation: NativeToolInvocation
+    arguments: dict[str, JsonValue]
+    dispatched_at: datetime | None = None
+    completed_at: datetime | None = None
+    response: dict[str, Any] | None = None
+    done: threading.Event = field(default_factory=threading.Event)
+
+
 class _ThreadingUnixServer(socketserver.ThreadingMixIn, socketserver.UnixStreamServer):
-    daemon_threads = False
-    block_on_close = True
+    daemon_threads = True
+    block_on_close = False
     allow_reuse_address = False
 
 
@@ -107,33 +238,48 @@ class ToolGatewayEndpoint:
     def __init__(
         self,
         *,
-        tools: Mapping[str, NativeTool],
+        tools: Sequence[NativeToolDefinition],
         evidence_path: Path,
         capability_token: str | None = None,
         client_timeout_seconds: float = 120.0,
+        close_timeout_seconds: float = 5.0,
+        generation_id: str | None = None,
     ) -> None:
         if not tools:
             raise ValueError("tool gateway requires at least one tool")
-        self._bindings = {name: _tool_binding(name, tool) for name, tool in tools.items()}
-        self.tools = dict(tools)
+        if client_timeout_seconds <= 0:
+            raise ValueError("tool gateway client timeout must be positive")
+        if close_timeout_seconds < 0:
+            raise ValueError("tool gateway close timeout must not be negative")
+        self._bindings = _tool_bindings(tools)
+        self.tools = tuple(binding.definition for binding in self._bindings.values())
         self.evidence_path = evidence_path
         self._capability_token = capability_token or secrets.token_urlsafe(32)
         self.client_timeout_seconds = client_timeout_seconds
+        self.close_timeout_seconds = close_timeout_seconds
+        self.generation_id = generation_id or f"tool-gateway-{uuid.uuid4().hex}"
         self._lock = threading.Lock()
+        self._condition = threading.Condition(self._lock)
+        self._evidence_lock = threading.Lock()
+        self._evidence_finalized = False
         self._responses: dict[str, tuple[str, dict[str, Any]]] = {}
+        self._active: dict[str, _AdmittedInvocation] = {}
+        self._cancelled_before_dispatch: set[str] = set()
         self._server: _ToolServer | None = None
         self._thread: threading.Thread | None = None
         self._socket_directory: Path | None = None
         self._socket_path: Path | None = None
         self._closing = False
+        self._generation_finalized = False
+        self._close_report: EndpointCloseReport | None = None
 
     def start(self) -> None:
         """Create the private socket and start accepting bounded requests."""
         with self._lock:
             if self._server is not None:
-                raise RuntimeError("lifecycle tool endpoint is already started")
+                raise RuntimeError("native tool endpoint is already started")
             if self._closing:
-                raise RuntimeError("lifecycle tool endpoint is closed")
+                raise RuntimeError("native tool endpoint is closed")
             socket_directory = Path(tempfile.mkdtemp(prefix="aec-dsh-tools-"))
             os.chmod(socket_directory, 0o700)
             socket_path = socket_directory / "tools.sock"
@@ -151,21 +297,45 @@ class ToolGatewayEndpoint:
             self._thread = thread
             thread.start()
 
-    def close(self) -> None:
-        """Stop acceptance, wait for active handlers, and remove the owned socket."""
-        with self._lock:
+    def close(self, *, timeout_seconds: float | None = None) -> EndpointCloseReport:
+        """Stop acceptance and report whether admitted handlers became quiescent."""
+        deadline_seconds = self.close_timeout_seconds if timeout_seconds is None else timeout_seconds
+        if deadline_seconds < 0:
+            raise ValueError("tool gateway close timeout must not be negative")
+        with self._condition:
+            if self._close_report is not None:
+                return self._close_report
             if self._closing:
-                return
+                while self._close_report is None:
+                    self._condition.wait()
+                return self._close_report
             self._closing = True
+            self._generation_finalized = True
             server = self._server
             thread = self._thread
             socket_path = self._socket_path
             socket_directory = self._socket_directory
+            for active in self._active.values():
+                active.invocation.cancellation._cancel()
+
         if server is not None:
             server.shutdown()
             server.server_close()
         if thread is not None:
             thread.join()
+
+        deadline = time.monotonic() + deadline_seconds
+        with self._condition:
+            while self._active:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                self._condition.wait(remaining)
+            unsettled = tuple(sorted(self._active))
+            unknown = tuple(
+                request_id for request_id in unsettled if self._active[request_id].dispatched_at is not None
+            )
+
         if socket_path is not None:
             socket_path.unlink(missing_ok=True)
         if socket_directory is not None:
@@ -174,11 +344,35 @@ class ToolGatewayEndpoint:
             except FileNotFoundError:
                 pass
 
+        report = EndpointCloseReport(
+            quiescent=not unsettled,
+            unsettled_request_ids=unsettled,
+            unknown_outcome_request_ids=unknown,
+            closed_at=datetime.now(UTC),
+        )
+        self._append_evidence(
+            {
+                "record_type": "close",
+                "protocol": TOOL_GATEWAY_PROTOCOL,
+                "generation_id": self.generation_id,
+                "closed_at": report.closed_at.isoformat(),
+                "quiescent": report.quiescent,
+                "unsettled_request_ids": list(report.unsettled_request_ids),
+                "unknown_outcome_request_ids": list(report.unknown_outcome_request_ids),
+                "late_results_after_close_are_ignored": True,
+            },
+            finalize=True,
+        )
+        with self._condition:
+            self._close_report = report
+            self._condition.notify_all()
+        return report
+
     def connection_environment(self) -> Mapping[str, str]:
-        """Return private runtime connection values and the exact enabled tool names."""
+        """Return private runtime connection values and the exact enabled tool manifest."""
         with self._lock:
             if self._socket_path is None or self._closing:
-                raise RuntimeError("lifecycle tool endpoint is not active")
+                raise RuntimeError("native tool endpoint is not active")
             return {
                 TOOL_GATEWAY_SOCKET_ENV: str(self._socket_path),
                 TOOL_GATEWAY_TOKEN_ENV: self._capability_token,
@@ -191,115 +385,354 @@ class ToolGatewayEndpoint:
 
     def _handle_payload(self, payload: bytes) -> dict[str, Any]:
         try:
-            request = _ToolRequest.model_validate_json(payload)
-        except ValueError:
+            raw = json.loads(payload)
+            if not isinstance(raw, dict):
+                raise ValueError
+            operation = raw.get("operation")
+            if operation == "invoke":
+                request: _ToolInvocationRequest | _ToolCancellationRequest = _ToolInvocationRequest.model_validate(raw)
+            elif operation == "cancel":
+                request = _ToolCancellationRequest.model_validate(raw)
+            else:
+                raise ValueError
+        except (TypeError, ValueError, json.JSONDecodeError):
             return _error_response("invalid_request", "Tool request is invalid.")
         if not hmac.compare_digest(request.capability, self._capability_token):
             return _error_response("unauthorized", "Tool authorization failed.")
+        if isinstance(request, _ToolCancellationRequest):
+            return self._cancel(request)
+        return self._invoke(request)
+
+    def _invoke(self, request: _ToolInvocationRequest) -> dict[str, Any]:
+        request_id = _trusted_request_id(request.metadata)
+        binding = self._bindings.get(request.tool)
+        if binding is None:
+            response = _error_response("tool_not_allowed", f"Tool is not enabled: {request.tool}")
+            self._append_unadmitted_evidence(request, request_id=request_id, response=response)
+            return response
+        try:
+            binding.validator.validate(request.arguments)
+        except ValidationError as exc:
+            response = _error_response("invalid_arguments", exc.message)
+            self._append_unadmitted_evidence(request, request_id=request_id, response=response)
+            return response
 
         fingerprint = _request_fingerprint(request)
+        owner = False
         with self._lock:
-            previous = self._responses.get(request.request_id)
+            previous = self._responses.get(request_id)
             if previous is not None:
                 previous_fingerprint, previous_response = previous
                 if previous_fingerprint != fingerprint:
                     response = _error_response(
                         "request_id_conflict",
-                        "Tool request_id was reused with a different call.",
+                        "Trusted tool request identity was reused with a different call.",
                     )
-                    self._append_evidence(request, response, idempotent_replay=False)
+                    self._append_duplicate_evidence(request, request_id, response, duplicate_of=request_id)
                     return response
-                self._append_evidence(request, previous_response, idempotent_replay=True)
+                self._append_duplicate_evidence(request, request_id, previous_response, duplicate_of=request_id)
                 return previous_response
-            if self._closing:
-                response = _error_response("endpoint_closing", "Lifecycle tool authority is closing.")
+
+            active = self._active.get(request_id)
+            if active is not None:
+                if active.fingerprint != fingerprint:
+                    response = _error_response(
+                        "request_id_conflict",
+                        "Trusted tool request identity was reused with a different call.",
+                    )
+                    self._append_duplicate_evidence(request, request_id, response, duplicate_of=request_id)
+                    return response
+            elif request_id in self._cancelled_before_dispatch:
+                response = _error_response("request_cancelled", "Tool request was cancelled before dispatch.")
+                self._append_unadmitted_evidence(request, request_id=request_id, response=response, cancelled=True)
+                return response
+            elif self._closing:
+                response = _error_response("endpoint_closing", "Native tool authority is closing.")
+                self._append_unadmitted_evidence(request, request_id=request_id, response=response)
+                return response
             else:
-                response = self._execute(request)
-            self._responses[request.request_id] = (fingerprint, response)
-            self._append_evidence(request, response, idempotent_replay=False)
+                admitted_at = datetime.now(UTC)
+                invocation = NativeToolInvocation(
+                    request_id=request_id,
+                    deepseek_session_id=request.metadata.deepseek_session_id,
+                    deepseek_tool_call_id=request.metadata.deepseek_tool_call_id,
+                    model_turn=request.metadata.aec_model_turn,
+                    tool_name=request.tool,
+                    generation_id=self.generation_id,
+                    admitted_at=admitted_at,
+                    cancellation=NativeCancellation(),
+                )
+                active = _AdmittedInvocation(
+                    fingerprint=fingerprint,
+                    invocation=invocation,
+                    arguments=dict(request.arguments),
+                )
+                self._active[request_id] = active
+                owner = True
+
+        if not owner:
+            if not active.done.wait(self.client_timeout_seconds):
+                response = _error_response("request_in_progress", "The identical tool request is still running.")
+                self._append_duplicate_evidence(request, request_id, response, duplicate_of=request_id)
+                return response
+            response = active.response or _error_response("unknown_outcome", "The tool request outcome is unknown.")
+            self._append_duplicate_evidence(request, request_id, response, duplicate_of=request_id)
             return response
 
-    def _execute(self, request: _ToolRequest) -> dict[str, Any]:
-        binding = self._bindings.get(request.tool)
-        if binding is None:
-            return _error_response("tool_not_allowed", f"Tool is not enabled: {request.tool}")
-        try:
-            arguments = binding.arguments_model.model_validate_json(json.dumps(request.arguments))
-            inspect.signature(binding.function).bind(**arguments.model_dump())
-            raw_result = binding.function(**arguments.model_dump())
-            result = json.loads(raw_result)
-            if not isinstance(result, dict):
-                raise ValueError("tool result must be a JSON object")
-        except (TypeError, ValueError, json.JSONDecodeError) as exc:
-            return _error_response("invalid_arguments", str(exc))
-        except Exception:
-            return _error_response("tool_failed", "Lifecycle tool execution failed.")
-        return {"protocol": TOOL_GATEWAY_PROTOCOL, "status": "ok", "result": result}
+        return self._execute(binding, request, active)
 
-    def _append_evidence(
+    def _execute(
         self,
-        request: _ToolRequest,
+        binding: _ToolBinding,
+        request: _ToolInvocationRequest,
+        active: _AdmittedInvocation,
+    ) -> dict[str, Any]:
+        request_id = active.invocation.request_id
+        with self._lock:
+            cancelled_before_dispatch = active.invocation.cancellation.cancelled
+            if not cancelled_before_dispatch:
+                active.dispatched_at = datetime.now(UTC)
+        if cancelled_before_dispatch:
+            response = _error_response("request_cancelled", "Tool request was cancelled before dispatch.")
+            outcome = "not-dispatched"
+            raw_result: JsonValue | None = None
+            disposition: NativeToolDisposition | None = None
+        else:
+            try:
+                tool_response = binding.definition.handler(active.invocation, active.arguments)
+                if not isinstance(tool_response, NativeToolResponse):
+                    raise TypeError("native tool handler must return NativeToolResponse")
+                json.dumps(tool_response.result, allow_nan=False)
+                response = {
+                    "protocol": TOOL_GATEWAY_PROTOCOL,
+                    "status": "ok",
+                    "result": tool_response.result,
+                    "disposition": tool_response.disposition.value,
+                }
+                raw_result = tool_response.result
+                disposition = tool_response.disposition
+                outcome = "completed"
+            except (TypeError, ValueError) as exc:
+                response = _error_response("invalid_result", str(exc))
+                raw_result = None
+                disposition = None
+                outcome = "completed"
+            except Exception:
+                response = _error_response("tool_failed", "Native tool execution failed.")
+                raw_result = None
+                disposition = None
+                outcome = "completed"
+
+        completed_at = datetime.now(UTC)
+        with self._condition:
+            active.completed_at = completed_at
+            stale = self._generation_finalized
+            if stale:
+                transport_response = _error_response(
+                    "generation_finalized",
+                    "Tool result arrived after endpoint finalization began.",
+                )
+                active.response = transport_response
+            else:
+                active.response = response
+                self._responses[request_id] = (active.fingerprint, response)
+                transport_response = response
+            self._active.pop(request_id, None)
+            active.done.set()
+            self._condition.notify_all()
+
+        self._append_invocation_evidence(
+            request,
+            active,
+            response=response,
+            result=raw_result,
+            disposition=disposition,
+            outcome=outcome,
+            stale=stale,
+        )
+        return transport_response
+
+    def _cancel(self, request: _ToolCancellationRequest) -> dict[str, Any]:
+        request_id = _trusted_request_id(request.metadata)
+        occurred_at = datetime.now(UTC)
+        with self._lock:
+            completed = request_id in self._responses
+            active = self._active.get(request_id)
+            if completed:
+                outcome = "completed"
+            elif active is None:
+                self._cancelled_before_dispatch.add(request_id)
+                outcome = "not-dispatched"
+            else:
+                active.invocation.cancellation._cancel()
+                outcome = "unknown" if active.dispatched_at is not None else "not-dispatched"
+        response = {
+            "protocol": TOOL_GATEWAY_PROTOCOL,
+            "status": "ok",
+            "result": {"outcome": outcome},
+        }
+        self._append_evidence(
+            {
+                "record_type": "cancellation",
+                "protocol": TOOL_GATEWAY_PROTOCOL,
+                "generation_id": self.generation_id,
+                "request_id": request_id,
+                "deepseek_session_id": request.metadata.deepseek_session_id,
+                "deepseek_tool_call_id": request.metadata.deepseek_tool_call_id,
+                "model_turn": request.metadata.aec_model_turn,
+                "occurred_at": occurred_at.isoformat(),
+                "outcome": outcome,
+            }
+        )
+        return response
+
+    def _append_invocation_evidence(
+        self,
+        request: _ToolInvocationRequest,
+        active: _AdmittedInvocation,
+        *,
+        response: dict[str, Any],
+        result: JsonValue | None,
+        disposition: NativeToolDisposition | None,
+        outcome: str,
+        stale: bool,
+    ) -> None:
+        cancellation_requested_at = active.invocation.cancellation.requested_at
+        self._append_evidence(
+            {
+                "record_type": "invocation",
+                "protocol": TOOL_GATEWAY_PROTOCOL,
+                "generation_id": self.generation_id,
+                "request_id": active.invocation.request_id,
+                "deepseek_session_id": request.metadata.deepseek_session_id,
+                "deepseek_tool_call_id": request.metadata.deepseek_tool_call_id,
+                "model_turn": request.metadata.aec_model_turn,
+                "tool": request.tool,
+                "arguments_sha256": _json_sha256(request.arguments),
+                "admitted_at": active.invocation.admitted_at.isoformat(),
+                "dispatched_at": active.dispatched_at.isoformat() if active.dispatched_at is not None else None,
+                "cancellation_requested_at": (
+                    cancellation_requested_at.isoformat() if cancellation_requested_at is not None else None
+                ),
+                "completed_at": active.completed_at.isoformat() if active.completed_at is not None else None,
+                "result_sha256": _json_sha256(result) if result is not None else None,
+                "error_code": _response_error_code(response),
+                "disposition": disposition.value if disposition is not None else None,
+                "duplicate_of": None,
+                "outcome": outcome,
+                "stale_ignored": stale,
+            }
+        )
+
+    def _append_unadmitted_evidence(
+        self,
+        request: _ToolInvocationRequest,
+        *,
+        request_id: str,
+        response: dict[str, Any],
+        cancelled: bool = False,
+    ) -> None:
+        occurred_at = datetime.now(UTC)
+        self._append_evidence(
+            {
+                "record_type": "invocation",
+                "protocol": TOOL_GATEWAY_PROTOCOL,
+                "generation_id": self.generation_id,
+                "request_id": request_id,
+                "deepseek_session_id": request.metadata.deepseek_session_id,
+                "deepseek_tool_call_id": request.metadata.deepseek_tool_call_id,
+                "model_turn": request.metadata.aec_model_turn,
+                "tool": request.tool,
+                "arguments_sha256": _json_sha256(request.arguments),
+                "admitted_at": None,
+                "dispatched_at": None,
+                "cancellation_requested_at": occurred_at.isoformat() if cancelled else None,
+                "completed_at": occurred_at.isoformat(),
+                "result_sha256": None,
+                "error_code": _response_error_code(response),
+                "disposition": None,
+                "duplicate_of": None,
+                "outcome": "not-dispatched",
+                "stale_ignored": False,
+            }
+        )
+
+    def _append_duplicate_evidence(
+        self,
+        request: _ToolInvocationRequest,
+        request_id: str,
         response: dict[str, Any],
         *,
-        idempotent_replay: bool,
+        duplicate_of: str,
     ) -> None:
+        self._append_evidence(
+            {
+                "record_type": "duplicate",
+                "protocol": TOOL_GATEWAY_PROTOCOL,
+                "generation_id": self.generation_id,
+                "request_id": request_id,
+                "deepseek_session_id": request.metadata.deepseek_session_id,
+                "deepseek_tool_call_id": request.metadata.deepseek_tool_call_id,
+                "model_turn": request.metadata.aec_model_turn,
+                "tool": request.tool,
+                "arguments_sha256": _json_sha256(request.arguments),
+                "occurred_at": datetime.now(UTC).isoformat(),
+                "error_code": _response_error_code(response),
+                "duplicate_of": duplicate_of,
+            }
+        )
+
+    def _append_evidence(self, record: Mapping[str, Any], *, finalize: bool = False) -> None:
         self.evidence_path.parent.mkdir(parents=True, exist_ok=True)
-        record = {
-            "protocol": TOOL_GATEWAY_PROTOCOL,
-            "occurred_at": datetime.now(UTC).isoformat(),
-            "request_id": request.request_id,
-            "tool": request.tool,
-            "arguments_sha256": hashlib.sha256(
-                json.dumps(request.arguments, sort_keys=True, separators=(",", ":")).encode("utf-8")
-            ).hexdigest(),
-            "metadata": request.metadata.model_dump(mode="json"),
-            "response_status": response.get("status"),
-            "response_error_code": (
-                response.get("error", {}).get("code") if isinstance(response.get("error"), dict) else None
-            ),
-            "idempotent_replay": idempotent_replay,
-        }
-        with self.evidence_path.open("a", encoding="utf-8") as stream:
-            stream.write(json.dumps(record, sort_keys=True) + "\n")
-            stream.flush()
-            os.fsync(stream.fileno())
+        with self._evidence_lock:
+            if self._evidence_finalized:
+                return
+            with self.evidence_path.open("a", encoding="utf-8") as stream:
+                stream.write(json.dumps(record, sort_keys=True) + "\n")
+                stream.flush()
+                os.fsync(stream.fileno())
+            if finalize:
+                self._evidence_finalized = True
 
 
-def _tool_binding(name: str, tool: NativeTool) -> _ToolBinding:
-    if not name or name != getattr(tool, "__name__", None):
-        raise ValueError("tool gateway names must match stable callable names")
-    fields: dict[str, tuple[Any, Any]] = {}
-    type_hints = get_type_hints(tool)
-    for parameter in inspect.signature(tool).parameters.values():
-        if parameter.kind not in {parameter.POSITIONAL_OR_KEYWORD, parameter.KEYWORD_ONLY}:
-            raise ValueError(f"tool gateway does not support parameter kind for {name}.{parameter.name}")
-        annotation = type_hints.get(parameter.name)
-        if annotation is None:
-            raise ValueError(f"tool gateway requires an annotation for {name}.{parameter.name}")
-        default = ... if parameter.default is inspect.Parameter.empty else parameter.default
-        fields[parameter.name] = (annotation, default)
-    model_factory = cast(Any, create_model)
-    arguments_model = cast(
-        type[BaseModel],
-        model_factory(
-            f"{''.join(part.title() for part in name.split('_'))}Arguments",
-            __base__=StrictModel,
-            **fields,
-        ),
-    )
-    parameters = arguments_model.model_json_schema()
-    parameters.pop("title", None)
-    description = inspect.getdoc(tool) or name.replace("_", " ")
-    return _ToolBinding(
-        function=tool,
-        arguments_model=arguments_model,
-        manifest={"name": name, "description": description, "parameters": parameters},
-    )
+def _tool_bindings(tools: Sequence[NativeToolDefinition]) -> dict[str, _ToolBinding]:
+    bindings: dict[str, _ToolBinding] = {}
+    for definition in tools:
+        if not _TOOL_NAME.fullmatch(definition.name):
+            raise ValueError(f"invalid native tool name: {definition.name!r}")
+        if not definition.description.strip():
+            raise ValueError(f"native tool description must not be blank: {definition.name}")
+        if definition.name in bindings:
+            raise ValueError(f"duplicate native tool: {definition.name}")
+        try:
+            Draft202012Validator.check_schema(definition.parameters_schema)
+        except SchemaError as exc:
+            raise ValueError(f"invalid parameter schema for native tool {definition.name}: {exc.message}") from exc
+        schema = json.loads(json.dumps(definition.parameters_schema, sort_keys=True))
+        bindings[definition.name] = _ToolBinding(
+            definition=definition,
+            validator=Draft202012Validator(schema),
+            manifest={"name": definition.name, "description": definition.description, "parameters": schema},
+        )
+    return bindings
 
 
-def _request_fingerprint(request: _ToolRequest) -> str:
-    payload = request.model_dump(mode="json", exclude={"capability"})
-    return hashlib.sha256(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+def _trusted_request_id(metadata: _ToolMetadata) -> str:
+    return f"dsh:{metadata.deepseek_session_id}:{metadata.deepseek_tool_call_id}"
+
+
+def _request_fingerprint(request: _ToolInvocationRequest) -> str:
+    return _json_sha256(request.model_dump(mode="json", exclude={"capability"}))
+
+
+def _json_sha256(value: Any) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _response_error_code(response: Mapping[str, Any]) -> str | None:
+    error = response.get("error")
+    return str(error.get("code")) if isinstance(error, dict) and error.get("code") is not None else None
 
 
 def _error_response(code: str, message: str) -> dict[str, Any]:

--- a/src/aec_bench/adapters/local_registry.py
+++ b/src/aec_bench/adapters/local_registry.py
@@ -4,9 +4,12 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from aec_bench.adapters.deepseek_harness.tool_gateway import NativeToolDefinition
 
 logger = logging.getLogger(__name__)
 
@@ -398,29 +401,32 @@ def _build_deepseek_harness(
     model_name: str,
     workspace: str,
     native_tools: list[Callable[..., str]] | None = None,
+    native_tool_definitions: Sequence[NativeToolDefinition] | None = None,
     **_kwargs: Any,
 ) -> Any:
     """Build the official DeepSeek Harness adapter through its shared runtime."""
     from aec_bench.adapters.deepseek_harness import DeepSeekHarnessAdapter
     from aec_bench.adapters.deepseek_harness.config import DeepSeekHarnessSettings
+    from aec_bench.adapters.deepseek_harness.tool_gateway import NativeToolDefinition
 
     provider = model_name.partition(":")[0].strip().lower()
     settings = DeepSeekHarnessSettings.from_execution_payload(
         model_name=model_name,
         payload={"provider": provider},
     )
-    tool_gateway: dict[str, Callable[..., str]] = {}
-    for tool in native_tools or []:
-        name = getattr(tool, "__name__", "")
-        if not name:
-            raise ValueError("DeepSeek native tools must have a stable callable name")
-        if name in tool_gateway:
-            raise ValueError(f"duplicate DeepSeek native tool: {name}")
-        tool_gateway[name] = tool
+    definitions = tuple(native_tool_definitions or ())
+    if native_tools and not definitions:
+        raise ValueError("DeepSeek native tools require explicit NativeToolDefinition values")
+    if not all(isinstance(definition, NativeToolDefinition) for definition in definitions):
+        raise TypeError("DeepSeek native tool definitions must be NativeToolDefinition values")
+    names = [definition.name for definition in definitions]
+    if len(names) != len(set(names)):
+        duplicate = next(name for name in names if names.count(name) > 1)
+        raise ValueError(f"duplicate DeepSeek native tool: {duplicate}")
     return DeepSeekHarnessAdapter(
         settings=settings,
         workspace=workspace,
-        native_tools=tool_gateway,
+        native_tools=definitions,
     )
 
 

--- a/src/aec_bench/harness/lifecycle_local.py
+++ b/src/aec_bench/harness/lifecycle_local.py
@@ -10,7 +10,9 @@ import uuid
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
-from typing import Any, Protocol, cast
+from typing import TYPE_CHECKING, Any, Protocol, cast
+
+from pydantic import JsonValue
 
 from aec_bench.adapters.base import AdapterRequest
 from aec_bench.adapters.deepseek_harness.config import DEFAULT_TIMEOUT_SECONDS
@@ -53,6 +55,9 @@ from aec_bench.lifecycles.runtime.operation_protocol import (
     LifecycleOperationResolver,
 )
 from aec_bench.trajectory.writer import TrajectoryWriter
+
+if TYPE_CHECKING:
+    from aec_bench.adapters.deepseek_harness.tool_gateway import NativeToolDefinition, NativeToolDisposition
 
 DEFAULT_DEEPSEEK_LIFECYCLE_MAX_TOKENS = 8192
 
@@ -315,6 +320,117 @@ class EvidenceLifecycleWorkspaceTool:
         return bool(parts[1] == state["active_checkpoint_id"])
 
 
+def _deepseek_lifecycle_tool_definitions(
+    *,
+    control: EvidenceLifecycleControlTool,
+    workspace: EvidenceLifecycleWorkspaceTool,
+    supports_evidence_requests: bool,
+    supports_lifecycle_operations: bool,
+    include_completion_tools: bool,
+) -> tuple[NativeToolDefinition, ...]:
+    from aec_bench.adapters.deepseek_harness.tool_gateway import json_native_tool_definition
+
+    definitions = [
+        json_native_tool_definition(
+            name="list_workspace",
+            description="List one visible lifecycle workspace directory.",
+            parameters_schema=_tool_parameters({"path": {"type": "string", "default": "."}}),
+            function=workspace.list_workspace,
+        ),
+        json_native_tool_definition(
+            name="read_workspace_file",
+            description="Read one released or persisted lifecycle workspace file.",
+            parameters_schema=_tool_parameters({"path": {"type": "string"}}, required=("path",)),
+            function=workspace.read_workspace_file,
+        ),
+        json_native_tool_definition(
+            name="write_checkpoint_submission",
+            description="Write the active checkpoint JSON submission.",
+            parameters_schema=_tool_parameters(
+                {"checkpoint_id": {"type": "string"}, "content": {"type": "string"}},
+                required=("checkpoint_id", "content"),
+            ),
+            function=workspace.write_checkpoint_submission,
+        ),
+    ]
+    if supports_evidence_requests:
+        definitions.append(
+            json_native_tool_definition(
+                name="request_evidence",
+                description="Request one declared evidence packet within the active checkpoint budget.",
+                parameters_schema=_tool_parameters(
+                    {"checkpoint_id": {"type": "string"}, "reason": {"type": "string"}},
+                    required=("checkpoint_id", "reason"),
+                ),
+                function=control.request_evidence,
+                trusted_request_argument="request_id",
+            )
+        )
+    if supports_lifecycle_operations:
+        definitions.append(
+            json_native_tool_definition(
+                name="execute_operation",
+                description="Execute one declared operation against the current visible source state.",
+                parameters_schema=_tool_parameters(
+                    {
+                        "checkpoint_id": {"type": "string"},
+                        "operation_id": {"type": "string"},
+                        "visible_source_state_sha256": {"type": "string"},
+                        "reason": {"type": "string"},
+                    },
+                    required=("checkpoint_id", "operation_id", "visible_source_state_sha256", "reason"),
+                ),
+                function=control.execute_operation,
+            )
+        )
+    if include_completion_tools:
+        definitions.extend(
+            (
+                json_native_tool_definition(
+                    name="submit_checkpoint",
+                    description="Archive the active checkpoint and release the next evidence packet.",
+                    parameters_schema=_tool_parameters(
+                        {"checkpoint_id": {"type": "string"}},
+                        required=("checkpoint_id",),
+                    ),
+                    function=control.submit_checkpoint,
+                    disposition=_checkpoint_disposition,
+                ),
+                json_native_tool_definition(
+                    name="revisit_checkpoint",
+                    description="Inspect and log an immutable prior checkpoint without rewinding the run.",
+                    parameters_schema=_tool_parameters(
+                        {"checkpoint_id": {"type": "string"}, "reason": {"type": "string"}},
+                        required=("checkpoint_id", "reason"),
+                    ),
+                    function=control.revisit_checkpoint,
+                ),
+            )
+        )
+    return tuple(definitions)
+
+
+def _checkpoint_disposition(result: JsonValue) -> NativeToolDisposition:
+    from aec_bench.adapters.deepseek_harness.tool_gateway import NativeToolDisposition
+
+    if isinstance(result, dict) and result.get("status") == "complete":
+        return NativeToolDisposition.CONCLUDE_TURN
+    return NativeToolDisposition.CONTINUE
+
+
+def _tool_parameters(
+    properties: dict[str, Any],
+    *,
+    required: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": list(required),
+        "additionalProperties": False,
+    }
+
+
 def run_local_evidence_lifecycle_session(
     *,
     package_dir: Path,
@@ -450,6 +566,17 @@ def run_local_evidence_lifecycle_session(
             workspace=initial["workspace"],
             trajectory_writer=trajectory_writer,
             native_tools=native_tools,
+            native_tool_definitions=(
+                _deepseek_lifecycle_tool_definitions(
+                    control=control,
+                    workspace=workspace_tool,
+                    supports_evidence_requests=supports_evidence_requests,
+                    supports_lifecycle_operations=supports_lifecycle_operations,
+                    include_completion_tools=True,
+                )
+                if adapter_kind == "deepseek_harness"
+                else None
+            ),
             enable_bash=False,
         )
         result = adapter.execute(
@@ -536,15 +663,22 @@ def run_local_evidence_lifecycle_session(
         adapter_kind=adapter_kind,
         request_configuration=request_configuration,
     )
+    lifecycle = read_evidence_lifecycle_state(package, run, operation_resolver=operation_resolver)
     returned_failure = (
         "adapter_identity_mismatch"
         if require_adapter_identity_match and agent_result["adapter_name"] != adapter_kind
         else _adapter_failure_kind(result)
     )
+    if (
+        adapter_kind == "deepseek_harness"
+        and returned_failure == "missing_output"
+        and _enum_value(result.agent_output.status) == "partial"
+        and lifecycle["status"] == "complete"
+    ):
+        returned_failure = None
     if returned_failure is not None:
         agent_result["status"] = "failed"
         agent_result["failure_kind"] = returned_failure
-    lifecycle = read_evidence_lifecycle_state(package, run, operation_resolver=operation_resolver)
     if returned_failure is not None and lifecycle["active_checkpoint_id"] is not None:
         fail_checkpoint_attempt(
             package,
@@ -980,6 +1114,17 @@ class LocalEvidenceLifecycleEpisodeEnvironment:
                 workspace=request.workspace,
                 trajectory_writer=trajectory_writer,
                 native_tools=native_tools,
+                native_tool_definitions=(
+                    _deepseek_lifecycle_tool_definitions(
+                        control=control,
+                        workspace=workspace_tool,
+                        supports_evidence_requests=supports_evidence_requests,
+                        supports_lifecycle_operations=supports_lifecycle_operations,
+                        include_completion_tools=False,
+                    )
+                    if self.adapter_kind == "deepseek_harness"
+                    else None
+                ),
                 enable_bash=False,
             )
             adapter_result = adapter.execute(

--- a/src/aec_bench/harness/pump_station_harbor/session.py
+++ b/src/aec_bench/harness/pump_station_harbor/session.py
@@ -9,7 +9,7 @@ import shutil
 from collections.abc import Callable
 from dataclasses import asdict, dataclass, replace
 from pathlib import Path
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from pydantic import JsonValue
 
@@ -65,6 +65,9 @@ from aec_bench.worlds.stewardship.wastewater_pump_station.world_run import PumpS
 from aec_bench.worlds.stewardship.wastewater_pump_station.world_run_repository import (
     PumpStationWorldRunRepository,
 )
+
+if TYPE_CHECKING:
+    from aec_bench.adapters.deepseek_harness.tool_gateway import NativeToolDefinition
 
 PUMP_STATION_MODEL_CONTROLLER_MODE = "model"
 PUMP_STATION_MODEL_MAX_TURNS = 90
@@ -133,6 +136,130 @@ class _PumpStationActorTools:
             self.request_condition_check,
             self.search_evidence,
             self.fetch_evidence,
+        )
+
+    @property
+    def native_tool_definitions(self) -> tuple[NativeToolDefinition, ...]:
+        """Return explicit DeepSeek schemas with infrastructure-owned request identity."""
+        string = {"type": "string"}
+        nullable_string = {"anyOf": [{"type": "string"}, {"type": "null"}]}
+        return (
+            self._definition("observe_pump_station", self.observe_pump_station, {}),
+            self._definition("continue_operation", self.continue_operation, {"reason": string}, ("reason",)),
+            self._definition(
+                "request_duty_assignment",
+                self.request_duty_assignment,
+                {
+                    "reason": string,
+                    "ordered_pump_ids": {"type": "array", "items": string},
+                    "source_outage_id": nullable_string,
+                    "source_backlog_item_id": nullable_string,
+                },
+                ("reason", "ordered_pump_ids"),
+            ),
+            self._definition(
+                "request_inspection",
+                self.request_inspection,
+                {"reason": string, "pump_id": string, "backlog_item_id": string},
+                ("reason", "pump_id", "backlog_item_id"),
+            ),
+            self._definition(
+                "request_obstruction_clearance",
+                self.request_obstruction_clearance,
+                {
+                    "reason": string,
+                    "pump_id": string,
+                    "backlog_item_id": string,
+                    "inspection_evidence_id": string,
+                },
+                ("reason", "pump_id", "backlog_item_id", "inspection_evidence_id"),
+            ),
+            self._definition(
+                "request_functional_check",
+                self.request_functional_check,
+                {"reason": string, "pump_id": string, "backlog_item_id": string},
+                ("reason", "pump_id", "backlog_item_id"),
+            ),
+            self._definition(
+                "request_provisional_return",
+                self.request_provisional_return,
+                {"reason": string, "pump_id": string, "functional_check_evidence_id": string},
+                ("reason", "pump_id", "functional_check_evidence_id"),
+            ),
+            self._definition(
+                "request_provisional_closure",
+                self.request_provisional_closure,
+                {"reason": string, "work_order_id": string},
+                ("reason", "work_order_id"),
+            ),
+            self._definition(
+                "request_post_maintenance_verification",
+                self.request_post_maintenance_verification,
+                {"reason": string, "pump_id": string, "backlog_item_id": string},
+                ("reason", "pump_id", "backlog_item_id"),
+            ),
+            self._definition(
+                "resume_process",
+                self.resume_process,
+                {"reason": string, "process_id": string},
+                ("reason", "process_id"),
+            ),
+            self._definition(
+                "cancel_process",
+                self.cancel_process,
+                {"reason": string, "process_id": string},
+                ("reason", "process_id"),
+            ),
+            self._definition(
+                "request_dependency_waiver",
+                self.request_dependency_waiver,
+                {"reason": string, "process_id": string, "dependency_id": string, "evidence_id": string},
+                ("reason", "process_id", "dependency_id", "evidence_id"),
+            ),
+            self._definition(
+                "request_condition_check",
+                self.request_condition_check,
+                {"reason": string, "pump_id": string},
+                ("reason", "pump_id"),
+            ),
+            self._definition(
+                "search_evidence",
+                self.search_evidence,
+                {
+                    "query": string,
+                    "scope": {"type": "string", "default": "all"},
+                    "limit": {"type": "integer", "default": 5},
+                },
+                ("query",),
+            ),
+            self._definition(
+                "fetch_evidence",
+                self.fetch_evidence,
+                {"reference": string},
+                ("reference",),
+            ),
+        )
+
+    @staticmethod
+    def _definition(
+        name: str,
+        function: Callable[..., str],
+        properties: dict[str, Any],
+        required: tuple[str, ...] = (),
+    ) -> NativeToolDefinition:
+        from aec_bench.adapters.deepseek_harness.tool_gateway import json_native_tool_definition
+
+        return json_native_tool_definition(
+            name=name,
+            description=function.__doc__ or name.replace("_", " "),
+            parameters_schema={
+                "type": "object",
+                "properties": properties,
+                "required": list(required),
+                "additionalProperties": False,
+            },
+            function=function,
+            trusted_request_argument=None if name == "observe_pump_station" else "request_id",
         )
 
     def observe_pump_station(self) -> str:
@@ -415,6 +542,7 @@ def run_pump_station_model_session(
                 workspace=str(destination),
                 trajectory_writer=trajectory,
                 native_tools=tools.native_tools,
+                native_tool_definitions=(tools.native_tool_definitions if adapter_kind == "deepseek_harness" else None),
                 enable_bash=False,
             )
             segment_result = adapter.execute(

--- a/tests/adapters/test_deepseek_harness.py
+++ b/tests/adapters/test_deepseek_harness.py
@@ -17,9 +17,14 @@ from aec_bench.adapters.deepseek_harness.runtime import (
     DeepSeekHarnessRuntimeError,
     DeepSeekHarnessRuntimeTimeout,
 )
+from aec_bench.adapters.deepseek_harness.tool_gateway import (
+    NativeToolDefinition,
+    NativeToolResponse,
+)
 from aec_bench.adapters.output_commit import build_output_commit_attestation
 from aec_bench.contracts.agent_output import AgentOutputStatus
 from aec_bench.contracts.output_completion import OutputCommitAttestation, OutputCompletionContract
+from aec_bench.contracts.task_definition import ToolSpec
 
 
 class _Runtime:
@@ -199,6 +204,39 @@ def test_normal_idle_without_a_candidate_is_missing_output(tmp_path: Path) -> No
     assert result.failure_kind is AdapterFailureKind.MISSING_OUTPUT
     assert result.completion_reason is None
     assert result.transcript[0].content == "You are a software engineering agent."
+
+
+def test_native_tool_catalogue_does_not_create_candidate_output(tmp_path: Path) -> None:
+    runtime = _Runtime(_run(tmp_path, finish_reason="completed", final_response=""))
+
+    adapter = DeepSeekHarnessAdapter(
+        settings=_settings(tmp_path),
+        workspace=tmp_path,
+        runtime=runtime,
+        native_tools=(
+            NativeToolDefinition(
+                name="observe_state",
+                description="Observe state",
+                parameters_schema={
+                    "type": "object",
+                    "properties": {},
+                    "required": [],
+                    "additionalProperties": False,
+                },
+                handler=lambda _invocation, _arguments: NativeToolResponse(result={"status": "observed"}),
+            ),
+        ),
+    )
+
+    result = adapter.execute(
+        AdapterRequest(
+            instruction="Observe the task",
+            tools=[ToolSpec(name="observe_state", source="builtin", description="Observe state")],
+        )
+    )
+
+    assert result.agent_output.status is AgentOutputStatus.EMPTY
+    assert result.failure_kind is AdapterFailureKind.MISSING_OUTPUT
 
 
 def test_only_an_accepted_commit_maps_to_output_contract_committed(tmp_path: Path) -> None:

--- a/tests/adapters/test_local_registry.py
+++ b/tests/adapters/test_local_registry.py
@@ -9,6 +9,10 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from aec_bench.adapters.deepseek_harness.tool_gateway import (
+    NativeToolDefinition,
+    NativeToolResponse,
+)
 from aec_bench.adapters.local_registry import (
     available_local_adapters,
     build_local_adapter,
@@ -163,6 +167,13 @@ class TestBuildDeepSeekHarness:
         def submit_checkpoint(checkpoint_id: str) -> str:
             return checkpoint_id
 
+        definition = NativeToolDefinition(
+            name="submit_checkpoint",
+            description="Submit checkpoint",
+            parameters_schema={"type": "object"},
+            handler=lambda _invocation, _arguments: NativeToolResponse(result={"status": "complete"}),
+        )
+
         monkeypatch.setattr("aec_bench.adapters.deepseek_harness.DeepSeekHarnessAdapter", fake_adapter)
 
         build_local_adapter(
@@ -170,26 +181,31 @@ class TestBuildDeepSeekHarness:
             model_name="azure:test-deployment",
             workspace=str(tmp_path),
             native_tools=[submit_checkpoint],
+            native_tool_definitions=[definition],
         )
 
-        assert captured["native_tools"] == {"submit_checkpoint": submit_checkpoint}
+        assert captured["native_tools"] == (definition,)
 
     def test_build_deepseek_harness_rejects_duplicate_native_tool_names(self, tmp_path: Path) -> None:
-        def first(checkpoint_id: str) -> str:
-            return checkpoint_id
-
-        def second(checkpoint_id: str) -> str:
-            return checkpoint_id
-
-        first.__name__ = "submit_checkpoint"
-        second.__name__ = "submit_checkpoint"
+        first = NativeToolDefinition(
+            name="submit_checkpoint",
+            description="Submit checkpoint",
+            parameters_schema={"type": "object"},
+            handler=lambda _invocation, _arguments: NativeToolResponse(result={}),
+        )
+        second = NativeToolDefinition(
+            name="submit_checkpoint",
+            description="Submit checkpoint again",
+            parameters_schema={"type": "object"},
+            handler=lambda _invocation, _arguments: NativeToolResponse(result={}),
+        )
 
         with pytest.raises(ValueError, match="duplicate DeepSeek native tool"):
             build_local_adapter(
                 adapter_kind="deepseek_harness",
                 model_name="azure:test-deployment",
                 workspace=str(tmp_path),
-                native_tools=[first, second],
+                native_tool_definitions=[first, second],
             )
 
 

--- a/tests/cli/test_optional_dependencies.py
+++ b/tests/cli/test_optional_dependencies.py
@@ -24,6 +24,7 @@ OPTIONAL_IMPORT_ROOTS = {
     "deepseek_harness",
     "fastapi",
     "harbor",
+    "jsonschema",
     "morphcloud",
     "numpy",
     "pydantic_ai",
@@ -54,7 +55,7 @@ def test_dependency_groups_have_one_named_feature_owner() -> None:
     extras = {name: _requirement_names(requirements) for name, requirements in project["optional-dependencies"].items()}
     assert extras == {
         "execution": {"harbor"},
-        "deepseek-harness": {"deepseek-harness-sdk"},
+        "deepseek-harness": {"deepseek-harness-sdk", "jsonschema"},
         "morph": {"morphcloud"},
         "local-agents": {"boto3", "botocore", "httpx", "pydantic-ai"},
         "prime": {"packaging", "prime", "verifiers"},
@@ -64,7 +65,10 @@ def test_dependency_groups_have_one_named_feature_owner() -> None:
         "prime-agent": {"agent-client-protocol"},
     }
     assert project["optional-dependencies"]["execution"] == ["harbor[modal]>=0.15,<0.16"]
-    assert project["optional-dependencies"]["deepseek-harness"] == [f"deepseek-harness-sdk=={DEEPSEEK_HARNESS_VERSION}"]
+    assert project["optional-dependencies"]["deepseek-harness"] == [
+        f"deepseek-harness-sdk=={DEEPSEEK_HARNESS_VERSION}",
+        "jsonschema>=4.26,<5",
+    ]
 
 
 def test_cli_startup_does_not_import_optional_feature_families() -> None:

--- a/tests/deepseek_harness/test_runtime.py
+++ b/tests/deepseek_harness/test_runtime.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import threading
 from pathlib import Path
 
 import pytest
@@ -20,6 +21,7 @@ from aec_bench.adapters.deepseek_harness.runtime import (
     DeepSeekHarnessRuntimeTimeout,
     build_deepseek_worker_environment,
 )
+from aec_bench.adapters.deepseek_harness.tool_gateway import json_native_tool_definition
 from aec_bench.contracts.task_definition import ToolSpec
 
 
@@ -454,9 +456,9 @@ assert [tool["name"] for tool in manifest] == ["list_workspace"]
 capability = os.environ["DSH_TOOLS_TOKEN"]
 print(f"capability={capability}")
 payload = {
-    "protocol": "aec-bench/deepseek-tools/1",
+    "protocol": "aec-bench/deepseek-tools/2",
     "capability": capability,
-    "request_id": "dsh:root:tool-1",
+    "operation": "invoke",
     "tool": "list_workspace",
     "arguments": {"path": "inbox"},
     "metadata": {
@@ -500,7 +502,19 @@ result_path.write_text(json.dumps({
         settings=_settings(tmp_path),
         workspace=tmp_path,
         worker_command=(sys.executable, str(worker)),
-        native_tools={"list_workspace": list_workspace},
+        native_tools=(
+            json_native_tool_definition(
+                name="list_workspace",
+                description="List files",
+                parameters_schema={
+                    "type": "object",
+                    "properties": {"path": {"type": "string", "default": ""}},
+                    "required": [],
+                    "additionalProperties": False,
+                },
+                function=list_workspace,
+            ),
+        ),
     )
     request = AdapterRequest(
         instruction="Review the lifecycle",
@@ -516,7 +530,11 @@ result_path.write_text(json.dumps({
     evidence = runtime.paths.tool_gateway_evidence.read_text(encoding="utf-8")
     assert "DSH_TOOLS_TOKEN" not in evidence
     assert "keyless-test-token" not in evidence
-    assert json.loads(evidence)["tool"] == "list_workspace"
+    invocation = next(
+        json.loads(line) for line in evidence.splitlines() if json.loads(line)["record_type"] == "invocation"
+    )
+    assert invocation["tool"] == "list_workspace"
+    assert invocation["request_id"] == "dsh:root:tool-1"
     composition = json.loads(runtime.paths.composition.read_text(encoding="utf-8"))
     assert composition["native_tools"] == ["list_workspace"]
     assert composition["environment"]["secret_names"] == ["DSH_API_KEY", "DSH_TOOLS_TOKEN"]
@@ -527,12 +545,106 @@ result_path.write_text(json.dumps({
             "artifact_path": "plugins/tools/index.js",
             "plugin_id": "@aec-bench/dsh-tools",
             "role": "native_tools",
-            "version": "0.1.0",
+            "version": "0.2.0",
         }
     ]
     assert {"tool_gateway_evidence", "optional_plugin"}.issubset(
         {artifact["role"] for artifact in manifest["artifacts"]}
     )
+
+
+def test_runtime_rejects_completion_after_nonquiescent_tool_close(tmp_path: Path) -> None:
+    started = threading.Event()
+    release = threading.Event()
+
+    def hang() -> str:
+        started.set()
+        release.wait(5)
+        return json.dumps({"status": "late"})
+
+    worker = _write_worker(
+        tmp_path / "unsettled_tool_worker.py",
+        """
+payload = {
+    "protocol": "aec-bench/deepseek-tools/2",
+    "capability": os.environ["DSH_TOOLS_TOKEN"],
+    "operation": "invoke",
+    "tool": "hang",
+    "arguments": {},
+    "metadata": {
+        "deepseek_session_id": "root",
+        "deepseek_tool_call_id": "hanging-tool",
+        "aec_model_turn": 1,
+    },
+}
+client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+client.connect(os.environ["DSH_TOOLS_SOCKET"])
+client.sendall(json.dumps(payload).encode() + b"\\n")
+time.sleep(0.1)
+client.close()
+notifications = [
+    {"method": "session.event", "params": {"sessionId": "root", "event": {
+        "type": "step/start", "seq": 1, "time": 1, "data": {"turn": 1, "step": 1},
+    }}},
+    {"method": "session.event", "params": {"sessionId": "root", "event": {
+        "type": "tool/call", "seq": 2, "time": 2,
+        "data": {"callId": "hanging-tool", "name": "hang", "arguments": {}},
+    }}},
+    {"method": "session.event", "params": {"sessionId": "root", "event": {
+        "type": "turn/end", "seq": 3, "time": 3,
+        "data": {"turn": 1, "reason": {"kind": "completed"}},
+    }}},
+    {"method": "session.status", "params": {"sessionId": "root", "status": "idle"}},
+]
+notifications_path.write_text("".join(json.dumps(item) + "\\n" for item in notifications))
+result_path.write_text(json.dumps({
+    "session_id": "root",
+    "final_response": "claimed completion",
+    "finish_reason": "completed",
+    "sdk_version": "fake-sdk",
+    "runtime_distribution_version": "fake-runtime",
+    "runtime_reported_version": None,
+}))
+""".strip(),
+    )
+    runtime = DeepSeekHarnessProcessRuntime(
+        settings=_settings(tmp_path),
+        workspace=tmp_path,
+        worker_command=(sys.executable, str(worker)),
+        native_tools=(
+            json_native_tool_definition(
+                name="hang",
+                description="Hang",
+                parameters_schema={
+                    "type": "object",
+                    "properties": {},
+                    "required": [],
+                    "additionalProperties": False,
+                },
+                function=hang,
+            ),
+        ),
+        tool_gateway_close_timeout_seconds=0.01,
+    )
+
+    try:
+        with pytest.raises(DeepSeekHarnessRuntimeError, match="unsettled requests: dsh:root:hanging-tool"):
+            runtime.run(
+                AdapterRequest(
+                    instruction="Call the hanging tool",
+                    tools=[ToolSpec(name="hang", source="builtin", description="Hang")],
+                    configuration={"timeout_sec": 5, "max_tokens": 512},
+                )
+            )
+    finally:
+        release.set()
+
+    assert started.is_set()
+    runtime_record = json.loads(runtime.paths.runtime_record.read_text(encoding="utf-8"))
+    assert runtime_record["status"] == "failed"
+    assert runtime_record["tool_gateway_close"]["quiescent"] is False
+    assert runtime_record["tool_gateway_close"]["unknown_outcome_request_ids"] == ["dsh:root:hanging-tool"]
+    verify_deepseek_evidence_manifest(runtime.paths.manifest)
 
 
 def test_runtime_invalidates_an_output_mutated_after_commit(tmp_path: Path) -> None:

--- a/tests/deepseek_harness/test_sdk_integration.py
+++ b/tests/deepseek_harness/test_sdk_integration.py
@@ -17,6 +17,10 @@ import pytest
 from aec_bench.adapters.base import AdapterRequest, SerializedAdapterExecution
 from aec_bench.adapters.deepseek_harness import DeepSeekHarnessAdapter
 from aec_bench.adapters.deepseek_harness.config import DeepSeekHarnessSettings
+from aec_bench.adapters.deepseek_harness.tool_gateway import (
+    NativeToolDisposition,
+    json_native_tool_definition,
+)
 from aec_bench.contracts.agent_output import AgentOutputStatus
 from aec_bench.contracts.task_definition import ToolSpec
 from aec_bench.harness.deepseek_harness_driver import DeepSeekHarnessExecutionDriver
@@ -415,7 +419,24 @@ def test_real_sdk_lifecycle_composition_exposes_only_the_gateway_tools(
         result = DeepSeekHarnessAdapter(
             settings=_azure_settings(),
             workspace=tmp_path,
-            native_tools={"submit_checkpoint": submit_checkpoint},
+            native_tools=(
+                json_native_tool_definition(
+                    name="submit_checkpoint",
+                    description="Submit checkpoint",
+                    parameters_schema={
+                        "type": "object",
+                        "properties": {"checkpoint_id": {"type": "string"}},
+                        "required": ["checkpoint_id"],
+                        "additionalProperties": False,
+                    },
+                    function=submit_checkpoint,
+                    disposition=lambda result: (
+                        NativeToolDisposition.CONCLUDE_TURN
+                        if isinstance(result, dict) and result.get("status") == "complete"
+                        else NativeToolDisposition.CONTINUE
+                    ),
+                ),
+            ),
         ).execute(
             AdapterRequest(
                 instruction="Submit the completed lifecycle checkpoint.",
@@ -436,7 +457,7 @@ def test_real_sdk_lifecycle_composition_exposes_only_the_gateway_tools(
         server.server_close()
         thread.join(timeout=5)
 
-    assert result.agent_output.status is AgentOutputStatus.COMPLETED
+    assert result.agent_output.status is AgentOutputStatus.PARTIAL
     assert calls == ["closeout_review"]
     assert len(_KeylessDeepSeekHandler.requests) == 1
     advertised_tools = {tool["function"]["name"] for tool in _KeylessDeepSeekHandler.requests[0]["body"]["tools"]}

--- a/tests/deepseek_harness/test_tool_gateway.py
+++ b/tests/deepseek_harness/test_tool_gateway.py
@@ -1,67 +1,119 @@
 # ABOUTME: Tests the authenticated DeepSeek gateway to exact AEC-owned native tools.
-# ABOUTME: Proves exact allowlists, bounded requests, idempotency, and secret-free evidence.
+# ABOUTME: Proves trusted identity, explicit schemas, cancellation, dispositions, and bounded close evidence.
 
 from __future__ import annotations
 
 import json
 import socket
+import threading
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+from pydantic import JsonValue
+
 from aec_bench.adapters.deepseek_harness.tool_gateway import (
     TOOL_GATEWAY_PROTOCOL,
+    NativeToolDefinition,
+    NativeToolDisposition,
+    NativeToolInvocation,
+    NativeToolResponse,
     ToolGatewayEndpoint,
 )
 
 
-def test_endpoint_executes_one_allowed_tool_and_replays_the_identical_request(tmp_path: Path) -> None:
-    calls: list[dict[str, str]] = []
+def test_endpoint_uses_explicit_schema_hidden_identity_and_exact_replay(tmp_path: Path) -> None:
+    calls: list[tuple[str, str]] = []
 
-    def read_workspace_file(path: str) -> str:
-        calls.append({"path": path})
-        return json.dumps({"status": "ok", "path": path, "content": "released evidence"})
+    def read_workspace_file(
+        invocation: NativeToolInvocation,
+        arguments: Mapping[str, JsonValue],
+    ) -> NativeToolResponse:
+        path = str(arguments["path"])
+        calls.append((invocation.request_id, path))
+        return NativeToolResponse(
+            result={"status": "ok", "path": path, "content": "released evidence"},
+            disposition=NativeToolDisposition.CONTINUE,
+        )
 
     evidence_path = tmp_path / "lifecycle-tool-evidence.jsonl"
     endpoint = ToolGatewayEndpoint(
-        tools={"read_workspace_file": read_workspace_file},
+        tools=(
+            _definition(
+                "read_workspace_file",
+                read_workspace_file,
+                properties={"path": {"type": "string"}},
+                required=("path",),
+            ),
+        ),
         evidence_path=evidence_path,
         capability_token="private-capability",
+        generation_id="generation-1",
     )
     endpoint.start()
     try:
         payload = _request(
-            endpoint,
-            request_id="dsh:root:tool-1",
-            tool_name="read_workspace_file",
-            arguments={"path": "inbox/checkpoint/evidence.md"},
+            endpoint, tool_call_id="tool-1", tool_name="read_workspace_file", arguments={"path": "inbox/evidence.md"}
         )
         first = _exchange(endpoint, payload)
         second = _exchange(endpoint, payload)
+        manifest = json.loads(endpoint.connection_environment()["DSH_TOOLS"])
     finally:
-        endpoint.close()
+        close_report = endpoint.close()
 
     assert first == {
         "protocol": TOOL_GATEWAY_PROTOCOL,
         "status": "ok",
-        "result": {
-            "status": "ok",
-            "path": "inbox/checkpoint/evidence.md",
-            "content": "released evidence",
-        },
+        "result": {"status": "ok", "path": "inbox/evidence.md", "content": "released evidence"},
+        "disposition": "continue",
     }
     assert second == first
-    assert calls == [{"path": "inbox/checkpoint/evidence.md"}]
-    evidence = [json.loads(line) for line in evidence_path.read_text(encoding="utf-8").splitlines()]
-    assert [item["idempotent_replay"] for item in evidence] == [False, True]
+    assert calls == [("dsh:root:tool-1", "inbox/evidence.md")]
+    assert "request_id" not in payload
+    assert manifest == [
+        {
+            "name": "read_workspace_file",
+            "description": "read workspace file",
+            "parameters": {
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+                "required": ["path"],
+                "additionalProperties": False,
+            },
+        }
+    ]
+    assert close_report.quiescent is True
+    evidence = _evidence(evidence_path)
+    invocation = next(item for item in evidence if item["record_type"] == "invocation")
+    duplicate = next(item for item in evidence if item["record_type"] == "duplicate")
+    assert invocation["request_id"] == "dsh:root:tool-1"
+    assert invocation["generation_id"] == "generation-1"
+    assert invocation["outcome"] == "completed"
+    assert invocation["disposition"] == "continue"
+    assert invocation["result_sha256"] is not None
+    assert duplicate["duplicate_of"] == "dsh:root:tool-1"
     assert all("private-capability" not in json.dumps(item) for item in evidence)
 
 
 def test_endpoint_rejects_unauthorised_unknown_invalid_and_conflicting_requests(tmp_path: Path) -> None:
-    def submit_checkpoint(checkpoint_id: str) -> str:
-        return json.dumps({"status": "complete", "checkpoint_id": checkpoint_id})
+    def submit_checkpoint(
+        _invocation: NativeToolInvocation,
+        arguments: Mapping[str, JsonValue],
+    ) -> NativeToolResponse:
+        return NativeToolResponse(
+            result={"status": "complete", "checkpoint_id": arguments["checkpoint_id"]},
+            disposition=NativeToolDisposition.CONCLUDE_TURN,
+        )
 
     endpoint = ToolGatewayEndpoint(
-        tools={"submit_checkpoint": submit_checkpoint},
+        tools=(
+            _definition(
+                "submit_checkpoint",
+                submit_checkpoint,
+                properties={"checkpoint_id": {"type": "string"}},
+                required=("checkpoint_id",),
+            ),
+        ),
         evidence_path=tmp_path / "tool-gateway-evidence.jsonl",
         capability_token="private-capability",
     )
@@ -69,7 +121,7 @@ def test_endpoint_rejects_unauthorised_unknown_invalid_and_conflicting_requests(
     try:
         unauthorized = _request(
             endpoint,
-            request_id="request-unauthorized",
+            tool_call_id="unauthorized",
             tool_name="submit_checkpoint",
             arguments={"checkpoint_id": "review"},
         )
@@ -78,7 +130,7 @@ def test_endpoint_rejects_unauthorised_unknown_invalid_and_conflicting_requests(
 
         unknown = _request(
             endpoint,
-            request_id="request-unknown",
+            tool_call_id="unknown",
             tool_name="read_workspace_file",
             arguments={"path": "instruction.md"},
         )
@@ -86,67 +138,151 @@ def test_endpoint_rejects_unauthorised_unknown_invalid_and_conflicting_requests(
 
         invalid = _request(
             endpoint,
-            request_id="request-invalid",
+            tool_call_id="invalid",
             tool_name="submit_checkpoint",
             arguments={"checkpoint_id": 3},
         )
         assert _exchange(endpoint, invalid)["error"]["code"] == "invalid_arguments"
 
+        model_chosen_identity = _request(
+            endpoint,
+            tool_call_id="model-chosen-identity",
+            tool_name="submit_checkpoint",
+            arguments={"checkpoint_id": "review", "request_id": "model-choice"},
+        )
+        assert _exchange(endpoint, model_chosen_identity)["error"]["code"] == "invalid_arguments"
+
         accepted = _request(
             endpoint,
-            request_id="request-conflict",
+            tool_call_id="conflict",
             tool_name="submit_checkpoint",
             arguments={"checkpoint_id": "review"},
         )
-        assert _exchange(endpoint, accepted)["status"] == "ok"
+        assert _exchange(endpoint, accepted)["disposition"] == "conclude-turn"
         conflicting = {**accepted, "arguments": {"checkpoint_id": "decision"}}
         assert _exchange(endpoint, conflicting)["error"]["code"] == "request_id_conflict"
     finally:
         endpoint.close()
 
 
-def test_endpoint_derives_array_and_integer_schema_from_a_world_tool(tmp_path: Path) -> None:
-    calls: list[tuple[tuple[str, ...], int]] = []
+def test_cancellation_reaches_a_cooperative_handler_and_pre_dispatch_cancel_is_retained(tmp_path: Path) -> None:
+    started = threading.Event()
 
-    def request_duty_assignment(ordered_pump_ids: tuple[str, ...], limit: int = 3) -> str:
-        calls.append((ordered_pump_ids, limit))
-        return json.dumps({"status": "accepted", "ordered_pump_ids": ordered_pump_ids, "limit": limit})
+    def wait_for_cancel(
+        invocation: NativeToolInvocation,
+        _arguments: Mapping[str, JsonValue],
+    ) -> NativeToolResponse:
+        started.set()
+        assert invocation.cancellation.wait(2)
+        return NativeToolResponse(result={"status": "cancelled"})
 
+    evidence_path = tmp_path / "tool-gateway-evidence.jsonl"
     endpoint = ToolGatewayEndpoint(
-        tools={"request_duty_assignment": request_duty_assignment},
-        evidence_path=tmp_path / "tool-gateway-evidence.jsonl",
+        tools=(_definition("wait_for_cancel", wait_for_cancel),),
+        evidence_path=evidence_path,
         capability_token="private-capability",
     )
     endpoint.start()
-    try:
-        manifest = json.loads(endpoint.connection_environment()["DSH_TOOLS"])
-        parameters = manifest[0]["parameters"]
-        ordered_ids = parameters["properties"]["ordered_pump_ids"]
-        assert ordered_ids["type"] == "array"
-        assert ordered_ids["items"] == {"type": "string"}
-        assert parameters["properties"]["limit"]["default"] == 3
-        assert parameters["properties"]["limit"]["type"] == "integer"
-        assert parameters["required"] == ["ordered_pump_ids"]
-        response = _exchange(
-            endpoint,
-            _request(
-                endpoint,
-                request_id="world-action-1",
-                tool_name="request_duty_assignment",
-                arguments={"ordered_pump_ids": ["P-101", "P-102"], "limit": 2},
-            ),
-        )
-    finally:
-        endpoint.close()
+    response: dict[str, Any] = {}
+    invocation = _request(endpoint, tool_call_id="active", tool_name="wait_for_cancel", arguments={})
+    thread = threading.Thread(target=lambda: response.update(_exchange(endpoint, invocation)))
+    thread.start()
+    assert started.wait(2)
 
-    assert response["status"] == "ok"
-    assert calls == [(("P-101", "P-102"), 2)]
+    cancellation = _exchange(endpoint, _cancel_request(endpoint, tool_call_id="active"))
+    thread.join(timeout=2)
+    assert not thread.is_alive()
+
+    early_cancel = _exchange(endpoint, _cancel_request(endpoint, tool_call_id="early"))
+    cancelled_request = _request(endpoint, tool_call_id="early", tool_name="wait_for_cancel", arguments={})
+    rejected = _exchange(endpoint, cancelled_request)
+    close_report = endpoint.close()
+
+    assert cancellation["result"]["outcome"] == "unknown"
+    assert response["result"] == {"status": "cancelled"}
+    assert early_cancel["result"]["outcome"] == "not-dispatched"
+    assert rejected["error"]["code"] == "request_cancelled"
+    assert close_report.quiescent is True
+    evidence = _evidence(evidence_path)
+    completed = next(
+        item for item in evidence if item.get("request_id") == "dsh:root:active" and item["record_type"] == "invocation"
+    )
+    not_dispatched = next(
+        item for item in evidence if item.get("request_id") == "dsh:root:early" and item["record_type"] == "invocation"
+    )
+    assert completed["cancellation_requested_at"] is not None
+    assert completed["outcome"] == "completed"
+    assert not_dispatched["outcome"] == "not-dispatched"
+
+
+def test_close_reports_unsettled_work_and_late_result_is_stale(tmp_path: Path) -> None:
+    started = threading.Event()
+    release = threading.Event()
+
+    def hang(
+        _invocation: NativeToolInvocation,
+        _arguments: Mapping[str, JsonValue],
+    ) -> NativeToolResponse:
+        started.set()
+        release.wait(2)
+        return NativeToolResponse(result={"status": "late"})
+
+    evidence_path = tmp_path / "tool-gateway-evidence.jsonl"
+    endpoint = ToolGatewayEndpoint(
+        tools=(_definition("hang", hang),),
+        evidence_path=evidence_path,
+        capability_token="private-capability",
+        close_timeout_seconds=0.01,
+    )
+    endpoint.start()
+    response: dict[str, Any] = {}
+    thread = threading.Thread(
+        target=lambda: response.update(
+            _exchange(endpoint, _request(endpoint, tool_call_id="hanging", tool_name="hang", arguments={}))
+        )
+    )
+    thread.start()
+    assert started.wait(2)
+
+    close_report = endpoint.close()
+    assert close_report.quiescent is False
+    assert close_report.unsettled_request_ids == ("dsh:root:hanging",)
+    assert close_report.unknown_outcome_request_ids == ("dsh:root:hanging",)
+
+    release.set()
+    thread.join(timeout=2)
+    assert not thread.is_alive()
+    assert response["error"]["code"] == "generation_finalized"
+    evidence = _evidence(evidence_path)
+    assert not any(item["record_type"] == "invocation" for item in evidence)
+    close_evidence = next(item for item in evidence if item["record_type"] == "close")
+    assert close_evidence["late_results_after_close_are_ignored"] is True
+
+
+def _definition(
+    name: str,
+    handler: Any,
+    *,
+    properties: dict[str, Any] | None = None,
+    required: tuple[str, ...] = (),
+) -> NativeToolDefinition:
+    return NativeToolDefinition(
+        name=name,
+        description=name.replace("_", " "),
+        parameters_schema={
+            "type": "object",
+            "properties": properties or {},
+            "required": list(required),
+            "additionalProperties": False,
+        },
+        handler=handler,
+    )
 
 
 def _request(
     endpoint: ToolGatewayEndpoint,
     *,
-    request_id: str,
+    tool_call_id: str,
     tool_name: str,
     arguments: dict[str, Any],
 ) -> dict[str, Any]:
@@ -154,12 +290,26 @@ def _request(
     return {
         "protocol": TOOL_GATEWAY_PROTOCOL,
         "capability": connection["DSH_TOOLS_TOKEN"],
-        "request_id": request_id,
+        "operation": "invoke",
         "tool": tool_name,
         "arguments": arguments,
         "metadata": {
             "deepseek_session_id": "root",
-            "deepseek_tool_call_id": request_id,
+            "deepseek_tool_call_id": tool_call_id,
+            "aec_model_turn": 1,
+        },
+    }
+
+
+def _cancel_request(endpoint: ToolGatewayEndpoint, *, tool_call_id: str) -> dict[str, Any]:
+    connection = endpoint.connection_environment()
+    return {
+        "protocol": TOOL_GATEWAY_PROTOCOL,
+        "capability": connection["DSH_TOOLS_TOKEN"],
+        "operation": "cancel",
+        "metadata": {
+            "deepseek_session_id": "root",
+            "deepseek_tool_call_id": tool_call_id,
             "aec_model_turn": 1,
         },
     }
@@ -173,3 +323,7 @@ def _exchange(endpoint: ToolGatewayEndpoint, payload: dict[str, Any]) -> dict[st
         response = json.loads(client.makefile().readline())
     assert isinstance(response, dict)
     return response
+
+
+def _evidence(path: Path) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]

--- a/tests/harness/test_pump_station_harbor.py
+++ b/tests/harness/test_pump_station_harbor.py
@@ -222,6 +222,13 @@ def test_deepseek_model_session_receives_only_actor_tools_and_token_limits(tmp_p
         "observe_pump_station",
         *PUMP_STATION_ACTOR_ACTION_NAMES,
     )
+    native_tool_definitions = builder["native_tool_definitions"]
+    assert isinstance(native_tool_definitions, tuple)
+    assert tuple(definition.name for definition in native_tool_definitions) == (
+        "observe_pump_station",
+        *PUMP_STATION_ACTOR_ACTION_NAMES,
+    )
+    assert all("request_id" not in definition.parameters_schema["properties"] for definition in native_tool_definitions)
     request = captured["request"]
     assert isinstance(request, AdapterRequest)
     assert request.configuration == {"max_tokens": 4096, "timeout_sec": 600}

--- a/tests/lifecycles/runtime/test_lifecycle.py
+++ b/tests/lifecycles/runtime/test_lifecycle.py
@@ -2104,6 +2104,65 @@ def test_persistent_deepseek_lifecycle_uses_only_enforceable_limits(tmp_path: Pa
     assert session["limits"] == agent["limits"]
 
 
+def test_completed_lifecycle_remains_authoritative_when_deepseek_has_no_candidate_output(tmp_path: Path) -> None:
+    package = _write_package(tmp_path / "package")
+    run_dir = tmp_path / "run"
+
+    def build_adapter(*, native_tools, **_kwargs):
+        submit_checkpoint = next(tool for tool in native_tools if tool.__name__ == "submit_checkpoint")
+
+        class _Adapter:
+            def execute(self, _request):
+                while True:
+                    state = read_evidence_lifecycle_state(package, run_dir)
+                    checkpoint_id = state["active_checkpoint_id"]
+                    if checkpoint_id is None:
+                        break
+                    _write_json(
+                        run_dir / "workspace" / "submissions" / f"{checkpoint_id}.json",
+                        {"checkpoint_id": checkpoint_id},
+                    )
+                    if json.loads(submit_checkpoint(checkpoint_id))["status"] == "complete":
+                        break
+                return SimpleNamespace(
+                    adapter_name="deepseek_harness",
+                    resolved_model="deepseek-v4-flash",
+                    configuration_record={},
+                    agent_output=SimpleNamespace(status=SimpleNamespace(value="partial")),
+                    transcript=[],
+                    raw_output_text=None,
+                    provider_error=None,
+                    failure_kind=SimpleNamespace(value="missing_output"),
+                    usage_input_tokens=10,
+                    usage_output_tokens=2,
+                    usage_cache_read_tokens=0,
+                    usage_cache_write_tokens=0,
+                )
+
+        return _Adapter()
+
+    result = run_local_evidence_lifecycle_session(
+        package_dir=package,
+        run_dir=run_dir,
+        model="azure:deepseek-v4-flash",
+        adapter_kind="deepseek_harness",
+        max_tokens=4096,
+        adapter_builder=build_adapter,
+        verifier=lambda _package, _run: {
+            "lifecycle_id": "lifecycle.demo",
+            "reward": 1.0,
+            "overall": "pass",
+            "passed": True,
+            "gates": {"continuity": {"passed": True, "score": 1.0, "failures": []}},
+        },
+    )
+
+    assert result["evidence"]["lifecycle"]["status"] == "complete"
+    session = result["evidence"]["agent"]["sessions"][0]
+    assert session["status"] == "partial"
+    assert session["failure_kind"] == "missing_output"
+
+
 @pytest.mark.parametrize("execution_mode", ["persistent_context", "fresh_context"])
 def test_local_runners_forward_an_explicit_experiment_recorder(
     tmp_path: Path,

--- a/tests/packaging/verify_wheel_profiles.py
+++ b/tests/packaging/verify_wheel_profiles.py
@@ -21,7 +21,10 @@ class Profile:
 PROFILES = {
     "base": Profile(None, ()),
     "execution": Profile("execution", ("harbor",)),
-    "deepseek-harness": Profile("deepseek-harness", ("deepseek_harness",)),
+    "deepseek-harness": Profile(
+        "deepseek-harness",
+        ("aec_bench.adapters.deepseek_harness", "deepseek_harness", "jsonschema"),
+    ),
     "morph": Profile("execution,morph", ("harbor", "morphcloud.api")),
     "local-agents": Profile(
         "local-agents",
@@ -55,6 +58,7 @@ OPTIONAL_BASE_MODULES = (
     "acp",
     "fastapi",
     "harbor",
+    "jsonschema",
     "morphcloud",
     "numpy",
     "pydantic_ai",

--- a/typings/jsonschema/__init__.pyi
+++ b/typings/jsonschema/__init__.pyi
@@ -1,0 +1,13 @@
+# ABOUTME: Supplies the typed JSON Schema validator surface used by the native tool gateway.
+# ABOUTME: Keeps strict type checking independent of the optional third-party stub package.
+
+from collections.abc import Mapping
+from typing import Any, ClassVar
+
+class Draft202012Validator:
+    META_SCHEMA: ClassVar[Mapping[str, Any]]
+
+    def __init__(self, schema: Mapping[str, Any]) -> None: ...
+    @classmethod
+    def check_schema(cls, schema: Mapping[str, Any]) -> None: ...
+    def validate(self, instance: object) -> None: ...

--- a/typings/jsonschema/exceptions.pyi
+++ b/typings/jsonschema/exceptions.pyi
@@ -1,0 +1,8 @@
+# ABOUTME: Types the JSON Schema exceptions inspected by the native tool gateway.
+# ABOUTME: Exposes the stable message attribute used in gateway validation errors.
+
+class SchemaError(Exception):
+    message: str
+
+class ValidationError(Exception):
+    message: str

--- a/uv.lock
+++ b/uv.lock
@@ -27,6 +27,7 @@ dependencies = [
 [package.optional-dependencies]
 deepseek-harness = [
     { name = "deepseek-harness-sdk" },
+    { name = "jsonschema" },
 ]
 evolution = [
     { name = "numpy" },
@@ -87,6 +88,7 @@ requires-dist = [
     { name = "harbor", extras = ["modal"], marker = "extra == 'execution'", specifier = ">=0.15,<0.16" },
     { name = "httpx", marker = "extra == 'local-agents'", specifier = ">=0.28,<1" },
     { name = "jinja2", specifier = ">=3.1,<4" },
+    { name = "jsonschema", marker = "extra == 'deepseek-harness'", specifier = ">=4.26,<5" },
     { name = "morphcloud", marker = "extra == 'morph'", specifier = ">=0.1.111" },
     { name = "numpy", marker = "extra == 'evolution'", specifier = ">=2.4,<3" },
     { name = "packaging", marker = "extra == 'prime'", specifier = ">=25,<26" },


### PR DESCRIPTION
## Summary

- Make the gateway invocation ID the canonical identity across native tool execution, lifecycle records, and evidence.
- Keep provider request IDs private to the adapter boundary while preserving the model-facing tool call ID.
- Apply explicit `continue`, `retry`, and `abort` dispositions and require terminal quiescence before close.
- Verify the evidence manifest and package the DeepSeek Harness profile with its required validation support.
- Update the public guidance, architecture, contracts, runtime protocol, and regression coverage for the corrected semantics.

## Validation

- Focused Python tests: 90 passed.
- DeepSeek Harness plugin tests: 9 passed.
- Release-manifest tests: 3 passed.
- Ruff lint and formatting checks passed.
- Strict type checking for the changed source passed.
- Lockfile and diff checks passed.
- `uv build` passed.
- Isolated wheel checks passed for the base and `deepseek-harness` profiles.
- An approved live Azure gateway smoke completed with two model calls and one tool call. The request ID remained private, the run closed in a quiescent state, and all 13 manifest artifacts verified.
