### PR TITLE
Add DeepSeek evidence and qualification completion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,3 +205,56 @@ jobs:
           tests/harness/pump_station_prime/test_session.py
           tests/harness/pump_station_prime/test_journey.py
           tests/worlds/stewardship/wastewater_pump_station/test_host_continuation.py
+
+  deepseek-release-qualification:
+    name: DeepSeek release qualification
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.13.2
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13.2"
+
+      - name: Set up Node.js 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: src/aec_bench/adapters/deepseek_harness/plugin/package-lock.json
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Install all-extras dependency profile
+        run: uv sync --frozen --all-extras
+
+      - name: Collect the complete Python suite
+        run: uv run pytest --collect-only -q tests/
+
+      - name: Run focused DeepSeek qualification gates
+        run: >-
+          uv run pytest -q
+          tests/deepseek_harness/
+          tests/harness/world_actor/test_provider_conformance.py
+          tests/harness/test_pump_station_harbor.py
+
+      - name: Install the locked DeepSeek plugin toolchain
+        working-directory: src/aec_bench/adapters/deepseek_harness/plugin
+        run: npm ci
+
+      - name: Test the DeepSeek plugins
+        working-directory: src/aec_bench/adapters/deepseek_harness/plugin
+        run: npm test
+
+      - name: Rebuild the DeepSeek plugins
+        working-directory: src/aec_bench/adapters/deepseek_harness/plugin
+        run: npm run build
+
+      - name: Verify reproducible plugin artifacts
+        run: git diff --exit-code -- src/aec_bench/adapters/deepseek_harness/plugin/dist/

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -248,13 +248,29 @@ The current public Harness hooks cannot both stop these operations at the exact
 boundary and retain a typed budget terminal reason. These limits remain
 unsupported until that full contract can be enforced and recorded.
 
-Each DeepSeek trial writes one validated evidence manifest. The manifest keeps
-the adapter, model, installed SDK and runtime versions, limits, execution
-status, composition modes, optional plugins, and redaction actions readable.
-Each retained artifact has one SHA-256 entry in that manifest. Summary fields
-do not duplicate artifact hashes. `RuntimeExecutionAttestation` binds the
-manifest SHA-256 when the adapter provides one; attestations from other
-adapters keep their existing shape.
+Each DeepSeek trial writes one `aec-bench/deepseek-evidence/2` manifest. The
+manifest keeps the adapter, model, exact installed SDK and runtime versions,
+AEC source revision status, limits, execution status, composition modes,
+optional plugins, qualification reference, and redaction actions readable.
+Each retained artifact has one SHA-256 entry. An attestation or qualification
+reference repeats the path and hash so that its claim is content-bound.
+`RuntimeExecutionAttestation` binds the manifest SHA-256 when the adapter
+provides one. Attestations from other adapters keep their existing shape.
+
+The manifest has three composition attestation levels:
+
+- `declared` identifies the exact AEC composition, Cordis input, and system
+  prompt that AEC supplied before launch;
+- `resolved_runtime` identifies the composition that the active DeepSeek
+  runtime resolved;
+- `model_visible` identifies the complete prompt, history, tool, parameter,
+  and dynamic context surface for model requests.
+
+Each level is `complete`, `partial`, or `unavailable`. A `complete` level must
+reference retained artifacts. An `unavailable` level must give a reason and
+must not reference inferred artifacts. Unknown future fields survive manifest
+read and write. The importer does not accept the superseded internal v1
+manifest as v2.
 
 The model identifier must use `provider:model`. `azure:` requires
 `AZURE_OPENAI_API_KEY` and `AZURE_OPENAI_ENDPOINT`; the runtime normalizes the
@@ -274,17 +290,37 @@ credential-free provider endpoint, not secret values. Redaction changes only
 owned runtime evidence. Its audit records file paths, categories, and
 replacement counts. It does not change the candidate output.
 
-The qualified DeepSeek compatibility conditions are:
+The package owns one versioned provider and feature matrix at
+`src/aec_bench/adapters/deepseek_harness/profiles/qualification-matrix.json`.
+Each row records the AEC revision, SDK version, runtime version, provider route,
+qualification date, and the evidence or reason for each feature cell. Keyless
+protocol proof and credentialed live-provider proof are different cells. A
+provider route is `qualified` only when every required cell passed for the
+exact version set. A trial with a different or unavailable source revision is
+`unqualified`, even when its protocol tests passed.
 
-| Treatment | AEC identity | DeepSeek identity | Optional plugin | Qualification proof |
-| --- | --- | --- | --- | --- |
-| Baseline | Installed AEC package version in the manifest | Exact SDK pin from `pyproject.toml`; worker requires the runtime distribution to match | None | Keyless real-composition suite |
-| Native tool gateway | Same | Same | `@aec-bench/dsh-tools` protocol v2 with exact `NativeToolDefinition` names and JSON schemas | Authenticated endpoint tests plus lifecycle and pump-world boundary tests |
-| Explicit output commit | Same | Same | Named, versioned build copied into the trial evidence | Keyless rejection, repair, acceptance, and stability suite |
+The initial matrix records both the Azure and official DeepSeek routes as
+`partial`. It does not claim retained live-provider evidence. Release owners
+must add content-addressed live evidence before they change either route to
+`qualified`.
 
-The manifest states that resolved composition and resolved tool-surface dumps
-are unavailable. The pinned SDK path does not expose them. The adapter retains
-the exact Cordis input and does not claim stronger evidence.
+The pinned SDK path does not expose a canonical resolved composition or the
+complete model-visible request surface. The manifest records both levels as
+`unavailable` with a reason. The exact Cordis input, system prompt, AEC native
+tool manifest, plugin build, and plugin package lock remain declared evidence.
+They do not become resolved-runtime or model-visible evidence.
+
+The supported dependency profiles are:
+
+| Profile | Installation | Required check |
+| --- | --- | --- |
+| `core` | `uv sync --frozen` | Public CLI, optional-boundary, and core lint gates |
+| `all-adapters` | `uv sync --frozen --extra execution --extra deepseek-harness --extra morph --extra local-agents --extra prime --extra prime-agent` | Adapter suites collect and run without undeclared imports |
+| `all-extras` | `uv sync --frozen --all-extras` | `uv run pytest --collect-only -q tests/` has no collection errors |
+| `release-qualification` | `all-extras` plus the locked DeepSeek Node toolchain | Focused DeepSeek, actor-conformance, pump-world, plugin test, and reproducible plugin-build gates pass |
+
+The release CI job implements the last two rows. It does not use provider
+credentials and cannot satisfy a live-provider matrix cell.
 
 For native-tool runs, the manifest records the exact tool names and copied
 plugin artifact. Generic tools supply an explicit `NativeToolDefinition`.
@@ -354,8 +390,13 @@ dispatch semantics at the actor boundary.
 A DeepSeek native world trial also retains
 `native-world-tool-surface.json`. This record contains the complete canonical
 catalogue, the action-to-public-tool mapping, the exact model-facing tool
-manifest, the catalogue SHA-256, and the public tool-surface SHA-256. The
-treatment record identifies the presentation mode as `deepseek-native`.
+manifest, the catalogue SHA-256, and the public tool-surface SHA-256. Each
+segment manifest also binds a `segment-snapshot` of
+`actor-invocation-evidence.jsonl` and `actor-correlation.jsonl`. The
+correlation artifact maps DeepSeek session and tool-call identities to the
+matching actor evidence sequences. The complete session-owned actor stream is
+final only after the shared authority closes. The treatment record identifies
+the presentation mode as `deepseek-native`.
 Deterministic conformance tests run the same stale, accepted, duplicate,
 conflict, and terminal script through `WorldActorEndpoint` and the compiled
 DeepSeek tools. They compare shared authority and world semantics, not

--- a/src/aec_bench/adapters/deepseek_harness/adapter.py
+++ b/src/aec_bench/adapters/deepseek_harness/adapter.py
@@ -25,6 +25,7 @@ from aec_bench.adapters.deepseek_harness.config import (
     treatment_record,
     validate_deepseek_request,
 )
+from aec_bench.adapters.deepseek_harness.native_world_tools import DeepSeekNativeWorldEvidence
 from aec_bench.adapters.deepseek_harness.runtime import (
     DeepSeekHarnessProcessRuntime,
     DeepSeekHarnessRun,
@@ -46,6 +47,7 @@ class DeepSeekHarnessAdapter:
         workspace: str | Path,
         runtime: DeepSeekRuntime | None = None,
         native_tools: Sequence[NativeToolDefinition] | None = None,
+        native_world_evidence: DeepSeekNativeWorldEvidence | None = None,
         adapter_name: str = "deepseek_harness",
     ) -> None:
         self._settings = settings
