### PR TITLE
perf: reduce Prime CI journey time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   linux-smoke:
     name: Linux smoke
@@ -129,7 +133,7 @@ jobs:
         run: uv sync --frozen
 
       - name: Run interactive-world tests
-        run: uv run pytest -q tests/worlds/
+        run: uv run pytest -q --durations=25 tests/worlds/
 
       - name: Check owned formatting
         run: >-
@@ -198,18 +202,12 @@ jobs:
 
       - name: Run Prime world journey tests
         run: >-
-          uv run pytest -q
+          uv run pytest -q --durations=25
           tests/prime_agent/test_acp.py
           tests/harness/world_actor/
           tests/harness/dam_seepage_prime/test_session.py
           tests/harness/pump_station_prime/test_session.py
           tests/harness/pump_station_prime/test_journey.py
-          tests/worlds/monitoring/dam_seepage/test_episode_runtime.py
-          tests/worlds/stewardship/wastewater_pump_station/test_bound_root_control_interface_envelope.py
-          tests/worlds/stewardship/wastewater_pump_station/test_host_continuation.py
-          tests/worlds/stewardship/wastewater_pump_station/test_reference_controller.py
-          tests/worlds/stewardship/wastewater_pump_station/test_reference_system_journey.py
-          tests/worlds/stewardship/wastewater_pump_station/test_root_control_capability_authority.py
 
       - name: Check Prime world journey formatting
         run: >-

--- a/src/aec_bench/worlds/stewardship/wastewater_pump_station/world_run_serialization.py
+++ b/src/aec_bench/worlds/stewardship/wastewater_pump_station/world_run_serialization.py
@@ -6,9 +6,11 @@ from __future__ import annotations
 import hashlib
 import json
 import types
+from collections.abc import Hashable
 from dataclasses import fields, is_dataclass
 from decimal import Decimal, InvalidOperation
 from enum import Enum
+from functools import cache
 from typing import Any, NoReturn, TypeVar, cast, get_args, get_origin, get_type_hints, overload
 
 from aec_bench.worlds.stewardship.wastewater_pump_station.world_run_models import (
@@ -84,6 +86,11 @@ def _decode_union(value: object, expected: object) -> object:
     _fail("artifact-type", str(detail))
 
 
+@cache
+def _dataclass_type_hints(expected: Hashable) -> dict[str, object]:
+    return cast(dict[str, object], get_type_hints(cast(type[Any], expected)))
+
+
 def _decode_dataclass(value: object, expected: type[Any]) -> object:
     if not isinstance(value, dict):
         _fail("artifact-shape", f"{expected.__name__} must be an object")
@@ -92,7 +99,7 @@ def _decode_dataclass(value: object, expected: type[Any]) -> object:
     declared_fields = fields(expected)
     if set(value) != {"$type", *(field.name for field in declared_fields)}:
         _fail("artifact-shape", f"{expected.__name__} fields differ")
-    type_hints = cast(dict[str, object], get_type_hints(expected))
+    type_hints = _dataclass_type_hints(cast(Hashable, expected))
     decoded = {field.name: _decode(value[field.name], type_hints[field.name]) for field in declared_fields}
     try:
         return expected(**decoded)

--- a/tests/worlds/stewardship/wastewater_pump_station/test_world_run_serialization.py
+++ b/tests/worlds/stewardship/wastewater_pump_station/test_world_run_serialization.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from aec_bench.contracts.world_interface import WorldActorActionRequest
+from aec_bench.worlds.stewardship.wastewater_pump_station import world_run_serialization
 from aec_bench.worlds.stewardship.wastewater_pump_station.episode_runtime import (
     PumpStationEpisodeHost,
 )
@@ -51,6 +52,20 @@ def test_current_state_round_trips_as_canonical_task_json(tmp_path: Path) -> Non
     assert restored == run.state
     assert pump_station_artifact_bytes(restored) == payload
     assert payload.endswith(b"\n")
+
+
+def test_current_state_resolves_each_dataclass_type_once(tmp_path: Path) -> None:
+    run = _run(tmp_path / "run")
+    payload = pump_station_artifact_bytes(run.state)
+    resolver = world_run_serialization._dataclass_type_hints
+    resolver.cache_clear()
+
+    restored = load_pump_station_artifact(payload, PumpStationStewardshipState)
+    cache_info = resolver.cache_info()
+
+    assert restored == run.state
+    assert cache_info.hits > 0
+    assert cache_info.misses == cache_info.currsize
 
 
 def test_current_state_rejects_unknown_fields_types_and_numbers(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- cache resolved dataclass type metadata during pump-world artifact decoding
- keep world tests in the Interactive worlds gate instead of running the same tests again in the Prime gate
- report the slowest tests and cancel superseded workflow runs

## Measured effect

- representative complete Prime journey: 64.08 seconds before, 28.81 seconds after
- revised local Prime gate: 88 passed in 147.95 seconds
- full world suite: 160 passed in 99.47 seconds

## Verification

- serializer regression: 4 passed
- repository Ruff: passed
- Prime and world formatting gates: passed
- scoped strict mypy: passed
- provenance audit: passed with zero violations
- workflow YAML parse and diff checks: passed