### PR TITLE
Compile native world tools from actor catalogues

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -108,6 +108,13 @@ Those are optional pump capabilities, not part of the World minimum. The dam
 seepage task uses the same functional and episode boundaries without those
 capabilities.
 
+Provider composition owns how the frozen actor catalogue is presented. Prime
+uses `WorldActorEndpoint`. DeepSeek compiles the same catalogue into
+`world_observe` and exact native action tools. Both paths use one
+`ActorInvocationAuthority` contract for actor identity, admission, order,
+budget, replay, terminal state, and evidence. A task-world package does not
+define provider-specific action wrappers.
+
 Interactive worlds and artifact tasks meet at the experiment and evidence
 layers. An interactive world does not need to pretend that each action is a
 workspace submission, and an artifact task does not need a world-session API.

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -287,12 +287,20 @@ are unavailable. The pinned SDK path does not expose them. The adapter retains
 the exact Cordis input and does not claim stronger evidence.
 
 For native-tool runs, the manifest records the exact tool names and copied
-plugin artifact. The AEC host supplies each model-facing parameter schema
-explicitly through `NativeToolDefinition`. The endpoint validates requests
-against that schema and gives the handler a hidden `NativeToolInvocation` with
-the DeepSeek session, tool-call, turn, generation, cancellation, and trusted
-request identity. A world action uses that trusted identity; the model-facing
-schema cannot supply or replace it.
+plugin artifact. Generic tools supply an explicit `NativeToolDefinition`.
+Native world tools are compiled from the frozen
+`WorldActorCapabilityCatalogue`: each action keeps its exact name,
+description, and input schema, and `world_observe` is the one reserved
+observation tool. The compiler accepts object properties, required fields,
+boolean `additionalProperties`, scalar and array types, item schemas, enums,
+bounds, descriptions, and one nullable `anyOf` union. Other schema keywords
+fail before model execution; the compiler does not widen them.
+
+The native world action schema cannot contain `request_id` or `decision_id`.
+The endpoint validates task arguments and gives the handler a hidden
+`NativeToolInvocation` with the DeepSeek session, tool-call, turn, generation,
+cancellation, and trusted request identity. That trusted request identity is
+the logical world request ID.
 
 `NativeToolRequestSemantics` identifies the component that owns logical
 request admission. The gateway owns replay for generic non-world tools. A
@@ -301,6 +309,14 @@ each exact retry, while `ActorInvocationAuthority` owns the actor principal,
 frozen catalogue identity, request fingerprint and table, action budget, total
 dispatch order, terminal latch, and semantic evidence. A transport correlation
 does not change logical world-action identity.
+
+One DeepSeek transport instance owns one private decision cursor. A successful
+`world_observe` sets it without using the action budget. An action atomically
+consumes it and can replace it only with a `next_observation` returned to the
+model. A stale decision clears it. An unknown action outcome freezes new calls
+until exact reconciliation. A terminal or truncated result closes the cursor
+and returns the generic `conclude-turn` disposition. This cursor coordinates
+model-visible information; it is not world state.
 
 `WorldActorEndpoint` exposes the same authority to a scoped local process. The
 outer request and response require protocol `aec-bench/world-actor/1` and one
@@ -334,6 +350,16 @@ segments. A non-quiescent or unknown authority outcome blocks a complete
 pump-station trial record. The task-owned world repository remains the
 transition and replay authority; the actor stream records admission and
 dispatch semantics at the actor boundary.
+
+A DeepSeek native world trial also retains
+`native-world-tool-surface.json`. This record contains the complete canonical
+catalogue, the action-to-public-tool mapping, the exact model-facing tool
+manifest, the catalogue SHA-256, and the public tool-surface SHA-256. The
+treatment record identifies the presentation mode as `deepseek-native`.
+Deterministic conformance tests run the same stale, accepted, duplicate,
+conflict, and terminal script through `WorldActorEndpoint` and the compiled
+DeepSeek tools. They compare shared authority and world semantics, not
+provider-specific process events.
 
 ## Output completion and explicit commit
 