@@ -55,6 +57,7 @@ class DeepSeekHarnessAdapter:
             settings=settings,
             workspace=self._workspace,
             native_tools=native_tools,
+            native_world_evidence=native_world_evidence,
         )
         self._adapter_name = adapter_name
 

--- a/src/aec_bench/adapters/deepseek_harness/evidence.py
+++ b/src/aec_bench/adapters/deepseek_harness/evidence.py
@@ -11,10 +11,10 @@ from typing import Literal, Self
 from pydantic import Field, field_validator, model_validator
 
 from aec_bench.contracts.harness_kernel import validate_sha256
-from aec_bench.contracts.validators import NonEmptyStr, StrictModel
+from aec_bench.contracts.validators import LenientModel, NonEmptyStr, StrictModel
 
 
-class DeepSeekEvidenceArtifact(StrictModel):
+class DeepSeekEvidenceArtifact(LenientModel):
     role: NonEmptyStr
     path: NonEmptyStr
     sha256: str
@@ -34,13 +34,34 @@ class DeepSeekEvidenceArtifact(StrictModel):
         return validate_sha256(value)
 
 
-class DeepSeekPluginIdentity(StrictModel):
+class DeepSeekEvidenceReference(LenientModel):
+    path: NonEmptyStr
+    sha256: str
+
+    @field_validator("path")
+    @classmethod
+    def validate_relative_path(cls, value: str) -> str:
+        path = PurePosixPath(value)
+        if path.is_absolute() or ".." in path.parts:
+            raise ValueError("evidence reference path must stay relative to the trial evidence root")
+        return value
+
+    @field_validator("sha256")
+    @classmethod
+    def validate_reference_sha256(cls, value: str) -> str:
+        return validate_sha256(value)
+
+
+class DeepSeekPluginIdentity(LenientModel):
     plugin_id: NonEmptyStr
     version: NonEmptyStr
     role: Literal["output_commit", "native_tools"]
     artifact_path: NonEmptyStr
+    artifact_sha256: str
+    package_lock_path: NonEmptyStr
+    package_lock_sha256: str
 
-    @field_validator("artifact_path")
+    @field_validator("artifact_path", "package_lock_path")
     @classmethod
     def validate_artifact_path(cls, value: str) -> str:
         path = PurePosixPath(value)
@@ -48,16 +69,29 @@ class DeepSeekPluginIdentity(StrictModel):
             raise ValueError("plugin artifact path must stay relative to the trial evidence root")
         return value
 
+    @field_validator("artifact_sha256", "package_lock_sha256")
+    @classmethod
+    def validate_plugin_sha256(cls, value: str) -> str:
+        return validate_sha256(value)
 
-class DeepSeekAdapterIdentity(StrictModel):
+
+class DeepSeekAdapterIdentity(LenientModel):
     kind: Literal["deepseek_harness"] = "deepseek_harness"
     aec_bench_version: NonEmptyStr
+    aec_bench_revision: NonEmptyStr | None = None
+    aec_bench_revision_reason: NonEmptyStr | None = None
     python_sdk_version: NonEmptyStr
     runtime_distribution_version: NonEmptyStr
     runtime_reported_version: str | None = None
 
+    @model_validator(mode="after")
+    def validate_revision(self) -> Self:
+        if (self.aec_bench_revision is None) == (self.aec_bench_revision_reason is None):
+            raise ValueError("AEC identity requires either a source revision or an unavailable reason")
+        return self
 
-class DeepSeekCompositionIdentity(StrictModel):
+
+class DeepSeekCompositionIdentity(LenientModel):
     sandbox_mode: Literal["workspace-write"] = "workspace-write"
     sandbox_enforcement: Literal["partial"] = "partial"
     subagents_enabled: Literal[False] = False
@@ -65,8 +99,6 @@ class DeepSeekCompositionIdentity(StrictModel):
     code_mode_enabled: Literal[False] = False
     output_commit_mode: Literal["disabled", "required"]
     native_tools: tuple[NonEmptyStr, ...] = ()
-    resolved_composition_available: Literal[False] = False
-    resolved_tool_surface_available: Literal[False] = False
 
     @field_validator("native_tools")
     @classmethod
@@ -76,14 +108,14 @@ class DeepSeekCompositionIdentity(StrictModel):
         return value
 
 
-class DeepSeekModelIdentity(StrictModel):
+class DeepSeekModelIdentity(LenientModel):
     provider: Literal["azure", "deepseek"]
     harness_route: Literal["azure", "deepseek-official"]
     requested: NonEmptyStr
     resolved: NonEmptyStr
 
 
-class DeepSeekExecutionIdentity(StrictModel):
+class DeepSeekExecutionIdentity(LenientModel):
     status: Literal["completed", "failed"]
     root_session_id: str | None = None
     child_session_ids: tuple[str, ...] = ()
@@ -108,15 +140,74 @@ class DeepSeekExecutionIdentity(StrictModel):
         return self
 
 
-class DeepSeekEvidenceManifest(StrictModel):
-    schema_version: Literal["aecbench.deepseek-evidence-manifest.v1"] = "aecbench.deepseek-evidence-manifest.v1"
+class DeepSeekAttestationLevel(LenientModel):
+    status: Literal["complete", "partial", "unavailable"]
+    artifacts: tuple[DeepSeekEvidenceReference, ...] = ()
+    reason: NonEmptyStr | None = None
+
+    @model_validator(mode="after")
+    def validate_status(self) -> Self:
+        if self.status == "complete" and (not self.artifacts or self.reason is not None):
+            raise ValueError("complete attestation requires artifacts and cannot have an unavailable reason")
+        if self.status == "partial" and not self.artifacts and self.reason is None:
+            raise ValueError("partial attestation requires an artifact or a reason")
+        if self.status == "unavailable" and (self.artifacts or self.reason is None):
+            raise ValueError("unavailable attestation requires a reason and cannot reference artifacts")
+        return self
+
+
+class DeepSeekCompositionAttestation(LenientModel):
+    declared: DeepSeekAttestationLevel
+    resolved_runtime: DeepSeekAttestationLevel
+    model_visible: DeepSeekAttestationLevel
+
+
+class DeepSeekQualificationIdentity(LenientModel):
+    matrix_id: NonEmptyStr
+    matrix: DeepSeekEvidenceReference
+    provider_route: Literal["azure", "deepseek-official"]
+    status: Literal["partial", "qualified", "unqualified"]
+    live_qualified: bool
+    qualified_features: tuple[NonEmptyStr, ...] = ()
+
+    @model_validator(mode="after")
+    def validate_qualification(self) -> Self:
+        if self.live_qualified != (self.status == "qualified"):
+            raise ValueError("live_qualified must agree with qualified status")
+        return self
+
+
+class DeepSeekActorToolEvidence(LenientModel):
+    task_world_id: NonEmptyStr
+    actor_catalogue_sha256: str
+    public_native_tool_surface_sha256: str
+    presentation_mode: Literal["deepseek-native"]
+    actor_authority_scope: Literal["segment-snapshot"]
+    mapping: DeepSeekEvidenceReference
+    actor_authority: DeepSeekEvidenceReference
+    correlation: DeepSeekEvidenceReference
+
+    @field_validator("actor_catalogue_sha256", "public_native_tool_surface_sha256")
+    @classmethod
+    def validate_identity_sha256(cls, value: str) -> str:
+        return validate_sha256(value)
+
+
+class DeepSeekEvidenceManifest(LenientModel):
+    schema_id: Literal["aec-bench/deepseek-evidence/2"] = Field(
+        alias="schema",
+        serialization_alias="schema",
+    )
     trial_id: NonEmptyStr
     generated_at: datetime
     adapter: DeepSeekAdapterIdentity
     composition: DeepSeekCompositionIdentity
+    attestation: DeepSeekCompositionAttestation
+    qualification: DeepSeekQualificationIdentity
     model: DeepSeekModelIdentity
     execution: DeepSeekExecutionIdentity
     plugins: tuple[DeepSeekPluginIdentity, ...] = ()
+    actor_native_tools: DeepSeekActorToolEvidence | None = None
     redaction_audit_path: NonEmptyStr
     artifacts: tuple[DeepSeekEvidenceArtifact, ...]
 
@@ -131,6 +222,13 @@ class DeepSeekEvidenceManifest(StrictModel):
         for plugin in self.plugins:
             if artifact_roles_by_path.get(plugin.artifact_path) != "optional_plugin":
                 raise ValueError("plugin artifact path must reference an optional_plugin artifact")
