### PR TITLE
Add shared actor invocation authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,8 @@ The current support boundary is:
 - artifact and workspace tasks that use the stock DeepSeek coding tools;
 - finite evidence lifecycles and the registered pump-station Harbor world through
   exact AEC-owned native tool gateways;
-- exact whole-trial `timeout_sec` and per-model-request `max_tokens` limits;
+- an exact whole-trial actor-action budget, whole-process `timeout_sec`, and
+  per-model-request `max_tokens` limit;
 - raw session evidence, readable treatment evidence, and optional exact-byte
   output commitment;
 - no general task-tool translation, arbitrary interactive-world bridge,
@@ -271,13 +272,17 @@ uv run aec-bench task pump-station-world run-harbor \
   --backend modal \
   --adapter deepseek_harness \
   --model "azure:<deployment-name>" \
+  --max-world-actions 90 \
   --max-tokens 8192 \
   --timeout-sec 1800
 ```
 
-The model sees actor observations and actor actions only. The task-owned host
-can apply its deterministic Operations controls between model segments. Harbor
-independently replays the final world run and owns reward.
+The model sees actor observations and actor actions only. One trial-wide actor
+authority owns request replay, action order, the action budget, terminal state,
+and semantic actor evidence across all model segments. The task-owned host can
+apply its deterministic Operations controls between segments while the action
+budget remains open. Harbor independently replays the final world run and owns
+reward.
 
 #### Prime Agent local adapter
 

--- a/agents/entrypoint_agent.py
+++ b/agents/entrypoint_agent.py
@@ -70,6 +70,7 @@ from aec_bench.harness.pump_station_harbor.session import (
     PUMP_STATION_MODEL_CONTROLLER_MODE,
     PUMP_STATION_MODEL_MAX_TOKENS,
     PUMP_STATION_MODEL_MAX_TURNS,
+    PUMP_STATION_MODEL_MAX_WORLD_ACTIONS,
     CompletedPumpStationModelSession,
     CompletedPumpStationReferenceSession,
     run_pump_station_model_session,
@@ -781,6 +782,9 @@ class EntrypointAgent(BaseAgent):
         else:
             provider_environment = _host_model_provider_environment(model)
         max_turns = configured_positive_int(self._params, "max_turns") or PUMP_STATION_MODEL_MAX_TURNS
+        max_world_actions = (
+            configured_positive_int(self._params, "max_world_actions") or PUMP_STATION_MODEL_MAX_WORLD_ACTIONS
+        )
         max_tokens = configured_positive_int(self._params, "max_tokens")
         timeout_sec = configured_positive_int(self._params, "timeout_sec")
         if adapter_kind == "deepseek_harness" and max_tokens is None:
@@ -799,6 +803,7 @@ class EntrypointAgent(BaseAgent):
                         model=model,
                         adapter_kind=adapter_kind,
                         max_turns=max_turns,
+                        max_world_actions=max_world_actions,
                         max_tokens=max_tokens,
                         timeout_sec=timeout_sec,
                         adapter_builder=self._lifecycle_adapter_builder(),

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -200,12 +200,15 @@ tool authority. The AEC host supplies one exact per-run manifest from explicit
 `NativeToolDefinition` values. The plugin registers those JSON schemas and
 forwards calls to an authenticated trial-local Unix socket. The endpoint owns
 trusted invocation identity, cancellation propagation, generic turn
-disposition, generation finalization, and bounded close reporting. It does not
-infer candidate output from tool availability. Lifecycle state, world state,
-effects, host controls, verification, and reward stay with their existing AEC
-owners. The pump-station Harbor journey can alternate fresh DeepSeek model
-segments with the same deterministic task-owned Operations controls used by
-the Prime pump journey.
+disposition, generation finalization, and bounded transport close reporting.
+For generic non-world tools, it also owns request replay. World definitions use
+`NativeWorldToolTransport` and delegate logical request admission, replay,
+budget, action order, terminal state, and semantic evidence to one trial-wide
+`ActorInvocationAuthority`. The authority depends only on the provider-neutral
+world host contract. It has no host-control, verification, evaluation, or
+reward access. The pump-station Harbor journey can alternate fresh DeepSeek
+model segments with the same authority instance and the deterministic
+task-owned Operations controls used by the Prime pump journey.
 
 The shared adapter entrypoint owns provider selection and host credential
 allowlisting. A DeepSeek Harness model uses `provider:model`, and the selected

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -294,6 +294,14 @@ the DeepSeek session, tool-call, turn, generation, cancellation, and trusted
 request identity. A world action uses that trusted identity; the model-facing
 schema cannot supply or replace it.
 
+`NativeToolRequestSemantics` identifies the component that owns logical
+request admission. The gateway owns replay for generic non-world tools. A
+world definition uses `handler-authority`: the gateway validates and forwards
+each exact retry, while `ActorInvocationAuthority` owns the actor principal,
+frozen catalogue identity, request fingerprint and table, action budget, total
+dispatch order, terminal latch, and semantic evidence. A transport correlation
+does not change logical world-action identity.
+
 The handler returns `NativeToolResponse`. Only its generic `conclude-turn`
 disposition can conclude the current model turn; the plugin does not inspect a
 tool name or task result field. Cancellation crosses the socket into a
@@ -303,6 +311,13 @@ non-quiescent close cannot produce a completed adapter result. The sealed close
 record prevents late handler output from changing finalized evidence. The
 provider plugin cannot add shell access, world host controls, verification, or
 reward authority.
+
+The actor authority closes separately from the native transport. It records a
+versioned append-only JSONL stream for the full trial actor, including all model
+segments. A non-quiescent or unknown authority outcome blocks a complete
+pump-station trial record. The task-owned world repository remains the
+transition and replay authority; the actor stream records admission and
+dispatch semantics at the actor boundary.
 
 ## Output completion and explicit commit
 

--- a/docs/protocols/interactive-world-runtime.md
+++ b/docs/protocols/interactive-world-runtime.md
@@ -64,9 +64,13 @@ is not content-addressed:
 
 The DeepSeek native-tool facade does not expose the installed request ID as a
 model argument. Its authenticated gateway derives one stable ID from the
-DeepSeek session and tool-call identity, then supplies that ID when the pump
-wrapper creates `WorldActorActionRequest`. This changes transport presentation,
-not the task-owned retry, conflict, state-transition, or evidence semantics.
+DeepSeek session and tool-call identity. `NativeWorldToolTransport` supplies
+that ID to one trial-wide `ActorInvocationAuthority`. The authority captures
+the current opaque decision for a new request and retains it for exact retries.
+It owns request conflicts, one action budget, total dispatch order, the terminal
+latch, and actor-boundary evidence. This changes transport presentation, not
+task-owned state-transition or receipt semantics. Generic non-world native
+tools keep their request replay in `ToolGatewayEndpoint`.
 
 The pump actor command resolves the selected run from `--run-dir` on every
 call. The repository lock and selected pointer support concurrent and
@@ -183,12 +187,16 @@ Harbor uses the concrete pump integration. The neutral world definition has no
 provider or Harbor port. Harbor import verifies durable pump evidence before
 calling evaluation.
 
-Prime ACP evidence and actor transport evidence are secondary execution
-evidence. The pump repository remains canonical replay authority. The actor log
-contains timestamps plus actor-visible requests, results, and errors. It also
-records malformed, unauthorized, and transport-level attempts using only a
-safe operation label. It excludes the capability secret, endpoint and
-repository paths, arbitrary malformed payload content, and hidden state.
+Prime ACP evidence, actor transport evidence, and DeepSeek actor-invocation
+evidence are secondary execution evidence. The pump repository remains
+canonical replay authority. The Prime actor log contains timestamps plus
+actor-visible requests, results, and errors. It also records malformed,
+unauthorized, and transport-level attempts using only a safe operation label.
+It excludes the capability secret, endpoint and repository paths, arbitrary
+malformed payload content, and hidden state. The DeepSeek semantic actor stream
+contains ordered digests, request identity, action sequence, budget movement,
+terminal state, and close state. It excludes raw arguments, opaque decisions,
+provider credentials, and host-only state.
 
 Prime HOME and XDG paths are trial-local under the actor workspace. A bounded
 session has one Prime runtime. A pump journey uses the same actor workspace for

--- a/src/aec_bench/adapters/deepseek_harness/native_world_tools.py
+++ b/src/aec_bench/adapters/deepseek_harness/native_world_tools.py
@@ -1,0 +1,130 @@
+# ABOUTME: Translates DeepSeek native world calls into the shared actor invocation authority.
+# ABOUTME: Keeps model presentation and correlation outside world action semantics.
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from pydantic import JsonValue
+
+from aec_bench.adapters.deepseek_harness.tool_gateway import (
+    NativeToolDefinition,
+    NativeToolDisposition,
+    NativeToolInvocation,
+    NativeToolRequestSemantics,
+    NativeToolResponse,
+)
+from aec_bench.harness.world_actor import (
+    ActorCorrelation,
+    ActorInvocationAuthority,
+    ActorInvocationError,
+    ActorTurnDisposition,
+)
+
+NATIVE_WORLD_TRANSPORT = "deepseek-native-world"
+
+
+class NativeWorldToolTransport:
+    """Present model-native world tools while delegating semantics to one authority."""
+
+    def __init__(self, authority: ActorInvocationAuthority) -> None:
+        self._authority = authority
+
+    def observation_definition(
+        self,
+        *,
+        name: str,
+        description: str,
+        parameters_schema: dict[str, Any],
+    ) -> NativeToolDefinition:
+        """Define one read-only native observation tool."""
+
+        def handle(
+            invocation: NativeToolInvocation,
+            _arguments: Mapping[str, JsonValue],
+        ) -> NativeToolResponse:
+            try:
+                observation = self._authority.observe(correlation=_correlation(invocation))
+            except ActorInvocationError as error:
+                return _error_response(error)
+            return NativeToolResponse(result=observation.model_dump(mode="json"))
+
+        return NativeToolDefinition(
+            name=name,
+            description=description,
+            parameters_schema=parameters_schema,
+            handler=handle,
+            request_semantics=NativeToolRequestSemantics.HANDLER_AUTHORITY,
+        )
+
+    def action_definition(
+        self,
+        *,
+        name: str,
+        description: str,
+        parameters_schema: dict[str, Any],
+    ) -> NativeToolDefinition:
+        """Define one native action whose logical request is owned by the authority."""
+
+        def handle(
+            invocation: NativeToolInvocation,
+            arguments: Mapping[str, JsonValue],
+        ) -> NativeToolResponse:
+            correlation = _correlation(invocation)
+            try:
+                outcome = self._authority.invoke_current(
+                    request_id=invocation.request_id,
+                    action_name=name,
+                    arguments=dict(arguments),
+                    transport=NATIVE_WORLD_TRANSPORT,
+                    correlation=correlation,
+                )
+            except ActorInvocationError as error:
+                return _error_response(error)
+            return NativeToolResponse(
+                result=outcome.result.model_dump(mode="json"),
+                disposition=_native_disposition(outcome.disposition),
+            )
+
+        return NativeToolDefinition(
+            name=name,
+            description=description,
+            parameters_schema=parameters_schema,
+            handler=handle,
+            request_semantics=NativeToolRequestSemantics.HANDLER_AUTHORITY,
+        )
+
+
+def _correlation(invocation: NativeToolInvocation) -> ActorCorrelation:
+    return ActorCorrelation(
+        transport_request_id=invocation.request_id,
+        provider_session_id=invocation.deepseek_session_id,
+        provider_tool_call_id=invocation.deepseek_tool_call_id,
+        model_turn=invocation.model_turn,
+    )
+
+
+def _error_response(error: ActorInvocationError) -> NativeToolResponse:
+    result: dict[str, JsonValue] = {
+        "status": "error",
+        "error": {
+            "code": error.code,
+            "detail": error.detail,
+            "outcome": error.outcome.value,
+            "action_sequence": error.action_sequence,
+        },
+    }
+    return NativeToolResponse(
+        result=result,
+        disposition=_native_disposition(error.disposition),
+    )
+
+
+def _native_disposition(disposition: ActorTurnDisposition) -> NativeToolDisposition:
+    if disposition is ActorTurnDisposition.CONCLUDE_TURN:
+        return NativeToolDisposition.CONCLUDE_TURN
+    return NativeToolDisposition.CONTINUE
+
+
+__all__ = ["NATIVE_WORLD_TRANSPORT", "NativeWorldToolTransport"]

--- a/src/aec_bench/adapters/deepseek_harness/tool_gateway.py
+++ b/src/aec_bench/adapters/deepseek_harness/tool_gateway.py
@@ -43,6 +43,13 @@ class NativeToolDisposition(StrEnum):
     CONCLUDE_TURN = "conclude-turn"
 
 
+class NativeToolRequestSemantics(StrEnum):
+    """Select the one component that owns logical request admission and replay."""
+
+    GATEWAY = "gateway"
+    HANDLER_AUTHORITY = "handler-authority"
+
+
 class NativeCancellation:
     """Expose cooperative cancellation to one synchronous AEC handler."""
 
@@ -106,6 +113,7 @@ class NativeToolDefinition:
     description: str
     parameters_schema: dict[str, Any]
     handler: NativeToolHandler
+    request_semantics: NativeToolRequestSemantics = NativeToolRequestSemantics.GATEWAY
 
 
 def json_native_tool_definition(
@@ -179,6 +187,7 @@ class _AdmittedInvocation:
     fingerprint: str
     invocation: NativeToolInvocation
     arguments: dict[str, JsonValue]
+    request_semantics: NativeToolRequestSemantics
     dispatched_at: datetime | None = None
     completed_at: datetime | None = None
     response: dict[str, Any] | None = None
@@ -264,6 +273,8 @@ class ToolGatewayEndpoint:
         self._evidence_finalized = False
         self._responses: dict[str, tuple[str, dict[str, Any]]] = {}
         self._active: dict[str, _AdmittedInvocation] = {}
+        self._handler_authority_active: dict[str, list[_AdmittedInvocation]] = {}
+        self._handler_authority_completed: set[str] = set()
         self._cancelled_before_dispatch: set[str] = set()
         self._server: _ToolServer | None = None
         self._thread: threading.Thread | None = None
@@ -315,7 +326,7 @@ class ToolGatewayEndpoint:
             thread = self._thread
             socket_path = self._socket_path
             socket_directory = self._socket_directory
-            for active in self._active.values():
+            for active in self._all_active_locked():
                 active.invocation.cancellation._cancel()
 
         if server is not None:
@@ -326,15 +337,13 @@ class ToolGatewayEndpoint:
 
         deadline = time.monotonic() + deadline_seconds
         with self._condition:
-            while self._active:
+            while self._has_active_locked():
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     break
                 self._condition.wait(remaining)
-            unsettled = tuple(sorted(self._active))
-            unknown = tuple(
-                request_id for request_id in unsettled if self._active[request_id].dispatched_at is not None
-            )
+            unsettled = tuple(sorted(self._active_request_ids_locked()))
+            unknown = tuple(sorted(self._unknown_active_request_ids_locked()))
 
         if socket_path is not None:
             socket_path.unlink(missing_ok=True)
@@ -418,6 +427,8 @@ class ToolGatewayEndpoint:
             return response
 
         fingerprint = _request_fingerprint(request)
+        if binding.definition.request_semantics is NativeToolRequestSemantics.HANDLER_AUTHORITY:
+            return self._invoke_handler_authority(binding, request, request_id=request_id, fingerprint=fingerprint)
         owner = False
         with self._lock:
             previous = self._responses.get(request_id)
@@ -466,6 +477,7 @@ class ToolGatewayEndpoint:
                     fingerprint=fingerprint,
                     invocation=invocation,
                     arguments=dict(request.arguments),
+                    request_semantics=NativeToolRequestSemantics.GATEWAY,
                 )
                 self._active[request_id] = active
                 owner = True
@@ -479,6 +491,42 @@ class ToolGatewayEndpoint:
             self._append_duplicate_evidence(request, request_id, response, duplicate_of=request_id)
             return response
 
+        return self._execute(binding, request, active)
+
+    def _invoke_handler_authority(
+        self,
+        binding: _ToolBinding,
+        request: _ToolInvocationRequest,
+        *,
+        request_id: str,
+        fingerprint: str,
+    ) -> dict[str, Any]:
+        with self._lock:
+            if request_id in self._cancelled_before_dispatch:
+                response = _error_response("request_cancelled", "Tool request was cancelled before dispatch.")
+                self._append_unadmitted_evidence(request, request_id=request_id, response=response, cancelled=True)
+                return response
+            if self._closing:
+                response = _error_response("endpoint_closing", "Native tool transport is closing.")
+                self._append_unadmitted_evidence(request, request_id=request_id, response=response)
+                return response
+            invocation = NativeToolInvocation(
+                request_id=request_id,
+                deepseek_session_id=request.metadata.deepseek_session_id,
+                deepseek_tool_call_id=request.metadata.deepseek_tool_call_id,
+                model_turn=request.metadata.aec_model_turn,
+                tool_name=request.tool,
+                generation_id=self.generation_id,
+                admitted_at=datetime.now(UTC),
+                cancellation=NativeCancellation(),
+            )
+            active = _AdmittedInvocation(
+                fingerprint=fingerprint,
+                invocation=invocation,
+                arguments=dict(request.arguments),
+                request_semantics=NativeToolRequestSemantics.HANDLER_AUTHORITY,
+            )
+            self._handler_authority_active.setdefault(request_id, []).append(active)
         return self._execute(binding, request, active)
 
     def _execute(
@@ -535,9 +583,19 @@ class ToolGatewayEndpoint:
                 active.response = transport_response
             else:
                 active.response = response
-                self._responses[request_id] = (active.fingerprint, response)
+                if active.request_semantics is NativeToolRequestSemantics.GATEWAY:
+                    self._responses[request_id] = (active.fingerprint, response)
+                else:
+                    self._handler_authority_completed.add(request_id)
                 transport_response = response
-            self._active.pop(request_id, None)
+            if active.request_semantics is NativeToolRequestSemantics.GATEWAY:
+                self._active.pop(request_id, None)
+            else:
+                remaining = [item for item in self._handler_authority_active.get(request_id, ()) if item is not active]
+                if remaining:
+                    self._handler_authority_active[request_id] = remaining
+                else:
+                    self._handler_authority_active.pop(request_id, None)
             active.done.set()
             self._condition.notify_all()
 
@@ -556,16 +614,21 @@ class ToolGatewayEndpoint:
         request_id = _trusted_request_id(request.metadata)
         occurred_at = datetime.now(UTC)
         with self._lock:
-            completed = request_id in self._responses
+            completed = request_id in self._responses or request_id in self._handler_authority_completed
             active = self._active.get(request_id)
+            handler_authority_active = self._handler_authority_active.get(request_id, ())
+            active_items = (*handler_authority_active, active) if active is not None else handler_authority_active
+            for item in active_items:
+                item.invocation.cancellation._cancel()
             if completed:
                 outcome = "completed"
-            elif active is None:
+            elif not active_items:
                 self._cancelled_before_dispatch.add(request_id)
                 outcome = "not-dispatched"
             else:
-                active.invocation.cancellation._cancel()
-                outcome = "unknown" if active.dispatched_at is not None else "not-dispatched"
+                outcome = (
+                    "unknown" if any(item.dispatched_at is not None for item in active_items) else "not-dispatched"
+                )
         response = {
             "protocol": TOOL_GATEWAY_PROTOCOL,
             "status": "ok",
@@ -608,6 +671,7 @@ class ToolGatewayEndpoint:
                 "deepseek_tool_call_id": request.metadata.deepseek_tool_call_id,
                 "model_turn": request.metadata.aec_model_turn,
                 "tool": request.tool,
+                "request_semantics": active.request_semantics.value,
                 "arguments_sha256": _json_sha256(request.arguments),
                 "admitted_at": active.invocation.admitted_at.isoformat(),
                 "dispatched_at": active.dispatched_at.isoformat() if active.dispatched_at is not None else None,
@@ -623,6 +687,27 @@ class ToolGatewayEndpoint:
                 "stale_ignored": stale,
             }
         )
+
+    def _all_active_locked(self) -> tuple[_AdmittedInvocation, ...]:
+        return (
+            *self._active.values(),
+            *(item for items in self._handler_authority_active.values() for item in items),
+        )
+
+    def _has_active_locked(self) -> bool:
+        return bool(self._active or self._handler_authority_active)
+
+    def _active_request_ids_locked(self) -> set[str]:
+        return {*self._active, *self._handler_authority_active}
+
+    def _unknown_active_request_ids_locked(self) -> set[str]:
+        unknown = {request_id for request_id, active in self._active.items() if active.dispatched_at is not None}
+        unknown.update(
+            request_id
+            for request_id, active_items in self._handler_authority_active.items()
+            if any(active.dispatched_at is not None for active in active_items)
+        )
+        return unknown
 
     def _append_unadmitted_evidence(
         self,

--- a/src/aec_bench/cli/commands/pump_station_world.py
+++ b/src/aec_bench/cli/commands/pump_station_world.py
@@ -52,6 +52,7 @@ app = typer.Typer(help="Run the synthetic wastewater pump-station stewardship wo
 _DEFAULT_REFERENCE_CONTROLLER_ID = PUMP_STATION_REFERENCE_SYSTEM_CONTROLLER_ID
 _DEFAULT_MODEL_MAX_TURNS = 90
 _DEFAULT_MODEL_MAX_TOKENS = 8192
+_DEFAULT_MODEL_MAX_WORLD_ACTIONS = 90
 
 
 def _model_payload(value: object) -> dict[str, object]:
@@ -325,6 +326,12 @@ def run_harbor_command(
         min=1,
         help="Maximum model requests for a model-controlled session",
     ),
+    max_world_actions: int = typer.Option(
+        _DEFAULT_MODEL_MAX_WORLD_ACTIONS,
+        "--max-world-actions",
+        min=1,
+        help="Maximum actor world actions across all model segments",
+    ),
     max_tokens: int = typer.Option(
         _DEFAULT_MODEL_MAX_TOKENS,
         "--max-tokens",
@@ -363,6 +370,7 @@ def run_harbor_command(
         model_name=model,
         adapter=adapter,
         max_turns=max_turns,
+        max_world_actions=max_world_actions,
         max_tokens=max_tokens if adapter == "deepseek_harness" else None,
         timeout_sec=timeout_sec,
         environment_binding=resolve_harbor_environment_binding(backend),
@@ -378,9 +386,13 @@ def run_harbor_command(
             "model": model,
             "adapter": adapter,
             "limits": (
-                {"max_tokens": max_tokens, "timeout_sec": timeout_sec}
+                {
+                    "max_world_actions": max_world_actions,
+                    "max_tokens": max_tokens,
+                    "timeout_sec": timeout_sec,
+                }
                 if adapter == "deepseek_harness"
-                else {"max_turns": max_turns}
+                else {"max_world_actions": max_world_actions, "max_turns": max_turns}
             ),
             "executed": execute,
             "exit_code": result.exit_code,

--- a/src/aec_bench/harness/pump_station_harbor/job.py
+++ b/src/aec_bench/harness/pump_station_harbor/job.py
@@ -21,6 +21,7 @@ from aec_bench.harness.pump_station_harbor.session import (
     PUMP_STATION_MODEL_CONTROLLER_MODE,
     PUMP_STATION_MODEL_MAX_TOKENS,
     PUMP_STATION_MODEL_MAX_TURNS,
+    PUMP_STATION_MODEL_MAX_WORLD_ACTIONS,
 )
 from aec_bench.worlds.stewardship.wastewater_pump_station.reference_controller import (
     PUMP_STATION_REFERENCE_SYSTEM_CONTROLLER_ID,
@@ -38,6 +39,7 @@ def build_pump_station_harbor_job_config(
     model_name: str = PUMP_STATION_REFERENCE_SYSTEM_CONTROLLER_ID,
     adapter: str = "tool_loop",
     max_turns: int = PUMP_STATION_MODEL_MAX_TURNS,
+    max_world_actions: int = PUMP_STATION_MODEL_MAX_WORLD_ACTIONS,
     max_tokens: int | None = None,
     timeout_sec: int | None = None,
     environment_binding: HarborEnvironmentBinding | None = None,
@@ -53,6 +55,8 @@ def build_pump_station_harbor_job_config(
         raise ValueError("pump-station Harbor model name is required")
     if max_turns < 1:
         raise ValueError("pump-station Harbor max turns must be positive")
+    if isinstance(max_world_actions, bool) or max_world_actions < 1:
+        raise ValueError("pump-station Harbor world action budget must be positive")
     reference_controller = model == PUMP_STATION_REFERENCE_SYSTEM_CONTROLLER_ID
     adapter_kind = "tool_loop" if reference_controller else adapter.strip()
     if adapter_kind not in {"deepseek_harness", "tool_loop"}:
@@ -66,6 +70,7 @@ def build_pump_station_harbor_job_config(
     agent_name = "pump-station-reference-controller"
     if not reference_controller:
         agent_name = "pump-station-model-controller"
+        agent_kwargs["max_world_actions"] = max_world_actions
         if adapter_kind == "deepseek_harness":
             resolved_max_tokens = PUMP_STATION_MODEL_MAX_TOKENS if max_tokens is None else max_tokens
             if isinstance(resolved_max_tokens, bool) or resolved_max_tokens <= 0:
@@ -122,6 +127,7 @@ def run_pump_station_harbor_job(
     model_name: str = PUMP_STATION_REFERENCE_SYSTEM_CONTROLLER_ID,
     adapter: str = "tool_loop",
     max_turns: int = PUMP_STATION_MODEL_MAX_TURNS,
+    max_world_actions: int = PUMP_STATION_MODEL_MAX_WORLD_ACTIONS,
     max_tokens: int | None = None,
     timeout_sec: int | None = None,
     environment_binding: HarborEnvironmentBinding | None = None,
@@ -141,6 +147,7 @@ def run_pump_station_harbor_job(
         model_name=model_name,
         adapter=adapter,
         max_turns=max_turns,
+        max_world_actions=max_world_actions,
         max_tokens=max_tokens,
         timeout_sec=timeout_sec,
         environment_binding=environment_binding,

--- a/src/aec_bench/harness/pump_station_harbor/session.py
+++ b/src/aec_bench/harness/pump_station_harbor/session.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any, cast
 from pydantic import JsonValue
 
 from aec_bench.adapters.base import AdapterRequest, AdapterResult
+from aec_bench.adapters.deepseek_harness.native_world_tools import NativeWorldToolTransport
 from aec_bench.adapters.local_registry import build_local_adapter
 from aec_bench.contracts.agent_output import AgentOutputStatus
 from aec_bench.contracts.task_definition import ToolSpec
@@ -30,6 +31,12 @@ from aec_bench.harness.pump_station_harbor.export import (
     PUMP_STATION_HARBOR_EXECUTION_KIND,
     PumpStationHarborBridge,
     is_pump_station_harbor_inventory_artifact,
+)
+from aec_bench.harness.world_actor import (
+    ActorCorrelation,
+    ActorInvocationAuthority,
+    ActorInvocationAuthorityConfig,
+    AuthorityCloseReport,
 )
 from aec_bench.trajectory.writer import TrajectoryWriter
 from aec_bench.worlds.stewardship.wastewater_pump_station.actor_interface import (
@@ -72,7 +79,9 @@ if TYPE_CHECKING:
 PUMP_STATION_MODEL_CONTROLLER_MODE = "model"
 PUMP_STATION_MODEL_MAX_TURNS = 90
 PUMP_STATION_MODEL_MAX_TOKENS = 8192
+PUMP_STATION_MODEL_MAX_WORLD_ACTIONS = 90
 _PUMP_STATION_MODEL_MAX_SEGMENTS = 8
+_PUMP_STATION_TOOL_LOOP_TRANSPORT = "python-tool-loop"
 
 
 @dataclass(frozen=True)
@@ -103,8 +112,9 @@ class CompletedPumpStationModelSession:
 class _PumpStationActorTools:
     """Translate provider-native tool calls into the one installed actor boundary."""
 
-    def __init__(self, host: PumpStationEpisodeHost) -> None:
-        self._host = host
+    def __init__(self, authority: ActorInvocationAuthority) -> None:
+        self._authority = authority
+        self._native_world_transport = NativeWorldToolTransport(authority)
 
     @property
     def tool_specs(self) -> tuple[ToolSpec, ...]:
@@ -240,43 +250,44 @@ class _PumpStationActorTools:
             ),
         )
 
-    @staticmethod
     def _definition(
+        self,
         name: str,
         function: Callable[..., str],
         properties: dict[str, Any],
         required: tuple[str, ...] = (),
     ) -> NativeToolDefinition:
-        from aec_bench.adapters.deepseek_harness.tool_gateway import json_native_tool_definition
-
-        return json_native_tool_definition(
+        parameters_schema = {
+            "type": "object",
+            "properties": properties,
+            "required": list(required),
+            "additionalProperties": False,
+        }
+        definition_factory = (
+            self._native_world_transport.observation_definition
+            if name == "observe_pump_station"
+            else self._native_world_transport.action_definition
+        )
+        return definition_factory(
             name=name,
             description=function.__doc__ or name.replace("_", " "),
-            parameters_schema={
-                "type": "object",
-                "properties": properties,
-                "required": list(required),
-                "additionalProperties": False,
-            },
-            function=function,
-            trusted_request_argument=None if name == "observe_pump_station" else "request_id",
+            parameters_schema=parameters_schema,
         )
 
     def observe_pump_station(self) -> str:
         """Read the complete current actor view without latent or future state."""
-        return json.dumps(self._host.observe().model_dump(mode="json"), sort_keys=True, separators=(",", ":"))
+        observation = self._authority.observe(correlation=ActorCorrelation())
+        return json.dumps(observation.model_dump(mode="json"), sort_keys=True, separators=(",", ":"))
 
     def _invoke(self, request_id: str, action_name: str, arguments: dict[str, JsonValue]) -> str:
-        observation = self._host.observe()
-        result = self._host.invoke(
-            WorldActorActionRequest(
-                request_id=request_id,
-                decision_id=observation.decision_id,
-                action_name=action_name,
-                arguments=arguments,
-            )
+        outcome = self._authority.invoke_current(
+            request_id=request_id,
+            action_name=action_name,
+            arguments=arguments,
+            transport=_PUMP_STATION_TOOL_LOOP_TRANSPORT,
+            correlation=ActorCorrelation(transport_request_id=request_id),
         )
-        return json.dumps(result.model_dump(mode="json"), sort_keys=True, separators=(",", ":"))
+        return json.dumps(outcome.result.model_dump(mode="json"), sort_keys=True, separators=(",", ":"))
 
     def continue_operation(self, request_id: str, reason: str) -> str:
         """Continue the permitted operating mode to the next declared decision event."""
@@ -484,6 +495,7 @@ def run_pump_station_model_session(
     model: str,
     adapter_kind: str = "tool_loop",
     max_turns: int = PUMP_STATION_MODEL_MAX_TURNS,
+    max_world_actions: int = PUMP_STATION_MODEL_MAX_WORLD_ACTIONS,
     max_tokens: int | None = None,
     timeout_sec: int | None = None,
     adapter_builder: Callable[..., Any] | None = None,
@@ -498,6 +510,8 @@ def run_pump_station_model_session(
         raise ValueError(f"unsupported pump-station model adapter: {adapter_kind}")
     if max_turns < 1:
         raise ValueError("pump-station model episode max turns must be positive")
+    if isinstance(max_world_actions, bool) or max_world_actions < 1:
+        raise ValueError("pump-station model episode world action budget must be positive")
     request_configuration: dict[str, int]
     if adapter_kind == "deepseek_harness":
         resolved_max_tokens = PUMP_STATION_MODEL_MAX_TOKENS if max_tokens is None else max_tokens
@@ -523,11 +537,22 @@ def run_pump_station_model_session(
     else:
         started = host.open(request)
         start = _private_snapshot(started.snapshot)
+    authority = ActorInvocationAuthority(
+        host=host,
+        config=ActorInvocationAuthorityConfig(
+            authority_id=f"actor-authority.{identity}",
+            actor_principal_id=f"actor.{identity}",
+            max_world_actions=max_world_actions,
+            evidence_path=destination / "actor-invocation-evidence.jsonl",
+        ),
+    )
+    authority.start()
     trajectory = TrajectoryWriter(path=str(destination / "trajectory.jsonl"))
     adapter_results: list[AdapterResult] = []
     host_control_count = 0
     journey_status = PumpStationJourneyStatus.ACTIVE
     stop_reason = "max-segments"
+    authority_close_report: AuthorityCloseReport | None = None
     try:
         resolved_builder = adapter_builder or build_local_adapter
         control = PumpStationWorldControl(
@@ -535,7 +560,7 @@ def run_pump_station_model_session(
             authorised_principal_ids=(PUMP_STATION_OPERATIONS_AUTHORITY_ID,),
         )
         for _segment_index in range(_PUMP_STATION_MODEL_MAX_SEGMENTS):
-            tools = _PumpStationActorTools(host)
+            tools = _PumpStationActorTools(authority)
             adapter = resolved_builder(
                 adapter_kind=adapter_kind,
                 model_name=model_name,
@@ -571,6 +596,9 @@ def run_pump_station_model_session(
             stop_reason = decision.reason
             if decision.status is PumpStationJourneyStatus.COMPLETED:
                 break
+            if authority.world_action_limit_reached:
+                stop_reason = "max-world-actions"
+                break
             if decision.control_request is None or bridge.rollout_child_ref is not None:
                 break
             control.execute(decision.control_request)
@@ -584,7 +612,12 @@ def run_pump_station_model_session(
                 stop_reason = "declared-terminal-state"
                 break
     finally:
-        trajectory.close()
+        try:
+            trajectory.close()
+        finally:
+            authority_close_report = authority.close()
+    if not authority_close_report.complete:
+        raise RuntimeError("pump-station actor invocation authority did not close completely")
     if not adapter_results:
         raise RuntimeError("pump-station model journey produced no adapter segment")
     adapter_result = _aggregate_adapter_results(
@@ -593,6 +626,23 @@ def run_pump_station_model_session(
         stop_reason=stop_reason,
         host_control_count=host_control_count,
     )
+    adapter_configuration = dict(adapter_result.configuration_record)
+    adapter_configuration["actor_invocation_authority"] = {
+        "authority_id": authority.authority_id,
+        "actor_principal_id": authority.config.actor_principal_id,
+        "catalogue_sha256": authority.catalogue_hash,
+        "max_world_actions": authority.config.max_world_actions,
+        "world_action_count": authority.world_action_count,
+        "evidence_path": "actor-invocation-evidence.jsonl",
+        "close": {
+            "quiescent": authority_close_report.quiescent,
+            "complete": authority_close_report.complete,
+            "unsettled_request_ids": list(authority_close_report.unsettled_request_ids),
+            "unknown_outcome_request_ids": list(authority_close_report.unknown_outcome_request_ids),
+            "closed_at": authority_close_report.closed_at.isoformat(),
+        },
+    }
+    adapter_result = replace(adapter_result, configuration_record=adapter_configuration)
     repository = PumpStationWorldRunRepository(repository_root)
     end = repository.current_snapshot()
     evidence_request, result = _episode_evidence(repository_root, identity, start, end)
@@ -954,6 +1004,7 @@ __all__ = (
     "PUMP_STATION_MODEL_CONTROLLER_MODE",
     "PUMP_STATION_MODEL_MAX_TURNS",
     "PUMP_STATION_MODEL_MAX_TOKENS",
+    "PUMP_STATION_MODEL_MAX_WORLD_ACTIONS",
     "run_pump_station_model_session",
     "run_pump_station_reference_session",
 )

--- a/src/aec_bench/harness/world_actor/__init__.py
+++ b/src/aec_bench/harness/world_actor/__init__.py
@@ -1,0 +1,34 @@
+# ABOUTME: Exposes the provider-neutral actor invocation authority for interactive worlds.
+# ABOUTME: Keeps world action semantics independent from Prime, DeepSeek, and transport framing.
+
+from aec_bench.harness.world_actor.authority import (
+    ACTOR_INVOCATION_EVIDENCE_SCHEMA,
+    ACTOR_INVOCATION_SEMANTICS,
+    ActorCorrelation,
+    ActorInvocationAuthority,
+    ActorInvocationAuthorityConfig,
+    ActorInvocationError,
+    ActorInvocationLifecycle,
+    ActorInvocationOutcome,
+    ActorInvocationOutcomeClass,
+    ActorInvocationRequest,
+    ActorTurnDisposition,
+    AuthorityCloseReport,
+    WorldActorHost,
+)
+
+__all__ = [
+    "ACTOR_INVOCATION_EVIDENCE_SCHEMA",
+    "ACTOR_INVOCATION_SEMANTICS",
+    "ActorCorrelation",
+    "ActorInvocationAuthority",
+    "ActorInvocationAuthorityConfig",
+    "ActorInvocationError",
+    "ActorInvocationLifecycle",
+    "ActorInvocationOutcome",
+    "ActorInvocationOutcomeClass",
+    "ActorInvocationRequest",
+    "ActorTurnDisposition",
+    "AuthorityCloseReport",
+    "WorldActorHost",
+]

--- a/src/aec_bench/harness/world_actor/authority.py
+++ b/src/aec_bench/harness/world_actor/authority.py
@@ -1,0 +1,939 @@
+# ABOUTME: Owns trial-wide world action identity, budget, ordering, terminal state, and evidence.
+# ABOUTME: Delegates task meaning to the world host and keeps provider transports semantically thin.
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, Protocol
+
+from pydantic import Field, JsonValue
+
+from aec_bench.contracts.validators import FrozenStrictModel, NonEmptyStr
+from aec_bench.contracts.world_interface import (
+    WorldActorActionRequest,
+    WorldActorActionResult,
+    WorldActorCapabilityCatalogue,
+    WorldActorObservation,
+    WorldInterfaceError,
+)
+
+ACTOR_INVOCATION_SEMANTICS = "aec-bench/actor-invocation/1"
+ACTOR_INVOCATION_EVIDENCE_SCHEMA = "aec-bench/actor-invocation-evidence/1"
+
+
+class WorldActorHost(Protocol):
+    """The actor-facing surface supplied by one concrete task world."""
+
+    def capabilities(self) -> WorldActorCapabilityCatalogue: ...
+
+    def observe(self) -> WorldActorObservation: ...
+
+    def invoke(self, request: WorldActorActionRequest) -> WorldActorActionResult: ...
+
+
+class ActorInvocationLifecycle(StrEnum):
+    """Lifecycle of one trial actor authority."""
+
+    CREATED = "created"
+    RUNNING = "running"
+    CLOSING = "closing"
+    CLOSED = "closed"
+
+
+class ActorInvocationOutcomeClass(StrEnum):
+    """State whether a world action was not dispatched, completed, or is unknown."""
+
+    NOT_DISPATCHED = "not-dispatched"
+    COMPLETED = "completed"
+    UNKNOWN = "unknown"
+
+
+class ActorTurnDisposition(StrEnum):
+    """Tell a provider-neutral actor loop whether the current turn can continue."""
+
+    CONTINUE = "continue"
+    CONCLUDE_TURN = "conclude-turn"
+
+
+class _RequestState(StrEnum):
+    IN_FLIGHT = "in-flight"
+    COMPLETED = "completed"
+    UNKNOWN = "unknown"
+
+
+class ActorCorrelation(FrozenStrictModel):
+    """Token-free transport correlation that does not participate in request identity."""
+
+    transport_request_id: NonEmptyStr | None = None
+    provider_session_id: NonEmptyStr | None = None
+    provider_tool_call_id: NonEmptyStr | None = None
+    model_turn: int | None = Field(default=None, ge=1)
+
+
+class ActorInvocationRequest(FrozenStrictModel):
+    """One transport-neutral logical world action request."""
+
+    request_id: NonEmptyStr
+    decision_id: NonEmptyStr
+    action_name: NonEmptyStr
+    arguments: dict[str, JsonValue]
+    transport: NonEmptyStr
+    correlation: ActorCorrelation
+
+
+@dataclass(frozen=True)
+class ActorInvocationAuthorityConfig:
+    """Fixed identity, limits, and evidence location for one trial actor."""
+
+    actor_principal_id: str
+    max_world_actions: int
+    evidence_path: Path
+    close_timeout_sec: float = 30.0
+    max_result_bytes: int = 4_194_304
+    authority_id: str | None = None
+
+    def __post_init__(self) -> None:
+        principal = self.actor_principal_id.strip()
+        if not principal:
+            raise ValueError("actor principal ID must not be blank")
+        if isinstance(self.max_world_actions, bool) or self.max_world_actions < 1:
+            raise ValueError("actor world action budget must be positive")
+        if self.close_timeout_sec < 0:
+            raise ValueError("actor authority close timeout must not be negative")
+        if isinstance(self.max_result_bytes, bool) or self.max_result_bytes < 1:
+            raise ValueError("actor authority maximum result bytes must be positive")
+        authority_id = self.authority_id.strip() if self.authority_id is not None else None
+        if self.authority_id is not None and not authority_id:
+            raise ValueError("actor authority ID must not be blank")
+        object.__setattr__(self, "actor_principal_id", principal)
+        object.__setattr__(self, "evidence_path", Path(self.evidence_path).resolve())
+        object.__setattr__(self, "authority_id", authority_id)
+
+
+@dataclass(frozen=True)
+class ActorInvocationOutcome:
+    """One completed world action outcome returned by the shared authority."""
+
+    result: WorldActorActionResult
+    action_sequence: int
+    duplicate: bool
+    disposition: ActorTurnDisposition
+
+
+@dataclass(frozen=True)
+class AuthorityCloseReport:
+    """State whether close is quiescent and suitable for complete trial evidence."""
+
+    quiescent: bool
+    complete: bool
+    unsettled_request_ids: tuple[str, ...]
+    unknown_outcome_request_ids: tuple[str, ...]
+    closed_at: datetime
+    lifecycle: ActorInvocationLifecycle
+
+
+class ActorInvocationError(RuntimeError):
+    """A stable actor-boundary failure that transports can render without interpretation."""
+
+    def __init__(
+        self,
+        code: str,
+        detail: str,
+        *,
+        outcome: ActorInvocationOutcomeClass,
+        request_id: str | None = None,
+        action_sequence: int | None = None,
+        duplicate: bool = False,
+        disposition: ActorTurnDisposition = ActorTurnDisposition.CONTINUE,
+    ) -> None:
+        self.code = code
+        self.detail = detail
+        self.outcome = outcome
+        self.request_id = request_id
+        self.action_sequence = action_sequence
+        self.duplicate = duplicate
+        self.disposition = disposition
+        super().__init__(f"{code}: {detail}")
+
+
+@dataclass(frozen=True)
+class _Failure:
+    code: str
+    detail: str
+    outcome: ActorInvocationOutcomeClass
+    disposition: ActorTurnDisposition
+
+
+@dataclass
+class _RequestEntry:
+    request: ActorInvocationRequest
+    fingerprint: str
+    action_sequence: int
+    state: _RequestState
+    admitted_at: datetime
+    dispatched_at: datetime | None = None
+    completed_at: datetime | None = None
+    result: WorldActorActionResult | None = None
+    failure: _Failure | None = None
+    duplicate_waiters: int = 0
+
+
+class ActorInvocationAuthority:
+    """Own all semantic admission and completion state for one trial actor."""
+
+    def __init__(self, *, host: WorldActorHost, config: ActorInvocationAuthorityConfig) -> None:
+        self._host = host
+        self.config = config
+        self.authority_id = config.authority_id or f"actor-authority-{uuid.uuid4().hex}"
+        self._condition = threading.Condition(threading.Lock())
+        self._host_operation_lock = threading.Lock()
+        self._admission_lock = threading.Lock()
+        self._evidence_lock = threading.Lock()
+        self._lifecycle = ActorInvocationLifecycle.CREATED
+        self._catalogue: WorldActorCapabilityCatalogue | None = None
+        self._catalogue_hash: str | None = None
+        self._action_names: frozenset[str] = frozenset()
+        self._requests: dict[str, _RequestEntry] = {}
+        self._active_request_ids: set[str] = set()
+        self._next_action_sequence = 1
+        self._next_dispatch_sequence = 1
+        self._budget_used = 0
+        self._budget_reserved = 0
+        self._terminal = False
+        self._terminal_action_sequence: int | None = None
+        self._evidence_sequence = 0
+        self._successful_close_report: AuthorityCloseReport | None = None
+
+    @property
+    def lifecycle(self) -> ActorInvocationLifecycle:
+        with self._condition:
+            return self._lifecycle
+
+    @property
+    def catalogue_hash(self) -> str | None:
+        with self._condition:
+            return self._catalogue_hash
+
+    @property
+    def world_action_count(self) -> int:
+        with self._condition:
+            return self._budget_used
+
+    @property
+    def world_action_limit_reached(self) -> bool:
+        with self._condition:
+            return self._budget_used + self._budget_reserved >= self.config.max_world_actions
+
+    @property
+    def terminal(self) -> bool:
+        with self._condition:
+            return self._terminal
+
+    def start(self) -> None:
+        """Freeze the task-owned catalogue and create the versioned evidence stream."""
+        with self._condition:
+            if self._lifecycle is not ActorInvocationLifecycle.CREATED:
+                raise RuntimeError("actor invocation authority can start only once")
+        catalogue = self._host.capabilities()
+        catalogue_hash = _json_sha256(catalogue.model_dump(mode="json"))
+        evidence_path = self.config.evidence_path
+        evidence_path.parent.mkdir(parents=True, exist_ok=True)
+        if evidence_path.exists() or evidence_path.is_symlink():
+            raise FileExistsError(f"actor invocation evidence already exists: {evidence_path}")
+        started_at = datetime.now(UTC)
+        with self._evidence_lock:
+            self._evidence_sequence = 1
+            header = {
+                "sequence": self._evidence_sequence,
+                "record_type": "header",
+                "schema": ACTOR_INVOCATION_EVIDENCE_SCHEMA,
+                "semantics": ACTOR_INVOCATION_SEMANTICS,
+                "authority_id": self.authority_id,
+                "actor_principal_id": self.config.actor_principal_id,
+                "catalogue_sha256": catalogue_hash,
+                "max_world_actions": self.config.max_world_actions,
+                "max_result_bytes": self.config.max_result_bytes,
+                "started_at": started_at.isoformat(),
+            }
+            with evidence_path.open("x", encoding="utf-8") as stream:
+                stream.write(json.dumps(header, sort_keys=True, separators=(",", ":")) + "\n")
+                stream.flush()
+                os.fsync(stream.fileno())
+            evidence_path.chmod(0o600)
+        with self._condition:
+            self._catalogue = catalogue
+            self._catalogue_hash = catalogue_hash
+            self._action_names = frozenset(action.name for action in catalogue.actions)
+            self._lifecycle = ActorInvocationLifecycle.RUNNING
+            self._condition.notify_all()
+
+    def capabilities(self, *, correlation: ActorCorrelation) -> WorldActorCapabilityCatalogue:
+        """Return the frozen catalogue after proving that the host has not drifted."""
+        self._require_readable()
+        self._require_catalogue_stable()
+        with self._condition:
+            assert self._catalogue is not None
+            catalogue = self._catalogue
+        self._append_evidence(
+            {
+                "record_type": "capabilities",
+                "correlation": correlation.model_dump(mode="json"),
+                "catalogue_sha256": self.catalogue_hash,
+                "occurred_at": datetime.now(UTC).isoformat(),
+            }
+        )
+        return catalogue
+
+    def observe(self, *, correlation: ActorCorrelation) -> WorldActorObservation:
+        """Read an actor view after all actions admitted before this call have settled."""
+        self._require_readable()
+        self._require_catalogue_stable()
+        with self._condition:
+            barrier = self._next_action_sequence - 1
+            while any(
+                entry.action_sequence <= barrier and entry.state is _RequestState.IN_FLIGHT
+                for entry in self._requests.values()
+            ):
+                self._condition.wait()
+            if self._lifecycle is not ActorInvocationLifecycle.RUNNING:
+                raise self._lifecycle_error()
+        observed_at = datetime.now(UTC)
+        try:
+            with self._host_operation_lock:
+                observation = self._host.observe()
+        except WorldInterfaceError as exc:
+            error = ActorInvocationError(
+                exc.code,
+                exc.detail,
+                outcome=ActorInvocationOutcomeClass.COMPLETED,
+            )
+            self._append_read_error("observe", correlation, error, observed_at)
+            raise error from exc
+        except Exception as exc:
+            error = ActorInvocationError(
+                "actor-observation-failed",
+                "World observation failed.",
+                outcome=ActorInvocationOutcomeClass.UNKNOWN,
+            )
+            self._append_read_error("observe", correlation, error, observed_at)
+            raise error from exc
+        self._append_evidence(
+            {
+                "record_type": "observe",
+                "correlation": correlation.model_dump(mode="json"),
+                "observed_at": observed_at.isoformat(),
+                "completed_at": datetime.now(UTC).isoformat(),
+                "decision_id_sha256": _text_sha256(observation.decision_id),
+                "observation_sha256": _json_sha256(observation.model_dump(mode="json")),
+                "barrier_action_sequence": barrier,
+            }
+        )
+        return observation
+
+    def invoke(self, request: ActorInvocationRequest) -> ActorInvocationOutcome:
+        """Admit, deduplicate, order, and dispatch one logical world action."""
+        with self._admission_lock:
+            admitted = self._admit(request)
+        if isinstance(admitted, ActorInvocationOutcome):
+            return admitted
+        return self._dispatch(admitted)
+
+    def invoke_current(
+        self,
+        *,
+        request_id: str,
+        action_name: str,
+        arguments: dict[str, JsonValue],
+        transport: str,
+        correlation: ActorCorrelation,
+    ) -> ActorInvocationOutcome:
+        """Capture one hidden current decision and retain it for exact retries."""
+        with self._admission_lock:
+            with self._condition:
+                existing = self._requests.get(request_id)
+                decision_id = existing.request.decision_id if existing is not None else None
+            if decision_id is None:
+                decision_id = self.observe(correlation=correlation).decision_id
+            admitted = self._admit(
+                ActorInvocationRequest(
+                    request_id=request_id,
+                    decision_id=decision_id,
+                    action_name=action_name,
+                    arguments=arguments,
+                    transport=transport,
+                    correlation=correlation,
+                )
+            )
+        if isinstance(admitted, ActorInvocationOutcome):
+            return admitted
+        return self._dispatch(admitted)
+
+    def _admit(self, request: ActorInvocationRequest) -> _RequestEntry | ActorInvocationOutcome:
+        fingerprint = _request_fingerprint(self.config.actor_principal_id, request)
+        with self._condition:
+            existing = self._requests.get(request.request_id)
+            if existing is not None:
+                return self._handle_existing_locked(existing, request, fingerprint)
+            if self._lifecycle is not ActorInvocationLifecycle.RUNNING:
+                error = self._lifecycle_error(request.request_id)
+                self._append_rejection(request, fingerprint, error)
+                raise error
+            if self._terminal:
+                error = ActorInvocationError(
+                    "episode-closed",
+                    "The world episode is closed.",
+                    outcome=ActorInvocationOutcomeClass.NOT_DISPATCHED,
+                    request_id=request.request_id,
+                    disposition=ActorTurnDisposition.CONCLUDE_TURN,
+                )
+                self._append_rejection(request, fingerprint, error)
+                raise error
+            if request.action_name not in self._action_names:
+                error = ActorInvocationError(
+                    "world-action-not-available",
+                    "The requested world action is not in the frozen catalogue.",
+                    outcome=ActorInvocationOutcomeClass.NOT_DISPATCHED,
+                    request_id=request.request_id,
+                )
+                self._append_rejection(request, fingerprint, error)
+                raise error
+            if self._budget_used + self._budget_reserved >= self.config.max_world_actions:
+                error = ActorInvocationError(
+                    "world-action-budget-exhausted",
+                    "The world action budget is exhausted.",
+                    outcome=ActorInvocationOutcomeClass.NOT_DISPATCHED,
+                    request_id=request.request_id,
+                    disposition=ActorTurnDisposition.CONCLUDE_TURN,
+                )
+                self._append_rejection(request, fingerprint, error)
+                raise error
+
+        self._require_catalogue_stable()
+        with self._condition:
+            existing = self._requests.get(request.request_id)
+            if existing is not None:
+                return self._handle_existing_locked(existing, request, fingerprint)
+            if self._lifecycle is not ActorInvocationLifecycle.RUNNING:
+                error = self._lifecycle_error(request.request_id)
+                self._append_rejection(request, fingerprint, error)
+                raise error
+            if self._terminal:
+                error = ActorInvocationError(
+                    "episode-closed",
+                    "The world episode is closed.",
+                    outcome=ActorInvocationOutcomeClass.NOT_DISPATCHED,
+                    request_id=request.request_id,
+                    disposition=ActorTurnDisposition.CONCLUDE_TURN,
+                )
+                self._append_rejection(request, fingerprint, error)
+                raise error
+            if self._budget_used + self._budget_reserved >= self.config.max_world_actions:
+                error = ActorInvocationError(
+                    "world-action-budget-exhausted",
+                    "The world action budget is exhausted.",
+                    outcome=ActorInvocationOutcomeClass.NOT_DISPATCHED,
+                    request_id=request.request_id,
+                    disposition=ActorTurnDisposition.CONCLUDE_TURN,
+                )
+                self._append_rejection(request, fingerprint, error)
+                raise error
+            action_sequence = self._next_action_sequence
+            self._next_action_sequence += 1
+            self._budget_reserved += 1
+            entry = _RequestEntry(
+                request=request,
+                fingerprint=fingerprint,
+                action_sequence=action_sequence,
+                state=_RequestState.IN_FLIGHT,
+                admitted_at=datetime.now(UTC),
+            )
+            self._requests[request.request_id] = entry
+            self._active_request_ids.add(request.request_id)
+            self._append_evidence(
+                {
+                    "record_type": "request-admitted",
+                    "request_id": request.request_id,
+                    "request_fingerprint": fingerprint,
+                    "action_sequence": action_sequence,
+                    "action_name": request.action_name,
+                    "transport": request.transport,
+                    "correlation": request.correlation.model_dump(mode="json"),
+                    "budget_used": self._budget_used,
+                    "budget_reserved": self._budget_reserved,
+                    "admitted_at": entry.admitted_at.isoformat(),
+                }
+            )
+            self._condition.notify_all()
+        return entry
+
+    def close(self, *, timeout_sec: float | None = None) -> AuthorityCloseReport:
+        """Reject new actions and report whether every admitted action is settled."""
+        timeout = self.config.close_timeout_sec if timeout_sec is None else timeout_sec
+        if timeout < 0:
+            raise ValueError("actor authority close timeout must not be negative")
+        with self._condition:
+            if self._successful_close_report is not None:
+                return self._successful_close_report
+            if self._lifecycle is ActorInvocationLifecycle.CREATED:
+                raise RuntimeError("actor invocation authority is not started")
+            if self._lifecycle is ActorInvocationLifecycle.RUNNING:
+                self._lifecycle = ActorInvocationLifecycle.CLOSING
+                self._condition.notify_all()
+            deadline = time.monotonic() + timeout
+            while self._active_request_ids:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                self._condition.wait(remaining)
+            unsettled = tuple(sorted(self._active_request_ids))
+            if unsettled:
+                for request_id in unsettled:
+                    entry = self._requests[request_id]
+                    if entry.dispatched_at is not None and entry.state is _RequestState.IN_FLIGHT:
+                        entry.state = _RequestState.UNKNOWN
+                        entry.failure = _Failure(
+                            code="actor-invocation-outcome-unknown",
+                            detail="The world action did not settle before authority close.",
+                            outcome=ActorInvocationOutcomeClass.UNKNOWN,
+                            disposition=ActorTurnDisposition.CONCLUDE_TURN,
+                        )
+                self._condition.notify_all()
+            unknown = self._unknown_request_ids_locked()
+            if not unsettled:
+                self._lifecycle = ActorInvocationLifecycle.CLOSED
+            report = AuthorityCloseReport(
+                quiescent=not unsettled,
+                complete=not unsettled and not unknown,
+                unsettled_request_ids=unsettled,
+                unknown_outcome_request_ids=unknown,
+                closed_at=datetime.now(UTC),
+                lifecycle=self._lifecycle,
+            )
+            if report.quiescent:
+                self._successful_close_report = report
+            self._append_evidence(
+                {
+                    "record_type": "close",
+                    "closed_at": report.closed_at.isoformat(),
+                    "lifecycle": report.lifecycle.value,
+                    "quiescent": report.quiescent,
+                    "complete": report.complete,
+                    "unsettled_request_ids": list(report.unsettled_request_ids),
+                    "unknown_outcome_request_ids": list(report.unknown_outcome_request_ids),
+                    "budget_used": self._budget_used,
+                    "terminal": self._terminal,
+                }
+            )
+            return report
+
+    def _dispatch(self, entry: _RequestEntry) -> ActorInvocationOutcome:
+        with self._condition:
+            while entry.state is _RequestState.IN_FLIGHT and entry.action_sequence != self._next_dispatch_sequence:
+                if self._lifecycle is not ActorInvocationLifecycle.RUNNING and entry.dispatched_at is None:
+                    self._cancel_before_dispatch_locked(entry)
+                    break
+                self._condition.wait()
+            if entry.state is not _RequestState.IN_FLIGHT:
+                return self._replay_locked(entry, duplicate=False)
+            if self._lifecycle is not ActorInvocationLifecycle.RUNNING:
+                self._reject_before_dispatch_locked(
+                    entry,
+                    _Failure(
+                        code="actor-authority-closing",
+                        detail="The actor invocation authority is closing.",
+                        outcome=ActorInvocationOutcomeClass.NOT_DISPATCHED,
+                        disposition=ActorTurnDisposition.CONCLUDE_TURN,
+                    ),
+                )
+                return self._replay_locked(entry, duplicate=False)
+            if self._terminal:
+                self._reject_before_dispatch_locked(
+                    entry,
+                    _Failure(
+                        code="episode-closed",
+                        detail="The world episode is closed.",
+                        outcome=ActorInvocationOutcomeClass.NOT_DISPATCHED,
+                        disposition=ActorTurnDisposition.CONCLUDE_TURN,
+                    ),
+                )
+                return self._replay_locked(entry, duplicate=False)
+            budget_before = self._budget_used
+            self._budget_reserved -= 1
+            self._budget_used += 1
+            entry.dispatched_at = datetime.now(UTC)
+            self._append_evidence(
+                {
+                    "record_type": "dispatch",
+                    "request_id": entry.request.request_id,
+                    "action_sequence": entry.action_sequence,
+                    "dispatched_at": entry.dispatched_at.isoformat(),
+                    "budget_before": budget_before,
+                    "budget_after": self._budget_used,
+                }
+            )
+
+        result: WorldActorActionResult | None = None
+        failure: _Failure | None = None
+        try:
+            with self._host_operation_lock:
+                result = self._host.invoke(
+                    WorldActorActionRequest(
+                        request_id=entry.request.request_id,
+                        decision_id=entry.request.decision_id,
+                        action_name=entry.request.action_name,
+                        arguments=entry.request.arguments,
+                    )
+                )
+            if not isinstance(result, WorldActorActionResult):
+                raise TypeError("world host returned an invalid action result")
+            if result.request_id != entry.request.request_id or result.action_name != entry.request.action_name:
+                raise ValueError("world result identity does not match the admitted request")
+            result_bytes = _json_bytes(result.model_dump(mode="json"))
+            if len(result_bytes) > self.config.max_result_bytes:
+                failure = _Failure(
+                    code="world-action-result-too-large",
+                    detail="The world action result exceeds the authority limit.",
+                    outcome=ActorInvocationOutcomeClass.COMPLETED,
+                    disposition=(
+                        ActorTurnDisposition.CONCLUDE_TURN
+                        if result.terminated or result.truncated
+                        else ActorTurnDisposition.CONTINUE
+                    ),
+                )
+        except WorldInterfaceError as exc:
+            failure = _Failure(
+                code=exc.code,
+                detail=exc.detail,
+                outcome=ActorInvocationOutcomeClass.COMPLETED,
+                disposition=ActorTurnDisposition.CONTINUE,
+            )
+        except (TypeError, ValueError):
+            result = None
+            failure = _Failure(
+                code="world-action-outcome-invalid",
+                detail="The world action returned an invalid outcome.",
+                outcome=ActorInvocationOutcomeClass.UNKNOWN,
+                disposition=ActorTurnDisposition.CONCLUDE_TURN,
+            )
+        except Exception:
+            failure = _Failure(
+                code="actor-invocation-outcome-unknown",
+                detail="The world action outcome is unknown.",
+                outcome=ActorInvocationOutcomeClass.UNKNOWN,
+                disposition=ActorTurnDisposition.CONCLUDE_TURN,
+            )
+
+        completed_at = datetime.now(UTC)
+        with self._condition:
+            late_ignored = self._is_unknown(entry)
+            if not late_ignored:
+                entry.completed_at = completed_at
+                if failure is None:
+                    assert result is not None
+                    entry.result = result
+                    entry.state = _RequestState.COMPLETED
+                    if result.terminated or result.truncated:
+                        self._terminal = True
+                        self._terminal_action_sequence = entry.action_sequence
+                else:
+                    entry.failure = failure
+                    entry.state = (
+                        _RequestState.UNKNOWN
+                        if failure.outcome is ActorInvocationOutcomeClass.UNKNOWN
+                        else _RequestState.COMPLETED
+                    )
+                    if failure.code == "world-action-result-too-large" and result is not None:
+                        if result.terminated or result.truncated:
+                            self._terminal = True
+                            self._terminal_action_sequence = entry.action_sequence
+            self._active_request_ids.discard(entry.request.request_id)
+            self._advance_dispatch_sequence_locked()
+            self._condition.notify_all()
+            effective_failure = entry.failure if late_ignored else failure
+            self._append_completion_locked(
+                entry,
+                result=result,
+                failure=effective_failure,
+                late_ignored=late_ignored,
+            )
+            return self._replay_locked(entry, duplicate=False)
+
+    def _handle_existing_locked(
+        self,
+        entry: _RequestEntry,
+        request: ActorInvocationRequest,
+        fingerprint: str,
+    ) -> ActorInvocationOutcome:
+        if entry.fingerprint != fingerprint:
+            error = ActorInvocationError(
+                "request-id-conflict",
+                "The request ID was reused with different world action content.",
+                outcome=ActorInvocationOutcomeClass.NOT_DISPATCHED,
+                request_id=request.request_id,
+                action_sequence=entry.action_sequence,
+            )
+            self._append_evidence(
+                {
+                    "record_type": "request-conflict",
+                    "request_id": request.request_id,
+                    "request_fingerprint": fingerprint,
+                    "conflicts_with_fingerprint": entry.fingerprint,
+                    "action_sequence": entry.action_sequence,
+                    "occurred_at": datetime.now(UTC).isoformat(),
+                }
+            )
+            raise error
+        entry.duplicate_waiters += 1
+        duplicate_state = entry.state
+        self._append_evidence(
+            {
+                "record_type": "request-duplicate",
+                "request_id": request.request_id,
+                "request_fingerprint": fingerprint,
+                "action_sequence": entry.action_sequence,
+                "original_state": duplicate_state.value,
+                "duplicate_waiter": duplicate_state is _RequestState.IN_FLIGHT,
+                "occurred_at": datetime.now(UTC).isoformat(),
+            }
+        )
+        while entry.state is _RequestState.IN_FLIGHT:
+            self._condition.wait()
+        return self._replay_locked(entry, duplicate=True)
+
+    def _replay_locked(self, entry: _RequestEntry, *, duplicate: bool) -> ActorInvocationOutcome:
+        if entry.result is not None:
+            disposition = (
+                ActorTurnDisposition.CONCLUDE_TURN
+                if entry.result.terminated or entry.result.truncated
+                else ActorTurnDisposition.CONTINUE
+            )
+            return ActorInvocationOutcome(
+                result=entry.result,
+                action_sequence=entry.action_sequence,
+                duplicate=duplicate,
+                disposition=disposition,
+            )
+        assert entry.failure is not None
+        raise ActorInvocationError(
+            entry.failure.code,
+            entry.failure.detail,
+            outcome=entry.failure.outcome,
+            request_id=entry.request.request_id,
+            action_sequence=entry.action_sequence,
+            duplicate=duplicate,
+            disposition=entry.failure.disposition,
+        )
+
+    def _cancel_before_dispatch_locked(self, entry: _RequestEntry) -> None:
+        self._reject_before_dispatch_locked(
+            entry,
+            _Failure(
+                code="actor-authority-closing",
+                detail="The actor invocation authority is closing.",
+                outcome=ActorInvocationOutcomeClass.NOT_DISPATCHED,
+                disposition=ActorTurnDisposition.CONCLUDE_TURN,
+            ),
+        )
+
+    def _reject_before_dispatch_locked(self, entry: _RequestEntry, failure: _Failure) -> None:
+        if entry.state is not _RequestState.IN_FLIGHT or entry.dispatched_at is not None:
+            return
+        self._budget_reserved -= 1
+        entry.state = _RequestState.COMPLETED
+        entry.completed_at = datetime.now(UTC)
+        entry.failure = failure
+        self._active_request_ids.discard(entry.request.request_id)
+        self._advance_dispatch_sequence_locked()
+        self._append_completion_locked(entry, result=None, failure=entry.failure, late_ignored=False)
+        self._condition.notify_all()
+
+    def _advance_dispatch_sequence_locked(self) -> None:
+        while self._next_dispatch_sequence < self._next_action_sequence:
+            current = next(
+                (entry for entry in self._requests.values() if entry.action_sequence == self._next_dispatch_sequence),
+                None,
+            )
+            if current is not None and current.state is _RequestState.IN_FLIGHT:
+                break
+            self._next_dispatch_sequence += 1
+
+    def _append_completion_locked(
+        self,
+        entry: _RequestEntry,
+        *,
+        result: WorldActorActionResult | None,
+        failure: _Failure | None,
+        late_ignored: bool,
+    ) -> None:
+        receipt = result.task_receipt if result is not None else None
+        self._append_evidence(
+            {
+                "record_type": "completion",
+                "request_id": entry.request.request_id,
+                "action_sequence": entry.action_sequence,
+                "completed_at": datetime.now(UTC).isoformat(),
+                "request_state": entry.state.value,
+                "result_sha256": _json_sha256(result.model_dump(mode="json")) if result is not None else None,
+                "result_bytes": len(_json_bytes(result.model_dump(mode="json"))) if result is not None else None,
+                "error_code": failure.code if failure is not None else None,
+                "error_sha256": _failure_sha256(failure) if failure is not None else None,
+                "task_receipt_sha256": _json_sha256(receipt) if receipt is not None else None,
+                "task_receipt_identity": _task_receipt_identity(receipt),
+                "terminal_latched": self._terminal and self._terminal_action_sequence == entry.action_sequence,
+                "late_ignored": late_ignored,
+            }
+        )
+
+    def _append_rejection(
+        self,
+        request: ActorInvocationRequest,
+        fingerprint: str,
+        error: ActorInvocationError,
+    ) -> None:
+        if self._lifecycle is ActorInvocationLifecycle.CREATED:
+            return
+        self._append_evidence(
+            {
+                "record_type": "request-rejected",
+                "request_id": request.request_id,
+                "request_fingerprint": fingerprint,
+                "action_name": request.action_name,
+                "transport": request.transport,
+                "correlation": request.correlation.model_dump(mode="json"),
+                "error_code": error.code,
+                "outcome": error.outcome.value,
+                "budget_used": self._budget_used,
+                "budget_reserved": self._budget_reserved,
+                "occurred_at": datetime.now(UTC).isoformat(),
+            }
+        )
+
+    def _append_read_error(
+        self,
+        operation: str,
+        correlation: ActorCorrelation,
+        error: ActorInvocationError,
+        occurred_at: datetime,
+    ) -> None:
+        self._append_evidence(
+            {
+                "record_type": operation,
+                "correlation": correlation.model_dump(mode="json"),
+                "occurred_at": occurred_at.isoformat(),
+                "error_code": error.code,
+                "error_sha256": _text_sha256(error.detail),
+                "outcome": error.outcome.value,
+            }
+        )
+
+    def _append_evidence(self, record: dict[str, Any]) -> None:
+        with self._evidence_lock:
+            self._evidence_sequence += 1
+            payload = {
+                "sequence": self._evidence_sequence,
+                "schema": ACTOR_INVOCATION_EVIDENCE_SCHEMA,
+                "authority_id": self.authority_id,
+                "actor_principal_id": self.config.actor_principal_id,
+                **record,
+            }
+            with self.config.evidence_path.open("a", encoding="utf-8") as stream:
+                stream.write(json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n")
+                stream.flush()
+                os.fsync(stream.fileno())
+
+    def _require_readable(self) -> None:
+        with self._condition:
+            if self._lifecycle is not ActorInvocationLifecycle.RUNNING:
+                raise self._lifecycle_error()
+
+    def _require_catalogue_stable(self) -> None:
+        current = self._host.capabilities()
+        current_hash = _json_sha256(current.model_dump(mode="json"))
+        with self._condition:
+            expected = self._catalogue_hash
+        if current_hash != expected:
+            raise ActorInvocationError(
+                "actor-catalogue-drift",
+                "The world actor capability catalogue changed during the trial.",
+                outcome=ActorInvocationOutcomeClass.NOT_DISPATCHED,
+                disposition=ActorTurnDisposition.CONCLUDE_TURN,
+            )
+
+    def _lifecycle_error(self, request_id: str | None = None) -> ActorInvocationError:
+        if self._lifecycle is ActorInvocationLifecycle.CREATED:
+            code = "actor-authority-not-started"
+            detail = "The actor invocation authority is not started."
+        else:
+            code = "actor-authority-closing"
+            detail = "The actor invocation authority is closing or closed."
+        return ActorInvocationError(
+            code,
+            detail,
+            outcome=ActorInvocationOutcomeClass.NOT_DISPATCHED,
+            request_id=request_id,
+            disposition=ActorTurnDisposition.CONCLUDE_TURN,
+        )
+
+    def _unknown_request_ids_locked(self) -> tuple[str, ...]:
+        return tuple(
+            sorted(request_id for request_id, entry in self._requests.items() if entry.state is _RequestState.UNKNOWN)
+        )
+
+    @staticmethod
+    def _is_unknown(entry: _RequestEntry) -> bool:
+        """Read state after another thread could have changed it during dispatch."""
+        return entry.state is _RequestState.UNKNOWN
+
+
+def _request_fingerprint(actor_principal_id: str, request: ActorInvocationRequest) -> str:
+    return _json_sha256(
+        {
+            "semantics": ACTOR_INVOCATION_SEMANTICS,
+            "actor_principal_id": actor_principal_id,
+            "decision_id": request.decision_id,
+            "action_name": request.action_name,
+            "arguments": request.arguments,
+        }
+    )
+
+
+def _json_bytes(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False).encode("utf-8")
+
+
+def _json_sha256(value: Any) -> str:
+    return hashlib.sha256(_json_bytes(value)).hexdigest()
+
+
+def _text_sha256(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _failure_sha256(failure: _Failure) -> str:
+    return _json_sha256(
+        {
+            "code": failure.code,
+            "detail": failure.detail,
+            "outcome": failure.outcome.value,
+            "disposition": failure.disposition.value,
+        }
+    )
+
+
+def _task_receipt_identity(receipt: dict[str, JsonValue] | None) -> JsonValue | None:
+    if receipt is None:
+        return None
+    for key in ("receipt_id", "transition_id", "content_id", "commit_id"):
+        value = receipt.get(key)
+        if isinstance(value, str | int) and not isinstance(value, bool):
+            return value
+    return None

--- a/tests/cli/test_pump_station_world.py
+++ b/tests/cli/test_pump_station_world.py
@@ -1,0 +1,71 @@
+# ABOUTME: Tests public CLI wiring for registered pump-station world execution.
+# ABOUTME: Proves trial-wide actor limits reach the Harbor job and emitted evidence.
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from typer.testing import CliRunner
+
+from aec_bench.cli.main import app
+
+
+def test_run_harbor_forwards_and_reports_world_action_budget(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run(**kwargs: object) -> SimpleNamespace:
+        captured.update(kwargs)
+        return SimpleNamespace(
+            config_path=tmp_path / "job.yaml",
+            command=("harbor", "run"),
+            exit_code=None,
+        )
+
+    monkeypatch.setattr(
+        "aec_bench.cli.commands.pump_station_world.require_optional_extra",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "aec_bench.cli.harbor_environment.resolve_harbor_environment_binding",
+        lambda _backend: None,
+    )
+    monkeypatch.setattr(
+        "aec_bench.harness.pump_station_harbor.job.run_pump_station_harbor_job",
+        fake_run,
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "--json",
+            "task",
+            "pump-station-world",
+            "run-harbor",
+            "--task-dir",
+            str(tmp_path / "task"),
+            "--project-root",
+            str(tmp_path),
+            "--jobs-dir",
+            str(tmp_path / "jobs"),
+            "--config-path",
+            str(tmp_path / "job.yaml"),
+            "--model",
+            "azure:model",
+            "--adapter",
+            "deepseek_harness",
+            "--max-world-actions",
+            "7",
+            "--no-execute",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["max_world_actions"] == 7
+    payload = json.loads(result.output)
+    assert payload["data"]["limits"]["max_world_actions"] == 7

--- a/tests/deepseek_harness/test_native_world_tools.py
+++ b/tests/deepseek_harness/test_native_world_tools.py
@@ -1,0 +1,163 @@
+# ABOUTME: Tests the DeepSeek native presentation of shared world invocation authority.
+# ABOUTME: Proves hidden correlation, exact retry, terminal disposition, and actor-visible errors.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from aec_bench.adapters.deepseek_harness.native_world_tools import NativeWorldToolTransport
+from aec_bench.adapters.deepseek_harness.tool_gateway import (
+    NativeCancellation,
+    NativeToolDisposition,
+    NativeToolInvocation,
+    NativeToolRequestSemantics,
+)
+from aec_bench.contracts.world_interface import (
+    WorldActorActionCapability,
+    WorldActorActionRequest,
+    WorldActorActionResult,
+    WorldActorCapabilityCatalogue,
+    WorldActorObservation,
+)
+from aec_bench.harness.world_actor import ActorInvocationAuthority, ActorInvocationAuthorityConfig
+
+
+class _WorldHost:
+    def __init__(self) -> None:
+        self.calls: list[WorldActorActionRequest] = []
+
+    def capabilities(self) -> WorldActorCapabilityCatalogue:
+        return WorldActorCapabilityCatalogue(
+            task_world_id="native-world",
+            actions=(
+                WorldActorActionCapability(name="act", description="Act.", input_schema={"type": "object"}),
+                WorldActorActionCapability(
+                    name="terminate",
+                    description="Terminate.",
+                    input_schema={"type": "object"},
+                ),
+            ),
+        )
+
+    def observe(self) -> WorldActorObservation:
+        return WorldActorObservation(decision_id=f"decision-{len(self.calls)}", view={"calls": len(self.calls)})
+
+    def invoke(self, request: WorldActorActionRequest) -> WorldActorActionResult:
+        self.calls.append(request)
+        terminated = request.action_name == "terminate"
+        return WorldActorActionResult(
+            request_id=request.request_id,
+            action_name=request.action_name,
+            status="accepted",
+            task_receipt={"transition_id": f"transition-{len(self.calls)}"},
+            next_observation=None,
+            terminated=terminated,
+        )
+
+
+def _authority(tmp_path: Path, host: _WorldHost) -> ActorInvocationAuthority:
+    authority = ActorInvocationAuthority(
+        host=host,
+        config=ActorInvocationAuthorityConfig(
+            authority_id="authority-native",
+            actor_principal_id="actor-native",
+            max_world_actions=5,
+            evidence_path=tmp_path / "actor-invocations.jsonl",
+        ),
+    )
+    authority.start()
+    return authority
+
+
+def _invocation(request_id: str, *, tool_name: str, tool_call_id: str) -> NativeToolInvocation:
+    return NativeToolInvocation(
+        request_id=request_id,
+        deepseek_session_id="session-1",
+        deepseek_tool_call_id=tool_call_id,
+        model_turn=1,
+        tool_name=tool_name,
+        generation_id="generation-1",
+        admitted_at=datetime.now(UTC),
+        cancellation=NativeCancellation(),
+    )
+
+
+def _schema() -> dict[str, object]:
+    return {
+        "type": "object",
+        "properties": {"value": {"type": "integer"}},
+        "required": ["value"],
+        "additionalProperties": False,
+    }
+
+
+def test_native_action_uses_authority_identity_and_replays_exact_retry(tmp_path: Path) -> None:
+    host = _WorldHost()
+    authority = _authority(tmp_path, host)
+    transport = NativeWorldToolTransport(authority)
+    definition = transport.action_definition(
+        name="act",
+        description="Act.",
+        parameters_schema=_schema(),
+    )
+    invocation = _invocation("dsh:session-1:tool-1", tool_name="act", tool_call_id="tool-1")
+
+    first = definition.handler(invocation, {"value": 1})
+    replay = definition.handler(invocation, {"value": 1})
+
+    assert definition.request_semantics is NativeToolRequestSemantics.HANDLER_AUTHORITY
+    assert first == replay
+    assert first.disposition is NativeToolDisposition.CONTINUE
+    assert isinstance(first.result, dict)
+    assert first.result["request_id"] == "dsh:session-1:tool-1"
+    assert len(host.calls) == 1
+    assert authority.world_action_count == 1
+    assert authority.close().complete is True
+
+
+def test_native_observation_and_terminal_errors_use_generic_dispositions(tmp_path: Path) -> None:
+    host = _WorldHost()
+    authority = _authority(tmp_path, host)
+    transport = NativeWorldToolTransport(authority)
+    observe = transport.observation_definition(
+        name="observe_world",
+        description="Observe.",
+        parameters_schema={"type": "object", "properties": {}, "additionalProperties": False},
+    )
+    terminate = transport.action_definition(
+        name="terminate",
+        description="Terminate.",
+        parameters_schema=_schema(),
+    )
+    act = transport.action_definition(name="act", description="Act.", parameters_schema=_schema())
+
+    observation = observe.handler(
+        _invocation("dsh:session-1:observe-1", tool_name="observe_world", tool_call_id="observe-1"),
+        {},
+    )
+    terminal = terminate.handler(
+        _invocation("dsh:session-1:terminate-1", tool_name="terminate", tool_call_id="terminate-1"),
+        {"value": 1},
+    )
+    after_terminal = act.handler(
+        _invocation("dsh:session-1:act-2", tool_name="act", tool_call_id="act-2"),
+        {"value": 2},
+    )
+
+    assert observation.result == {"decision_id": "decision-0", "view": {"calls": 0}}
+    assert terminal.disposition is NativeToolDisposition.CONCLUDE_TURN
+    assert isinstance(terminal.result, dict)
+    assert terminal.result["terminated"] is True
+    assert after_terminal.disposition is NativeToolDisposition.CONCLUDE_TURN
+    assert after_terminal.result == {
+        "status": "error",
+        "error": {
+            "code": "episode-closed",
+            "detail": "The world episode is closed.",
+            "outcome": "not-dispatched",
+            "action_sequence": None,
+        },
+    }
+    assert len(host.calls) == 1
+    assert authority.close().complete is True

--- a/tests/deepseek_harness/test_tool_gateway.py
+++ b/tests/deepseek_harness/test_tool_gateway.py
@@ -17,6 +17,7 @@ from aec_bench.adapters.deepseek_harness.tool_gateway import (
     NativeToolDefinition,
     NativeToolDisposition,
     NativeToolInvocation,
+    NativeToolRequestSemantics,
     NativeToolResponse,
     ToolGatewayEndpoint,
 )
@@ -93,6 +94,54 @@ def test_endpoint_uses_explicit_schema_hidden_identity_and_exact_replay(tmp_path
     assert invocation["result_sha256"] is not None
     assert duplicate["duplicate_of"] == "dsh:root:tool-1"
     assert all("private-capability" not in json.dumps(item) for item in evidence)
+
+
+def test_handler_authority_receives_exact_retries_without_gateway_replay(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    def authority_managed(
+        invocation: NativeToolInvocation,
+        _arguments: Mapping[str, JsonValue],
+    ) -> NativeToolResponse:
+        calls.append(invocation.request_id)
+        return NativeToolResponse(result={"call_count": len(calls)})
+
+    evidence_path = tmp_path / "tool-gateway-evidence.jsonl"
+    endpoint = ToolGatewayEndpoint(
+        tools=(
+            NativeToolDefinition(
+                name="world_action",
+                description="world action",
+                parameters_schema={
+                    "type": "object",
+                    "properties": {},
+                    "required": [],
+                    "additionalProperties": False,
+                },
+                handler=authority_managed,
+                request_semantics=NativeToolRequestSemantics.HANDLER_AUTHORITY,
+            ),
+        ),
+        evidence_path=evidence_path,
+        capability_token="private-capability",
+    )
+    endpoint.start()
+    try:
+        payload = _request(endpoint, tool_call_id="world-1", tool_name="world_action", arguments={})
+        first = _exchange(endpoint, payload)
+        second = _exchange(endpoint, payload)
+    finally:
+        close_report = endpoint.close()
+
+    assert first["result"] == {"call_count": 1}
+    assert second["result"] == {"call_count": 2}
+    assert calls == ["dsh:root:world-1", "dsh:root:world-1"]
+    assert close_report.quiescent is True
+    evidence = _evidence(evidence_path)
+    invocations = [item for item in evidence if item["record_type"] == "invocation"]
+    assert len(invocations) == 2
+    assert {item["request_semantics"] for item in invocations} == {"handler-authority"}
+    assert not any(item["record_type"] == "duplicate" for item in evidence)
 
 
 def test_endpoint_rejects_unauthorised_unknown_invalid_and_conflicting_requests(tmp_path: Path) -> None:

--- a/tests/harness/test_pump_station_harbor.py
+++ b/tests/harness/test_pump_station_harbor.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import json
 from dataclasses import asdict
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -13,6 +14,11 @@ import pytest
 from harbor.models.trial.config import TrialConfig  # type: ignore[import-untyped]
 
 from aec_bench.adapters.base import AdapterRequest, AdapterResult
+from aec_bench.adapters.deepseek_harness.tool_gateway import (
+    NativeCancellation,
+    NativeToolInvocation,
+    NativeToolRequestSemantics,
+)
 from aec_bench.contracts.agent_output import AgentOutput, AgentOutputStatus
 from aec_bench.harness.pump_station_harbor.export import (
     PUMP_STATION_HARBOR_BRIDGE_MODE,
@@ -50,6 +56,19 @@ from aec_bench.worlds.stewardship.wastewater_pump_station.world_run_repository i
 from tests.support.harbor_local_environment import run_harbor_trial
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _native_invocation(request_id: str, tool_name: str) -> NativeToolInvocation:
+    return NativeToolInvocation(
+        request_id=request_id,
+        deepseek_session_id="session-1",
+        deepseek_tool_call_id=request_id,
+        model_turn=1,
+        tool_name=tool_name,
+        generation_id="generation-1",
+        admitted_at=datetime.now(UTC),
+        cancellation=NativeCancellation(),
+    )
 
 
 def test_registered_profile_export_uses_the_canonical_harbor_bridge(
@@ -100,6 +119,7 @@ def test_registered_profile_builds_a_deepseek_world_session_without_a_false_turn
         backend="modal",
         model_name="azure:gpt-4.1-mini-standard",
         adapter="deepseek_harness",
+        max_world_actions=17,
         max_tokens=4096,
         timeout_sec=600,
     )
@@ -109,6 +129,7 @@ def test_registered_profile_builds_a_deepseek_world_session_without_a_false_turn
         "adapter": "deepseek_harness",
         "execution_kind": PUMP_STATION_HARBOR_EXECUTION_KIND,
         "max_tokens": 4096,
+        "max_world_actions": 17,
         "timeout_sec": 600,
         "world_session": {
             "bridge_mode": PUMP_STATION_HARBOR_BRIDGE_MODE,
@@ -180,8 +201,16 @@ def test_deepseek_model_session_receives_only_actor_tools_and_token_limits(tmp_p
     captured: dict[str, object] = {}
 
     class FakeAdapter:
+        def __init__(self, native_tool_definitions: tuple[Any, ...]) -> None:
+            self._definitions = {definition.name: definition for definition in native_tool_definitions}
+
         def execute(self, request: AdapterRequest) -> AdapterResult:
             captured["request"] = request
+            observation = self._definitions["observe_pump_station"].handler(
+                _native_invocation("dsh:session-1:observe-1", "observe_pump_station"),
+                {},
+            )
+            captured["observation"] = observation.result
             return AdapterResult(
                 adapter_name="deepseek_harness",
                 resolved_model="gpt-4.1-mini-standard",
@@ -199,7 +228,9 @@ def test_deepseek_model_session_receives_only_actor_tools_and_token_limits(tmp_p
 
     def build_adapter(**kwargs: object) -> FakeAdapter:
         captured["builder"] = kwargs
-        return FakeAdapter()
+        definitions = kwargs["native_tool_definitions"]
+        assert isinstance(definitions, tuple)
+        return FakeAdapter(definitions)
 
     completed = run_pump_station_model_session(
         bridge=bridge,
@@ -229,6 +260,11 @@ def test_deepseek_model_session_receives_only_actor_tools_and_token_limits(tmp_p
         *PUMP_STATION_ACTOR_ACTION_NAMES,
     )
     assert all("request_id" not in definition.parameters_schema["properties"] for definition in native_tool_definitions)
+    assert all(
+        definition.request_semantics is NativeToolRequestSemantics.HANDLER_AUTHORITY
+        for definition in native_tool_definitions
+    )
+    assert isinstance(captured["observation"], dict)
     request = captured["request"]
     assert isinstance(request, AdapterRequest)
     assert request.configuration == {"max_tokens": 4096, "timeout_sec": 600}
@@ -239,10 +275,21 @@ def test_deepseek_model_session_receives_only_actor_tools_and_token_limits(tmp_p
     assert evidence["limits"] == {"max_tokens": 4096, "timeout_sec": 600}
     inventory = json.loads((completed.output_dir / "artifact-inventory.json").read_text(encoding="utf-8"))
     assert inventory["controller_id"] == "gpt-4.1-mini-standard"
+    assert "actor-invocation-evidence.jsonl" in {artifact["path"] for artifact in inventory["artifacts"]}
+    authority_record = completed.adapter_result.configuration_record["actor_invocation_authority"]
+    assert authority_record["actor_principal_id"] == "actor.deepseek-world"
+    assert authority_record["max_world_actions"] == 90
+    assert authority_record["world_action_count"] == 0
+    assert authority_record["close"]["complete"] is True
+    actor_evidence = [
+        json.loads(line)
+        for line in (completed.output_dir / "actor-invocation-evidence.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert [record["record_type"] for record in actor_evidence] == ["header", "observe", "close"]
     assert "Do not stop only because one action was accepted" in request.instruction
 
 
-def test_model_journey_applies_host_authority_between_adapter_segments(tmp_path: Path) -> None:
+def test_model_journey_shares_actor_authority_across_segments_and_stops_at_budget(tmp_path: Path) -> None:
     exported = export_pump_station_harbor_task(
         tmp_path / "task",
         project_root=PROJECT_ROOT,
@@ -252,22 +299,28 @@ def test_model_journey_applies_host_authority_between_adapter_segments(tmp_path:
     builds: list[dict[str, object]] = []
 
     class FakeAdapter:
-        def __init__(self, native_tools: tuple[Any, ...], segment_index: int) -> None:
-            self._tools = {tool.__name__: tool for tool in native_tools}
+        def __init__(self, native_tool_definitions: tuple[Any, ...], segment_index: int) -> None:
+            self._definitions = {definition.name: definition for definition in native_tool_definitions}
             self._segment_index = segment_index
 
         def execute(self, request: AdapterRequest) -> AdapterResult:
             if self._segment_index == 0:
-                self._tools["request_post_maintenance_verification"](
-                    request_id="verification-a",
-                    reason="Complete the visible verification obligation.",
-                    pump_id="pump-a",
-                    backlog_item_id="backlog-a-verification-001",
+                verification = self._definitions["request_post_maintenance_verification"].handler(
+                    _native_invocation("dsh:session-1:verification-a", "request_post_maintenance_verification"),
+                    {
+                        "reason": "Complete the visible verification obligation.",
+                        "pump_id": "pump-a",
+                        "backlog_item_id": "backlog-a-verification-001",
+                    },
                 )
-                self._tools["continue_operation"](
-                    request_id="continue-to-verification",
-                    reason="Advance to the next declared decision event.",
+                continued = self._definitions["continue_operation"].handler(
+                    _native_invocation("dsh:session-1:continue-to-verification", "continue_operation"),
+                    {"reason": "Advance to the next declared decision event."},
                 )
+                assert isinstance(verification.result, dict)
+                assert isinstance(continued.result, dict)
+                assert verification.result["status"] == "applied"
+                assert continued.result["status"] == "applied"
             return AdapterResult(
                 adapter_name="deepseek_harness",
                 resolved_model="gpt-4.1-mini-standard",
@@ -285,9 +338,9 @@ def test_model_journey_applies_host_authority_between_adapter_segments(tmp_path:
 
     def build_adapter(**kwargs: object) -> FakeAdapter:
         builds.append(kwargs)
-        native_tools = kwargs["native_tools"]
-        assert isinstance(native_tools, tuple)
-        return FakeAdapter(native_tools, len(builds) - 1)
+        native_tool_definitions = kwargs["native_tool_definitions"]
+        assert isinstance(native_tool_definitions, tuple)
+        return FakeAdapter(native_tool_definitions, len(builds) - 1)
 
     completed = run_pump_station_model_session(
         bridge=bridge,
@@ -304,9 +357,43 @@ def test_model_journey_applies_host_authority_between_adapter_segments(tmp_path:
     assert completed.stop_reason == "actor-or-external-progress-required"
     assert completed.adapter_result.agent_output.status is AgentOutputStatus.PARTIAL
     assert completed.adapter_result.configuration_record["world_host_control_count"] == 1
+    authority_record = completed.adapter_result.configuration_record["actor_invocation_authority"]
+    assert authority_record["world_action_count"] == 2
+    assert authority_record["close"]["complete"] is True
+    actor_evidence = [
+        json.loads(line)
+        for line in (completed.output_dir / "actor-invocation-evidence.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    dispatches = [record for record in actor_evidence if record["record_type"] == "dispatch"]
+    assert [record["action_sequence"] for record in dispatches] == [1, 2]
     repository = PumpStationWorldRunRepository(completed.output_dir / "world-run")
     run = PumpStationWorldRun.resume_reference_system(repository=repository, snapshot=repository.current_snapshot())
     assert "restriction-a-run-in-001" not in run.state.active_restriction_ids
+
+    bounded_builds: list[dict[str, object]] = []
+
+    def build_bounded_adapter(**kwargs: object) -> FakeAdapter:
+        bounded_builds.append(kwargs)
+        native_tool_definitions = kwargs["native_tool_definitions"]
+        assert isinstance(native_tool_definitions, tuple)
+        return FakeAdapter(native_tool_definitions, len(bounded_builds) - 1)
+
+    bounded = run_pump_station_model_session(
+        bridge=bridge,
+        output_dir=tmp_path / "bounded-world-session",
+        session_identity="bounded-host-continuation",
+        model="azure:gpt-4.1-mini-standard",
+        adapter_kind="deepseek_harness",
+        max_world_actions=2,
+        max_tokens=4096,
+        adapter_builder=build_bounded_adapter,
+    )
+
+    assert bounded.segment_count == 1
+    assert bounded.host_control_count == 0
+    assert bounded.stop_reason == "max-world-actions"
+    bounded_authority = bounded.adapter_result.configuration_record["actor_invocation_authority"]
+    assert bounded_authority["world_action_count"] == 2
 
 
 def test_model_session_preserves_adapter_failure_status(tmp_path: Path) -> None:

--- a/tests/harness/world_actor/test_authority.py
+++ b/tests/harness/world_actor/test_authority.py
@@ -1,0 +1,585 @@
+# ABOUTME: Tests the shared trial-wide authority for actor world actions.
+# ABOUTME: Proves exact retry, causal order, budget, terminal latch, evidence, and close semantics.
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from pydantic import JsonValue, ValidationError
+
+from aec_bench.contracts.world_interface import (
+    WorldActorActionCapability,
+    WorldActorActionRequest,
+    WorldActorActionResult,
+    WorldActorCapabilityCatalogue,
+    WorldActorObservation,
+    WorldInterfaceError,
+)
+from aec_bench.harness.world_actor import (
+    ACTOR_INVOCATION_EVIDENCE_SCHEMA,
+    ActorCorrelation,
+    ActorInvocationAuthority,
+    ActorInvocationAuthorityConfig,
+    ActorInvocationError,
+    ActorInvocationLifecycle,
+    ActorInvocationOutcome,
+    ActorInvocationOutcomeClass,
+    ActorInvocationRequest,
+    ActorTurnDisposition,
+)
+
+
+def _catalogue(*names: str) -> WorldActorCapabilityCatalogue:
+    return WorldActorCapabilityCatalogue(
+        task_world_id="test-world",
+        actions=tuple(
+            WorldActorActionCapability(
+                name=name,
+                description=f"Run {name}.",
+                input_schema={"type": "object"},
+            )
+            for name in names
+        ),
+    )
+
+
+def _result(
+    request: WorldActorActionRequest,
+    *,
+    status: str = "accepted",
+    terminated: bool = False,
+    truncated: bool = False,
+    task_receipt: dict[str, JsonValue] | None = None,
+) -> WorldActorActionResult:
+    return WorldActorActionResult(
+        request_id=request.request_id,
+        action_name=request.action_name,
+        status=status,
+        task_receipt=task_receipt or {"transition_id": f"transition-{request.request_id}"},
+        next_observation=None,
+        terminated=terminated,
+        truncated=truncated,
+    )
+
+
+class _FakeWorldHost:
+    def __init__(
+        self,
+        *,
+        invoke: Callable[[WorldActorActionRequest], WorldActorActionResult] | None = None,
+        catalogue: WorldActorCapabilityCatalogue | None = None,
+    ) -> None:
+        self.catalogue = catalogue or _catalogue("act")
+        self.calls: list[WorldActorActionRequest] = []
+        self.observe_calls = 0
+        self._invoke = invoke
+        self._lock = threading.Lock()
+
+    def capabilities(self) -> WorldActorCapabilityCatalogue:
+        return self.catalogue
+
+    def observe(self) -> WorldActorObservation:
+        with self._lock:
+            self.observe_calls += 1
+            call_count = len(self.calls)
+        return WorldActorObservation(decision_id=f"decision-{call_count}", view={"call_count": call_count})
+
+    def invoke(self, request: WorldActorActionRequest) -> WorldActorActionResult:
+        with self._lock:
+            self.calls.append(request)
+        if self._invoke is not None:
+            return self._invoke(request)
+        return _result(request)
+
+
+def _authority(
+    tmp_path: Path,
+    host: _FakeWorldHost,
+    *,
+    max_world_actions: int = 10,
+    close_timeout_sec: float = 0.1,
+    max_result_bytes: int = 4_194_304,
+) -> ActorInvocationAuthority:
+    authority = ActorInvocationAuthority(
+        host=host,
+        config=ActorInvocationAuthorityConfig(
+            authority_id="authority-1",
+            actor_principal_id="actor-1",
+            max_world_actions=max_world_actions,
+            evidence_path=tmp_path / "actor-invocations.jsonl",
+            close_timeout_sec=close_timeout_sec,
+            max_result_bytes=max_result_bytes,
+        ),
+    )
+    authority.start()
+    return authority
+
+
+def _request(
+    request_id: str,
+    *,
+    decision_id: str = "decision-0",
+    action_name: str = "act",
+    arguments: dict[str, JsonValue] | None = None,
+) -> ActorInvocationRequest:
+    return ActorInvocationRequest(
+        request_id=request_id,
+        decision_id=decision_id,
+        action_name=action_name,
+        arguments=arguments or {},
+        transport="test",
+        correlation=ActorCorrelation(transport_request_id=f"transport-{request_id}"),
+    )
+
+
+def _invoke_thread(
+    authority: ActorInvocationAuthority,
+    request: ActorInvocationRequest,
+    outcomes: list[ActorInvocationOutcome],
+    errors: list[ActorInvocationError],
+) -> None:
+    try:
+        outcomes.append(authority.invoke(request))
+    except ActorInvocationError as exc:
+        errors.append(exc)
+
+
+def _evidence(path: Path) -> list[dict[str, object]]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def test_start_freezes_and_hashes_catalogue_and_rejects_drift(tmp_path: Path) -> None:
+    host = _FakeWorldHost()
+    authority = _authority(tmp_path, host)
+
+    frozen = authority.capabilities(correlation=ActorCorrelation(transport_request_id="catalogue-1"))
+    original_hash = authority.catalogue_hash
+    host.catalogue = _catalogue("act", "drifted-action")
+
+    with pytest.raises(ActorInvocationError) as error:
+        authority.capabilities(correlation=ActorCorrelation(transport_request_id="catalogue-2"))
+
+    assert frozen == _catalogue("act")
+    assert original_hash is not None
+    assert error.value.code == "actor-catalogue-drift"
+    assert error.value.outcome is ActorInvocationOutcomeClass.NOT_DISPATCHED
+    assert authority.world_action_count == 0
+    assert authority.close().complete is True
+
+
+def test_completed_duplicate_replays_and_conflict_fails_without_dispatch(tmp_path: Path) -> None:
+    host = _FakeWorldHost()
+    authority = _authority(tmp_path, host)
+    request = _request("request-1", arguments={"value": 1})
+
+    first = authority.invoke(request)
+    replay = authority.invoke(request)
+    with pytest.raises(ActorInvocationError) as conflict:
+        authority.invoke(_request("request-1", arguments={"value": 2}))
+
+    assert first.action_sequence == 1
+    assert first.duplicate is False
+    assert replay.result == first.result
+    assert replay.action_sequence == first.action_sequence
+    assert replay.duplicate is True
+    assert conflict.value.code == "request-id-conflict"
+    assert conflict.value.outcome is ActorInvocationOutcomeClass.NOT_DISPATCHED
+    assert len(host.calls) == 1
+    assert authority.world_action_count == 1
+    assert authority.close().complete is True
+
+
+def test_invoke_current_retains_the_original_hidden_decision_for_retry(tmp_path: Path) -> None:
+    host = _FakeWorldHost()
+    authority = _authority(tmp_path, host)
+    correlation = ActorCorrelation(transport_request_id="native-1")
+
+    first = authority.invoke_current(
+        request_id="native-request",
+        action_name="act",
+        arguments={"value": 1},
+        transport="native",
+        correlation=correlation,
+    )
+    replay = authority.invoke_current(
+        request_id="native-request",
+        action_name="act",
+        arguments={"value": 1},
+        transport="native",
+        correlation=correlation,
+    )
+    with pytest.raises(ActorInvocationError) as conflict:
+        authority.invoke_current(
+            request_id="native-request",
+            action_name="act",
+            arguments={"value": 2},
+            transport="native",
+            correlation=correlation,
+        )
+
+    assert first.result == replay.result
+    assert replay.duplicate is True
+    assert conflict.value.code == "request-id-conflict"
+    assert host.observe_calls == 1
+    assert len(host.calls) == 1
+    assert authority.close().complete is True
+
+
+def test_hidden_decision_capture_and_admission_precede_explicit_request(tmp_path: Path) -> None:
+    observe_started = threading.Event()
+    release_observe = threading.Event()
+
+    class BlockingObserveHost(_FakeWorldHost):
+        def observe(self) -> WorldActorObservation:
+            observe_started.set()
+            assert release_observe.wait(2)
+            return super().observe()
+
+    host = BlockingObserveHost()
+    authority = _authority(tmp_path, host)
+    outcomes: list[ActorInvocationOutcome] = []
+    errors: list[ActorInvocationError] = []
+
+    def invoke_hidden() -> None:
+        try:
+            outcomes.append(
+                authority.invoke_current(
+                    request_id="hidden",
+                    action_name="act",
+                    arguments={},
+                    transport="native",
+                    correlation=ActorCorrelation(transport_request_id="native-hidden"),
+                )
+            )
+        except ActorInvocationError as exc:
+            errors.append(exc)
+
+    hidden = threading.Thread(target=invoke_hidden)
+    explicit = threading.Thread(
+        target=_invoke_thread,
+        args=(authority, _request("explicit"), outcomes, errors),
+    )
+    hidden.start()
+    assert observe_started.wait(2)
+    explicit.start()
+    time.sleep(0.02)
+    assert not host.calls
+    release_observe.set()
+    hidden.join(timeout=2)
+    explicit.join(timeout=2)
+
+    assert not errors
+    assert [request.request_id for request in host.calls] == ["hidden", "explicit"]
+    assert sorted(outcome.action_sequence for outcome in outcomes) == [1, 2]
+    assert authority.close().complete is True
+
+
+def test_in_flight_duplicate_waits_and_dispatches_once(tmp_path: Path) -> None:
+    started = threading.Event()
+    release = threading.Event()
+
+    def invoke(request: WorldActorActionRequest) -> WorldActorActionResult:
+        started.set()
+        assert release.wait(2)
+        return _result(request)
+
+    host = _FakeWorldHost(invoke=invoke)
+    authority = _authority(tmp_path, host)
+    request = _request("same-request")
+    outcomes: list[ActorInvocationOutcome] = []
+    errors: list[ActorInvocationError] = []
+    owner = threading.Thread(target=_invoke_thread, args=(authority, request, outcomes, errors))
+    duplicate = threading.Thread(target=_invoke_thread, args=(authority, request, outcomes, errors))
+
+    owner.start()
+    assert started.wait(2)
+    duplicate.start()
+    time.sleep(0.02)
+    assert duplicate.is_alive()
+    release.set()
+    owner.join(timeout=2)
+    duplicate.join(timeout=2)
+
+    assert not errors
+    assert not owner.is_alive()
+    assert not duplicate.is_alive()
+    assert len(host.calls) == 1
+    assert authority.world_action_count == 1
+    assert sorted(outcome.duplicate for outcome in outcomes) == [False, True]
+    assert {outcome.action_sequence for outcome in outcomes} == {1}
+    assert authority.close().complete is True
+
+
+def test_budget_charges_dispatched_rejection_and_not_rejected_new_request(tmp_path: Path) -> None:
+    host = _FakeWorldHost(invoke=lambda request: _result(request, status="rejected", task_receipt={"code": "stale"}))
+    authority = _authority(tmp_path, host, max_world_actions=1)
+
+    rejected_by_world = authority.invoke(_request("world-rejection"))
+    with pytest.raises(ActorInvocationError) as exhausted:
+        authority.invoke(_request("over-budget"))
+
+    assert rejected_by_world.result.status == "rejected"
+    assert authority.world_action_count == 1
+    assert authority.world_action_limit_reached is True
+    assert exhausted.value.code == "world-action-budget-exhausted"
+    assert exhausted.value.outcome is ActorInvocationOutcomeClass.NOT_DISPATCHED
+    assert len(host.calls) == 1
+    assert authority.close().complete is True
+
+
+def test_terminal_latch_replays_duplicates_and_rejects_queued_and_new_actions(tmp_path: Path) -> None:
+    started = threading.Event()
+    release = threading.Event()
+
+    def invoke(request: WorldActorActionRequest) -> WorldActorActionResult:
+        if request.request_id == "terminal":
+            started.set()
+            assert release.wait(2)
+            return _result(request, terminated=True)
+        return _result(request)
+
+    host = _FakeWorldHost(invoke=invoke)
+    authority = _authority(tmp_path, host, max_world_actions=2)
+    outcomes: list[ActorInvocationOutcome] = []
+    errors: list[ActorInvocationError] = []
+    terminal_request = _request("terminal")
+    terminal_thread = threading.Thread(
+        target=_invoke_thread,
+        args=(authority, terminal_request, outcomes, errors),
+    )
+    queued_thread = threading.Thread(
+        target=_invoke_thread,
+        args=(authority, _request("queued"), outcomes, errors),
+    )
+
+    terminal_thread.start()
+    assert started.wait(2)
+    queued_thread.start()
+    for _ in range(100):
+        if authority.world_action_limit_reached:
+            break
+        time.sleep(0.005)
+    assert authority.world_action_limit_reached
+    release.set()
+    terminal_thread.join(timeout=2)
+    queued_thread.join(timeout=2)
+
+    replay = authority.invoke(terminal_request)
+    with pytest.raises(ActorInvocationError) as after_terminal:
+        authority.invoke(_request("new-after-terminal"))
+
+    assert authority.terminal is True
+    assert authority.world_action_count == 1
+    assert len(host.calls) == 1
+    assert replay.duplicate is True
+    assert replay.disposition is ActorTurnDisposition.CONCLUDE_TURN
+    assert {error.code for error in errors} == {"episode-closed"}
+    assert after_terminal.value.code == "episode-closed"
+    assert after_terminal.value.disposition is ActorTurnDisposition.CONCLUDE_TURN
+    assert authority.close().complete is True
+
+
+def test_concurrent_unique_actions_have_one_dispatch_order(tmp_path: Path) -> None:
+    active = 0
+    maximum_active = 0
+    state_lock = threading.Lock()
+
+    def invoke(request: WorldActorActionRequest) -> WorldActorActionResult:
+        nonlocal active, maximum_active
+        with state_lock:
+            active += 1
+            maximum_active = max(maximum_active, active)
+        time.sleep(0.01)
+        with state_lock:
+            active -= 1
+        return _result(request)
+
+    host = _FakeWorldHost(invoke=invoke)
+    authority = _authority(tmp_path, host)
+    outcomes: list[ActorInvocationOutcome] = []
+    errors: list[ActorInvocationError] = []
+    threads = [
+        threading.Thread(
+            target=_invoke_thread,
+            args=(authority, _request(f"request-{index}", arguments={"index": index}), outcomes, errors),
+        )
+        for index in range(6)
+    ]
+
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=2)
+
+    assert not errors
+    assert all(not thread.is_alive() for thread in threads)
+    assert maximum_active == 1
+    assert sorted(outcome.action_sequence for outcome in outcomes) == list(range(1, 7))
+    assert authority.world_action_count == 6
+    assert authority.close().complete is True
+
+
+def test_observe_waits_for_an_earlier_admitted_action(tmp_path: Path) -> None:
+    started = threading.Event()
+    release = threading.Event()
+    observed = threading.Event()
+
+    def invoke(request: WorldActorActionRequest) -> WorldActorActionResult:
+        started.set()
+        assert release.wait(2)
+        return _result(request)
+
+    host = _FakeWorldHost(invoke=invoke)
+    authority = _authority(tmp_path, host)
+    outcomes: list[ActorInvocationOutcome] = []
+    errors: list[ActorInvocationError] = []
+    action_thread = threading.Thread(
+        target=_invoke_thread,
+        args=(authority, _request("blocking"), outcomes, errors),
+    )
+
+    def observe() -> None:
+        authority.observe(correlation=ActorCorrelation(transport_request_id="observe-1"))
+        observed.set()
+
+    observe_thread = threading.Thread(target=observe)
+    action_thread.start()
+    assert started.wait(2)
+    observe_thread.start()
+    time.sleep(0.02)
+    assert not observed.is_set()
+    release.set()
+    action_thread.join(timeout=2)
+    observe_thread.join(timeout=2)
+
+    assert observed.is_set()
+    assert not errors
+    assert host.observe_calls == 1
+    assert authority.close().complete is True
+
+
+def test_world_error_and_oversized_result_are_cached_after_one_dispatch(tmp_path: Path) -> None:
+    def world_error(_request: WorldActorActionRequest) -> WorldActorActionResult:
+        raise WorldInterfaceError("decision-stale", "The actor decision is stale.")
+
+    error_host = _FakeWorldHost(invoke=world_error)
+    error_authority = _authority(tmp_path / "error", error_host)
+    request = _request("world-error")
+    for duplicate in (False, True):
+        with pytest.raises(ActorInvocationError) as error:
+            error_authority.invoke(request)
+        assert error.value.code == "decision-stale"
+        assert error.value.outcome is ActorInvocationOutcomeClass.COMPLETED
+        assert error.value.duplicate is duplicate
+    assert len(error_host.calls) == 1
+    assert error_authority.close().complete is True
+
+    large_host = _FakeWorldHost(
+        invoke=lambda action: _result(action, terminated=True, task_receipt={"payload": "x" * 1_000}),
+    )
+    large_authority = _authority(tmp_path / "large", large_host, max_result_bytes=128)
+    large_request = _request("large-result")
+    for duplicate in (False, True):
+        with pytest.raises(ActorInvocationError) as error:
+            large_authority.invoke(large_request)
+        assert error.value.code == "world-action-result-too-large"
+        assert error.value.outcome is ActorInvocationOutcomeClass.COMPLETED
+        assert error.value.duplicate is duplicate
+        assert error.value.disposition is ActorTurnDisposition.CONCLUDE_TURN
+    with pytest.raises(ActorInvocationError) as after_terminal:
+        large_authority.invoke(_request("after-large-terminal"))
+    assert len(large_host.calls) == 1
+    assert large_authority.terminal is True
+    assert after_terminal.value.code == "episode-closed"
+    assert large_authority.close().complete is True
+
+
+def test_invalid_world_outcome_is_unknown_and_does_not_break_authority_state(tmp_path: Path) -> None:
+    host = _FakeWorldHost(invoke=lambda _request: cast(Any, {"not": "a world result"}))
+    authority = _authority(tmp_path, host)
+    request = _request("invalid-result")
+
+    for duplicate in (False, True):
+        with pytest.raises(ActorInvocationError) as error:
+            authority.invoke(request)
+        assert error.value.code == "world-action-outcome-invalid"
+        assert error.value.outcome is ActorInvocationOutcomeClass.UNKNOWN
+        assert error.value.duplicate is duplicate
+
+    close_report = authority.close()
+    assert len(host.calls) == 1
+    assert close_report.quiescent is True
+    assert close_report.complete is False
+    assert close_report.unknown_outcome_request_ids == ("invalid-result",)
+
+
+def test_incomplete_close_retains_unknown_identity_and_ignores_late_result(tmp_path: Path) -> None:
+    started = threading.Event()
+    release = threading.Event()
+
+    def invoke(request: WorldActorActionRequest) -> WorldActorActionResult:
+        started.set()
+        assert release.wait(2)
+        return _result(request)
+
+    host = _FakeWorldHost(invoke=invoke)
+    authority = _authority(tmp_path, host, close_timeout_sec=0.01)
+    request = _request("unsettled")
+    outcomes: list[ActorInvocationOutcome] = []
+    errors: list[ActorInvocationError] = []
+    thread = threading.Thread(target=_invoke_thread, args=(authority, request, outcomes, errors))
+    thread.start()
+    assert started.wait(2)
+
+    incomplete = authority.close()
+    with pytest.raises(ActorInvocationError) as retry:
+        authority.invoke(request)
+    release.set()
+    thread.join(timeout=2)
+    settled = authority.close()
+
+    assert incomplete.quiescent is False
+    assert incomplete.complete is False
+    assert incomplete.lifecycle is ActorInvocationLifecycle.CLOSING
+    assert incomplete.unsettled_request_ids == ("unsettled",)
+    assert incomplete.unknown_outcome_request_ids == ("unsettled",)
+    assert retry.value.code == "actor-invocation-outcome-unknown"
+    assert retry.value.duplicate is True
+    assert not outcomes
+    assert len(errors) == 1
+    assert errors[0].outcome is ActorInvocationOutcomeClass.UNKNOWN
+    assert settled.quiescent is True
+    assert settled.complete is False
+    assert settled.lifecycle is ActorInvocationLifecycle.CLOSED
+    assert settled.unknown_outcome_request_ids == ("unsettled",)
+    completion = next(item for item in _evidence(authority.config.evidence_path) if item["record_type"] == "completion")
+    assert completion["late_ignored"] is True
+    assert completion["error_code"] == "actor-invocation-outcome-unknown"
+
+
+def test_evidence_is_monotonic_content_bound_and_token_free(tmp_path: Path) -> None:
+    with pytest.raises(ValidationError):
+        ActorCorrelation.model_validate({"transport_request_id": "request", "capability_token": "secret"})
+
+    host = _FakeWorldHost()
+    authority = _authority(tmp_path, host)
+    authority.observe(correlation=ActorCorrelation(transport_request_id="observe-1"))
+    authority.invoke(_request("request-1", arguments={"private": "value"}))
+    authority.close()
+
+    evidence = _evidence(authority.config.evidence_path)
+    assert [item["sequence"] for item in evidence] == list(range(1, len(evidence) + 1))
+    assert evidence[0]["record_type"] == "header"
+    assert evidence[0]["schema"] == ACTOR_INVOCATION_EVIDENCE_SCHEMA
+    assert evidence[0]["catalogue_sha256"] == authority.catalogue_hash
+    assert evidence[-1]["record_type"] == "close"
+    serialized = json.dumps(evidence)
+    assert "capability_token" not in serialized
+    assert '"arguments"' not in serialized
+    assert '"decision_id"' not in serialized

--- a/tests/harness/world_actor/test_pump_station_gateway.py
+++ b/tests/harness/world_actor/test_pump_station_gateway.py
@@ -1,0 +1,132 @@
+# ABOUTME: Tests the complete DeepSeek-native gateway path into a real pump-station world.
+# ABOUTME: Proves socket identity, authority replay, one dispatch, and separate close evidence.
+
+from __future__ import annotations
+
+import json
+import socket
+from pathlib import Path
+from typing import Any
+
+from aec_bench.adapters.deepseek_harness.native_world_tools import NativeWorldToolTransport
+from aec_bench.adapters.deepseek_harness.tool_gateway import (
+    TOOL_GATEWAY_PROTOCOL,
+    TOOL_GATEWAY_SOCKET_ENV,
+    TOOL_GATEWAY_TOKEN_ENV,
+    ToolGatewayEndpoint,
+)
+from aec_bench.contracts.world_session import (
+    WorldSessionExecutionKind,
+    WorldSessionOpenMode,
+    WorldSessionRequest,
+)
+from aec_bench.harness.world_actor import ActorInvocationAuthority, ActorInvocationAuthorityConfig
+from aec_bench.worlds.stewardship.wastewater_pump_station.episode_runtime import (
+    PUMP_STATION_TASK_WORLD_ID,
+    PumpStationEpisodeHost,
+)
+from aec_bench.worlds.stewardship.wastewater_pump_station.world_run_repository import (
+    PumpStationWorldRunRepository,
+)
+
+
+def test_socket_gateway_dispatches_one_exactly_replayed_action_to_real_pump_host(tmp_path: Path) -> None:
+    world_root = tmp_path / "world-run"
+    host = PumpStationEpisodeHost(world_root)
+    host.open(
+        WorldSessionRequest(
+            execution_kind=WorldSessionExecutionKind.STEWARDSHIP,
+            open_mode=WorldSessionOpenMode.START,
+            session_id="gateway-session",
+            task_world_id=PUMP_STATION_TASK_WORLD_ID,
+            agent_tenure_id="gateway-actor",
+            run_id="gateway-run",
+            episode_id="gateway-episode",
+            world_branch_id="gateway-branch",
+        )
+    )
+    actor_evidence_path = tmp_path / "actor-invocation-evidence.jsonl"
+    authority = ActorInvocationAuthority(
+        host=host,
+        config=ActorInvocationAuthorityConfig(
+            authority_id="gateway-authority",
+            actor_principal_id="gateway-actor",
+            max_world_actions=3,
+            evidence_path=actor_evidence_path,
+        ),
+    )
+    authority.start()
+    native_transport = NativeWorldToolTransport(authority)
+    gateway_evidence_path = tmp_path / "tool-gateway-evidence.jsonl"
+    endpoint = ToolGatewayEndpoint(
+        tools=(
+            native_transport.action_definition(
+                name="continue_operation",
+                description="Continue to the next declared decision event.",
+                parameters_schema={
+                    "type": "object",
+                    "properties": {"reason": {"type": "string"}},
+                    "required": ["reason"],
+                    "additionalProperties": False,
+                },
+            ),
+        ),
+        evidence_path=gateway_evidence_path,
+        capability_token="gateway-private-capability",
+        generation_id="gateway-generation",
+    )
+    endpoint.start()
+    connection = endpoint.connection_environment()
+    payload = {
+        "protocol": TOOL_GATEWAY_PROTOCOL,
+        "capability": connection[TOOL_GATEWAY_TOKEN_ENV],
+        "operation": "invoke",
+        "tool": "continue_operation",
+        "arguments": {"reason": "Advance once through the complete local gateway path."},
+        "metadata": {
+            "deepseek_session_id": "pump-e2e",
+            "deepseek_tool_call_id": "continue-1",
+            "aec_model_turn": 1,
+        },
+    }
+    try:
+        first = _exchange(connection[TOOL_GATEWAY_SOCKET_ENV], payload)
+        replay = _exchange(connection[TOOL_GATEWAY_SOCKET_ENV], payload)
+    finally:
+        gateway_close = endpoint.close()
+        authority_close = authority.close()
+
+    assert first == replay
+    assert first["status"] == "ok"
+    assert first["result"]["request_id"] == "dsh:pump-e2e:continue-1"
+    assert first["result"]["status"] == "applied"
+    assert authority.world_action_count == 1
+    assert gateway_close.quiescent is True
+    assert authority_close.complete is True
+
+    repository = PumpStationWorldRunRepository(world_root)
+    assert repository.current_snapshot().sequence == 1
+    assert len(repository.command_steps()) == 1
+
+    actor_evidence = _evidence(actor_evidence_path)
+    assert len([record for record in actor_evidence if record["record_type"] == "dispatch"]) == 1
+    assert len([record for record in actor_evidence if record["record_type"] == "request-duplicate"]) == 1
+    gateway_evidence = _evidence(gateway_evidence_path)
+    invocations = [record for record in gateway_evidence if record["record_type"] == "invocation"]
+    assert len(invocations) == 2
+    assert {record["request_semantics"] for record in invocations} == {"handler-authority"}
+    assert "gateway-private-capability" not in json.dumps([*actor_evidence, *gateway_evidence])
+
+
+def _exchange(socket_path: str, payload: dict[str, Any]) -> dict[str, Any]:
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+        client.connect(socket_path)
+        client.sendall(json.dumps(payload).encode("utf-8") + b"\n")
+        response = json.loads(client.makefile().readline())
+    if not isinstance(response, dict):
+        raise TypeError("tool gateway response must be an object")
+    return response
+
+
+def _evidence(path: Path) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]


### PR DESCRIPTION
## Summary

- add one trial-wide authority for world action identity, replay, conflicts, budget, ordering, terminal state, evidence, and close
- route direct pump-station and DeepSeek-native world actions through the same authority across all model segments
- add a public world-action budget and complete local socket-to-world integration coverage

## Verification

- `uv run pytest -q tests/harness/world_actor/ tests/deepseek_harness/ tests/cli/test_pump_station_world.py tests/harness/test_pump_station_harbor.py` (97 passed)
- `uv run ruff check src/ tests/ agents/entrypoint_agent.py`
- `uv run ruff format --check src/ tests/ agents/entrypoint_agent.py`
- targeted mypy across changed authority, adapter, Harbor, entrypoint, and test files
- `uv build`

## Scope

Prime remains unchanged. Its atomic endpoint replacement belongs to PRD3.