--- a/src/aec_bench/adapters/deepseek_harness/native_world_tools.py
+++ b/src/aec_bench/adapters/deepseek_harness/native_world_tools.py
@@ -1,11 +1,17 @@
-# ABOUTME: Translates DeepSeek native world calls into the shared actor invocation authority.
-# ABOUTME: Keeps model presentation and correlation outside world action semantics.
+# ABOUTME: Compiles frozen world catalogues into DeepSeek native tools backed by shared actor authority.
+# ABOUTME: Keeps trusted request identity and the model-visible decision cursor outside task schemas.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+import hashlib
+import json
+import threading
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
 from typing import Any
 
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
 from pydantic import JsonValue
 
 from aec_bench.adapters.deepseek_harness.tool_gateway import (
@@ -14,86 +20,323 @@ from aec_bench.adapters.deepseek_harness.tool_gateway import (
     NativeToolInvocation,
     NativeToolRequestSemantics,
     NativeToolResponse,
+    native_tool_manifest,
 )
+from aec_bench.contracts.world_interface import WorldActorCapabilityCatalogue, WorldActorObservation
 from aec_bench.harness.world_actor import (
     ActorCorrelation,
     ActorInvocationAuthority,
     ActorInvocationError,
+    ActorInvocationOutcomeClass,
+    ActorInvocationRequest,
     ActorTurnDisposition,
+    actor_catalogue_sha256,
+    canonical_actor_catalogue,
 )
 
 NATIVE_WORLD_TRANSPORT = "deepseek-native-world"
+NATIVE_WORLD_TOOL_SURFACE_SCHEMA = "aec-bench/native-world-tool-surface/1"
+WORLD_OBSERVE_TOOL_NAME = "world_observe"
+WORLD_OBSERVE_DESCRIPTION = "Read the complete current actor-visible world observation."
+_EMPTY_OBJECT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+_SUPPORTED_SCHEMA_KEYS = frozenset(
+    {
+        "type",
+        "properties",
+        "required",
+        "additionalProperties",
+        "items",
+        "enum",
+        "anyOf",
+        "description",
+        "title",
+        "default",
+        "minimum",
+        "maximum",
+        "exclusiveMinimum",
+        "exclusiveMaximum",
+        "multipleOf",
+        "minLength",
+        "maxLength",
+        "pattern",
+        "minItems",
+        "maxItems",
+        "uniqueItems",
+    }
+)
+_SUPPORTED_SCHEMA_TYPES = frozenset({"object", "array", "string", "integer", "number", "boolean", "null"})
+_INFRASTRUCTURE_ARGUMENTS = frozenset({"request_id", "decision_id"})
+
+
+@dataclass
+class _CursorRequest:
+    decision_id: str
+    completion_applied: bool = False
 
 
 class NativeWorldToolTransport:
-    """Present model-native world tools while delegating semantics to one authority."""
+    """Own one DeepSeek actor session's private model-visible decision cursor."""
 
     def __init__(self, authority: ActorInvocationAuthority) -> None:
         self._authority = authority
+        self._lock = threading.Lock()
+        self._cursor: str | None = None
+        self._requests: dict[str, _CursorRequest] = {}
+        self._frozen_request_id: str | None = None
+        self._closed = False
 
-    def observation_definition(
-        self,
-        *,
-        name: str,
-        description: str,
-        parameters_schema: dict[str, Any],
-    ) -> NativeToolDefinition:
-        """Define one read-only native observation tool."""
-
-        def handle(
-            invocation: NativeToolInvocation,
-            _arguments: Mapping[str, JsonValue],
-        ) -> NativeToolResponse:
-            try:
-                observation = self._authority.observe(correlation=_correlation(invocation))
-            except ActorInvocationError as error:
-                return _error_response(error)
-            return NativeToolResponse(result=observation.model_dump(mode="json"))
-
-        return NativeToolDefinition(
-            name=name,
-            description=description,
-            parameters_schema=parameters_schema,
-            handler=handle,
+    def definitions(self, catalogue: WorldActorCapabilityCatalogue) -> tuple[NativeToolDefinition, ...]:
+        """Return one observation tool and one exact tool for each catalogue action."""
+        observation = NativeToolDefinition(
+            name=WORLD_OBSERVE_TOOL_NAME,
+            description=WORLD_OBSERVE_DESCRIPTION,
+            parameters_schema=_EMPTY_OBJECT_SCHEMA,
+            handler=self._observe,
             request_semantics=NativeToolRequestSemantics.HANDLER_AUTHORITY,
         )
+        actions = tuple(
+            NativeToolDefinition(
+                name=action.name,
+                description=action.description,
+                parameters_schema=_canonical_json(action.input_schema),
+                handler=self._action_handler(action.name),
+                request_semantics=NativeToolRequestSemantics.HANDLER_AUTHORITY,
+            )
+            for action in sorted(catalogue.actions, key=lambda action: action.name)
+        )
+        return (observation, *actions)
 
-    def action_definition(
+    def _observe(
         self,
-        *,
-        name: str,
-        description: str,
-        parameters_schema: dict[str, Any],
-    ) -> NativeToolDefinition:
-        """Define one native action whose logical request is owned by the authority."""
+        invocation: NativeToolInvocation,
+        _arguments: Mapping[str, JsonValue],
+    ) -> NativeToolResponse:
+        with self._lock:
+            if self._closed:
+                return _local_error_response(
+                    "episode-closed",
+                    "The world episode is closed.",
+                    disposition=NativeToolDisposition.CONCLUDE_TURN,
+                )
+            if self._frozen_request_id is not None:
+                return _local_error_response(
+                    "world-action-outcome-unknown",
+                    "The prior world action outcome must be reconciled before another observation.",
+                    outcome=ActorInvocationOutcomeClass.UNKNOWN,
+                    disposition=NativeToolDisposition.CONCLUDE_TURN,
+                )
+        try:
+            observation = self._authority.observe(correlation=_correlation(invocation))
+        except ActorInvocationError as error:
+            return _error_response(error)
+        with self._lock:
+            if self._authority.terminal:
+                self._closed = True
+                self._cursor = None
+                disposition = NativeToolDisposition.CONCLUDE_TURN
+            else:
+                self._cursor = observation.decision_id
+                disposition = NativeToolDisposition.CONTINUE
+        return NativeToolResponse(result=observation.model_dump(mode="json"), disposition=disposition)
 
+    def _action_handler(self, action_name: str) -> Callable[..., NativeToolResponse]:
         def handle(
             invocation: NativeToolInvocation,
             arguments: Mapping[str, JsonValue],
         ) -> NativeToolResponse:
-            correlation = _correlation(invocation)
+            request, error = self._prepare_request(invocation.request_id)
+            if error is not None:
+                return error
+            assert request is not None
             try:
-                outcome = self._authority.invoke_current(
-                    request_id=invocation.request_id,
-                    action_name=name,
-                    arguments=dict(arguments),
-                    transport=NATIVE_WORLD_TRANSPORT,
-                    correlation=correlation,
+                outcome = self._authority.invoke(
+                    ActorInvocationRequest(
+                        request_id=invocation.request_id,
+                        decision_id=request.decision_id,
+                        action_name=action_name,
+                        arguments=dict(arguments),
+                        transport=NATIVE_WORLD_TRANSPORT,
+                        correlation=_correlation(invocation),
+                    )
                 )
-            except ActorInvocationError as error:
-                return _error_response(error)
+            except ActorInvocationError as actor_error:
+                self._apply_error(request, invocation.request_id, actor_error)
+                return _error_response(actor_error)
+            self._apply_outcome(request, outcome.result.next_observation, outcome.disposition)
             return NativeToolResponse(
                 result=outcome.result.model_dump(mode="json"),
                 disposition=_native_disposition(outcome.disposition),
             )
 
-        return NativeToolDefinition(
-            name=name,
-            description=description,
-            parameters_schema=parameters_schema,
-            handler=handle,
-            request_semantics=NativeToolRequestSemantics.HANDLER_AUTHORITY,
-        )
+        return handle
+
+    def _prepare_request(
+        self,
+        request_id: str,
+    ) -> tuple[_CursorRequest | None, NativeToolResponse | None]:
+        with self._lock:
+            existing = self._requests.get(request_id)
+            if existing is not None:
+                return existing, None
+            if self._frozen_request_id is not None:
+                return None, _local_error_response(
+                    "world-action-outcome-unknown",
+                    "The prior world action outcome must be reconciled before another action.",
+                    outcome=ActorInvocationOutcomeClass.UNKNOWN,
+                    disposition=NativeToolDisposition.CONCLUDE_TURN,
+                )
+            if self._closed:
+                return None, _local_error_response(
+                    "episode-closed",
+                    "The world episode is closed.",
+                    disposition=NativeToolDisposition.CONCLUDE_TURN,
+                )
+            if self._cursor is None:
+                return None, _local_error_response(
+                    "world-observation-required",
+                    "Call world_observe before invoking a world action.",
+                )
+            request = _CursorRequest(decision_id=self._cursor)
+            self._requests[request_id] = request
+            self._cursor = None
+            return request, None
+
+    def _apply_outcome(
+        self,
+        request: _CursorRequest,
+        next_observation: WorldActorObservation | None,
+        disposition: ActorTurnDisposition,
+    ) -> None:
+        with self._lock:
+            if request.completion_applied:
+                return
+            request.completion_applied = True
+            if disposition is ActorTurnDisposition.CONCLUDE_TURN:
+                self._closed = True
+                self._cursor = None
+            elif next_observation is not None:
+                self._cursor = next_observation.decision_id
+
+    def _apply_error(
+        self,
+        request: _CursorRequest,
+        request_id: str,
+        error: ActorInvocationError,
+    ) -> None:
+        with self._lock:
+            if request.completion_applied:
+                return
+            request.completion_applied = True
+            if error.outcome is ActorInvocationOutcomeClass.UNKNOWN:
+                self._frozen_request_id = request_id
+                self._cursor = None
+            elif error.code == "decision-stale":
+                self._cursor = None
+            elif error.disposition is ActorTurnDisposition.CONCLUDE_TURN:
+                self._closed = True
+                self._cursor = None
+
+
+def compile_world_native_tools(
+    *,
+    authority: ActorInvocationAuthority,
+    catalogue: WorldActorCapabilityCatalogue,
+) -> tuple[NativeToolDefinition, ...]:
+    """Compile one frozen task catalogue into the complete DeepSeek world surface."""
+    frozen = authority.capabilities(correlation=ActorCorrelation())
+    expected_hash = authority.catalogue_hash
+    supplied_hash = actor_catalogue_sha256(catalogue)
+    if expected_hash is None or actor_catalogue_sha256(frozen) != expected_hash:
+        raise ValueError("actor invocation authority does not have a valid frozen catalogue")
+    if supplied_hash != expected_hash:
+        raise ValueError("native world catalogue differs from the frozen actor catalogue")
+    if any(action.name == WORLD_OBSERVE_TOOL_NAME for action in catalogue.actions):
+        raise ValueError("world actor catalogue collides with reserved tool name: world_observe")
+    for action in catalogue.actions:
+        _validate_action_schema(action.name, action.input_schema)
+    definitions = NativeWorldToolTransport(authority).definitions(catalogue)
+    native_tool_manifest(definitions)
+    return definitions
+
+
+def native_world_tool_surface_record(
+    *,
+    catalogue: WorldActorCapabilityCatalogue,
+    definitions: tuple[NativeToolDefinition, ...],
+) -> dict[str, Any]:
+    """Return the complete canonical catalogue, mapping, and public tool identity."""
+    manifest = native_tool_manifest(definitions)
+    mapping = tuple(
+        {"catalogue_action": action.name, "public_tool": action.name}
+        for action in sorted(catalogue.actions, key=lambda action: action.name)
+    )
+    surface_identity = {"action_mapping": mapping, "tools": manifest}
+    return {
+        "schema": NATIVE_WORLD_TOOL_SURFACE_SCHEMA,
+        "task_world_id": catalogue.task_world_id,
+        "catalogue_sha256": actor_catalogue_sha256(catalogue),
+        "public_tool_surface_sha256": _json_sha256(surface_identity),
+        "catalogue": canonical_actor_catalogue(catalogue),
+        "action_mapping": mapping,
+        "tools": manifest,
+    }
+
+
+def _validate_action_schema(action_name: str, schema: dict[str, JsonValue]) -> None:
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError as error:
+        raise ValueError(f"invalid world action schema for {action_name}: {error.message}") from error
+    if schema.get("type") != "object":
+        raise ValueError(f"unsupported world action schema for {action_name}: root type must be object")
+    properties = schema.get("properties", {})
+    if not isinstance(properties, dict):
+        raise ValueError(f"unsupported world action schema for {action_name}: properties must be an object")
+    hidden = _INFRASTRUCTURE_ARGUMENTS.intersection(properties)
+    if hidden:
+        names = ", ".join(sorted(hidden))
+        raise ValueError(f"world action schema exposes infrastructure fields for {action_name}: {names}")
+    _validate_schema_node(schema, path=action_name)
+
+
+def _validate_schema_node(schema: Mapping[str, Any], *, path: str) -> None:
+    unsupported = set(schema) - _SUPPORTED_SCHEMA_KEYS
+    if unsupported:
+        names = ", ".join(sorted(unsupported))
+        raise ValueError(f"unsupported JSON Schema keywords at {path}: {names}")
+    schema_type = schema.get("type")
+    if schema_type is not None and schema_type not in _SUPPORTED_SCHEMA_TYPES:
+        raise ValueError(f"unsupported JSON Schema type at {path}: {schema_type}")
+    properties = schema.get("properties")
+    if properties is not None:
+        if not isinstance(properties, dict):
+            raise ValueError(f"JSON Schema properties must be an object at {path}")
+        for name, child in properties.items():
+            if not isinstance(child, dict):
+                raise ValueError(f"JSON Schema property must be an object at {path}.{name}")
+            _validate_schema_node(child, path=f"{path}.{name}")
+    items = schema.get("items")
+    if items is not None:
+        if not isinstance(items, dict):
+            raise ValueError(f"JSON Schema items must be an object at {path}")
+        _validate_schema_node(items, path=f"{path}[]")
+    additional = schema.get("additionalProperties")
+    if additional is not None and not isinstance(additional, bool):
+        raise ValueError(f"JSON Schema additionalProperties must be boolean at {path}")
+    alternatives = schema.get("anyOf")
+    if alternatives is not None:
+        if not isinstance(alternatives, list) or len(alternatives) != 2:
+            raise ValueError(f"JSON Schema anyOf must be one nullable union at {path}")
+        if not all(isinstance(item, dict) for item in alternatives):
+            raise ValueError(f"JSON Schema anyOf members must be objects at {path}")
+        if sum(item.get("type") == "null" for item in alternatives) != 1:
+            raise ValueError(f"JSON Schema anyOf must contain exactly one null type at {path}")
+        for index, item in enumerate(alternatives):
+            _validate_schema_node(item, path=f"{path}.anyOf[{index}]")
 
 
 def _correlation(invocation: NativeToolInvocation) -> ActorCorrelation:
@@ -106,19 +349,33 @@ def _correlation(invocation: NativeToolInvocation) -> ActorCorrelation:
 
 
 def _error_response(error: ActorInvocationError) -> NativeToolResponse:
+    return _local_error_response(
+        error.code,
+        error.detail,
+        outcome=error.outcome,
+        action_sequence=error.action_sequence,
+        disposition=_native_disposition(error.disposition),
+    )
+
+
+def _local_error_response(
+    code: str,
+    detail: str,
+    *,
+    outcome: ActorInvocationOutcomeClass = ActorInvocationOutcomeClass.NOT_DISPATCHED,
+    action_sequence: int | None = None,
+    disposition: NativeToolDisposition = NativeToolDisposition.CONTINUE,
+) -> NativeToolResponse:
     result: dict[str, JsonValue] = {
         "status": "error",
         "error": {
-            "code": error.code,
-            "detail": error.detail,
-            "outcome": error.outcome.value,
-            "action_sequence": error.action_sequence,
+            "code": code,
+            "detail": detail,
+            "outcome": outcome.value,
+            "action_sequence": action_sequence,
         },
     }
-    return NativeToolResponse(
-        result=result,
-        disposition=_native_disposition(error.disposition),
-    )
+    return NativeToolResponse(result=result, disposition=disposition)
 
 
 def _native_disposition(disposition: ActorTurnDisposition) -> NativeToolDisposition:
@@ -127,4 +384,21 @@ def _native_disposition(disposition: ActorTurnDisposition) -> NativeToolDisposit
     return NativeToolDisposition.CONTINUE
 
 
-__all__ = ["NATIVE_WORLD_TRANSPORT", "NativeWorldToolTransport"]
+def _canonical_json(value: Any) -> Any:
+    return json.loads(json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False))
+
+
+def _json_sha256(value: Any) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+__all__ = [
+    "NATIVE_WORLD_TOOL_SURFACE_SCHEMA",
+    "NATIVE_WORLD_TRANSPORT",
+    "WORLD_OBSERVE_DESCRIPTION",
+    "WORLD_OBSERVE_TOOL_NAME",
+    "NativeWorldToolTransport",
+    "compile_world_native_tools",
+    "native_world_tool_surface_record",
+]

--- a/src/aec_bench/adapters/deepseek_harness/tool_gateway.py
+++ b/src/aec_bench/adapters/deepseek_harness/tool_gateway.py
@@ -802,6 +802,12 @@ def _tool_bindings(tools: Sequence[NativeToolDefinition]) -> dict[str, _ToolBind
     return bindings
 
 
+def native_tool_manifest(tools: Sequence[NativeToolDefinition]) -> tuple[dict[str, Any], ...]:
+    """Validate tools and return the exact canonical model-facing manifest."""
+    bindings = _tool_bindings(tools)
+    return tuple(bindings[name].manifest for name in sorted(bindings))
+
+
 def _trusted_request_id(metadata: _ToolMetadata) -> str:
     return f"dsh:{metadata.deepseek_session_id}:{metadata.deepseek_tool_call_id}"
 

--- a/src/aec_bench/adapters/local_registry.py
+++ b/src/aec_bench/adapters/local_registry.py
@@ -290,7 +290,7 @@ def _build_tool_loop(
     workspace: str,
     client: Any | None = None,
     trajectory_writer: Any | None = None,
-    native_tools: list[Callable[..., str]] | None = None,
+    native_tools: Sequence[Any] | None = None,
     enable_bash: bool = True,
     cache: bool = True,
     adapter_name: str = "tool_loop",

--- a/src/aec_bench/adapters/tool_loop_local.py
+++ b/src/aec_bench/adapters/tool_loop_local.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import json
 import logging
 import subprocess
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -342,7 +342,7 @@ class PydanticAiToolLoopClient:
         advisor_config: AdvisorConfig | None = None,
         trajectory_writer: Any | None = None,
         stream_mode: str = "auto",
-        native_tools: list[Callable[..., str]] | None = None,
+        native_tools: Sequence[Any] | None = None,
         enable_bash: bool = True,
         cache: bool = True,
     ) -> None:
@@ -369,6 +369,7 @@ class PydanticAiToolLoopClient:
             system_prompt="",
             retries=2,
             model_settings=model_settings,
+            tools=list(native_tools or ()),
         )
         self._last_request_usages: tuple[tuple[int, int], ...] = ()
 
@@ -382,9 +383,6 @@ class PydanticAiToolLoopClient:
                 if result.error_message:
                     return f"Error: {result.error_message}"
                 return result.output_text
-
-        for native_tool in native_tools or []:
-            self._agent.tool_plain(native_tool)
 
         # Register advisor as a native tool when the advisor client + config are provided.
         # Mirrors Anthropic's native advisor tool shape: zero parameters, context is

--- a/src/aec_bench/harness/pump_station_harbor/session.py
+++ b/src/aec_bench/harness/pump_station_harbor/session.py
@@ -6,19 +6,23 @@ from __future__ import annotations
 import hashlib
 import json
 import shutil
+import uuid
 from collections.abc import Callable
 from dataclasses import asdict, dataclass, replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
-
-from pydantic import JsonValue
+from typing import Any, cast
 
 from aec_bench.adapters.base import AdapterRequest, AdapterResult
-from aec_bench.adapters.deepseek_harness.native_world_tools import NativeWorldToolTransport
+from aec_bench.adapters.deepseek_harness.native_world_tools import (
+    WORLD_OBSERVE_DESCRIPTION,
+    WORLD_OBSERVE_TOOL_NAME,
+    compile_world_native_tools,
+    native_world_tool_surface_record,
+)
 from aec_bench.adapters.local_registry import build_local_adapter
 from aec_bench.contracts.agent_output import AgentOutputStatus
 from aec_bench.contracts.task_definition import ToolSpec
-from aec_bench.contracts.world_interface import WorldActorActionRequest
+from aec_bench.contracts.world_interface import WorldActorActionRequest, WorldActorCapabilityCatalogue
 from aec_bench.contracts.world_session import (
     StewardshipStateSnapshotRef,
     WorldSessionExecutionKind,
@@ -73,9 +77,6 @@ from aec_bench.worlds.stewardship.wastewater_pump_station.world_run_repository i
     PumpStationWorldRunRepository,
 )
 
-if TYPE_CHECKING:
-    from aec_bench.adapters.deepseek_harness.tool_gateway import NativeToolDefinition
-
 PUMP_STATION_MODEL_CONTROLLER_MODE = "model"
 PUMP_STATION_MODEL_MAX_TURNS = 90
 PUMP_STATION_MODEL_MAX_TOKENS = 8192
@@ -109,332 +110,61 @@ class CompletedPumpStationModelSession:
     host_control_count: int
 
 
-class _PumpStationActorTools:
-    """Translate provider-native tool calls into the one installed actor boundary."""
+def _world_tool_specs(catalogue: WorldActorCapabilityCatalogue) -> tuple[ToolSpec, ...]:
+    return (
+        ToolSpec(name=WORLD_OBSERVE_TOOL_NAME, source="builtin", description=WORLD_OBSERVE_DESCRIPTION),
+        *(
+            ToolSpec(name=action.name, source="builtin", description=action.description)
+            for action in sorted(catalogue.actions, key=lambda action: action.name)
+        ),
+    )
 
-    def __init__(self, authority: ActorInvocationAuthority) -> None:
-        self._authority = authority
-        self._native_world_transport = NativeWorldToolTransport(authority)
 
-    @property
-    def tool_specs(self) -> tuple[ToolSpec, ...]:
-        methods = self.native_tools
-        return tuple(
-            ToolSpec(
-                name=method.__name__,
-                source="builtin",
-                description=method.__doc__ or method.__name__.replace("_", " "),
-            )
-            for method in methods
-        )
+def _compile_tool_loop_world_tools(
+    authority: ActorInvocationAuthority,
+    catalogue: WorldActorCapabilityCatalogue,
+) -> tuple[Any, ...]:
+    """Compile the frozen catalogue into explicit PydanticAI tools."""
+    from pydantic_ai import Tool
 
-    @property
-    def native_tools(self) -> tuple[Callable[..., str], ...]:
-        return (
-            self.observe_pump_station,
-            self.continue_operation,
-            self.request_duty_assignment,
-            self.request_inspection,
-            self.request_obstruction_clearance,
-            self.request_functional_check,
-            self.request_provisional_return,
-            self.request_provisional_closure,
-            self.request_post_maintenance_verification,
-            self.resume_process,
-            self.cancel_process,
-            self.request_dependency_waiver,
-            self.request_condition_check,
-            self.search_evidence,
-            self.fetch_evidence,
-        )
-
-    @property
-    def native_tool_definitions(self) -> tuple[NativeToolDefinition, ...]:
-        """Return explicit DeepSeek schemas with infrastructure-owned request identity."""
-        string = {"type": "string"}
-        nullable_string = {"anyOf": [{"type": "string"}, {"type": "null"}]}
-        return (
-            self._definition("observe_pump_station", self.observe_pump_station, {}),
-            self._definition("continue_operation", self.continue_operation, {"reason": string}, ("reason",)),
-            self._definition(
-                "request_duty_assignment",
-                self.request_duty_assignment,
-                {
-                    "reason": string,
-                    "ordered_pump_ids": {"type": "array", "items": string},
-                    "source_outage_id": nullable_string,
-                    "source_backlog_item_id": nullable_string,
-                },
-                ("reason", "ordered_pump_ids"),
-            ),
-            self._definition(
-                "request_inspection",
-                self.request_inspection,
-                {"reason": string, "pump_id": string, "backlog_item_id": string},
-                ("reason", "pump_id", "backlog_item_id"),
-            ),
-            self._definition(
-                "request_obstruction_clearance",
-                self.request_obstruction_clearance,
-                {
-                    "reason": string,
-                    "pump_id": string,
-                    "backlog_item_id": string,
-                    "inspection_evidence_id": string,
-                },
-                ("reason", "pump_id", "backlog_item_id", "inspection_evidence_id"),
-            ),
-            self._definition(
-                "request_functional_check",
-                self.request_functional_check,
-                {"reason": string, "pump_id": string, "backlog_item_id": string},
-                ("reason", "pump_id", "backlog_item_id"),
-            ),
-            self._definition(
-                "request_provisional_return",
-                self.request_provisional_return,
-                {"reason": string, "pump_id": string, "functional_check_evidence_id": string},
-                ("reason", "pump_id", "functional_check_evidence_id"),
-            ),
-            self._definition(
-                "request_provisional_closure",
-                self.request_provisional_closure,
-                {"reason": string, "work_order_id": string},
-                ("reason", "work_order_id"),
-            ),
-            self._definition(
-                "request_post_maintenance_verification",
-                self.request_post_maintenance_verification,
-                {"reason": string, "pump_id": string, "backlog_item_id": string},
-                ("reason", "pump_id", "backlog_item_id"),
-            ),
-            self._definition(
-                "resume_process",
-                self.resume_process,
-                {"reason": string, "process_id": string},
-                ("reason", "process_id"),
-            ),
-            self._definition(
-                "cancel_process",
-                self.cancel_process,
-                {"reason": string, "process_id": string},
-                ("reason", "process_id"),
-            ),
-            self._definition(
-                "request_dependency_waiver",
-                self.request_dependency_waiver,
-                {"reason": string, "process_id": string, "dependency_id": string, "evidence_id": string},
-                ("reason", "process_id", "dependency_id", "evidence_id"),
-            ),
-            self._definition(
-                "request_condition_check",
-                self.request_condition_check,
-                {"reason": string, "pump_id": string},
-                ("reason", "pump_id"),
-            ),
-            self._definition(
-                "search_evidence",
-                self.search_evidence,
-                {
-                    "query": string,
-                    "scope": {"type": "string", "default": "all"},
-                    "limit": {"type": "integer", "default": 5},
-                },
-                ("query",),
-            ),
-            self._definition(
-                "fetch_evidence",
-                self.fetch_evidence,
-                {"reference": string},
-                ("reference",),
-            ),
-        )
-
-    def _definition(
-        self,
-        name: str,
-        function: Callable[..., str],
-        properties: dict[str, Any],
-        required: tuple[str, ...] = (),
-    ) -> NativeToolDefinition:
-        parameters_schema = {
-            "type": "object",
-            "properties": properties,
-            "required": list(required),
-            "additionalProperties": False,
-        }
-        definition_factory = (
-            self._native_world_transport.observation_definition
-            if name == "observe_pump_station"
-            else self._native_world_transport.action_definition
-        )
-        return definition_factory(
-            name=name,
-            description=function.__doc__ or name.replace("_", " "),
-            parameters_schema=parameters_schema,
-        )
-
-    def observe_pump_station(self) -> str:
-        """Read the complete current actor view without latent or future state."""
-        observation = self._authority.observe(correlation=ActorCorrelation())
+    def observe() -> str:
+        observation = authority.observe(correlation=ActorCorrelation())
         return json.dumps(observation.model_dump(mode="json"), sort_keys=True, separators=(",", ":"))
 
-    def _invoke(self, request_id: str, action_name: str, arguments: dict[str, JsonValue]) -> str:
-        outcome = self._authority.invoke_current(
-            request_id=request_id,
-            action_name=action_name,
-            arguments=arguments,
-            transport=_PUMP_STATION_TOOL_LOOP_TRANSPORT,
-            correlation=ActorCorrelation(transport_request_id=request_id),
+    def action_handler(action_name: str) -> Callable[..., str]:
+        def invoke(**arguments: Any) -> str:
+            request_id = f"tool-loop:{uuid.uuid4().hex}"
+            outcome = authority.invoke_current(
+                request_id=request_id,
+                action_name=action_name,
+                arguments=arguments,
+                transport=_PUMP_STATION_TOOL_LOOP_TRANSPORT,
+                correlation=ActorCorrelation(transport_request_id=request_id),
+            )
+            return json.dumps(outcome.result.model_dump(mode="json"), sort_keys=True, separators=(",", ":"))
+
+        return invoke
+
+    tools: list[Any] = [
+        Tool.from_schema(
+            observe,
+            name=WORLD_OBSERVE_TOOL_NAME,
+            description=WORLD_OBSERVE_DESCRIPTION,
+            json_schema={"type": "object", "properties": {}, "additionalProperties": False},
+            sequential=True,
         )
-        return json.dumps(outcome.result.model_dump(mode="json"), sort_keys=True, separators=(",", ":"))
-
-    def continue_operation(self, request_id: str, reason: str) -> str:
-        """Continue the permitted operating mode to the next declared decision event."""
-        return self._invoke(request_id, "continue_operation", {"reason": reason})
-
-    def request_duty_assignment(
-        self,
-        request_id: str,
-        reason: str,
-        ordered_pump_ids: tuple[str, ...],
-        source_outage_id: str | None = None,
-        source_backlog_item_id: str | None = None,
-    ) -> str:
-        """Request an ordered assignment of eligible pumps to declared service."""
-        arguments: dict[str, JsonValue] = {
-            "reason": reason,
-            "ordered_pump_ids": list(ordered_pump_ids),
-        }
-        if source_outage_id is not None:
-            arguments["source_outage_id"] = source_outage_id
-        if source_backlog_item_id is not None:
-            arguments["source_backlog_item_id"] = source_backlog_item_id
-        return self._invoke(request_id, "request_duty_assignment", arguments)
-
-    def request_inspection(self, request_id: str, reason: str, pump_id: str, backlog_item_id: str) -> str:
-        """Request a scheduled inspection of one named pump."""
-        return self._invoke(
-            request_id,
-            "request_inspection",
-            {"reason": reason, "pump_id": pump_id, "backlog_item_id": backlog_item_id},
+    ]
+    tools.extend(
+        Tool.from_schema(
+            action_handler(action.name),
+            name=action.name,
+            description=action.description,
+            json_schema=action.input_schema,
+            sequential=True,
         )
-
-    def request_obstruction_clearance(
-        self,
-        request_id: str,
-        reason: str,
-        pump_id: str,
-        backlog_item_id: str,
-        inspection_evidence_id: str,
-    ) -> str:
-        """Request clearance against named inspection evidence."""
-        return self._invoke(
-            request_id,
-            "request_obstruction_clearance",
-            {
-                "reason": reason,
-                "pump_id": pump_id,
-                "backlog_item_id": backlog_item_id,
-                "inspection_evidence_id": inspection_evidence_id,
-            },
-        )
-
-    def request_functional_check(self, request_id: str, reason: str, pump_id: str, backlog_item_id: str) -> str:
-        """Request one controlled functional check for a named pump."""
-        return self._invoke(
-            request_id,
-            "request_functional_check",
-            {"reason": reason, "pump_id": pump_id, "backlog_item_id": backlog_item_id},
-        )
-
-    def request_provisional_return(
-        self,
-        request_id: str,
-        reason: str,
-        pump_id: str,
-        functional_check_evidence_id: str,
-    ) -> str:
-        """Request return against accepted functional-check evidence."""
-        return self._invoke(
-            request_id,
-            "request_provisional_return",
-            {
-                "reason": reason,
-                "pump_id": pump_id,
-                "functional_check_evidence_id": functional_check_evidence_id,
-            },
-        )
-
-    def request_provisional_closure(self, request_id: str, reason: str, work_order_id: str) -> str:
-        """Request administrative closure while operational duties remain open."""
-        return self._invoke(
-            request_id,
-            "request_provisional_closure",
-            {"reason": reason, "work_order_id": work_order_id},
-        )
-
-    def request_post_maintenance_verification(
-        self,
-        request_id: str,
-        reason: str,
-        pump_id: str,
-        backlog_item_id: str,
-    ) -> str:
-        """Request independent post-maintenance verification."""
-        return self._invoke(
-            request_id,
-            "request_post_maintenance_verification",
-            {"reason": reason, "pump_id": pump_id, "backlog_item_id": backlog_item_id},
-        )
-
-    def resume_process(self, request_id: str, reason: str, process_id: str) -> str:
-        """Resume blocked or suspended work after dependency checks."""
-        return self._invoke(request_id, "resume_process", {"reason": reason, "process_id": process_id})
-
-    def cancel_process(self, request_id: str, reason: str, process_id: str) -> str:
-        """Cancel live work and release unused reservations."""
-        return self._invoke(request_id, "cancel_process", {"reason": reason, "process_id": process_id})
-
-    def request_dependency_waiver(
-        self,
-        request_id: str,
-        reason: str,
-        process_id: str,
-        dependency_id: str,
-        evidence_id: str,
-    ) -> str:
-        """Request one narrow dependency waiver with named evidence."""
-        return self._invoke(
-            request_id,
-            "request_dependency_waiver",
-            {
-                "reason": reason,
-                "process_id": process_id,
-                "dependency_id": dependency_id,
-                "evidence_id": evidence_id,
-            },
-        )
-
-    def request_condition_check(self, request_id: str, reason: str, pump_id: str) -> str:
-        """Request one sensor-based condition check for a named pump."""
-        return self._invoke(
-            request_id,
-            "request_condition_check",
-            {"reason": reason, "pump_id": pump_id},
-        )
-
-    def search_evidence(self, request_id: str, query: str, scope: str = "all", limit: int = 5) -> str:
-        """Search the documentary evidence available to this actor now."""
-        return self._invoke(
-            request_id,
-            "search_evidence",
-            {"query": query, "scope": scope, "limit": limit},
-        )
-
-    def fetch_evidence(self, request_id: str, reference: str) -> str:
-        """Fetch content through an opaque reference from an earlier search."""
-        return self._invoke(request_id, "fetch_evidence", {"reference": reference})
+        for action in sorted(catalogue.actions, key=lambda action: action.name)
+    )
+    return tuple(tools)
 
 
 def run_pump_station_reference_session(
@@ -549,25 +279,46 @@ def run_pump_station_model_session(
     authority.start()
     trajectory = TrajectoryWriter(path=str(destination / "trajectory.jsonl"))
     adapter_results: list[AdapterResult] = []
+    native_world_surface: dict[str, Any] | None = None
     host_control_count = 0
     journey_status = PumpStationJourneyStatus.ACTIVE
     stop_reason = "max-segments"
     authority_close_report: AuthorityCloseReport | None = None
     try:
+        catalogue = authority.capabilities(correlation=ActorCorrelation())
+        if tuple(action.name for action in catalogue.actions) != bridge.allowed_tools:
+            raise ValueError("pump-station bridge tools differ from the frozen actor catalogue")
+        tool_specs = _world_tool_specs(catalogue)
         resolved_builder = adapter_builder or build_local_adapter
         control = PumpStationWorldControl(
             repository_root,
             authorised_principal_ids=(PUMP_STATION_OPERATIONS_AUTHORITY_ID,),
         )
         for _segment_index in range(_PUMP_STATION_MODEL_MAX_SEGMENTS):
-            tools = _PumpStationActorTools(authority)
+            if adapter_kind == "deepseek_harness":
+                native_tool_definitions = compile_world_native_tools(authority=authority, catalogue=catalogue)
+                segment_surface = native_world_tool_surface_record(
+                    catalogue=catalogue,
+                    definitions=native_tool_definitions,
+                )
+                if native_world_surface is None:
+                    native_world_surface = segment_surface
+                    _write_json(destination / "native-world-tool-surface.json", native_world_surface)
+                elif (
+                    segment_surface["public_tool_surface_sha256"] != native_world_surface["public_tool_surface_sha256"]
+                ):
+                    raise RuntimeError("DeepSeek native world tool surface changed between model segments")
+                native_tools = None
+            else:
+                native_tool_definitions = None
+                native_tools = _compile_tool_loop_world_tools(authority, catalogue)
             adapter = resolved_builder(
                 adapter_kind=adapter_kind,
                 model_name=model_name,
                 workspace=str(destination),
                 trajectory_writer=trajectory,
-                native_tools=tools.native_tools,
-                native_tool_definitions=(tools.native_tool_definitions if adapter_kind == "deepseek_harness" else None),
+                native_tools=native_tools,
+                native_tool_definitions=native_tool_definitions,
                 enable_bash=False,
             )
             segment_result = adapter.execute(
@@ -577,7 +328,7 @@ def run_pump_station_model_session(
                         "You are the accountable wastewater pump-station steward. Do not infer latent state, hidden "
                         "events, another branch, verifier expectations, or a prescribed action sequence."
                     ),
-                    tools=list(tools.tool_specs),
+                    tools=list(tool_specs),
                     configuration=request_configuration,
                     output_path=str(destination / "output.md"),
                     output_format="markdown",
@@ -642,6 +393,13 @@ def run_pump_station_model_session(
             "closed_at": authority_close_report.closed_at.isoformat(),
         },
     }
+    if native_world_surface is not None:
+        adapter_configuration["native_world_tools"] = {
+            "catalogue_sha256": native_world_surface["catalogue_sha256"],
+            "public_tool_surface_sha256": native_world_surface["public_tool_surface_sha256"],
+            "evidence_path": "native-world-tool-surface.json",
+            "presentation_mode": "deepseek-native",
+        }
     adapter_result = replace(adapter_result, configuration_record=adapter_configuration)
     repository = PumpStationWorldRunRepository(repository_root)
     end = repository.current_snapshot()

--- a/src/aec_bench/harness/world_actor/__init__.py
+++ b/src/aec_bench/harness/world_actor/__init__.py
@@ -15,6 +15,8 @@ from aec_bench.harness.world_actor.authority import (
     ActorTurnDisposition,
     AuthorityCloseReport,
     WorldActorHost,
+    actor_catalogue_sha256,
+    canonical_actor_catalogue,
 )
 from aec_bench.harness.world_actor.client_bundle import (
     InstalledClient,
@@ -58,5 +60,7 @@ __all__ = [
     "WorldActorEndpointError",
     "WorldActorEndpointLifecycle",
     "WorldActorHost",
+    "actor_catalogue_sha256",
+    "canonical_actor_catalogue",
     "install_world_actor_client",
 ]

--- a/src/aec_bench/harness/world_actor/authority.py
+++ b/src/aec_bench/harness/world_actor/authority.py
@@ -256,7 +256,7 @@ class ActorInvocationAuthority:
             if self._lifecycle is not ActorInvocationLifecycle.CREATED:
                 raise RuntimeError("actor invocation authority can start only once")
         catalogue = self._host.capabilities()
-        catalogue_hash = _json_sha256(catalogue.model_dump(mode="json"))
+        catalogue_hash = actor_catalogue_sha256(catalogue)
         evidence_path = self.config.evidence_path
         evidence_path.parent.mkdir(parents=True, exist_ok=True)
         if evidence_path.exists() or evidence_path.is_symlink():
@@ -869,7 +869,7 @@ class ActorInvocationAuthority:
 
     def _require_catalogue_stable(self) -> None:
         current = self._host.capabilities()
-        current_hash = _json_sha256(current.model_dump(mode="json"))
+        current_hash = actor_catalogue_sha256(current)
         with self._condition:
             expected = self._catalogue_hash
         if current_hash != expected:
@@ -916,6 +916,21 @@ def _request_fingerprint(actor_principal_id: str, request: ActorInvocationReques
             "arguments": request.arguments,
         }
     )
+
+
+def canonical_actor_catalogue(catalogue: WorldActorCapabilityCatalogue) -> dict[str, Any]:
+    """Return the task catalogue with a stable action order and canonical JSON values."""
+    return {
+        "task_world_id": catalogue.task_world_id,
+        "actions": [
+            action.model_dump(mode="json") for action in sorted(catalogue.actions, key=lambda action: action.name)
+        ],
+    }
+
+
+def actor_catalogue_sha256(catalogue: WorldActorCapabilityCatalogue) -> str:
+    """Return one transport-neutral identity for a frozen actor catalogue."""
+    return _json_sha256(canonical_actor_catalogue(catalogue))
 
 
 def _json_bytes(value: Any) -> bytes:

--- a/tests/adapters/test_tool_loop_trajectory.py
+++ b/tests/adapters/test_tool_loop_trajectory.py
@@ -177,10 +177,11 @@ class TestPydanticAiNativeTools:
         from aec_bench.adapters.tool_loop_local import PydanticAiToolLoopClient
 
         registered: list[str] = []
+        constructor_tools: list[object] = []
 
         class FakeAgent:
-            def __init__(self, *_args: Any, **_kwargs: Any) -> None:
-                pass
+            def __init__(self, *_args: Any, **kwargs: Any) -> None:
+                constructor_tools.extend(kwargs["tools"])
 
             def tool_plain(self, func=None, /, *, name=None, **_kwargs):
                 def register(callback):
@@ -212,7 +213,8 @@ class TestPydanticAiNativeTools:
             native_tools=[submit_checkpoint],
         )
 
-        assert registered == ["bash", "submit_checkpoint"]
+        assert constructor_tools == [submit_checkpoint]
+        assert registered == ["bash"]
 
     def test_pydantic_ai_client_can_disable_bash_for_confined_native_tools(
         self,
@@ -220,15 +222,11 @@ class TestPydanticAiNativeTools:
     ) -> None:
         from aec_bench.adapters.tool_loop_local import PydanticAiToolLoopClient
 
-        registered: list[str] = []
+        constructor_tools: list[object] = []
 
         class FakeAgent:
-            def __init__(self, *_args, **_kwargs) -> None:
-                pass
-
-            def tool_plain(self, tool):
-                registered.append(tool.__name__)
-                return tool
+            def __init__(self, *_args: Any, **kwargs: Any) -> None:
+                constructor_tools.extend(kwargs["tools"])
 
         def read_workspace_file(path: str) -> str:
             return path
@@ -254,4 +252,4 @@ class TestPydanticAiNativeTools:
             enable_bash=False,
         )
 
-        assert registered == ["read_workspace_file"]
+        assert constructor_tools == [read_workspace_file]

--- a/tests/deepseek_harness/test_native_world_tools.py
+++ b/tests/deepseek_harness/test_native_world_tools.py
@@ -1,14 +1,22 @@
-# ABOUTME: Tests the DeepSeek native presentation of shared world invocation authority.
-# ABOUTME: Proves hidden correlation, exact retry, terminal disposition, and actor-visible errors.
+# ABOUTME: Tests catalogue-compiled DeepSeek world tools and their private decision cursor.
+# ABOUTME: Proves exact schemas, trusted identity, retry, stale recovery, terminal close, and unknown freeze.
 
 from __future__ import annotations
 
+import threading
 from datetime import UTC, datetime
 from pathlib import Path
 
-from aec_bench.adapters.deepseek_harness.native_world_tools import NativeWorldToolTransport
+import pytest
+
+from aec_bench.adapters.deepseek_harness.native_world_tools import (
+    WORLD_OBSERVE_TOOL_NAME,
+    compile_world_native_tools,
+    native_world_tool_surface_record,
+)
 from aec_bench.adapters.deepseek_harness.tool_gateway import (
     NativeCancellation,
+    NativeToolDefinition,
     NativeToolDisposition,
     NativeToolInvocation,
     NativeToolRequestSemantics,
@@ -19,31 +27,37 @@ from aec_bench.contracts.world_interface import (
     WorldActorActionResult,
     WorldActorCapabilityCatalogue,
     WorldActorObservation,
+    WorldInterfaceError,
 )
-from aec_bench.harness.world_actor import ActorInvocationAuthority, ActorInvocationAuthorityConfig
+from aec_bench.harness.world_actor import (
+    ActorInvocationAuthority,
+    ActorInvocationAuthorityConfig,
+    ActorInvocationError,
+    actor_catalogue_sha256,
+)
 
 
 class _WorldHost:
-    def __init__(self) -> None:
+    def __init__(self, catalogue: WorldActorCapabilityCatalogue | None = None) -> None:
         self.calls: list[WorldActorActionRequest] = []
+        self.decision_generation = 0
+        self.unknown_outcome = False
+        self.catalogue = catalogue or _catalogue()
 
     def capabilities(self) -> WorldActorCapabilityCatalogue:
-        return WorldActorCapabilityCatalogue(
-            task_world_id="native-world",
-            actions=(
-                WorldActorActionCapability(name="act", description="Act.", input_schema={"type": "object"}),
-                WorldActorActionCapability(
-                    name="terminate",
-                    description="Terminate.",
-                    input_schema={"type": "object"},
-                ),
-            ),
-        )
+        return self.catalogue
 
     def observe(self) -> WorldActorObservation:
-        return WorldActorObservation(decision_id=f"decision-{len(self.calls)}", view={"calls": len(self.calls)})
+        return WorldActorObservation(
+            decision_id=f"decision-{self.decision_generation}-{len(self.calls)}",
+            view={"calls": len(self.calls)},
+        )
 
     def invoke(self, request: WorldActorActionRequest) -> WorldActorActionResult:
+        if self.unknown_outcome:
+            raise RuntimeError("unknown external outcome")
+        if request.decision_id != self.observe().decision_id:
+            raise WorldInterfaceError("decision-stale", "The decision is stale.")
         self.calls.append(request)
         terminated = request.action_name == "terminate"
         return WorldActorActionResult(
@@ -51,9 +65,40 @@ class _WorldHost:
             action_name=request.action_name,
             status="accepted",
             task_receipt={"transition_id": f"transition-{len(self.calls)}"},
-            next_observation=None,
+            next_observation=None if terminated else self.observe(),
             terminated=terminated,
         )
+
+
+def _catalogue(*, action_names: tuple[str, ...] = ("terminate", "act")) -> WorldActorCapabilityCatalogue:
+    schemas = {
+        "act": {
+            "type": "object",
+            "properties": {
+                "value": {"type": "integer", "minimum": 0},
+                "note": {"anyOf": [{"type": "string"}, {"type": "null"}], "default": None},
+            },
+            "required": ["value"],
+            "additionalProperties": False,
+        },
+        "terminate": {
+            "type": "object",
+            "properties": {"reason": {"type": "string"}},
+            "required": ["reason"],
+            "additionalProperties": False,
+        },
+    }
+    return WorldActorCapabilityCatalogue(
+        task_world_id="native-world",
+        actions=tuple(
+            WorldActorActionCapability(
+                name=name,
+                description=f"{name.title()} through the task catalogue.",
+                input_schema=schemas.get(name, {"type": "object", "properties": {}}),
+            )
+            for name in action_names
+        ),
+    )
 
 
 def _authority(tmp_path: Path, host: _WorldHost) -> ActorInvocationAuthority:
@@ -62,7 +107,7 @@ def _authority(tmp_path: Path, host: _WorldHost) -> ActorInvocationAuthority:
         config=ActorInvocationAuthorityConfig(
             authority_id="authority-native",
             actor_principal_id="actor-native",
-            max_world_actions=5,
+            max_world_actions=8,
             evidence_path=tmp_path / "actor-invocations.jsonl",
         ),
     )
@@ -70,11 +115,11 @@ def _authority(tmp_path: Path, host: _WorldHost) -> ActorInvocationAuthority:
     return authority
 
 
-def _invocation(request_id: str, *, tool_name: str, tool_call_id: str) -> NativeToolInvocation:
+def _invocation(request_id: str, *, tool_name: str) -> NativeToolInvocation:
     return NativeToolInvocation(
         request_id=request_id,
         deepseek_session_id="session-1",
-        deepseek_tool_call_id=tool_call_id,
+        deepseek_tool_call_id=request_id,
         model_turn=1,
         tool_name=tool_name,
         generation_id="generation-1",
@@ -83,81 +128,221 @@ def _invocation(request_id: str, *, tool_name: str, tool_call_id: str) -> Native
     )
 
 
-def _schema() -> dict[str, object]:
-    return {
-        "type": "object",
-        "properties": {"value": {"type": "integer"}},
-        "required": ["value"],
-        "additionalProperties": False,
-    }
+def _definitions(
+    tmp_path: Path,
+    host: _WorldHost,
+) -> tuple[ActorInvocationAuthority, dict[str, NativeToolDefinition]]:
+    authority = _authority(tmp_path, host)
+    definitions = compile_world_native_tools(authority=authority, catalogue=host.catalogue)
+    return authority, {definition.name: definition for definition in definitions}
 
 
-def test_native_action_uses_authority_identity_and_replays_exact_retry(tmp_path: Path) -> None:
+def _error_code(result: object) -> str:
+    assert isinstance(result, dict)
+    error = result["error"]
+    assert isinstance(error, dict)
+    return str(error["code"])
+
+
+def test_compiler_uses_only_the_canonical_catalogue_and_records_exact_hashes(tmp_path: Path) -> None:
     host = _WorldHost()
     authority = _authority(tmp_path, host)
-    transport = NativeWorldToolTransport(authority)
-    definition = transport.action_definition(
-        name="act",
-        description="Act.",
-        parameters_schema=_schema(),
+
+    definitions = compile_world_native_tools(authority=authority, catalogue=host.catalogue)
+    surface = native_world_tool_surface_record(catalogue=host.catalogue, definitions=definitions)
+
+    assert tuple(definition.name for definition in definitions) == (WORLD_OBSERVE_TOOL_NAME, "act", "terminate")
+    assert definitions[1].description == host.catalogue.actions[1].description
+    assert definitions[1].parameters_schema == host.catalogue.actions[1].input_schema
+    assert all(
+        definition.request_semantics is NativeToolRequestSemantics.HANDLER_AUTHORITY for definition in definitions
     )
-    invocation = _invocation("dsh:session-1:tool-1", tool_name="act", tool_call_id="tool-1")
+    assert all(
+        "request_id" not in definition.parameters_schema.get("properties", {})
+        and "decision_id" not in definition.parameters_schema.get("properties", {})
+        for definition in definitions
+    )
+    reordered = _catalogue(action_names=("act", "terminate"))
+    assert actor_catalogue_sha256(reordered) == authority.catalogue_hash
+    assert surface["catalogue_sha256"] == authority.catalogue_hash
+    assert len(str(surface["public_tool_surface_sha256"])) == 64
+    assert surface["action_mapping"] == (
+        {"catalogue_action": "act", "public_tool": "act"},
+        {"catalogue_action": "terminate", "public_tool": "terminate"},
+    )
+    assert authority.close().complete is True
 
-    first = definition.handler(invocation, {"value": 1})
-    replay = definition.handler(invocation, {"value": 1})
 
-    assert definition.request_semantics is NativeToolRequestSemantics.HANDLER_AUTHORITY
-    assert first == replay
+@pytest.mark.parametrize(
+    ("capability", "message"),
+    [
+        (
+            WorldActorActionCapability(
+                name=WORLD_OBSERVE_TOOL_NAME,
+                description="Collision.",
+                input_schema={"type": "object", "properties": {}},
+            ),
+            "reserved tool name",
+        ),
+        (
+            WorldActorActionCapability(
+                name="exposes_identity",
+                description="Bad identity.",
+                input_schema={"type": "object", "properties": {"request_id": {"type": "string"}}},
+            ),
+            "exposes infrastructure fields",
+        ),
+        (
+            WorldActorActionCapability(
+                name="unsupported_schema",
+                description="Unsupported schema.",
+                input_schema={"type": "object", "properties": {"value": {"oneOf": [{"type": "string"}]}}},
+            ),
+            "unsupported JSON Schema keywords",
+        ),
+        (
+            WorldActorActionCapability(
+                name="invalid-name",
+                description="Invalid provider name.",
+                input_schema={"type": "object", "properties": {}},
+            ),
+            "invalid native tool name",
+        ),
+    ],
+)
+def test_compiler_fails_closed_for_invalid_catalogues(
+    tmp_path: Path,
+    capability: WorldActorActionCapability,
+    message: str,
+) -> None:
+    catalogue = WorldActorCapabilityCatalogue(task_world_id="invalid-world", actions=(capability,))
+    host = _WorldHost(catalogue)
+    authority = _authority(tmp_path, host)
+
+    with pytest.raises(ValueError, match=message):
+        compile_world_native_tools(authority=authority, catalogue=catalogue)
+
+    assert authority.close().complete is True
+
+
+def test_compiler_rejects_catalogue_drift_before_model_execution(tmp_path: Path) -> None:
+    host = _WorldHost()
+    frozen_catalogue = host.catalogue
+    authority = _authority(tmp_path, host)
+    host.catalogue = _catalogue(action_names=("act",))
+
+    with pytest.raises(ActorInvocationError, match="actor-catalogue-drift"):
+        compile_world_native_tools(authority=authority, catalogue=frozen_catalogue)
+
+    assert authority.close().complete is True
+
+
+def test_native_cursor_requires_visible_observation_and_preserves_exact_retry(tmp_path: Path) -> None:
+    host = _WorldHost()
+    authority, definitions = _definitions(tmp_path, host)
+    act = definitions["act"]
+    terminate = definitions["terminate"]
+
+    before_observe = act.handler(_invocation("action-before-observe", tool_name="act"), {"value": 1})
+    observation = definitions[WORLD_OBSERVE_TOOL_NAME].handler(
+        _invocation("observe-1", tool_name=WORLD_OBSERVE_TOOL_NAME),
+        {},
+    )
+    invocation = _invocation("action-1", tool_name="act")
+    first = act.handler(invocation, {"value": 1})
+    duplicate = act.handler(invocation, {"value": 1})
+    terminal = terminate.handler(_invocation("terminal-1", tool_name="terminate"), {"reason": "done"})
+    after_terminal = act.handler(_invocation("action-after-terminal", tool_name="act"), {"value": 2})
+
+    assert _error_code(before_observe.result) == "world-observation-required"
+    assert observation.result == {"decision_id": "decision-0-0", "view": {"calls": 0}}
+    assert first == duplicate
     assert first.disposition is NativeToolDisposition.CONTINUE
-    assert isinstance(first.result, dict)
-    assert first.result["request_id"] == "dsh:session-1:tool-1"
+    assert terminal.disposition is NativeToolDisposition.CONCLUDE_TURN
+    assert _error_code(after_terminal.result) == "episode-closed"
+    assert [request.request_id for request in host.calls] == ["action-1", "terminal-1"]
+    assert host.calls[0].decision_id == "decision-0-0"
+    assert authority.world_action_count == 2
+    assert authority.close().complete is True
+
+
+def test_native_cursor_allows_only_one_concurrent_action_to_consume_an_observation(tmp_path: Path) -> None:
+    dispatch_started = threading.Event()
+    release_dispatch = threading.Event()
+
+    class BlockingHost(_WorldHost):
+        def invoke(self, request: WorldActorActionRequest) -> WorldActorActionResult:
+            dispatch_started.set()
+            assert release_dispatch.wait(timeout=3)
+            return super().invoke(request)
+
+    host = BlockingHost()
+    authority, definitions = _definitions(tmp_path, host)
+    definitions[WORLD_OBSERVE_TOOL_NAME].handler(
+        _invocation("observe-1", tool_name=WORLD_OBSERVE_TOOL_NAME),
+        {},
+    )
+    first_result: list[object] = []
+    first = threading.Thread(
+        target=lambda: first_result.append(
+            definitions["act"].handler(_invocation("action-1", tool_name="act"), {"value": 1}).result
+        )
+    )
+    first.start()
+    assert dispatch_started.wait(timeout=3)
+    competing = definitions["act"].handler(_invocation("action-2", tool_name="act"), {"value": 2})
+    release_dispatch.set()
+    first.join(timeout=3)
+
+    assert not first.is_alive()
+    assert _error_code(competing.result) == "world-observation-required"
+    assert len(first_result) == 1
     assert len(host.calls) == 1
     assert authority.world_action_count == 1
     assert authority.close().complete is True
 
 
-def test_native_observation_and_terminal_errors_use_generic_dispositions(tmp_path: Path) -> None:
+def test_stale_decision_clears_cursor_until_the_model_observes_again(tmp_path: Path) -> None:
     host = _WorldHost()
-    authority = _authority(tmp_path, host)
-    transport = NativeWorldToolTransport(authority)
-    observe = transport.observation_definition(
-        name="observe_world",
-        description="Observe.",
-        parameters_schema={"type": "object", "properties": {}, "additionalProperties": False},
-    )
-    terminate = transport.action_definition(
-        name="terminate",
-        description="Terminate.",
-        parameters_schema=_schema(),
-    )
-    act = transport.action_definition(name="act", description="Act.", parameters_schema=_schema())
+    authority, definitions = _definitions(tmp_path, host)
+    observe = definitions[WORLD_OBSERVE_TOOL_NAME]
+    act = definitions["act"]
 
-    observation = observe.handler(
-        _invocation("dsh:session-1:observe-1", tool_name="observe_world", tool_call_id="observe-1"),
-        {},
-    )
-    terminal = terminate.handler(
-        _invocation("dsh:session-1:terminate-1", tool_name="terminate", tool_call_id="terminate-1"),
-        {"value": 1},
-    )
-    after_terminal = act.handler(
-        _invocation("dsh:session-1:act-2", tool_name="act", tool_call_id="act-2"),
-        {"value": 2},
-    )
+    observe.handler(_invocation("observe-1", tool_name=WORLD_OBSERVE_TOOL_NAME), {})
+    host.decision_generation += 1
+    stale = act.handler(_invocation("stale-action", tool_name="act"), {"value": 1})
+    blocked = act.handler(_invocation("blocked-action", tool_name="act"), {"value": 2})
+    refreshed = observe.handler(_invocation("observe-2", tool_name=WORLD_OBSERVE_TOOL_NAME), {})
+    accepted = act.handler(_invocation("accepted-action", tool_name="act"), {"value": 3})
 
-    assert observation.result == {"decision_id": "decision-0", "view": {"calls": 0}}
-    assert terminal.disposition is NativeToolDisposition.CONCLUDE_TURN
-    assert isinstance(terminal.result, dict)
-    assert terminal.result["terminated"] is True
-    assert after_terminal.disposition is NativeToolDisposition.CONCLUDE_TURN
-    assert after_terminal.result == {
-        "status": "error",
-        "error": {
-            "code": "episode-closed",
-            "detail": "The world episode is closed.",
-            "outcome": "not-dispatched",
-            "action_sequence": None,
-        },
-    }
-    assert len(host.calls) == 1
+    assert _error_code(stale.result) == "decision-stale"
+    assert _error_code(blocked.result) == "world-observation-required"
+    assert refreshed.result == {"decision_id": "decision-1-0", "view": {"calls": 0}}
+    assert isinstance(accepted.result, dict)
+    assert accepted.result["status"] == "accepted"
+    assert [request.request_id for request in host.calls] == ["accepted-action"]
     assert authority.close().complete is True
+
+
+def test_unknown_outcome_freezes_new_native_calls_and_requires_exact_reconciliation(tmp_path: Path) -> None:
+    host = _WorldHost()
+    authority, definitions = _definitions(tmp_path, host)
+    observe = definitions[WORLD_OBSERVE_TOOL_NAME]
+    act = definitions["act"]
+
+    observe.handler(_invocation("observe-1", tool_name=WORLD_OBSERVE_TOOL_NAME), {})
+    host.unknown_outcome = True
+    invocation = _invocation("unknown-action", tool_name="act")
+    unknown = act.handler(invocation, {"value": 1})
+    blocked_action = act.handler(_invocation("new-action", tool_name="act"), {"value": 2})
+    blocked_observe = observe.handler(_invocation("observe-2", tool_name=WORLD_OBSERVE_TOOL_NAME), {})
+    exact_retry = act.handler(invocation, {"value": 1})
+
+    for response in (unknown, blocked_action, blocked_observe, exact_retry):
+        assert _error_code(response.result) in {
+            "actor-invocation-outcome-unknown",
+            "world-action-outcome-unknown",
+        }
+        assert response.disposition is NativeToolDisposition.CONCLUDE_TURN
+    assert authority.world_action_count == 1
+    assert authority.close().complete is False

--- a/tests/harness/test_pump_station_harbor.py
+++ b/tests/harness/test_pump_station_harbor.py
@@ -14,6 +14,7 @@ import pytest
 from harbor.models.trial.config import TrialConfig  # type: ignore[import-untyped]
 
 from aec_bench.adapters.base import AdapterRequest, AdapterResult
+from aec_bench.adapters.deepseek_harness.native_world_tools import WORLD_OBSERVE_TOOL_NAME
 from aec_bench.adapters.deepseek_harness.tool_gateway import (
     NativeCancellation,
     NativeToolInvocation,
@@ -45,6 +46,7 @@ from aec_bench.worlds.stewardship.wastewater_pump_station.continual_definition i
 )
 from aec_bench.worlds.stewardship.wastewater_pump_station.episode_runtime import (
     PUMP_STATION_TASK_WORLD_ID,
+    PumpStationEpisodeHost,
 )
 from aec_bench.worlds.stewardship.wastewater_pump_station.reference_controller import (
     PUMP_STATION_REFERENCE_SYSTEM_CONTROLLER_ID,
@@ -206,8 +208,8 @@ def test_deepseek_model_session_receives_only_actor_tools_and_token_limits(tmp_p
 
         def execute(self, request: AdapterRequest) -> AdapterResult:
             captured["request"] = request
-            observation = self._definitions["observe_pump_station"].handler(
-                _native_invocation("dsh:session-1:observe-1", "observe_pump_station"),
+            observation = self._definitions[WORLD_OBSERVE_TOOL_NAME].handler(
+                _native_invocation("dsh:session-1:observe-1", WORLD_OBSERVE_TOOL_NAME),
                 {},
             )
             captured["observation"] = observation.result
@@ -247,18 +249,18 @@ def test_deepseek_model_session_receives_only_actor_tools_and_token_limits(tmp_p
     assert isinstance(builder, dict)
     assert builder["adapter_kind"] == "deepseek_harness"
     assert builder["enable_bash"] is False
-    native_tools = builder["native_tools"]
-    assert isinstance(native_tools, tuple)
-    assert tuple(tool.__name__ for tool in native_tools) == (
-        "observe_pump_station",
-        *PUMP_STATION_ACTOR_ACTION_NAMES,
-    )
+    assert builder["native_tools"] is None
     native_tool_definitions = builder["native_tool_definitions"]
     assert isinstance(native_tool_definitions, tuple)
     assert tuple(definition.name for definition in native_tool_definitions) == (
-        "observe_pump_station",
-        *PUMP_STATION_ACTOR_ACTION_NAMES,
+        WORLD_OBSERVE_TOOL_NAME,
+        *sorted(PUMP_STATION_ACTOR_ACTION_NAMES),
     )
+    catalogue = PumpStationEpisodeHost(tmp_path / "catalogue-host").capabilities()
+    catalogue_schemas = {action.name: action.input_schema for action in catalogue.actions}
+    assert {
+        definition.name: definition.parameters_schema for definition in native_tool_definitions[1:]
+    } == catalogue_schemas
     assert all("request_id" not in definition.parameters_schema["properties"] for definition in native_tool_definitions)
     assert all(
         definition.request_semantics is NativeToolRequestSemantics.HANDLER_AUTHORITY
@@ -275,18 +277,98 @@ def test_deepseek_model_session_receives_only_actor_tools_and_token_limits(tmp_p
     assert evidence["limits"] == {"max_tokens": 4096, "timeout_sec": 600}
     inventory = json.loads((completed.output_dir / "artifact-inventory.json").read_text(encoding="utf-8"))
     assert inventory["controller_id"] == "gpt-4.1-mini-standard"
-    assert "actor-invocation-evidence.jsonl" in {artifact["path"] for artifact in inventory["artifacts"]}
+    inventory_paths = {artifact["path"] for artifact in inventory["artifacts"]}
+    assert "actor-invocation-evidence.jsonl" in inventory_paths
+    assert "native-world-tool-surface.json" in inventory_paths
     authority_record = completed.adapter_result.configuration_record["actor_invocation_authority"]
     assert authority_record["actor_principal_id"] == "actor.deepseek-world"
     assert authority_record["max_world_actions"] == 90
     assert authority_record["world_action_count"] == 0
     assert authority_record["close"]["complete"] is True
+    surface_record = json.loads((completed.output_dir / "native-world-tool-surface.json").read_text(encoding="utf-8"))
+    assert surface_record["catalogue_sha256"] == authority_record["catalogue_sha256"]
+    assert surface_record["action_mapping"] == [
+        {"catalogue_action": action_name, "public_tool": action_name}
+        for action_name in sorted(PUMP_STATION_ACTOR_ACTION_NAMES)
+    ]
+    assert completed.adapter_result.configuration_record["native_world_tools"] == {
+        "catalogue_sha256": surface_record["catalogue_sha256"],
+        "public_tool_surface_sha256": surface_record["public_tool_surface_sha256"],
+        "evidence_path": "native-world-tool-surface.json",
+        "presentation_mode": "deepseek-native",
+    }
     actor_evidence = [
         json.loads(line)
         for line in (completed.output_dir / "actor-invocation-evidence.jsonl").read_text(encoding="utf-8").splitlines()
     ]
-    assert [record["record_type"] for record in actor_evidence] == ["header", "observe", "close"]
+    assert [record["record_type"] for record in actor_evidence] == [
+        "header",
+        "capabilities",
+        "capabilities",
+        "observe",
+        "close",
+    ]
     assert "Do not stop only because one action was accepted" in request.instruction
+
+
+def test_tool_loop_model_session_uses_catalogue_compiled_pydantic_tools(tmp_path: Path) -> None:
+    exported = export_pump_station_harbor_task(
+        tmp_path / "task",
+        project_root=PROJECT_ROOT,
+        profile_ref=pump_station_continual_world_definition().profiles[0],
+    )
+    bridge = load_pump_station_harbor_bridge(exported.task_dir / "environment")
+    captured: dict[str, object] = {}
+
+    class FakeAdapter:
+        def execute(self, request: AdapterRequest) -> AdapterResult:
+            captured["request"] = request
+            return AdapterResult(
+                adapter_name="tool_loop",
+                resolved_model="gpt-4.1-mini-standard",
+                configuration_record=dict(request.configuration),
+                agent_output=AgentOutput(
+                    status=AgentOutputStatus.COMPLETED,
+                    output_path=request.output_path,
+                    output_format=request.output_format,
+                ),
+                transcript=[],
+                turns_used=1,
+                raw_output_text="Observed no action requirement.",
+                usage_model_calls=1,
+            )
+
+    def build_adapter(**kwargs: object) -> FakeAdapter:
+        captured["builder"] = kwargs
+        return FakeAdapter()
+
+    run_pump_station_model_session(
+        bridge=bridge,
+        output_dir=tmp_path / "world-session",
+        session_identity="tool-loop-world",
+        model="azure:gpt-4.1-mini-standard",
+        adapter_kind="tool_loop",
+        max_turns=4,
+        adapter_builder=build_adapter,
+    )
+
+    builder = captured["builder"]
+    assert isinstance(builder, dict)
+    assert builder["native_tool_definitions"] is None
+    native_tools = builder["native_tools"]
+    assert isinstance(native_tools, tuple)
+    assert tuple(tool.name for tool in native_tools) == (
+        WORLD_OBSERVE_TOOL_NAME,
+        *sorted(PUMP_STATION_ACTOR_ACTION_NAMES),
+    )
+    catalogue = PumpStationEpisodeHost(tmp_path / "catalogue-host").capabilities()
+    assert {tool.name: tool.function_schema.json_schema for tool in native_tools[1:]} == {
+        action.name: action.input_schema for action in catalogue.actions
+    }
+    assert all("request_id" not in tool.function_schema.json_schema.get("properties", {}) for tool in native_tools)
+    request = captured["request"]
+    assert isinstance(request, AdapterRequest)
+    assert request.configuration == {"max_turns": 4}
 
 
 def test_model_journey_shares_actor_authority_across_segments_and_stops_at_budget(tmp_path: Path) -> None:
@@ -305,6 +387,10 @@ def test_model_journey_shares_actor_authority_across_segments_and_stops_at_budge
 
         def execute(self, request: AdapterRequest) -> AdapterResult:
             if self._segment_index == 0:
+                observation = self._definitions[WORLD_OBSERVE_TOOL_NAME].handler(
+                    _native_invocation("dsh:session-1:observe-before-actions", WORLD_OBSERVE_TOOL_NAME),
+                    {},
+                )
                 verification = self._definitions["request_post_maintenance_verification"].handler(
                     _native_invocation("dsh:session-1:verification-a", "request_post_maintenance_verification"),
                     {
@@ -317,6 +403,7 @@ def test_model_journey_shares_actor_authority_across_segments_and_stops_at_budge
                     _native_invocation("dsh:session-1:continue-to-verification", "continue_operation"),
                     {"reason": "Advance to the next declared decision event."},
                 )
+                assert isinstance(observation.result, dict)
                 assert isinstance(verification.result, dict)
                 assert isinstance(continued.result, dict)
                 assert verification.result["status"] == "applied"

--- a/tests/harness/world_actor/test_provider_conformance.py
+++ b/tests/harness/world_actor/test_provider_conformance.py
@@ -1,0 +1,349 @@
+# ABOUTME: Runs one deterministic actor script through Prime and DeepSeek world transports.
+# ABOUTME: Proves provider changes do not change catalogue, cursor, replay, receipt, or terminal semantics.
+
+from __future__ import annotations
+
+import json
+import socket
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, cast
+
+from aec_bench.adapters.deepseek_harness.native_world_tools import (
+    WORLD_OBSERVE_TOOL_NAME,
+    compile_world_native_tools,
+)
+from aec_bench.adapters.deepseek_harness.tool_gateway import (
+    NativeCancellation,
+    NativeToolDefinition,
+    NativeToolDisposition,
+    NativeToolInvocation,
+)
+from aec_bench.contracts.world_interface import (
+    WorldActorActionCapability,
+    WorldActorActionRequest,
+    WorldActorActionResult,
+    WorldActorCapabilityCatalogue,
+    WorldActorObservation,
+    WorldInterfaceError,
+)
+from aec_bench.harness.world_actor import (
+    WORLD_ACTOR_CAPABILITY_ENV,
+    WORLD_ACTOR_PROTOCOL,
+    WORLD_ACTOR_SOCKET_ENV,
+    ActorInvocationAuthority,
+    ActorInvocationAuthorityConfig,
+    WorldActorEndpoint,
+    actor_catalogue_sha256,
+)
+
+
+class _ConformanceHost:
+    def __init__(self) -> None:
+        self.catalogue = WorldActorCapabilityCatalogue(
+            task_world_id="provider-conformance-world",
+            actions=(
+                WorldActorActionCapability(
+                    name="terminate",
+                    description="Finish the deterministic episode.",
+                    input_schema={
+                        "type": "object",
+                        "properties": {"reason": {"type": "string"}},
+                        "required": ["reason"],
+                        "additionalProperties": False,
+                    },
+                ),
+                WorldActorActionCapability(
+                    name="act",
+                    description="Apply one deterministic value.",
+                    input_schema={
+                        "type": "object",
+                        "properties": {"value": {"type": "integer"}},
+                        "required": ["value"],
+                        "additionalProperties": False,
+                    },
+                ),
+            ),
+        )
+        self.decision_generation = 0
+        self.attempts: list[WorldActorActionRequest] = []
+        self.calls: list[WorldActorActionRequest] = []
+        self.terminated = False
+
+    def capabilities(self) -> WorldActorCapabilityCatalogue:
+        return self.catalogue
+
+    def observe(self) -> WorldActorObservation:
+        return WorldActorObservation(
+            decision_id=f"decision-{self.decision_generation}-{len(self.calls)}",
+            view={"accepted_actions": len(self.calls), "terminated": self.terminated},
+        )
+
+    def advance_decision(self) -> None:
+        self.decision_generation += 1
+
+    def invoke(self, request: WorldActorActionRequest) -> WorldActorActionResult:
+        self.attempts.append(request)
+        if request.decision_id != self.observe().decision_id:
+            raise WorldInterfaceError("decision-stale", "The decision is stale.")
+        self.calls.append(request)
+        self.terminated = request.action_name == "terminate"
+        return WorldActorActionResult(
+            request_id=request.request_id,
+            action_name=request.action_name,
+            status="applied",
+            task_receipt={"receipt_id": f"receipt-{len(self.calls)}"},
+            next_observation=None if self.terminated else self.observe(),
+            terminated=self.terminated,
+        )
+
+    def verify(self) -> dict[str, Any]:
+        return {
+            "valid": self.terminated and [call.action_name for call in self.calls] == ["act", "terminate"],
+            "receipts": [f"receipt-{index}" for index in range(1, len(self.calls) + 1)],
+        }
+
+
+def _authority(tmp_path: Path, host: _ConformanceHost, name: str) -> ActorInvocationAuthority:
+    return ActorInvocationAuthority(
+        host=host,
+        config=ActorInvocationAuthorityConfig(
+            authority_id="provider-conformance-authority",
+            actor_principal_id="provider-conformance-actor",
+            max_world_actions=8,
+            evidence_path=tmp_path / name / "actor-authority.jsonl",
+        ),
+    )
+
+
+def _prime_call(environment: dict[str, str], request: dict[str, Any], sequence: int) -> dict[str, Any]:
+    payload = {
+        "protocol": WORLD_ACTOR_PROTOCOL,
+        "transport_request_id": f"prime-transport-{sequence}",
+        "capability": environment[WORLD_ACTOR_CAPABILITY_ENV],
+        "request": request,
+    }
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+        client.settimeout(3)
+        client.connect(environment[WORLD_ACTOR_SOCKET_ENV])
+        client.sendall(json.dumps(payload).encode("utf-8") + b"\n")
+        response = client.makefile("rb").readline()
+    return cast(dict[str, Any], json.loads(response))
+
+
+def _invocation(request_id: str, tool_name: str) -> NativeToolInvocation:
+    return NativeToolInvocation(
+        request_id=request_id,
+        deepseek_session_id="deepseek-conformance-session",
+        deepseek_tool_call_id=request_id,
+        model_turn=1,
+        tool_name=tool_name,
+        generation_id="deepseek-conformance-generation",
+        admitted_at=datetime.now(UTC),
+        cancellation=NativeCancellation(),
+    )
+
+
+def _prime_script(tmp_path: Path) -> dict[str, Any]:
+    host = _ConformanceHost()
+    authority = _authority(tmp_path, host, "prime")
+    endpoint = WorldActorEndpoint(
+        authority=authority,
+        socket_directory=tmp_path / "prime" / "socket",
+        evidence_file=tmp_path / "prime" / "actor-transport.jsonl",
+    )
+    with endpoint:
+        environment = endpoint.connection_environment()
+        catalogue = _prime_call(environment, {"operation": "capabilities"}, 1)["result"]
+        first_observation = _prime_call(environment, {"operation": "observe"}, 2)["result"]
+        host.advance_decision()
+        stale = _prime_call(
+            environment,
+            {
+                "operation": "invoke",
+                "request_id": "stale-1",
+                "decision_id": first_observation["decision_id"],
+                "action_name": "act",
+                "arguments": {"value": 0},
+            },
+            3,
+        )
+        fresh_observation = _prime_call(environment, {"operation": "observe"}, 4)["result"]
+        action_request = {
+            "operation": "invoke",
+            "request_id": "action-1",
+            "decision_id": fresh_observation["decision_id"],
+            "action_name": "act",
+            "arguments": {"value": 1},
+        }
+        accepted = _prime_call(environment, action_request, 5)["result"]
+        duplicate = _prime_call(environment, action_request, 6)["result"]
+        conflict = _prime_call(
+            environment,
+            {**action_request, "arguments": {"value": 2}},
+            7,
+        )
+        terminal = _prime_call(
+            environment,
+            {
+                "operation": "invoke",
+                "request_id": "terminal-1",
+                "decision_id": accepted["next_observation"]["decision_id"],
+                "action_name": "terminate",
+                "arguments": {"reason": "Complete conformance script."},
+            },
+            8,
+        )["result"]
+    return _script_result(
+        catalogue=catalogue,
+        first_observation=first_observation,
+        stale=stale["error"],
+        fresh_observation=fresh_observation,
+        accepted=accepted,
+        duplicate=duplicate,
+        conflict=conflict["error"],
+        terminal=terminal,
+        host=host,
+        authority=authority,
+        evidence_path=authority.config.evidence_path,
+    )
+
+
+def _deepseek_script(tmp_path: Path) -> dict[str, Any]:
+    host = _ConformanceHost()
+    authority = _authority(tmp_path, host, "deepseek")
+    authority.start()
+    definitions = {
+        definition.name: definition
+        for definition in compile_world_native_tools(authority=authority, catalogue=host.catalogue)
+    }
+    first_observation = _native_result(definitions[WORLD_OBSERVE_TOOL_NAME], "observe-1", {})
+    host.advance_decision()
+    stale = _native_result(definitions["act"], "stale-1", {"value": 0})
+    fresh_observation = _native_result(definitions[WORLD_OBSERVE_TOOL_NAME], "observe-2", {})
+    accepted = _native_result(definitions["act"], "action-1", {"value": 1})
+    duplicate = _native_result(definitions["act"], "action-1", {"value": 1})
+    conflict = _native_result(definitions["act"], "action-1", {"value": 2})
+    terminal_response = definitions["terminate"].handler(
+        _invocation("terminal-1", "terminate"),
+        {"reason": "Complete conformance script."},
+    )
+    assert terminal_response.disposition is NativeToolDisposition.CONCLUDE_TURN
+    terminal = cast(dict[str, Any], terminal_response.result)
+    assert authority.close().complete is True
+    return _script_result(
+        catalogue=host.catalogue.model_dump(mode="json"),
+        first_observation=first_observation,
+        stale=stale["error"],
+        fresh_observation=fresh_observation,
+        accepted=accepted,
+        duplicate=duplicate,
+        conflict=conflict["error"],
+        terminal=terminal,
+        host=host,
+        authority=authority,
+        evidence_path=authority.config.evidence_path,
+    )
+
+
+def _native_result(definition: NativeToolDefinition, request_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    response = definition.handler(_invocation(request_id, definition.name), arguments)
+    return cast(dict[str, Any], response.result)
+
+
+def _script_result(
+    *,
+    catalogue: dict[str, Any],
+    first_observation: dict[str, Any],
+    stale: dict[str, Any],
+    fresh_observation: dict[str, Any],
+    accepted: dict[str, Any],
+    duplicate: dict[str, Any],
+    conflict: dict[str, Any],
+    terminal: dict[str, Any],
+    host: _ConformanceHost,
+    authority: ActorInvocationAuthority,
+    evidence_path: Path,
+) -> dict[str, Any]:
+    return {
+        "catalogue_sha256": actor_catalogue_sha256(WorldActorCapabilityCatalogue.model_validate(catalogue)),
+        "first_observation": first_observation,
+        "stale": {"code": stale["code"], "outcome": stale["outcome"]},
+        "fresh_observation": fresh_observation,
+        "accepted": accepted,
+        "duplicate": duplicate,
+        "conflict": {"code": conflict["code"], "outcome": conflict["outcome"]},
+        "terminal": terminal,
+        "attempts": [request.model_dump(mode="json") for request in host.attempts],
+        "calls": [request.model_dump(mode="json") for request in host.calls],
+        "world_action_count": authority.world_action_count,
+        "terminal_latched": authority.terminal,
+        "verification": host.verify(),
+        "authority_evidence": _semantic_evidence(evidence_path),
+    }
+
+
+def _semantic_evidence(path: Path) -> list[dict[str, Any]]:
+    excluded = {
+        "admitted_at",
+        "closed_at",
+        "completed_at",
+        "correlation",
+        "dispatched_at",
+        "observed_at",
+        "occurred_at",
+        "started_at",
+        "transport",
+    }
+    return [
+        {key: value for key, value in json.loads(line).items() if key not in excluded}
+        for line in path.read_text(encoding="utf-8").splitlines()
+    ]
+
+
+def test_prime_and_deepseek_share_one_world_action_contract(tmp_path: Path) -> None:
+    prime = _prime_script(tmp_path)
+    deepseek = _deepseek_script(tmp_path)
+
+    assert deepseek == prime
+    assert deepseek["stale"] == {"code": "decision-stale", "outcome": "completed"}
+    assert deepseek["conflict"] == {"code": "request-id-conflict", "outcome": "not-dispatched"}
+    assert [attempt["request_id"] for attempt in deepseek["attempts"]] == ["stale-1", "action-1", "terminal-1"]
+    assert deepseek["accepted"] == deepseek["duplicate"]
+    assert deepseek["world_action_count"] == 3
+    assert deepseek["terminal_latched"] is True
+    assert deepseek["verification"]["valid"] is True
+    deepseek_evidence = [
+        json.loads(line)
+        for line in (tmp_path / "deepseek" / "actor-authority.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    deepseek_action = next(
+        record
+        for record in deepseek_evidence
+        if record["record_type"] == "request-admitted" and record["request_id"] == "action-1"
+    )
+    deepseek_completion = next(
+        record
+        for record in deepseek_evidence
+        if record["record_type"] == "completion" and record["request_id"] == "action-1"
+    )
+    assert deepseek_action["transport"] == "deepseek-native-world"
+    assert deepseek_action["correlation"] == {
+        "transport_request_id": "action-1",
+        "provider_session_id": "deepseek-conformance-session",
+        "provider_tool_call_id": "action-1",
+        "model_turn": 1,
+    }
+    assert deepseek_completion["task_receipt_identity"] == "receipt-1"
+    assert len(deepseek_completion["task_receipt_sha256"]) == 64
+    prime_evidence = [
+        json.loads(line)
+        for line in (tmp_path / "prime" / "actor-authority.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    prime_action = next(
+        record
+        for record in prime_evidence
+        if record["record_type"] == "request-admitted" and record["request_id"] == "action-1"
+    )
+    assert prime_action["transport"] == "world-actor-endpoint"
+    assert prime_action["correlation"]["transport_request_id"] == "prime-transport-5"

--- a/tests/harness/world_actor/test_provider_conformance.py
+++ b/tests/harness/world_actor/test_provider_conformance.py
@@ -146,6 +146,7 @@ def _invocation(request_id: str, tool_name: str) -> NativeToolInvocation:
 
 def _prime_script(tmp_path: Path) -> dict[str, Any]:
     host = _ConformanceHost()
+    (tmp_path / "prime").mkdir()
     authority = _authority(tmp_path, host, "prime")
     endpoint = WorldActorEndpoint(
         authority=authority,

--- a/tests/harness/world_actor/test_pump_station_gateway.py
+++ b/tests/harness/world_actor/test_pump_station_gateway.py
@@ -8,7 +8,10 @@ import socket
 from pathlib import Path
 from typing import Any
 
-from aec_bench.adapters.deepseek_harness.native_world_tools import NativeWorldToolTransport
+from aec_bench.adapters.deepseek_harness.native_world_tools import (
+    WORLD_OBSERVE_TOOL_NAME,
+    compile_world_native_tools,
+)
 from aec_bench.adapters.deepseek_harness.tool_gateway import (
     TOOL_GATEWAY_PROTOCOL,
     TOOL_GATEWAY_SOCKET_ENV,
@@ -56,21 +59,10 @@ def test_socket_gateway_dispatches_one_exactly_replayed_action_to_real_pump_host
         ),
     )
     authority.start()
-    native_transport = NativeWorldToolTransport(authority)
+    native_tools = compile_world_native_tools(authority=authority, catalogue=host.capabilities())
     gateway_evidence_path = tmp_path / "tool-gateway-evidence.jsonl"
     endpoint = ToolGatewayEndpoint(
-        tools=(
-            native_transport.action_definition(
-                name="continue_operation",
-                description="Continue to the next declared decision event.",
-                parameters_schema={
-                    "type": "object",
-                    "properties": {"reason": {"type": "string"}},
-                    "required": ["reason"],
-                    "additionalProperties": False,
-                },
-            ),
-        ),
+        tools=native_tools,
         evidence_path=gateway_evidence_path,
         capability_token="gateway-private-capability",
         generation_id="gateway-generation",
@@ -90,12 +82,28 @@ def test_socket_gateway_dispatches_one_exactly_replayed_action_to_real_pump_host
         },
     }
     try:
+        observed = _exchange(
+            connection[TOOL_GATEWAY_SOCKET_ENV],
+            {
+                "protocol": TOOL_GATEWAY_PROTOCOL,
+                "capability": connection[TOOL_GATEWAY_TOKEN_ENV],
+                "operation": "invoke",
+                "tool": WORLD_OBSERVE_TOOL_NAME,
+                "arguments": {},
+                "metadata": {
+                    "deepseek_session_id": "pump-e2e",
+                    "deepseek_tool_call_id": "observe-1",
+                    "aec_model_turn": 1,
+                },
+            },
+        )
         first = _exchange(connection[TOOL_GATEWAY_SOCKET_ENV], payload)
         replay = _exchange(connection[TOOL_GATEWAY_SOCKET_ENV], payload)
     finally:
         gateway_close = endpoint.close()
         authority_close = authority.close()
 
+    assert observed["status"] == "ok"
     assert first == replay
     assert first["status"] == "ok"
     assert first["result"]["request_id"] == "dsh:pump-e2e:continue-1"
@@ -113,7 +121,7 @@ def test_socket_gateway_dispatches_one_exactly_replayed_action_to_real_pump_host
     assert len([record for record in actor_evidence if record["record_type"] == "request-duplicate"]) == 1
     gateway_evidence = _evidence(gateway_evidence_path)
     invocations = [record for record in gateway_evidence if record["record_type"] == "invocation"]
-    assert len(invocations) == 2
+    assert len(invocations) == 3
     assert {record["request_semantics"] for record in invocations} == {"handler-authority"}
     assert "gateway-private-capability" not in json.dumps([*actor_evidence, *gateway_evidence])
 


### PR DESCRIPTION
## Summary

- compile the frozen actor catalogue into exact DeepSeek native tools and reserve world_observe
- keep request identity and the decision cursor outside model arguments
- remove the handwritten pump-station action wrappers and retain catalogue and tool-surface hashes
- add deterministic Prime and DeepSeek actor-boundary conformance coverage
- document the supported schema and provider-composition contracts

## Verification

- uv run pytest tests/deepseek_harness/test_native_world_tools.py tests/harness/world_actor/test_provider_conformance.py -q
- uv run pytest tests/harness/world_actor/test_authority.py -q
- targeted pump-station and PydanticAI integration tests: 6 passed
- keyless DeepSeek SDK and runtime composition tests: 2 passed
- targeted Ruff check and format
- targeted mypy: no issues
- git diff --check