+            if artifact_roles_by_path.get(plugin.package_lock_path) != "plugin_package_lock":
+                raise ValueError("plugin package lock must reference the plugin_package_lock artifact")
+            artifact_by_path = {artifact.path: artifact for artifact in self.artifacts}
+            if artifact_by_path[plugin.artifact_path].sha256 != plugin.artifact_sha256:
+                raise ValueError("plugin build hash must match its evidence artifact")
+            if artifact_by_path[plugin.package_lock_path].sha256 != plugin.package_lock_sha256:
+                raise ValueError("plugin package lock hash must match its evidence artifact")
         output_commit_plugins = [plugin for plugin in self.plugins if plugin.role == "output_commit"]
         tool_plugins = [plugin for plugin in self.plugins if plugin.role == "native_tools"]
         if self.composition.output_commit_mode == "required" and len(output_commit_plugins) != 1:
@@ -140,6 +238,30 @@ class DeepSeekEvidenceManifest(StrictModel):
         expected_tool_plugins = 1 if self.composition.native_tools else 0
         if len(tool_plugins) != expected_tool_plugins:
             raise ValueError("native tool evidence must match its plugin artifact")
+        references = [
+            *self.attestation.declared.artifacts,
+            *self.attestation.resolved_runtime.artifacts,
+            *self.attestation.model_visible.artifacts,
+            self.qualification.matrix,
+        ]
+        if self.actor_native_tools is not None:
+            references.extend(
+                (
+                    self.actor_native_tools.mapping,
+                    self.actor_native_tools.actor_authority,
+                    self.actor_native_tools.correlation,
+                )
+            )
+        artifact_by_path = {artifact.path: artifact for artifact in self.artifacts}
+        for reference in references:
+            artifact = artifact_by_path.get(reference.path)
+            if artifact is None or artifact.sha256 != reference.sha256:
+                raise ValueError(f"evidence reference does not match a retained artifact: {reference.path}")
+        declared_roles = {artifact_roles_by_path[reference.path] for reference in self.attestation.declared.artifacts}
+        if not {"composition_identity", "cordis_input", "system_prompt"}.issubset(declared_roles):
+            raise ValueError("declared attestation must reference composition, Cordis, and system prompt evidence")
+        if self.actor_native_tools is not None and not self.composition.native_tools:
+            raise ValueError("actor native evidence requires a native tool composition")
         return self
 
 

--- a/src/aec_bench/adapters/deepseek_harness/native_world_tools.py
+++ b/src/aec_bench/adapters/deepseek_harness/native_world_tools.py
@@ -8,6 +8,7 @@ import json
 import threading
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 from jsonschema import Draft202012Validator
@@ -76,6 +77,39 @@ _INFRASTRUCTURE_ARGUMENTS = frozenset({"request_id", "decision_id"})
 class _CursorRequest:
     decision_id: str
     completion_applied: bool = False
+
+
+@dataclass(frozen=True)
+class DeepSeekNativeWorldEvidence:
+    """Supply task-owned world identity and actor evidence to one DeepSeek run."""
+
+    surface_record: dict[str, Any]
+    actor_authority_evidence_path: Path
+
+    def __post_init__(self) -> None:
+        surface = _canonical_json(self.surface_record)
+        if surface.get("schema") != NATIVE_WORLD_TOOL_SURFACE_SCHEMA:
+            raise ValueError("native world evidence requires the current tool-surface schema")
+        for name in ("task_world_id", "catalogue_sha256", "public_tool_surface_sha256"):
+            value = surface.get(name)
+            if not isinstance(value, str) or not value:
+                raise ValueError(f"native world evidence requires {name}")
+        for name in ("catalogue_sha256", "public_tool_surface_sha256"):
+            value = surface[name]
+            if len(value) != 64 or any(character not in "0123456789abcdef" for character in value):
+                raise ValueError(f"native world evidence requires a canonical {name}")
+        surface_identity = {
+            "action_mapping": surface.get("action_mapping"),
+            "tools": surface.get("tools"),
+        }
+        if _json_sha256(surface_identity) != surface["public_tool_surface_sha256"]:
+            raise ValueError("native world evidence public tool-surface hash does not match its content")
+        source_path = Path(self.actor_authority_evidence_path)
+        if source_path.is_symlink() or not source_path.is_file():
+            raise ValueError("native world evidence requires a regular actor authority evidence file")
+        evidence_path = source_path.resolve()
+        object.__setattr__(self, "surface_record", surface)
+        object.__setattr__(self, "actor_authority_evidence_path", evidence_path)
 
 
 class NativeWorldToolTransport:
@@ -398,6 +432,7 @@ __all__ = [
     "NATIVE_WORLD_TRANSPORT",
     "WORLD_OBSERVE_DESCRIPTION",
     "WORLD_OBSERVE_TOOL_NAME",
+    "DeepSeekNativeWorldEvidence",
     "NativeWorldToolTransport",
     "compile_world_native_tools",
     "native_world_tool_surface_record",

--- a/src/aec_bench/adapters/deepseek_harness/profiles/qualification-matrix.json
+++ b/src/aec_bench/adapters/deepseek_harness/profiles/qualification-matrix.json
@@ -1,0 +1,103 @@
+{
+  "schema": "aec-bench/deepseek-qualification/1",
+  "matrix_id": "deepseek-harness-0.1.0rc6-initial",
+  "qualification_date": "2026-08-17",
+  "aec_bench_version": "0.1.0",
+  "aec_bench_revision": "60aea77ed8768ab20725bac536ce2b0cc9a51898",
+  "rows": [
+    {
+      "provider_route": "azure",
+      "sdk_version": "0.1.0rc6",
+      "runtime_version": "0.1.0rc6",
+      "status": "partial",
+      "features": {
+        "keyless_protocol": {
+          "status": "passed",
+          "evidence": [
+            "tests/deepseek_harness/test_sdk_integration.py::test_real_sdk_composition_reaches_keyless_model_endpoint"
+          ]
+        },
+        "live_basic": {
+          "status": "not-run",
+          "reason": "No retained credentialed Azure baseline bundle is committed."
+        },
+        "live_tool_call": {
+          "status": "not-run",
+          "reason": "No retained credentialed Azure tool-call bundle is committed."
+        },
+        "live_output_commit": {
+          "status": "not-run",
+          "reason": "No retained credentialed Azure output-commit bundle is committed."
+        },
+        "live_world_episode": {
+          "status": "not-run",
+          "reason": "No retained credentialed Azure world-episode bundle is committed."
+        },
+        "max_token_terminal": {
+          "status": "passed",
+          "evidence": [
+            "tests/deepseek_harness/test_sdk_integration.py::test_real_sdk_enforces_max_tokens_and_maps_truncation"
+          ]
+        },
+        "timeout_cleanup": {
+          "status": "passed",
+          "evidence": [
+            "tests/deepseek_harness/test_runtime.py::test_timeout_terminates_the_worker_process_group"
+          ]
+        },
+        "evidence_redaction": {
+          "status": "passed",
+          "evidence": [
+            "tests/deepseek_harness/test_sdk_integration.py::test_real_sdk_composition_writes_the_requested_workspace_artifact"
+          ]
+        }
+      }
+    },
+    {
+      "provider_route": "deepseek-official",
+      "sdk_version": "0.1.0rc6",
+      "runtime_version": "0.1.0rc6",
+      "status": "partial",
+      "features": {
+        "keyless_protocol": {
+          "status": "passed",
+          "evidence": [
+            "tests/deepseek_harness/test_sdk_integration.py::test_real_sdk_composition_uses_the_selected_deepseek_provider"
+          ]
+        },
+        "live_basic": {
+          "status": "not-run",
+          "reason": "The official DeepSeek route has no retained credentialed baseline bundle."
+        },
+        "live_tool_call": {
+          "status": "not-run",
+          "reason": "The official DeepSeek route has no retained credentialed tool-call bundle."
+        },
+        "live_output_commit": {
+          "status": "not-run",
+          "reason": "The official DeepSeek route has no retained credentialed output-commit bundle."
+        },
+        "live_world_episode": {
+          "status": "not-run",
+          "reason": "The official DeepSeek route has no retained credentialed world-episode bundle."
+        },
+        "max_token_terminal": {
+          "status": "not-run",
+          "reason": "The official DeepSeek route has no retained credentialed max-token bundle."
+        },
+        "timeout_cleanup": {
+          "status": "passed",
+          "evidence": [
+            "tests/deepseek_harness/test_runtime.py::test_timeout_terminates_the_worker_process_group"
+          ]
+        },
+        "evidence_redaction": {
+          "status": "passed",
+          "evidence": [
+            "tests/deepseek_harness/test_runtime.py::test_process_runtime_collects_a_keyless_fake_worker_result"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/src/aec_bench/adapters/deepseek_harness/qualification.py
+++ b/src/aec_bench/adapters/deepseek_harness/qualification.py
@@ -1,0 +1,109 @@
+# ABOUTME: Validates the versioned DeepSeek provider and feature qualification matrix.
+# ABOUTME: Keeps keyless protocol proof separate from credentialed live-provider claims.
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from aec_bench.contracts.validators import LenientModel, NonEmptyStr
+
+DeepSeekQualificationFeature = Literal[
+    "keyless_protocol",
+    "live_basic",
+    "live_tool_call",
+    "live_output_commit",
+    "live_world_episode",
+    "max_token_terminal",
+    "timeout_cleanup",
+    "evidence_redaction",
+]
+DEEPSEEK_QUALIFICATION_FEATURES = (
+    "keyless_protocol",
+    "live_basic",
+    "live_tool_call",
+    "live_output_commit",
+    "live_world_episode",
+    "max_token_terminal",
+    "timeout_cleanup",
+    "evidence_redaction",
+)
+
+
+class DeepSeekQualificationCell(LenientModel):
+    status: Literal["passed", "not-run", "not-applicable"]
+    evidence: tuple[NonEmptyStr, ...] = ()
+    reason: NonEmptyStr | None = None
+
+    @model_validator(mode="after")
+    def validate_status(self) -> Self:
+        if self.status == "passed" and (not self.evidence or self.reason is not None):
+            raise ValueError("a passed qualification cell requires evidence and cannot have a reason")
+        if self.status != "passed" and (self.evidence or self.reason is None):
+            raise ValueError("an unpassed qualification cell requires a reason and cannot claim evidence")
+        return self
+
+
+class DeepSeekQualificationRow(LenientModel):
+    provider_route: Literal["azure", "deepseek-official"]
+    sdk_version: NonEmptyStr
+    runtime_version: NonEmptyStr
+    status: Literal["partial", "qualified", "unqualified"]
+    features: dict[DeepSeekQualificationFeature, DeepSeekQualificationCell]
+
+    @model_validator(mode="after")
+    def validate_row(self) -> Self:
+        expected = set(DEEPSEEK_QUALIFICATION_FEATURES)
+        if set(self.features) != expected:
+            raise ValueError("qualification row must contain every supported feature")
+        all_passed = all(cell.status == "passed" for cell in self.features.values())
+        if (self.status == "qualified") != all_passed:
+            raise ValueError("qualified provider status requires every feature to pass")
+        return self
+
+    @property
+    def passed_features(self) -> tuple[str, ...]:
+        return tuple(sorted(name for name, cell in self.features.items() if cell.status == "passed"))
+
+
+class DeepSeekQualificationMatrix(LenientModel):
+    schema_id: Literal["aec-bench/deepseek-qualification/1"] = Field(
+        alias="schema",
+        serialization_alias="schema",
+    )
+    matrix_id: NonEmptyStr
+    qualification_date: date
+    aec_bench_version: NonEmptyStr
+    aec_bench_revision: NonEmptyStr
+    rows: tuple[DeepSeekQualificationRow, ...]
+
+    @model_validator(mode="after")
+    def validate_routes(self) -> Self:
+        routes = [row.provider_route for row in self.rows]
+        if len(routes) != len(set(routes)):
+            raise ValueError("qualification matrix provider routes must be unique")
+        if set(routes) != {"azure", "deepseek-official"}:
+            raise ValueError("qualification matrix must contain Azure and DeepSeek official routes")
+        return self
+
+    def row_for(self, provider_route: str) -> DeepSeekQualificationRow:
+        for row in self.rows:
+            if row.provider_route == provider_route:
+                return row
+        raise ValueError(f"qualification matrix does not contain provider route: {provider_route}")
+
+
+def deepseek_qualification_matrix_path() -> Path:
+    """Return the package-owned compatibility and feature matrix."""
+    return Path(__file__).parent / "profiles" / "qualification-matrix.json"
+
+
+def load_deepseek_qualification_matrix(path: Path | None = None) -> DeepSeekQualificationMatrix:
+    """Validate and return the current package-owned qualification matrix."""
+    source = deepseek_qualification_matrix_path() if path is None else path
+    if source.is_symlink() or not source.is_file():
+        raise ValueError(f"DeepSeek qualification matrix must be a regular file: {source}")
+    return DeepSeekQualificationMatrix.model_validate_json(source.read_text(encoding="utf-8"))

--- a/src/aec_bench/adapters/deepseek_harness/runtime.py
+++ b/src/aec_bench/adapters/deepseek_harness/runtime.py
@@ -51,16 +51,26 @@ from aec_bench.adapters.deepseek_harness.events import (
     reduce_deepseek_notifications,
 )
 from aec_bench.adapters.deepseek_harness.evidence import (
+    DeepSeekActorToolEvidence,
     DeepSeekAdapterIdentity,
+    DeepSeekAttestationLevel,
+    DeepSeekCompositionAttestation,
     DeepSeekCompositionIdentity,
     DeepSeekEvidenceArtifact,
     DeepSeekEvidenceManifest,
+    DeepSeekEvidenceReference,
     DeepSeekExecutionIdentity,
     DeepSeekModelIdentity,
     DeepSeekPluginIdentity,
+    DeepSeekQualificationIdentity,
     DeepSeekRedactedFile,
     DeepSeekRedactionAudit,
     verify_deepseek_evidence_manifest,
+)
+from aec_bench.adapters.deepseek_harness.native_world_tools import DeepSeekNativeWorldEvidence
+from aec_bench.adapters.deepseek_harness.qualification import (
+    deepseek_qualification_matrix_path,
+    load_deepseek_qualification_matrix,
 )
 from aec_bench.adapters.deepseek_harness.tool_gateway import (
     TOOL_GATEWAY_MANIFEST_ENV,
@@ -69,6 +79,7 @@ from aec_bench.adapters.deepseek_harness.tool_gateway import (
     EndpointCloseReport,
     NativeToolDefinition,
     ToolGatewayEndpoint,
+    native_tool_manifest,
 )
 from aec_bench.adapters.output_commit import read_output_completion_content, validate_stable_output_commit
 from aec_bench.contracts.output_completion import OutputCommitAttestation, OutputCompletionContract
@@ -124,11 +135,16 @@ class DeepSeekHarnessPaths:
     runtime_record: Path
     composition: Path
     manifest: Path
+    qualification_reference: Path
     redaction_audit: Path
     commit_evidence: Path
     tool_gateway_evidence: Path
     output_commit_plugin: Path
     tool_gateway_plugin: Path
+    plugin_package_lock: Path
+    native_world_surface: Path
+    actor_authority_evidence: Path
+    actor_correlation: Path
     home: Path
     temporary: Path
     sessions: Path
@@ -174,6 +190,7 @@ class DeepSeekHarnessProcessRuntime:
         workspace: Path,
         worker_command: tuple[str, ...] | None = None,
         native_tools: Sequence[NativeToolDefinition] | None = None,
+        native_world_evidence: DeepSeekNativeWorldEvidence | None = None,
         tool_gateway_close_timeout_seconds: float = 5.0,
     ) -> None:
         self.settings = settings
@@ -185,6 +202,13 @@ class DeepSeekHarnessProcessRuntime:
         )
         self.native_tools = tuple(native_tools or ())
         self.native_tool_names = tuple(sorted(tool.name for tool in self.native_tools))
+        self.native_world_evidence = native_world_evidence
+        if self.native_world_evidence is not None and not self.native_tools:
+            raise ValueError("native world evidence requires native tool definitions")
+        if self.native_world_evidence is not None and tuple(self.native_world_evidence.surface_record["tools"]) != (
+            native_tool_manifest(self.native_tools)
+        ):
+            raise ValueError("native world evidence does not match the configured native tool definitions")
         self.tool_gateway_close_timeout_seconds = tool_gateway_close_timeout_seconds
         self.paths = _deepseek_paths(self.workspace, trial_id=f"run-{uuid.uuid4().hex}")
         self._has_run = False
@@ -508,13 +532,27 @@ class DeepSeekHarnessProcessRuntime:
         _contract, commit_required = deepseek_output_commit_configuration(request)
         system_prompt = deepseek_system_prompt(request)
         self.paths.system_prompt.write_text(system_prompt, encoding="utf-8")
+        shutil.copyfile(deepseek_qualification_matrix_path(), self.paths.qualification_reference)
         cordis_template = (
             tool_gateway_cordis_template(self.settings.provider)
             if self.native_tools
             else baseline_cordis_template(self.settings.provider)
         )
         shutil.copyfile(cordis_template, self.paths.cordis_input)
+        if self.native_world_evidence is not None:
+            _write_json(self.paths.native_world_surface, self.native_world_evidence.surface_record)
         plugins: list[DeepSeekPluginIdentity] = []
+        plugin_lock_source = Path(__file__).parent / "plugin" / "package-lock.json"
+        if (commit_required or self.native_tools) and (
+            plugin_lock_source.is_symlink() or not plugin_lock_source.is_file()
+        ):
+            raise DeepSeekHarnessRuntimeError(f"DeepSeek plugin package lock is missing: {plugin_lock_source}")
+        if commit_required or self.native_tools:
+            self.paths.plugin_package_lock.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(plugin_lock_source, self.paths.plugin_package_lock)
+        plugin_lock_sha256 = (
+            _file_sha256(self.paths.plugin_package_lock) if self.paths.plugin_package_lock.is_file() else None
+        )
         if commit_required:
             source_plugin = output_commit_plugin_path().resolve()
             if not source_plugin.is_file():
@@ -531,6 +569,9 @@ class DeepSeekHarnessProcessRuntime:
                     version=OUTPUT_COMMIT_PLUGIN_VERSION,
                     role="output_commit",
                     artifact_path=self.paths.output_commit_plugin.relative_to(self.paths.root).as_posix(),
+                    artifact_sha256=_file_sha256(self.paths.output_commit_plugin),
+                    package_lock_path=self.paths.plugin_package_lock.relative_to(self.paths.root).as_posix(),
+                    package_lock_sha256=cast(str, plugin_lock_sha256),
                 )
             )
         if self.native_tools:
@@ -548,6 +589,9 @@ class DeepSeekHarnessProcessRuntime:
                     version=TOOL_GATEWAY_PLUGIN_VERSION,
                     role="native_tools",
                     artifact_path=self.paths.tool_gateway_plugin.relative_to(self.paths.root).as_posix(),
+                    artifact_sha256=_file_sha256(self.paths.tool_gateway_plugin),
+                    package_lock_path=self.paths.plugin_package_lock.relative_to(self.paths.root).as_posix(),
+                    package_lock_sha256=cast(str, plugin_lock_sha256),
                 )
             )
         return tuple(plugins)
@@ -576,6 +620,7 @@ class DeepSeekHarnessProcessRuntime:
         _write_json(
             self.paths.composition,
             {
+                "schema": "aec-bench/deepseek-declared-composition/1",
                 **treatment_record(
                     self.settings,
                     timeout_seconds=request_timeout_seconds(request),
@@ -590,8 +635,10 @@ class DeepSeekHarnessProcessRuntime:
                     "secret_names": secret_names,
                 },
                 "plugins": [plugin.model_dump(mode="json") for plugin in plugins],
-                "resolved_composition_available": False,
-                "resolved_tool_surface_available": False,
+                "cordis_sha256": _file_sha256(self.paths.cordis_input),
+                "system_prompt_sha256": _file_sha256(self.paths.system_prompt),
+                "aec_native_tool_manifest": list(native_tool_manifest(self.native_tools)),
+                "aec_native_tool_manifest_sha256": _json_sha256(native_tool_manifest(self.native_tools)),
             },
         )
 
@@ -692,6 +739,7 @@ class DeepSeekHarnessProcessRuntime:
             commit_required=commit_required,
             native_tools=self.native_tool_names,
             plugins=plugins,
+            native_world_evidence=self.native_world_evidence,
             started_at=started_at,
             finished_at=finished_at,
         )
@@ -742,6 +790,7 @@ class DeepSeekHarnessProcessRuntime:
             commit_required=commit_required,
             native_tools=self.native_tool_names,
             plugins=plugins,
+            native_world_evidence=self.native_world_evidence,
             started_at=started_at,
             finished_at=finished_at,
         )
@@ -828,11 +877,16 @@ def _deepseek_paths(workspace: Path, *, trial_id: str) -> DeepSeekHarnessPaths:
         runtime_record=root / "runtime.json",
         composition=root / "composition.json",
         manifest=root / "evidence-manifest.json",
+        qualification_reference=root / "qualification-reference.json",
         redaction_audit=root / "redaction-audit.json",
         commit_evidence=root / "output-commit-evidence.jsonl",
         tool_gateway_evidence=root / "tool-gateway-evidence.jsonl",
         output_commit_plugin=root / "plugins" / "output-commit" / "index.js",
         tool_gateway_plugin=root / "plugins" / "tools" / "index.js",
+        plugin_package_lock=root / "plugins" / "package-lock.json",
+        native_world_surface=root / "native-world-tool-surface.json",
+        actor_authority_evidence=root / "actor-invocation-evidence.jsonl",
+        actor_correlation=root / "actor-correlation.jsonl",
         home=root / "runtime-home",
         temporary=root / "tmp",
         sessions=root / "sessions",
@@ -914,9 +968,12 @@ def _write_evidence_manifest(
     commit_required: bool,
     native_tools: tuple[str, ...],
     plugins: tuple[DeepSeekPluginIdentity, ...],
+    native_world_evidence: DeepSeekNativeWorldEvidence | None,
     started_at: datetime,
     finished_at: datetime,
 ) -> None:
+    if native_world_evidence is not None:
+        _write_actor_evidence_snapshot(paths, native_world_evidence)
     artifacts: list[DeepSeekEvidenceArtifact] = []
     roles = {
         paths.request: "worker_request",
@@ -928,11 +985,16 @@ def _write_evidence_manifest(
         paths.cordis_input: "cordis_input",
         paths.runtime_record: "runtime_identity",
         paths.composition: "composition_identity",
+        paths.qualification_reference: "qualification_matrix",
         paths.redaction_audit: "redaction_audit",
         paths.commit_evidence: "output_commit_evidence",
         paths.tool_gateway_evidence: "tool_gateway_evidence",
         paths.output_commit_plugin: "optional_plugin",
         paths.tool_gateway_plugin: "optional_plugin",
+        paths.plugin_package_lock: "plugin_package_lock",
+        paths.native_world_surface: "native_world_tool_surface",
+        paths.actor_authority_evidence: "actor_authority_evidence",
+        paths.actor_correlation: "actor_correlation",
     }
     for session_path in sorted(paths.sessions.rglob("*.jsonl")):
         roles[session_path] = "deepseek_session_jsonl"
@@ -956,11 +1018,45 @@ def _write_evidence_manifest(
         if worker_result is not None
         else _distribution_version("deepseek-harness-runtime-bin")
     )
+    artifact_by_role = {artifact.role: artifact for artifact in artifacts}
+    declared_references = tuple(
+        _artifact_reference(artifact_by_role[role])
+        for role in ("composition_identity", "cordis_input", "system_prompt")
+    )
+    matrix = load_deepseek_qualification_matrix(paths.qualification_reference)
+    provider_route = harness_provider_route(settings.provider)
+    qualification_row = matrix.row_for(provider_route)
+    source_revision, source_revision_reason = _aec_bench_source_revision()
+    version_matches = (
+        qualification_row.sdk_version == sdk_version
+        and qualification_row.runtime_version == runtime_distribution_version
+        and matrix.aec_bench_version == _distribution_version("aec-bench")
+        and matrix.aec_bench_revision == source_revision
+    )
+    qualification_status: Literal["partial", "qualified", "unqualified"] = qualification_row.status
+    if not version_matches:
+        qualification_status = "unqualified"
+    actor_native_tools: DeepSeekActorToolEvidence | None = None
+    if native_world_evidence is not None:
+        surface = native_world_evidence.surface_record
+        actor_native_tools = DeepSeekActorToolEvidence(
+            task_world_id=cast(str, surface["task_world_id"]),
+            actor_catalogue_sha256=cast(str, surface["catalogue_sha256"]),
+            public_native_tool_surface_sha256=cast(str, surface["public_tool_surface_sha256"]),
+            presentation_mode="deepseek-native",
+            actor_authority_scope="segment-snapshot",
+            mapping=_artifact_reference(artifact_by_role["native_world_tool_surface"]),
+            actor_authority=_artifact_reference(artifact_by_role["actor_authority_evidence"]),
+            correlation=_artifact_reference(artifact_by_role["actor_correlation"]),
+        )
     manifest = DeepSeekEvidenceManifest(
+        schema="aec-bench/deepseek-evidence/2",
         trial_id=paths.root.name,
         generated_at=finished_at,
         adapter=DeepSeekAdapterIdentity(
             aec_bench_version=_distribution_version("aec-bench"),
+            aec_bench_revision=source_revision,
+            aec_bench_revision_reason=source_revision_reason,
             python_sdk_version=sdk_version,
             runtime_distribution_version=runtime_distribution_version,
             runtime_reported_version=(worker_result.runtime_reported_version if worker_result is not None else None),
@@ -968,6 +1064,25 @@ def _write_evidence_manifest(
         composition=DeepSeekCompositionIdentity(
             output_commit_mode="required" if commit_required else "disabled",
             native_tools=native_tools,
+        ),
+        attestation=DeepSeekCompositionAttestation(
+            declared=DeepSeekAttestationLevel(status="complete", artifacts=declared_references),
+            resolved_runtime=DeepSeekAttestationLevel(
+                status="unavailable",
+                reason="deepseek-harness-sdk-does-not-expose-resolved-runtime-composition",
+            ),
+            model_visible=DeepSeekAttestationLevel(
+                status="unavailable",
+                reason="deepseek-harness-sdk-does-not-expose-the-complete-model-visible-request-surface",
+            ),
+        ),
+        qualification=DeepSeekQualificationIdentity(
+            matrix_id=matrix.matrix_id,
+            matrix=_artifact_reference(artifact_by_role["qualification_matrix"]),
+            provider_route=provider_route,
+            status=qualification_status,
+            live_qualified=qualification_status == "qualified",
+            qualified_features=qualification_row.passed_features if version_matches else (),
         ),
         model=DeepSeekModelIdentity(
             provider=settings.provider,
@@ -1000,10 +1115,11 @@ def _write_evidence_manifest(
             process_group_retired=True,
         ),
         plugins=plugins,
+        actor_native_tools=actor_native_tools,
         redaction_audit_path=paths.redaction_audit.relative_to(paths.root).as_posix(),
         artifacts=tuple(artifacts),
     )
-    _write_json(paths.manifest, manifest.model_dump(mode="json"))
+    _write_json(paths.manifest, manifest.model_dump(mode="json", by_alias=True))
     try:
         verify_deepseek_evidence_manifest(paths.manifest)
     except ValueError as exc:
@@ -1015,6 +1131,102 @@ def _distribution_version(name: str) -> str:
         return importlib.metadata.version(name)
     except importlib.metadata.PackageNotFoundError:
         return "not-installed"
+
+
+def _aec_bench_source_revision() -> tuple[str | None, str | None]:
+    repository_root = Path(__file__).resolve().parents[4]
+    try:
+        status = subprocess.run(
+            ("git", "status", "--porcelain"),
+            cwd=repository_root,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        if status.stdout.strip():
+            return None, "aec-bench-source-tree-is-not-a-clean-git-revision"
+        revision = subprocess.run(
+            ("git", "rev-parse", "HEAD"),
+            cwd=repository_root,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        ).stdout.strip()
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return None, "aec-bench-source-revision-is-unavailable"
+    if not revision:
+        return None, "aec-bench-source-revision-is-unavailable"
+    return revision, None
+
+
+def _artifact_reference(artifact: DeepSeekEvidenceArtifact) -> DeepSeekEvidenceReference:
+    return DeepSeekEvidenceReference(path=artifact.path, sha256=artifact.sha256)
+
+
+def _write_actor_evidence_snapshot(
+    paths: DeepSeekHarnessPaths,
+    native_world_evidence: DeepSeekNativeWorldEvidence,
+) -> None:
+    source = native_world_evidence.actor_authority_evidence_path
+    if source.is_symlink() or not source.is_file():
+        raise DeepSeekHarnessRuntimeError("actor authority evidence is unavailable at manifest finalization")
+    shutil.copyfile(source, paths.actor_authority_evidence)
+    actor_records = _read_jsonl_objects(paths.actor_authority_evidence)
+    gateway_records = _read_jsonl_objects(paths.tool_gateway_evidence) if paths.tool_gateway_evidence.is_file() else []
+    correlations: list[dict[str, Any]] = []
+    for gateway in gateway_records:
+        if gateway.get("record_type") != "invocation":
+            continue
+        session_id = gateway.get("deepseek_session_id")
+        tool_call_id = gateway.get("deepseek_tool_call_id")
+        request_id = gateway.get("request_id")
+        if not all(isinstance(value, str) and value for value in (session_id, tool_call_id, request_id)):
+            continue
+        actor_sequences = []
+        for actor in actor_records:
+            correlation = actor.get("correlation")
+            if not isinstance(correlation, dict):
+                continue
+            if (
+                correlation.get("provider_session_id") == session_id
+                and correlation.get("provider_tool_call_id") == tool_call_id
+                and correlation.get("transport_request_id") == request_id
+            ):
+                sequence = actor.get("sequence")
+                if isinstance(sequence, int):
+                    actor_sequences.append(sequence)
+        correlations.append(
+            {
+                "schema": "aec-bench/actor-correlation/1",
+                "request_id": request_id,
+                "deepseek_session_id": session_id,
+                "deepseek_tool_call_id": tool_call_id,
+                "model_turn": gateway.get("model_turn"),
+                "tool": gateway.get("tool"),
+                "actor_evidence_sequences": sorted(actor_sequences),
+            }
+        )
+    paths.actor_correlation.write_text(
+        "".join(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n" for record in correlations),
+        encoding="utf-8",
+    )
+
+
+def _read_jsonl_objects(path: Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise DeepSeekHarnessRuntimeError(f"invalid JSONL evidence at {path.name}:{line_number}") from exc
+        if not isinstance(value, dict):
+            raise DeepSeekHarnessRuntimeError(f"JSONL evidence must contain objects at {path.name}:{line_number}")
+        records.append(cast(dict[str, Any], value))
+    return records
 
 
 def _projection_session_id(projection: DeepSeekRunProjection | None) -> str | None:
@@ -1087,6 +1299,11 @@ def _write_json(path: Path, payload: dict[str, Any]) -> None:
 
 def _file_sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _json_sha256(value: Any) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
 
 
 def _stop_process_group(process: subprocess.Popen[str]) -> None:

--- a/src/aec_bench/adapters/local_registry.py
+++ b/src/aec_bench/adapters/local_registry.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from aec_bench.adapters.deepseek_harness.native_world_tools import DeepSeekNativeWorldEvidence
     from aec_bench.adapters.deepseek_harness.tool_gateway import NativeToolDefinition
 
 logger = logging.getLogger(__name__)
@@ -402,6 +403,7 @@ def _build_deepseek_harness(
     workspace: str,
     native_tools: list[Callable[..., str]] | None = None,
     native_tool_definitions: Sequence[NativeToolDefinition] | None = None,
+    native_world_evidence: DeepSeekNativeWorldEvidence | None = None,
     **_kwargs: Any,
 ) -> Any:
     """Build the official DeepSeek Harness adapter through its shared runtime."""
@@ -427,6 +429,7 @@ def _build_deepseek_harness(
         settings=settings,
         workspace=workspace,
         native_tools=definitions,
+        native_world_evidence=native_world_evidence,
     )
 
 

--- a/src/aec_bench/harness/pump_station_harbor/session.py
+++ b/src/aec_bench/harness/pump_station_harbor/session.py
@@ -16,6 +16,7 @@ from aec_bench.adapters.base import AdapterRequest, AdapterResult
 from aec_bench.adapters.deepseek_harness.native_world_tools import (
     WORLD_OBSERVE_DESCRIPTION,
     WORLD_OBSERVE_TOOL_NAME,
+    DeepSeekNativeWorldEvidence,
     compile_world_native_tools,
     native_world_tool_surface_record,
 )
@@ -309,9 +310,14 @@ def run_pump_station_model_session(
                 ):
                     raise RuntimeError("DeepSeek native world tool surface changed between model segments")
                 native_tools = None
+                native_world_evidence = DeepSeekNativeWorldEvidence(
+                    surface_record=segment_surface,
+                    actor_authority_evidence_path=authority.config.evidence_path,
+                )
             else:
                 native_tool_definitions = None
                 native_tools = _compile_tool_loop_world_tools(authority, catalogue)
+                native_world_evidence = None
             adapter = resolved_builder(
                 adapter_kind=adapter_kind,
                 model_name=model_name,
@@ -319,6 +325,7 @@ def run_pump_station_model_session(
                 trajectory_writer=trajectory,
                 native_tools=native_tools,
                 native_tool_definitions=native_tool_definitions,
+                native_world_evidence=native_world_evidence,
                 enable_bash=False,
             )
             segment_result = adapter.execute(

--- a/tests/deepseek_harness/test_qualification.py
+++ b/tests/deepseek_harness/test_qualification.py
@@ -1,0 +1,62 @@
+# ABOUTME: Tests the versioned DeepSeek provider and feature qualification matrix.
+# ABOUTME: Prevents keyless protocol checks from becoming unsupported live-provider claims.
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from aec_bench.adapters.deepseek_harness.evidence import DeepSeekAttestationLevel
+from aec_bench.adapters.deepseek_harness.qualification import (
+    DEEPSEEK_QUALIFICATION_FEATURES,
+    DeepSeekQualificationMatrix,
+    load_deepseek_qualification_matrix,
+)
+
+
+def test_current_matrix_is_complete_and_links_each_passing_cell_to_a_test() -> None:
+    matrix = load_deepseek_qualification_matrix()
+    repository_root = Path(__file__).resolve().parents[2]
+
+    assert matrix.schema_id == "aec-bench/deepseek-qualification/1"
+    assert {row.provider_route for row in matrix.rows} == {"azure", "deepseek-official"}
+    for row in matrix.rows:
+        assert set(row.features) == set(DEEPSEEK_QUALIFICATION_FEATURES)
+        for cell in row.features.values():
+            for reference in cell.evidence:
+                relative_path, separator, test_name = reference.partition("::")
+                assert separator == "::"
+                source = repository_root / relative_path
+                assert source.is_file()
+                assert f"def {test_name}(" in source.read_text(encoding="utf-8")
+
+
+def test_matrix_import_preserves_unknown_future_fields() -> None:
+    payload = load_deepseek_qualification_matrix().model_dump(mode="json", by_alias=True)
+    payload["future_matrix_field"] = {"retained": True}
+    payload["rows"][0]["features"]["keyless_protocol"]["future_cell_field"] = "retained"
+
+    imported = DeepSeekQualificationMatrix.model_validate(payload).model_dump(mode="json", by_alias=True)
+
+    assert imported["future_matrix_field"] == {"retained": True}
+    assert imported["rows"][0]["features"]["keyless_protocol"]["future_cell_field"] == "retained"
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ({"status": "complete", "artifacts": []}, "complete attestation requires artifacts"),
+        (
+            {
+                "status": "unavailable",
+                "reason": "sdk-does-not-expose",
+                "artifacts": [{"path": "x", "sha256": "a" * 64}],
+            },
+            "unavailable attestation requires a reason and cannot reference artifacts",
+        ),
+        ({"status": "partial"}, "partial attestation requires an artifact or a reason"),
+    ],
+)
+def test_attestation_levels_reject_false_or_unexplained_claims(payload: dict[str, object], message: str) -> None:
+    with pytest.raises(ValidationError, match=message):
+        DeepSeekAttestationLevel.model_validate(payload)

--- a/tests/deepseek_harness/test_runtime.py
+++ b/tests/deepseek_harness/test_runtime.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import sys
@@ -14,14 +15,18 @@ import pytest
 from aec_bench.adapters.base import AdapterRequest
 from aec_bench.adapters.deepseek_harness import runtime as deepseek_runtime
 from aec_bench.adapters.deepseek_harness.config import DeepSeekHarnessSettings
-from aec_bench.adapters.deepseek_harness.evidence import verify_deepseek_evidence_manifest
+from aec_bench.adapters.deepseek_harness.evidence import (
+    DeepSeekEvidenceManifest,
+    verify_deepseek_evidence_manifest,
+)
+from aec_bench.adapters.deepseek_harness.native_world_tools import DeepSeekNativeWorldEvidence
 from aec_bench.adapters.deepseek_harness.runtime import (
     DeepSeekHarnessProcessRuntime,
     DeepSeekHarnessRuntimeError,
     DeepSeekHarnessRuntimeTimeout,
     build_deepseek_worker_environment,
 )
-from aec_bench.adapters.deepseek_harness.tool_gateway import json_native_tool_definition
+from aec_bench.adapters.deepseek_harness.tool_gateway import json_native_tool_definition, native_tool_manifest
 from aec_bench.contracts.task_definition import ToolSpec
 
 
@@ -275,15 +280,16 @@ result_path.write_text(json.dumps({
     assert result.manifest_path is not None
     assert result.manifest_path.is_file()
     manifest = json.loads(result.manifest_path.read_text(encoding="utf-8"))
-    assert manifest["schema_version"] == "aecbench.deepseek-evidence-manifest.v1"
+    assert manifest["schema"] == "aec-bench/deepseek-evidence/2"
     assert manifest["trial_id"] == runtime.paths.root.name
-    assert manifest["adapter"] == {
-        "kind": "deepseek_harness",
-        "aec_bench_version": "0.1.0",
-        "python_sdk_version": "fake-sdk",
-        "runtime_distribution_version": "fake-runtime",
-        "runtime_reported_version": None,
-    }
+    assert manifest["adapter"]["kind"] == "deepseek_harness"
+    assert manifest["adapter"]["aec_bench_version"] == "0.1.0"
+    assert manifest["adapter"]["python_sdk_version"] == "fake-sdk"
+    assert manifest["adapter"]["runtime_distribution_version"] == "fake-runtime"
+    assert manifest["adapter"]["runtime_reported_version"] is None
+    assert (manifest["adapter"]["aec_bench_revision"] is None) != (
+        manifest["adapter"]["aec_bench_revision_reason"] is None
+    )
     assert manifest["model"] == {
         "provider": "azure",
         "harness_route": "azure",
@@ -296,12 +302,29 @@ result_path.write_text(json.dumps({
     assert manifest["execution"]["max_tokens"] == 17
     assert manifest["execution"]["process_group_retired"] is True
     assert manifest["plugins"] == []
-    assert manifest["composition"]["resolved_composition_available"] is False
-    assert manifest["composition"]["resolved_tool_surface_available"] is False
+    assert manifest["attestation"]["declared"]["status"] == "complete"
+    assert manifest["attestation"]["resolved_runtime"] == {
+        "status": "unavailable",
+        "artifacts": [],
+        "reason": "deepseek-harness-sdk-does-not-expose-resolved-runtime-composition",
+    }
+    assert manifest["attestation"]["model_visible"]["status"] == "unavailable"
+    assert manifest["qualification"] == {
+        "matrix_id": "deepseek-harness-0.1.0rc6-initial",
+        "matrix": {
+            "path": "qualification-reference.json",
+            "sha256": deepseek_runtime._file_sha256(runtime.paths.qualification_reference),
+        },
+        "provider_route": "azure",
+        "status": "unqualified",
+        "live_qualified": False,
+        "qualified_features": [],
+    }
     roles = {artifact["role"] for artifact in manifest["artifacts"]}
     assert {
         "all_session_notifications",
         "composition_identity",
+        "qualification_matrix",
         "redaction_audit",
         "runtime_identity",
     }.issubset(roles)
@@ -319,12 +342,13 @@ result_path.write_text(json.dumps({
     assert "must-be-redacted" not in redaction_text
     composition = json.loads(runtime.paths.composition.read_text(encoding="utf-8"))
     runtime_record = json.loads(runtime.paths.runtime_record.read_text(encoding="utf-8"))
-    assert "schema_version" not in composition
+    assert composition["schema"] == "aec-bench/deepseek-declared-composition/1"
     assert "qualified_source_revision" not in composition
     assert "sdk_version" not in composition
     assert "schema_version" not in runtime_record
     assert composition["timeout_sec"] == 5
     assert composition["max_tokens"] == 17
+    assert composition["aec_native_tool_manifest"] == []
     assert composition["environment"]["secret_names"] == ["DSH_API_KEY"]
     assert composition["environment"]["passthrough_names"]
     assert "DSH_API_KEY" not in composition["environment"]["passthrough_names"]
@@ -333,6 +357,18 @@ result_path.write_text(json.dumps({
     assert runtime_record["timeout_sec"] == 5
     assert runtime_record["max_tokens"] == 17
     assert result.evidence_manifest_sha256 is not None
+
+    future_payload = json.loads(result.manifest_path.read_text(encoding="utf-8"))
+    future_payload["future_manifest_field"] = {"retained": True}
+    future_payload["attestation"]["declared"]["future_level_field"] = "retained"
+    imported = DeepSeekEvidenceManifest.model_validate(future_payload).model_dump(mode="json", by_alias=True)
+    assert imported["future_manifest_field"] == {"retained": True}
+    assert imported["attestation"]["declared"]["future_level_field"] == "retained"
+    legacy_payload = json.loads(result.manifest_path.read_text(encoding="utf-8"))
+    legacy_payload["schema_version"] = "aecbench.deepseek-evidence-manifest.v1"
+    del legacy_payload["schema"]
+    with pytest.raises(ValueError, match="schema"):
+        DeepSeekEvidenceManifest.model_validate(legacy_payload)
 
     with pytest.raises(DeepSeekHarnessRuntimeError, match="only one trial"):
         runtime.run(AdapterRequest(instruction="Do the work again", configuration={"timeout_sec": 5}))
@@ -426,6 +462,9 @@ result_path.write_text(json.dumps({
     assert composition["plugins"] == [
         {
             "artifact_path": "plugins/output-commit/index.js",
+            "artifact_sha256": deepseek_runtime._file_sha256(runtime.paths.output_commit_plugin),
+            "package_lock_path": "plugins/package-lock.json",
+            "package_lock_sha256": deepseek_runtime._file_sha256(runtime.paths.plugin_package_lock),
             "plugin_id": "@aec-bench/dsh-output-commit",
             "role": "output_commit",
             "version": "0.1.0",
@@ -436,6 +475,13 @@ result_path.write_text(json.dumps({
         {artifact["role"] for artifact in manifest["artifacts"]}
     )
     assert manifest["plugins"] == composition["plugins"]
+    assert manifest["plugins"][0]["artifact_sha256"] == deepseek_runtime._file_sha256(
+        runtime.paths.output_commit_plugin
+    )
+    assert manifest["plugins"][0]["package_lock_path"] == "plugins/package-lock.json"
+    assert manifest["plugins"][0]["package_lock_sha256"] == deepseek_runtime._file_sha256(
+        runtime.paths.plugin_package_lock
+    )
 
 
 def test_runtime_binds_exact_native_tools_and_records_secret_free_evidence(tmp_path: Path) -> None:
@@ -498,22 +544,57 @@ result_path.write_text(json.dumps({
 }))
 """.strip(),
     )
+    definition = json_native_tool_definition(
+        name="list_workspace",
+        description="List files",
+        parameters_schema={
+            "type": "object",
+            "properties": {"path": {"type": "string", "default": ""}},
+            "required": [],
+            "additionalProperties": False,
+        },
+        function=list_workspace,
+    )
+    tool_manifest = native_tool_manifest((definition,))
+    action_mapping = ({"catalogue_action": "list_workspace", "public_tool": "list_workspace"},)
+    surface_identity = {"action_mapping": action_mapping, "tools": tool_manifest}
+    public_surface_sha256 = hashlib.sha256(
+        json.dumps(surface_identity, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    actor_evidence_path = tmp_path / "actor-invocation-evidence.jsonl"
+    actor_evidence_path.write_text(
+        json.dumps(
+            {
+                "sequence": 7,
+                "record_type": "request-admitted",
+                "request_id": "dsh:root:tool-1",
+                "correlation": {
+                    "transport_request_id": "dsh:root:tool-1",
+                    "provider_session_id": "root",
+                    "provider_tool_call_id": "tool-1",
+                    "model_turn": 1,
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
     runtime = DeepSeekHarnessProcessRuntime(
         settings=_settings(tmp_path),
         workspace=tmp_path,
         worker_command=(sys.executable, str(worker)),
-        native_tools=(
-            json_native_tool_definition(
-                name="list_workspace",
-                description="List files",
-                parameters_schema={
-                    "type": "object",
-                    "properties": {"path": {"type": "string", "default": ""}},
-                    "required": [],
-                    "additionalProperties": False,
-                },
-                function=list_workspace,
-            ),
+        native_tools=(definition,),
+        native_world_evidence=DeepSeekNativeWorldEvidence(
+            surface_record={
+                "schema": "aec-bench/native-world-tool-surface/1",
+                "task_world_id": "test/list-workspace",
+                "catalogue_sha256": "a" * 64,
+                "public_tool_surface_sha256": public_surface_sha256,
+                "catalogue": {},
+                "action_mapping": action_mapping,
+                "tools": tool_manifest,
+            },
+            actor_authority_evidence_path=actor_evidence_path,
         ),
     )
     request = AdapterRequest(
@@ -540,17 +621,32 @@ result_path.write_text(json.dumps({
     assert composition["environment"]["secret_names"] == ["DSH_API_KEY", "DSH_TOOLS_TOKEN"]
     manifest = json.loads(runtime.paths.manifest.read_text(encoding="utf-8"))
     assert manifest["composition"]["native_tools"] == ["list_workspace"]
-    assert manifest["plugins"] == [
-        {
-            "artifact_path": "plugins/tools/index.js",
-            "plugin_id": "@aec-bench/dsh-tools",
-            "role": "native_tools",
-            "version": "0.2.0",
-        }
-    ]
-    assert {"tool_gateway_evidence", "optional_plugin"}.issubset(
-        {artifact["role"] for artifact in manifest["artifacts"]}
-    )
+    assert manifest["actor_native_tools"]["task_world_id"] == "test/list-workspace"
+    assert manifest["actor_native_tools"]["actor_catalogue_sha256"] == "a" * 64
+    assert manifest["actor_native_tools"]["public_native_tool_surface_sha256"] == public_surface_sha256
+    assert manifest["actor_native_tools"]["presentation_mode"] == "deepseek-native"
+    assert manifest["actor_native_tools"]["actor_authority_scope"] == "segment-snapshot"
+    correlation = [json.loads(line) for line in runtime.paths.actor_correlation.read_text().splitlines()]
+    assert correlation[0]["request_id"] == "dsh:root:tool-1"
+    assert correlation[0]["actor_evidence_sequences"] == [7]
+    assert len(manifest["plugins"]) == 1
+    assert manifest["plugins"][0] == {
+        "artifact_path": "plugins/tools/index.js",
+        "artifact_sha256": deepseek_runtime._file_sha256(runtime.paths.tool_gateway_plugin),
+        "package_lock_path": "plugins/package-lock.json",
+        "package_lock_sha256": deepseek_runtime._file_sha256(runtime.paths.plugin_package_lock),
+        "plugin_id": "@aec-bench/dsh-tools",
+        "role": "native_tools",
+        "version": "0.2.0",
+    }
+    assert {
+        "actor_authority_evidence",
+        "actor_correlation",
+        "native_world_tool_surface",
+        "tool_gateway_evidence",
+        "optional_plugin",
+        "plugin_package_lock",
+    }.issubset({artifact["role"] for artifact in manifest["artifacts"]})
 
 
 def test_runtime_rejects_completion_after_nonquiescent_tool_close(tmp_path: Path) -> None:

--- a/tests/deepseek_harness/test_sdk_integration.py
+++ b/tests/deepseek_harness/test_sdk_integration.py
@@ -595,15 +595,15 @@ def test_real_sdk_output_commit_plugin_accepts_and_concludes_the_turn(
     assert "aec_commit_output" in advertised_tools
     assert result.configuration_record["output_commit_mode"] == "required"
     assert result.configuration_record["plugin_free_baseline"] is False
-    manifest_plugins = [
-        {
-            "artifact_path": "plugins/output-commit/index.js",
-            "plugin_id": "@aec-bench/dsh-output-commit",
-            "role": "output_commit",
-            "version": "0.1.0",
-        }
-    ]
-    assert result.configuration_record["optional_plugins"] == manifest_plugins
+    manifest_plugins = result.configuration_record["optional_plugins"]
+    assert len(manifest_plugins) == 1
+    assert manifest_plugins[0]["artifact_path"] == "plugins/output-commit/index.js"
+    assert manifest_plugins[0]["package_lock_path"] == "plugins/package-lock.json"
+    assert manifest_plugins[0]["plugin_id"] == "@aec-bench/dsh-output-commit"
+    assert manifest_plugins[0]["role"] == "output_commit"
+    assert manifest_plugins[0]["version"] == "0.1.0"
+    assert len(manifest_plugins[0]["artifact_sha256"]) == 64
+    assert len(manifest_plugins[0]["package_lock_sha256"]) == 64
     manifest_path = Path(result.configuration_record["manifest_path"])
     assert json.loads(manifest_path.read_text(encoding="utf-8"))["plugins"] == manifest_plugins
     commit_evidence = Path(result.configuration_record["commit_evidence_path"]).read_text(encoding="utf-8")

--- a/tests/packaging/verify_wheel_profiles.py
+++ b/tests/packaging/verify_wheel_profiles.py
@@ -179,7 +179,22 @@ def _verify_profile(
 ) -> None:
     imports = ";".join(f"import {module}" for module in profile.imports)
     _run([str(python), "-I", "-c", imports], cwd=work, env=env)
-    if name == "prime":
+    if name == "deepseek-harness":
+        _run(
+            [
+                str(python),
+                "-I",
+                "-c",
+                (
+                    "from aec_bench.adapters.deepseek_harness.qualification import "
+                    "load_deepseek_qualification_matrix; "
+                    "matrix=load_deepseek_qualification_matrix(); assert len(matrix.rows) == 2"
+                ),
+            ],
+            cwd=work,
+            env=env,
+        )
+    elif name == "prime":
         _run([str(_command(python.parents[1], "prime")), "--version"], cwd=work, env=env, expected="0.6.2")
     elif name == "webui":
         _run(


### PR DESCRIPTION
## Summary

- replace the internal DeepSeek evidence manifest v1 with explicit declared, resolved-runtime, and model-visible attestation levels
- bind qualification, plugin-lock, native world-surface, actor-authority, and correlation evidence by content hash
- add a versioned provider feature matrix that keeps live qualification separate from keyless protocol proof
- add an all-extras collection and focused DeepSeek release-qualification CI gate
- update the governing DeepSeek evidence contract and packaged-profile verification

## Validation

- 29 focused manifest, provider-conformance, and pump-world tests passed
- 10 real-SDK keyless integration tests passed
- 9 DeepSeek plugin tests passed
- plugin rebuild produced no tracked diff
- targeted Ruff, format, strict mypy, workflow YAML, and diff checks passed

## Qualification status

Azure and DeepSeek official remain partial. This PR does not claim credentialed live-provider evidence. The release CI job is keyless and cannot promote a live qualification cell.