### PR TITLE
task-genome: stop duplicating task source inside evidence packets

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -129,6 +129,13 @@ templates, generators, and task-world compilers turn repository sources into
 validated runnable material. Task-family semantics stay with their task or
 template owner.
 
+Task-genome extraction creates derived review evidence. One task snapshot owns
+the source identity; relative source spans locate supporting material without
+copying task configuration, instructions, verifier source, or per-file hashes
+into the review. Review metadata and decomposition do not participate in task
+or dataset identity. The artifact repository stores a review only when a
+workflow needs durable review history.
+
 ### Experiment, trial, and episode orchestration
 
 The harness owns ordinary trial staging, backend execution, collection, and

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -30,6 +30,7 @@ readable.
 | --- | --- | --- | --- | --- | --- |
 | Task specification | Task authoring and loading | Repository or imported task material becomes runnable input | Protected where task packages are published; otherwise internal | [`TaskDefinition`](../src/aec_bench/contracts/task_definition.py) and task loaders | Persisted task package |
 | Task instance and revision identity | Generation and harness | Selected task bytes become one exact execution identity | Protected when recorded in a dataset or trial | [`ResolvedTaskInstance`](../src/aec_bench/tasks/instance.py), `TaskReference`, and `DatasetTaskEntry` | Internal resolution; persisted references |
+| Task genome review | Tasks and feedback | A derived genome and its source spans become review evidence for one exact task snapshot | Internal; independently retained reviews use current-format artifacts | [`TaskGenomeReview`](../src/aec_bench/contracts/task_genome.py), `TaskSnapshotRef`, and `ArtifactRef` | Regenerable review; optional persisted artifact |
 | Generated-task replay | Task generation | Template sources and sampling inputs become optional reproducibility data | Schema 1 sidecar; not a runtime task contract | [`GenerationManifest`](../src/aec_bench/generation/replay.py) and the `generate replay` command | Optional persisted sidecar |
 | Finite lifecycle execution | Lifecycle task and host | Stage-specific task evidence and actor results become one bounded host-controlled progression | Internal package and runtime contract; persisted accepted evidence is current-format only | [`EvidenceLifecycleSpec`](../src/aec_bench/contracts/evidence_lifecycle.py) and the [staged evidence protocol](protocols/staged-evidence-and-publication.md) | Packaged task, runtime state, and persisted accepted evidence |
 | Experiment manifest | Experiment orchestration | User configuration becomes an executable plan | Internal, except documented CLI/config behavior | [`ExperimentManifest`](../src/aec_bench/contracts/experiment_manifest.py) | Persisted configuration |
@@ -56,6 +57,23 @@ remain task-owned; the global contract does not attempt to model every output.
 Executable interactive worlds use their registered world definition and
 profile instead of pretending to be a static `TaskDefinition`. Both families
 can still enter the same experiment, trial, evaluation, and reporting layers.
+
+## Task genome reviews
+
+`TaskGenomeReview` is derived review evidence, not a task definition or a task
+identity. It binds one `TaskGenomeManifest` and a map of relative `SourceSpan`
+values to one exact `TaskSnapshotRef`. A span can identify stable line numbers,
+a named section, and a short extracted signal. It does not contain source bytes
+or a separate digest.
+
+The selected snapshot resolves all source spans. A review is stale when that
+snapshot changes. Changes to confidence, reviewer, notes, span presentation,
+or the genome decomposition do not change the task or dataset identity.
+
+An independently retained review is stored as one canonical model artifact
+and receives one `ArtifactRef`. Durable review history records its reviewer,
+event time, and review artifact reference separately. It does not modify the
+runnable task package.
 
 ## Public library catalogue
 

--- a/src/aec_bench/cli/commands/task.py
+++ b/src/aec_bench/cli/commands/task.py
@@ -106,9 +106,9 @@ def genome_command(
         root = task_dir.parent
 
     from aec_bench.tasks.genome import (
-        build_task_genome_evidence,
+        build_task_genome_review,
         extract_task_genome,
-        task_genome_evidence_to_yaml,
+        task_genome_review_to_yaml,
         task_genome_to_yaml,
     )
 
@@ -117,20 +117,32 @@ def genome_command(
         typer.echo(task_genome_to_yaml(manifest))
         return
 
-    if mode == "evidence":
-        packet = build_task_genome_evidence(task_dir, root)
-        typer.echo(task_genome_evidence_to_yaml(packet))
-        return
+    if mode in {"evidence", "llm"}:
+        from aec_bench.harness.compilation.task_snapshot import build_task_snapshot
+        from aec_bench.tasks.loader import load_task_definition
 
-    if mode == "llm":
+        task_snapshot = build_task_snapshot(
+            task=load_task_definition(task_dir, root),
+            tasks_root=root,
+        )
+        review = build_task_genome_review(task_dir, root, task=task_snapshot)
+
+        if mode == "evidence":
+            typer.echo(task_genome_review_to_yaml(review))
+            return
+
         if not model:
             console.print("[red]--model is required when --mode llm[/red]")
             raise typer.Exit(1)
         from aec_bench.evolution.task_genome_decomposer import decompose_task_genome
 
-        packet = build_task_genome_evidence(task_dir, root)
-        manifest = decompose_task_genome(packet, model_name=model)
-        typer.echo(task_genome_to_yaml(manifest))
+        review = decompose_task_genome(
+            review,
+            task_dir=task_dir,
+            current_task=task_snapshot,
+            model_name=model,
+        )
+        typer.echo(task_genome_review_to_yaml(review))
         return
 
     console.print("[red]Invalid --mode. Expected heuristic, evidence, or llm.[/red]")
@@ -186,9 +198,9 @@ def genome_batch_command(
         raise typer.Exit(1)
 
     from aec_bench.tasks.genome import (
-        build_task_genome_evidence,
+        build_task_genome_review,
         extract_task_genome,
-        task_genome_evidence_to_yaml,
+        publish_task_genome_review,
         task_genome_to_yaml,
     )
     from aec_bench.tasks.loader import iter_task_instance_dirs
@@ -197,9 +209,15 @@ def genome_batch_command(
     destination = Path(output_dir).resolve()
     destination.mkdir(parents=True, exist_ok=True)
 
-    entries: list[dict[str, str]] = []
+    entries: list[dict[str, object]] = []
     skipped = 0
     errors: list[str] = []
+
+    review_repository = None
+    if mode in {"evidence", "llm"}:
+        from aec_bench.ledger.artifact_repository import ArtifactRepository
+
+        review_repository = ArtifactRepository(destination / "review_artifacts")
 
     for task_dir in iter_task_instance_dirs(root):
         relative_parts = task_dir.relative_to(root).parts
@@ -209,18 +227,34 @@ def genome_batch_command(
 
         try:
             if mode == "evidence":
-                packet = build_task_genome_evidence(task_dir, root)
-                manifest = packet.deterministic_manifest
-                body = task_genome_evidence_to_yaml(packet)
+                from aec_bench.harness.compilation.task_snapshot import build_task_snapshot
+                from aec_bench.tasks.loader import load_task_definition
+
+                task_snapshot = build_task_snapshot(
+                    task=load_task_definition(task_dir, root),
+                    tasks_root=root,
+                )
+                review = build_task_genome_review(task_dir, root, task=task_snapshot)
+                manifest = review.genome
             elif mode == "llm":
                 from aec_bench.evolution.task_genome_decomposer import decompose_task_genome
+                from aec_bench.harness.compilation.task_snapshot import build_task_snapshot
+                from aec_bench.tasks.loader import load_task_definition
 
-                packet = build_task_genome_evidence(task_dir, root)
-                manifest = decompose_task_genome(packet, model_name=model or "")
-                body = task_genome_to_yaml(manifest)
+                task_snapshot = build_task_snapshot(
+                    task=load_task_definition(task_dir, root),
+                    tasks_root=root,
+                )
+                review = build_task_genome_review(task_dir, root, task=task_snapshot)
+                review = decompose_task_genome(
+                    review,
+                    task_dir=task_dir,
+                    current_task=task_snapshot,
+                    model_name=model or "",
+                )
+                manifest = review.genome
             else:
                 manifest = extract_task_genome(task_dir, root)
-                body = task_genome_to_yaml(manifest)
         except Exception as exc:
             errors.append(f"{task_dir.relative_to(root).as_posix()}: {type(exc).__name__}: {exc}")
             continue
@@ -229,18 +263,27 @@ def genome_batch_command(
             skipped += 1
             continue
 
-        sidecar_path = _catalogue_sidecar_path(destination, manifest.task_id)
-        sidecar_path.parent.mkdir(parents=True, exist_ok=True)
-        sidecar_path.write_text(body, encoding="utf-8")
-
-        entries.append(
-            {
-                "task_id": manifest.task_id,
-                "domain": manifest.domain_frame.discipline,
-                "path": sidecar_path.relative_to(destination).as_posix(),
-                "status": manifest.status,
-            }
-        )
+        entry: dict[str, object] = {
+            "task_id": manifest.task_id,
+            "domain": manifest.domain_frame.discipline,
+        }
+        if mode in {"evidence", "llm"}:
+            if review_repository is None:
+                raise RuntimeError("task genome review repository is not configured")
+            review_ref = publish_task_genome_review(review, review_repository)
+            entry.update(
+                status=review.status,
+                review=review_ref.model_dump(mode="json"),
+            )
+        else:
+            sidecar_path = _catalogue_sidecar_path(destination, manifest.task_id)
+            sidecar_path.parent.mkdir(parents=True, exist_ok=True)
+            sidecar_path.write_text(task_genome_to_yaml(manifest), encoding="utf-8")
+            entry.update(
+                status="extracted",
+                path=sidecar_path.relative_to(destination).as_posix(),
+            )
+        entries.append(entry)
         if limit is not None and len(entries) >= limit:
             break
 
@@ -329,7 +372,8 @@ def genome_template_batch_command(
                 "task_id": manifest.task_id,
                 "domain": manifest.domain_frame.discipline,
                 "path": sidecar_path.relative_to(destination).as_posix(),
-                "status": manifest.status,
+                "status": "extracted",
+                "template_path": _relative_catalogue_path(template_dir, repo_root),
             }
         )
         if limit is not None and len(entries) >= limit:

--- a/src/aec_bench/contracts/task_genome.py
+++ b/src/aec_bench/contracts/task_genome.py
@@ -1,11 +1,15 @@
-# ABOUTME: Contract models for task genome sidecar manifests.
-# ABOUTME: Describes decomposed task pressures with provenance and review metadata.
+# ABOUTME: Contract models for task genome decomposition and snapshot-bound review artifacts.
+# ABOUTME: Keeps derived review evidence separate from runnable task identity and source bytes.
 
-from typing import Any, Literal
+from __future__ import annotations
 
-from pydantic import Field, field_validator
+from typing import Any, Literal, Self
 
+from pydantic import Field, PositiveInt, field_validator, model_validator
+
+from aec_bench.contracts.run_bundle import TaskSnapshotRef
 from aec_bench.contracts.validators import (
+    FrozenStrictModel,
     NonEmptyStr,
     StrictModel,
     ensure_optional_relative_path,
@@ -13,18 +17,38 @@ from aec_bench.contracts.validators import (
 )
 
 Confidence = Literal["high", "medium", "low"]
-TaskGenomeStatus = Literal["extracted", "needs_review"]
+TaskGenomeStatus = Literal["extracted", "needs_review", "reviewed"]
+TASK_GENOME_REVIEW_MEDIA_TYPE = "application/vnd.aec-bench.task-genome-review+json"
 
 
-class ProvenanceRef(StrictModel):
-    file: NonEmptyStr
+class SourceSpan(FrozenStrictModel):
+    """One source location resolved only through the review's task snapshot."""
+
+    path: NonEmptyStr
+    start_line: PositiveInt | None = None
+    end_line: PositiveInt | None = None
     section: str | None = None
     signal: str | None = None
 
-    @field_validator("file")
+    @field_validator("path")
     @classmethod
-    def validate_file(cls, value: str) -> str:
+    def validate_path(cls, value: str) -> str:
         return ensure_relative_path(value)
+
+    @field_validator("section", "signal")
+    @classmethod
+    def validate_optional_text(cls, value: str | None) -> str | None:
+        if value is not None and not value.strip():
+            raise ValueError("source span text must not be blank")
+        return value
+
+    @model_validator(mode="after")
+    def validate_line_range(self) -> Self:
+        if (self.start_line is None) != (self.end_line is None):
+            raise ValueError("source span must set both start_line and end_line")
+        if self.start_line is not None and self.end_line is not None and self.end_line < self.start_line:
+            raise ValueError("source span end_line must not precede start_line")
+        return self
 
 
 class DomainFrame(StrictModel):
@@ -54,9 +78,7 @@ class PressurePoint(StrictModel):
     id: NonEmptyStr
     type: NonEmptyStr
     description: NonEmptyStr
-    provenance: list[ProvenanceRef] = Field(default_factory=list)
     confidence: Confidence = "medium"
-    reviewed_by: NonEmptyStr = "deterministic_extractor"
 
 
 class OutputContract(StrictModel):
@@ -85,9 +107,9 @@ class ExtractionSummary(StrictModel):
 
 
 class TaskGenomeManifest(StrictModel):
+    """Derived semantic decomposition without a source locator or review state."""
+
     task_id: NonEmptyStr
-    source_task_path: NonEmptyStr
-    status: TaskGenomeStatus = "extracted"
     domain_frame: DomainFrame
     scenario: Scenario
     input_bundle: InputBundle
@@ -99,32 +121,53 @@ class TaskGenomeManifest(StrictModel):
     trajectory_affordances: dict[str, Any] = Field(default_factory=dict)
     extraction: ExtractionSummary
 
-    @field_validator("source_task_path")
+
+class TaskGenomeReview(FrozenStrictModel):
+    """Regenerable review evidence bound to one exact runnable task snapshot."""
+
+    task: TaskSnapshotRef
+    status: TaskGenomeStatus
+    extractor: NonEmptyStr
+    reviewer: NonEmptyStr | None = None
+    genome: TaskGenomeManifest
+    evidence: dict[NonEmptyStr, list[SourceSpan]]
+
+    @field_validator("evidence")
     @classmethod
-    def validate_source_task_path(cls, value: str) -> str:
-        return ensure_relative_path(value)
+    def validate_evidence(cls, value: dict[str, list[SourceSpan]]) -> dict[str, list[SourceSpan]]:
+        if not value:
+            raise ValueError("task genome review evidence must not be empty")
+        empty_keys = [key for key, spans in value.items() if not spans]
+        if empty_keys:
+            raise ValueError(f"task genome evidence entries must contain source spans: {', '.join(empty_keys)}")
+        return value
+
+    @model_validator(mode="after")
+    def validate_review(self) -> Self:
+        if self.task.task_id != self.genome.task_id:
+            raise ValueError("task genome review task does not match the genome task_id")
+        if self.status == "reviewed" and self.reviewer is None:
+            raise ValueError("reviewed task genome evidence must identify its reviewer")
+        return self
+
+    def is_stale(self, current_task: TaskSnapshotRef) -> bool:
+        """Return whether the selected task snapshot differs from this review."""
+
+        return self.task != current_task
 
 
-class TaskGenomeEvidencePacket(StrictModel):
-    task_id: NonEmptyStr
-    source_task_path: NonEmptyStr
-    deterministic_manifest: TaskGenomeManifest
-    task_toml: dict[str, Any] = Field(default_factory=dict)
-    instruction_sections: dict[str, str] = Field(default_factory=dict)
-    verifier_files: dict[str, str] = Field(default_factory=dict)
-    artifact_paths: list[str] = Field(default_factory=list)
-
-    @field_validator("source_task_path")
-    @classmethod
-    def validate_source_task_path(cls, value: str) -> str:
-        return ensure_relative_path(value)
-
-    @field_validator("verifier_files")
-    @classmethod
-    def validate_verifier_file_paths(cls, value: dict[str, str]) -> dict[str, str]:
-        return {ensure_relative_path(path): content for path, content in value.items()}
-
-    @field_validator("artifact_paths")
-    @classmethod
-    def validate_artifact_paths(cls, value: list[str]) -> list[str]:
-        return [ensure_relative_path(item) for item in value]
+__all__ = (
+    "TASK_GENOME_REVIEW_MEDIA_TYPE",
+    "Confidence",
+    "DomainFrame",
+    "ExtractionSummary",
+    "InputBundle",
+    "OutputContract",
+    "PressurePoint",
+    "Scenario",
+    "SourceSpan",
+    "TaskGenomeManifest",
+    "TaskGenomeReview",
+    "TaskGenomeStatus",
+    "VerifierContract",
+)

--- a/src/aec_bench/evolution/task_genome_decomposer.py
+++ b/src/aec_bench/evolution/task_genome_decomposer.py
@@ -1,31 +1,45 @@
 # ABOUTME: Runs LLM-driven semantic decomposition for task genome sidecars.
-# ABOUTME: Converts bounded evidence packets into validated TaskGenomeManifest objects.
+# ABOUTME: Reviews snapshot-resolved source spans without persisting copied task source.
 
 from __future__ import annotations
 
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 import yaml
 
-from aec_bench.contracts.task_genome import TaskGenomeEvidencePacket, TaskGenomeManifest
+from aec_bench.contracts.run_bundle import TaskSnapshotRef
+from aec_bench.contracts.task_genome import TaskGenomeManifest, TaskGenomeReview
+from aec_bench.tasks.genome import resolve_task_genome_evidence
 
 Reviewer = Callable[[str], TaskGenomeManifest | dict[str, Any]]
 
 _DECOMPOSITION_SYSTEM = """You decompose AEC benchmark tasks into task genome manifests.
 
-Use only the supplied evidence packet. Do not invent files, verifier behavior, or standards.
+Use only the supplied review artifact and snapshot-resolved excerpts. Do not invent files,
+verifier behavior, or standards.
 Improve the deterministic manifest semantically: identify pressure points, recombinable
 parts, reasoning moves, difficulty controls, and trajectory affordances. Every pressure
-point must include provenance. Mark uncertain semantic calls with confidence='low' or
-status='needs_review'.
+point must be supported by the supplied evidence map. Mark uncertain semantic calls with
+confidence='low'.
 """
 
 
-def build_decomposition_prompt(packet: TaskGenomeEvidencePacket) -> str:
-    """Build the bounded prompt handed to a lite decomposition reviewer."""
-    evidence_yaml = yaml.safe_dump(
-        packet.model_dump(mode="json", exclude_none=True),
+def build_decomposition_prompt(
+    review: TaskGenomeReview,
+    *,
+    task_dir: Path,
+    current_task: TaskSnapshotRef,
+) -> str:
+    """Build a prompt from one review and its verified snapshot-resolved excerpts."""
+    review_yaml = yaml.safe_dump(
+        review.model_dump(mode="json", exclude_none=True),
+        sort_keys=False,
+        allow_unicode=False,
+    )
+    excerpts_yaml = yaml.safe_dump(
+        resolve_task_genome_evidence(review, task_dir=task_dir, current_task=current_task),
         sort_keys=False,
         allow_unicode=False,
     )
@@ -40,24 +54,30 @@ def build_decomposition_prompt(packet: TaskGenomeEvidencePacket) -> str:
         "- difficulty_controls: explain knobs that would make variants easier or harder.\n"
         "- trajectory_affordances: list intermediate evidence a good trajectory should show.\n"
         "- extraction: record which fields still need human review.\n\n"
-        "Evidence packet:\n"
-        f"{evidence_yaml}"
+        "Review artifact:\n"
+        f"{review_yaml}\n"
+        "Snapshot-resolved evidence excerpts:\n"
+        f"{excerpts_yaml}"
     )
 
 
 def decompose_task_genome(
-    packet: TaskGenomeEvidencePacket,
+    review: TaskGenomeReview,
     *,
+    task_dir: Path,
+    current_task: TaskSnapshotRef,
     model_name: str,
     reviewer: Reviewer | None = None,
-) -> TaskGenomeManifest:
-    """Run semantic decomposition with an injected or real PydanticAI reviewer."""
-    prompt = build_decomposition_prompt(packet)
+) -> TaskGenomeReview:
+    """Run semantic decomposition and return a new review of the same task snapshot."""
+    prompt = build_decomposition_prompt(review, task_dir=task_dir, current_task=current_task)
     if reviewer is not None:
         reviewer_result = reviewer(prompt)
         if isinstance(reviewer_result, TaskGenomeManifest):
-            return reviewer_result
-        return TaskGenomeManifest.model_validate(reviewer_result)
+            genome = reviewer_result
+        else:
+            genome = TaskGenomeManifest.model_validate(reviewer_result)
+        return _with_reviewed_genome(review, genome=genome, reviewer=model_name)
 
     from pydantic_ai import Agent
 
@@ -71,4 +91,15 @@ def decompose_task_genome(
         retries=2,
     )
     run_result = agent.run_sync(prompt)
-    return run_result.output
+    return _with_reviewed_genome(review, genome=run_result.output, reviewer=model_name)
+
+
+def _with_reviewed_genome(
+    review: TaskGenomeReview,
+    *,
+    genome: TaskGenomeManifest,
+    reviewer: str,
+) -> TaskGenomeReview:
+    payload = review.model_dump(mode="python")
+    payload.update(status="needs_review", reviewer=reviewer, genome=genome)
+    return TaskGenomeReview.model_validate(payload)

--- a/src/aec_bench/experimentation/task_ecology/benchmark.py
+++ b/src/aec_bench/experimentation/task_ecology/benchmark.py
@@ -11,6 +11,7 @@ from typing import Any, Literal
 
 import yaml
 
+from aec_bench.contracts.validators import ensure_relative_path
 from aec_bench.evolution.config_loader import load_evolution_config
 from aec_bench.evolution.report_data import list_runs
 from aec_bench.generation.contracts import SampledInstance
@@ -47,7 +48,7 @@ DEFAULT_SEED = 20260514
 class TemplateEntry:
     task_id: str
     domain: str
-    source_task_path: str
+    template_path: str
 
 
 @dataclass(frozen=True)
@@ -71,13 +72,14 @@ def load_template_entries(index_path: Path) -> list[TemplateEntry]:
     root = index_path.parent
     entries: list[TemplateEntry] = []
     for entry in index.get("entries", []):
-        genome_path = root / entry["path"]
-        genome = yaml.safe_load(genome_path.read_text(encoding="utf-8"))
+        genome_path = root / ensure_relative_path(str(entry["path"]))
+        if not genome_path.is_file():
+            raise ValueError(f"template genome does not exist: {entry['path']}")
         entries.append(
             TemplateEntry(
                 task_id=entry["task_id"],
                 domain=entry["domain"],
-                source_task_path=genome["source_task_path"],
+                template_path=ensure_relative_path(str(entry["template_path"])),
             )
         )
     return entries
@@ -132,7 +134,7 @@ def materialise_suite(
     suite_root.mkdir(parents=True, exist_ok=True)
     require_available_sidecar_paths(suite_root)
 
-    loaded_entries = [(entry, load_template(repo_root / entry.source_task_path)) for entry in entries]
+    loaded_entries = [(entry, load_template(repo_root / entry.template_path)) for entry in entries]
     prepared_source = prepare_template_source(tuple(template for _, template in loaded_entries), suite_root)
 
     materialised: list[MaterialisedInstance] = []

--- a/src/aec_bench/tasks/genome.py
+++ b/src/aec_bench/tasks/genome.py
@@ -1,5 +1,5 @@
-# ABOUTME: Extracts task genome sidecar manifests from existing task directories.
-# ABOUTME: Uses deterministic parsers first and marks semantic fields for lite review.
+# ABOUTME: Extracts task genomes and snapshot-bound review evidence from task directories.
+# ABOUTME: Stores source locations instead of copying task, instruction, or verifier bytes.
 
 from __future__ import annotations
 
@@ -12,18 +12,22 @@ from typing import Any
 
 import yaml
 
+from aec_bench.contracts.artifacts import ArtifactRef
+from aec_bench.contracts.run_bundle import TaskSnapshotRef
 from aec_bench.contracts.task_genome import (
+    TASK_GENOME_REVIEW_MEDIA_TYPE,
     DomainFrame,
     ExtractionSummary,
     InputBundle,
     OutputContract,
     PressurePoint,
-    ProvenanceRef,
     Scenario,
-    TaskGenomeEvidencePacket,
+    SourceSpan,
     TaskGenomeManifest,
+    TaskGenomeReview,
     VerifierContract,
 )
+from aec_bench.ledger.artifact_repository import ArtifactRepository
 from aec_bench.tasks.loader import load_task_definition
 
 _HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$", re.MULTILINE)
@@ -75,12 +79,8 @@ def extract_task_genome(task_dir: Path, tasks_root: Path) -> TaskGenomeManifest:
     if not pressure_points:
         missing_fields.append("pressure_points")
 
-    source_path = f"{tasks_root.name}/{task_dir.relative_to(tasks_root).as_posix()}"
-
     return TaskGenomeManifest(
         task_id=task.task_id,
-        source_task_path=source_path,
-        status="extracted",
         domain_frame=DomainFrame(
             discipline=task.domain,
             subdomain=_extract_subdomain(task.task_id, task.task_type, task.metadata),
@@ -119,31 +119,163 @@ def task_genome_to_yaml(manifest: TaskGenomeManifest) -> str:
     return yaml.safe_dump(payload, sort_keys=False, allow_unicode=False)
 
 
-def build_task_genome_evidence(task_dir: Path, tasks_root: Path) -> TaskGenomeEvidencePacket:
-    """Build a bounded evidence packet for LLM-driven task decomposition."""
+def build_task_genome_review(
+    task_dir: Path,
+    tasks_root: Path,
+    *,
+    task: TaskSnapshotRef,
+    extractor: str = "deterministic-task-genome",
+) -> TaskGenomeReview:
+    """Build a regenerable review that points to one exact task snapshot."""
     task_dir = task_dir.resolve()
     tasks_root = tasks_root.resolve()
-    deterministic_manifest = extract_task_genome(task_dir, tasks_root)
+    genome = extract_task_genome(task_dir, tasks_root)
+    if task.task_id != genome.task_id:
+        raise ValueError("task snapshot does not match the extracted task genome")
 
     instruction = (task_dir / "instruction.md").read_text(encoding="utf-8")
-    task_toml = _read_toml(task_dir / "task.toml")
-    verifier_files = _read_verifier_files(task_dir)
-
-    return TaskGenomeEvidencePacket(
-        task_id=deterministic_manifest.task_id,
-        source_task_path=deterministic_manifest.source_task_path,
-        deterministic_manifest=deterministic_manifest,
-        task_toml=task_toml,
-        instruction_sections=_parse_markdown_sections(instruction),
-        verifier_files=verifier_files,
-        artifact_paths=deterministic_manifest.input_bundle.artifacts,
+    return TaskGenomeReview(
+        task=task,
+        status="extracted",
+        extractor=extractor,
+        genome=genome,
+        evidence=_build_review_evidence(
+            task_dir=task_dir,
+            instruction=instruction,
+            verifier_script=genome.verifier_contract.script,
+        ),
     )
 
 
-def task_genome_evidence_to_yaml(packet: TaskGenomeEvidencePacket) -> str:
-    """Serialise an evidence packet as YAML for inspection or model prompts."""
-    payload = packet.model_dump(mode="json", exclude_none=True)
+def task_genome_review_to_yaml(review: TaskGenomeReview) -> str:
+    """Serialise a task genome review without embedding source bytes."""
+    payload = review.model_dump(mode="json", exclude_none=True)
     return yaml.safe_dump(payload, sort_keys=False, allow_unicode=False)
+
+
+def publish_task_genome_review(review: TaskGenomeReview, repository: ArtifactRepository) -> ArtifactRef:
+    """Retain one review as one content-bound artifact."""
+
+    return repository.publish_model(value=review, media_type=TASK_GENOME_REVIEW_MEDIA_TYPE)
+
+
+def load_task_genome_review(ref: ArtifactRef, repository: ArtifactRepository) -> TaskGenomeReview:
+    """Load and validate one retained task genome review."""
+
+    if ref.media_type != TASK_GENOME_REVIEW_MEDIA_TYPE:
+        raise ValueError(f"unsupported task genome review media type: {ref.media_type}")
+    return TaskGenomeReview.model_validate_json(repository.read_bytes(ref))
+
+
+def resolve_task_genome_evidence(
+    review: TaskGenomeReview,
+    *,
+    task_dir: Path,
+    current_task: TaskSnapshotRef,
+) -> dict[str, list[str]]:
+    """Resolve review excerpts only when the selected task snapshot is unchanged."""
+
+    if review.is_stale(current_task):
+        raise ValueError("task genome review is stale for the selected task snapshot")
+    root = task_dir.resolve()
+    resolved: dict[str, list[str]] = {}
+    for key, spans in review.evidence.items():
+        resolved[key] = [_resolve_source_span(root, span) for span in spans]
+    return resolved
+
+
+def _build_review_evidence(
+    *,
+    task_dir: Path,
+    instruction: str,
+    verifier_script: str | None,
+) -> dict[str, list[SourceSpan]]:
+    instruction_spans = _markdown_source_spans(instruction)
+    evidence: dict[str, list[SourceSpan]] = {
+        "task_configuration": [_source_file_span(task_dir, "task.toml")],
+        "instructions": list(instruction_spans.values()),
+    }
+
+    verifier_paths = _existing_source_paths(
+        task_dir,
+        [verifier_script, "tests/test.sh", "tests/verify.py", "tests/ground_truth.json", "validation_rules.toml"],
+    )
+    if verifier_paths:
+        evidence["verifier_contract"] = [_source_file_span(task_dir, path) for path in verifier_paths]
+    return evidence
+
+
+def _markdown_source_spans(text: str) -> dict[str, SourceSpan]:
+    matches = list(_HEADING_RE.finditer(text))
+    if not matches:
+        lines = text.splitlines()
+        return {
+            "body": SourceSpan(
+                path="instruction.md",
+                start_line=1 if lines else None,
+                end_line=len(lines) if lines else None,
+                section="body",
+            )
+        }
+
+    spans: dict[str, SourceSpan] = {}
+    for index, match in enumerate(matches):
+        key = _normalise_key(match.group(2))
+        start_line = text.count("\n", 0, match.start()) + 1
+        if index + 1 < len(matches):
+            end_line = text.count("\n", 0, matches[index + 1].start())
+        else:
+            end_line = max(start_line, len(text.splitlines()))
+        spans[key] = SourceSpan(
+            path="instruction.md",
+            start_line=start_line,
+            end_line=max(start_line, end_line),
+            section=match.group(2).strip(),
+        )
+    return spans
+
+
+def _source_file_span(
+    task_dir: Path,
+    relative_path: str,
+    *,
+    section: str | None = None,
+    signal: str | None = None,
+) -> SourceSpan:
+    path = task_dir / relative_path
+    line_count = len(path.read_text(encoding="utf-8").splitlines())
+    return SourceSpan(
+        path=relative_path,
+        start_line=1 if line_count else None,
+        end_line=line_count or None,
+        section=section,
+        signal=signal,
+    )
+
+
+def _existing_source_paths(task_dir: Path, candidates: list[str | None]) -> list[str]:
+    paths: list[str] = []
+    for candidate in candidates:
+        if candidate is None or candidate in paths:
+            continue
+        if (task_dir / candidate).is_file():
+            paths.append(candidate)
+    return paths
+
+
+def _resolve_source_span(task_dir: Path, span: SourceSpan) -> str:
+    path = (task_dir / span.path).resolve()
+    if not path.is_relative_to(task_dir):
+        raise ValueError(f"task genome evidence path escapes the task snapshot: {span.path}")
+    if not path.is_file():
+        raise ValueError(f"task genome evidence source does not exist: {span.path}")
+    text = path.read_text(encoding="utf-8")
+    if span.start_line is None or span.end_line is None:
+        return text
+    lines = text.splitlines()
+    if span.end_line > len(lines):
+        raise ValueError(f"task genome evidence span exceeds source lines: {span.path}")
+    return "\n".join(lines[span.start_line - 1 : span.end_line])
 
 
 def _read_toml(path: Path) -> dict[str, Any]:
@@ -162,16 +294,6 @@ def _read_json(path: Path) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise ValueError(f"expected JSON object in {path}")
     return payload
-
-
-def _read_verifier_files(task_dir: Path) -> dict[str, str]:
-    verifier_files: dict[str, str] = {}
-    tests_dir = task_dir / "tests"
-    for name in ("test.sh", "verify.py", "ground_truth.json"):
-        path = tests_dir / name
-        if path.exists():
-            verifier_files[path.relative_to(task_dir).as_posix()] = path.read_text(encoding="utf-8")
-    return verifier_files
 
 
 def _parse_markdown_sections(text: str) -> dict[str, str]:
@@ -404,13 +526,6 @@ def _extract_pressure_points(
                     "Solver must preserve the impedance-method pressure rather than "
                     "falling back to a resistance-only shortcut."
                 ),
-                provenance=[
-                    ProvenanceRef(
-                        file="instruction.md",
-                        section="Constraints",
-                        signal="resistance-only shortcut excluded",
-                    )
-                ],
                 confidence="high",
             )
         )
@@ -421,13 +536,6 @@ def _extract_pressure_points(
                 id="no_external_lookup",
                 type="tool_constraint",
                 description="Solver must rely on supplied context and engineering knowledge.",
-                provenance=[
-                    ProvenanceRef(
-                        file="instruction.md",
-                        section="Constraints",
-                        signal="no internet",
-                    )
-                ],
                 confidence="high",
             )
         )
@@ -441,17 +549,16 @@ def _pressure_points_from_validation_rules(
 ) -> list[PressurePoint]:
     points: list[PressurePoint] = []
     for rule in validation_rules.get("global_rules", []):
-        points.append(_pressure_point_from_rule(rule, "global_rules"))
+        points.append(_pressure_point_from_rule(rule))
 
     for section in validation_rules.get("sections", []):
-        section_id = str(section.get("id", "section"))
         for rule in section.get("rules", []):
-            points.append(_pressure_point_from_rule(rule, f"section:{section_id}"))
+            points.append(_pressure_point_from_rule(rule))
 
     return points
 
 
-def _pressure_point_from_rule(rule: dict[str, Any], section: str) -> PressurePoint:
+def _pressure_point_from_rule(rule: dict[str, Any]) -> PressurePoint:
     rule_id = _normalise_key(str(rule.get("id", "validation_rule")))
     level = str(rule.get("level", "warning"))
     category = str(rule.get("category", "validation"))
@@ -459,13 +566,6 @@ def _pressure_point_from_rule(rule: dict[str, Any], section: str) -> PressurePoi
         id=rule_id,
         type=f"{category}_{level}",
         description=str(rule.get("text", rule_id)),
-        provenance=[
-            ProvenanceRef(
-                file="validation_rules.toml",
-                section=section,
-                signal=str(rule.get("pattern", rule_id)),
-            )
-        ],
         confidence="high",
     )
 

--- a/src/aec_bench/templates/genome.py
+++ b/src/aec_bench/templates/genome.py
@@ -16,7 +16,6 @@ from aec_bench.contracts.task_genome import (
     InputBundle,
     OutputContract,
     PressurePoint,
-    ProvenanceRef,
     Scenario,
     TaskGenomeManifest,
     VerifierContract,
@@ -45,8 +44,6 @@ def extract_template_genome(template_dir: Path, repo_root: Path) -> TaskGenomeMa
 
     return TaskGenomeManifest(
         task_id=task_id,
-        source_task_path=_relative_to_repo(template_dir, repo_root),
-        status="extracted",
         domain_frame=DomainFrame(
             discipline=discipline,
             subdomain=str(meta.get("category", name)),
@@ -211,7 +208,6 @@ def _extract_template_pressure_points(
                 id="unit_conversion",
                 type="unit_conversion",
                 description=("Solver must apply explicit unit conversions from the template instructions."),
-                provenance=[ProvenanceRef(file="instruction.md", section="Constraints")],
                 confidence="medium",
             )
         )
@@ -223,7 +219,6 @@ def _extract_template_pressure_points(
                 id="explicit_range_check",
                 type="threshold_decision",
                 description=("Solver must calculate margins or pass/fail flags against explicit criteria."),
-                provenance=[ProvenanceRef(file="params.toml", section="outputs")],
                 confidence="high",
             )
         )
@@ -242,7 +237,6 @@ def _extract_template_pressure_points(
                 id="infer_hidden_parameters",
                 type="context_inference",
                 description=("Harder variants require inferring hidden parameters from scenario context."),
-                provenance=[ProvenanceRef(file="params.toml", section="difficulty.hidden_params")],
                 confidence="high",
             )
         )
@@ -253,7 +247,6 @@ def _extract_template_pressure_points(
                 id="constraint_satisfaction",
                 type="input_constraint",
                 description="Generated instances must satisfy template constraint expressions.",
-                provenance=[ProvenanceRef(file="params.toml", section="constraints")],
                 confidence="high",
             )
         )
@@ -264,7 +257,6 @@ def _extract_template_pressure_points(
                 id="parameterised_calculation",
                 type="calculation",
                 description=("Solver must map supplied parameters to the template calculation outputs."),
-                provenance=[ProvenanceRef(file="params.toml", section="params")],
                 confidence="medium",
             )
         )

--- a/tests/cli/test_task.py
+++ b/tests/cli/test_task.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import yaml
 from typer.testing import CliRunner
 
 from aec_bench.cli.main import app
@@ -123,8 +124,11 @@ class TestTaskGenome:
         )
 
         assert result.exit_code == 0
-        assert "deterministic_manifest:" in result.output
-        assert "instruction_sections:" in result.output
+        assert "extractor: deterministic-task-genome" in result.output
+        assert "genome:" in result.output
+        assert "evidence:" in result.output
+        assert "instruction_sections:" not in result.output
+        assert "verifier_files:" not in result.output
 
     def test_genome_batch_writes_engineering_catalogue(self, tmp_path: Path) -> None:
         tasks_root = tmp_path / "tasks"
@@ -150,6 +154,32 @@ class TestTaskGenome:
         assert not (output_dir / "generated" / "suite" / "electrical" / "demo.yaml").exists()
         assert (output_dir / "index.yaml").exists()
         assert "written: 2" in result.output
+
+    def test_genome_batch_retains_each_review_as_one_artifact_reference(self, tmp_path: Path) -> None:
+        tasks_root = tmp_path / "tasks"
+        _make_valid_named_task(tasks_root, "electrical", "voltage-drop")
+        output_dir = tmp_path / "task_genomes"
+
+        result = runner.invoke(
+            app,
+            [
+                "task",
+                "genome-batch",
+                str(tasks_root),
+                "--output-dir",
+                str(output_dir),
+                "--mode",
+                "evidence",
+            ],
+        )
+
+        assert result.exit_code == 0
+        index = yaml.safe_load((output_dir / "index.yaml").read_text(encoding="utf-8"))
+        entry = index["entries"][0]
+        assert entry["status"] == "extracted"
+        assert set(entry["review"]) == {"artifact_id", "sha256", "size_bytes", "media_type"}
+        assert (output_dir / "review_artifacts" / entry["review"]["artifact_id"]).is_file()
+        assert not (output_dir / "electrical" / "voltage-drop.yaml").exists()
 
     def test_genome_batch_can_include_generated_instances(self, tmp_path: Path) -> None:
         tasks_root = tmp_path / "tasks"
@@ -243,6 +273,8 @@ class TestTaskGenome:
         assert result.exit_code == 0
         assert (output_dir / "mechanical" / "velocity-check.yaml").exists()
         assert (output_dir / "index.yaml").exists()
+        index = yaml.safe_load((output_dir / "index.yaml").read_text(encoding="utf-8"))
+        assert index["entries"][0]["template_path"] == "templates/mechanical/velocity_check"
         assert "written: 1" in result.output
 
     def test_decomposition_template_batch_writes_decomposition_catalogue(
@@ -255,8 +287,6 @@ class TestTaskGenome:
         mechanical_dir.mkdir()
         (mechanical_dir / "velocity-check.yaml").write_text(
             "task_id: mechanical/velocity-check\n"
-            "source_task_path: src/aec_bench/templates/builtin/mechanical/velocity_check\n"
-            "status: extracted\n"
             "domain_frame:\n"
             "  discipline: mechanical\n"
             "  subdomain: pipe-hydraulics\n"
@@ -272,7 +302,6 @@ class TestTaskGenome:
             "  - id: explicit_range_check\n"
             "    type: threshold_decision\n"
             "    description: Solver must compare velocity against an explicit range.\n"
-            "    provenance: []\n"
             "output_contract:\n"
             "  format: markdown_with_json_block\n"
             "  required_fields: [velocity_m_s, velocity_within_range]\n"

--- a/tests/contracts/test_task_genome.py
+++ b/tests/contracts/test_task_genome.py
@@ -4,15 +4,17 @@
 import pytest
 from pydantic import ValidationError
 
+from aec_bench.contracts.run_bundle import TaskSnapshotRef
 from aec_bench.contracts.task_genome import (
     DomainFrame,
     ExtractionSummary,
     InputBundle,
     OutputContract,
     PressurePoint,
-    ProvenanceRef,
     Scenario,
+    SourceSpan,
     TaskGenomeManifest,
+    TaskGenomeReview,
     VerifierContract,
 )
 
@@ -20,8 +22,6 @@ from aec_bench.contracts.task_genome import (
 def build_manifest(**overrides: object) -> TaskGenomeManifest:
     payload = {
         "task_id": "electrical/voltage-drop",
-        "source_task_path": "tasks/electrical/voltage-drop",
-        "status": "extracted",
         "domain_frame": DomainFrame(
             discipline="electrical",
             subdomain="voltage-drop",
@@ -40,9 +40,7 @@ def build_manifest(**overrides: object) -> TaskGenomeManifest:
                 id="include_reactance_term",
                 type="omitted_term",
                 description="Use impedance method rather than resistance-only approximation.",
-                provenance=[ProvenanceRef(file="instruction.md", section="Constraints", signal=None)],
                 confidence="high",
-                reviewed_by="deterministic_extractor",
             )
         ],
         "output_contract": OutputContract(
@@ -72,12 +70,19 @@ def test_task_genome_manifest_accepts_valid_payload() -> None:
 
     assert manifest.task_id == "electrical/voltage-drop"
     assert manifest.domain_frame.discipline == "electrical"
-    assert manifest.pressure_points[0].provenance[0].file == "instruction.md"
+    assert manifest.pressure_points[0].confidence == "high"
 
 
-def test_task_genome_manifest_rejects_absolute_source_task_path() -> None:
+def test_source_span_rejects_absolute_path() -> None:
     with pytest.raises(ValidationError):
-        build_manifest(source_task_path="/tmp/tasks/electrical/voltage-drop")
+        SourceSpan(path="/tmp/tasks/electrical/voltage-drop", start_line=1, end_line=2)
+
+
+def test_source_span_requires_a_complete_ordered_line_range() -> None:
+    with pytest.raises(ValidationError, match="both start_line and end_line"):
+        SourceSpan(path="instruction.md", start_line=1)
+    with pytest.raises(ValidationError, match="must not precede"):
+        SourceSpan(path="instruction.md", start_line=3, end_line=2)
 
 
 def test_pressure_point_rejects_blank_description() -> None:
@@ -86,7 +91,41 @@ def test_pressure_point_rejects_blank_description() -> None:
             id="bad",
             type="omitted_term",
             description=" ",
-            provenance=[],
             confidence="low",
-            reviewed_by="deterministic_extractor",
         )
+
+
+def test_task_genome_review_staleness_depends_only_on_task_snapshot() -> None:
+    snapshot = _snapshot()
+    review = TaskGenomeReview(
+        task=snapshot,
+        status="extracted",
+        extractor="deterministic-task-genome",
+        genome=build_manifest(),
+        evidence={"instructions": [SourceSpan(path="instruction.md", start_line=1, end_line=2)]},
+    )
+
+    changed_review = review.model_copy(update={"reviewer": "theo", "status": "needs_review"})
+
+    assert not changed_review.is_stale(snapshot)
+    assert changed_review.is_stale(snapshot.model_copy(update={"package_sha256": "3" * 64}))
+    assert changed_review.task == review.task
+
+
+def test_reviewed_task_genome_requires_a_reviewer() -> None:
+    with pytest.raises(ValidationError, match="identify its reviewer"):
+        TaskGenomeReview(
+            task=_snapshot(),
+            status="reviewed",
+            extractor="deterministic-task-genome",
+            genome=build_manifest(),
+            evidence={"instructions": [SourceSpan(path="instruction.md", start_line=1, end_line=2)]},
+        )
+
+
+def _snapshot() -> TaskSnapshotRef:
+    return TaskSnapshotRef(
+        task_id="electrical/voltage-drop",
+        definition_sha256="1" * 64,
+        package_sha256="2" * 64,
+    )

--- a/tests/evolution/test_task_genome_decomposer.py
+++ b/tests/evolution/test_task_genome_decomposer.py
@@ -3,56 +3,68 @@
 
 from pathlib import Path
 
-from aec_bench.contracts.task_genome import PressurePoint, ProvenanceRef
+from aec_bench.contracts.run_bundle import TaskSnapshotRef
+from aec_bench.contracts.task_genome import PressurePoint, TaskGenomeReview
 from aec_bench.evolution.task_genome_decomposer import (
     build_decomposition_prompt,
     decompose_task_genome,
 )
-from aec_bench.tasks.genome import build_task_genome_evidence
+from aec_bench.harness.compilation.task_snapshot import build_task_snapshot
+from aec_bench.tasks.genome import build_task_genome_review
+from aec_bench.tasks.loader import load_task_definition
 
 TASKS_ROOT = Path(__file__).resolve().parents[2] / "tasks"
 
 
 def test_build_decomposition_prompt_includes_schema_and_evidence() -> None:
-    packet = build_task_genome_evidence(TASKS_ROOT / "electrical" / "voltage-drop", TASKS_ROOT)
+    task_dir = TASKS_ROOT / "electrical" / "voltage-drop"
+    review, snapshot = _build_review(task_dir)
 
-    prompt = build_decomposition_prompt(packet)
+    prompt = build_decomposition_prompt(review, task_dir=task_dir, current_task=snapshot)
 
     assert "TaskGenomeManifest" in prompt
     assert "electrical/voltage-drop" in prompt
-    assert "Evidence packet" in prompt
+    assert "Snapshot-resolved evidence excerpts" in prompt
     assert "pressure_points" in prompt
 
 
 def test_decompose_task_genome_accepts_injected_lite_reviewer() -> None:
-    packet = build_task_genome_evidence(TASKS_ROOT / "electrical" / "voltage-drop", TASKS_ROOT)
+    task_dir = TASKS_ROOT / "electrical" / "voltage-drop"
+    review, snapshot = _build_review(task_dir)
 
     def reviewer(prompt: str) -> dict:
-        assert "Evidence packet" in prompt
-        payload = packet.deterministic_manifest.model_dump(mode="json")
-        payload["status"] = "needs_review"
+        assert "Snapshot-resolved evidence excerpts" in prompt
+        payload = review.genome.model_dump(mode="json")
         payload["pressure_points"].append(
             PressurePoint(
                 id="three_phase_impedance_formula",
                 type="formula_selection",
                 description="Solver must apply the three-phase impedance voltage-drop formula.",
-                provenance=[
-                    ProvenanceRef(
-                        file="instruction.md",
-                        section="Problem",
-                        signal="three-phase cable circuit",
-                    )
-                ],
                 confidence="medium",
-                reviewed_by="lite_reviewer",
             ).model_dump(mode="json")
         )
         payload["extraction"]["reasoning_review_fields"] = []
         payload["extraction"]["deterministic_fields"].append("llm_pressure_points")
         return payload
 
-    manifest = decompose_task_genome(packet, model_name="lite-test", reviewer=reviewer)
+    updated = decompose_task_genome(
+        review,
+        task_dir=task_dir,
+        current_task=snapshot,
+        model_name="lite-test",
+        reviewer=reviewer,
+    )
 
-    assert manifest.status == "needs_review"
-    assert manifest.pressure_points[-1].id == "three_phase_impedance_formula"
-    assert manifest.pressure_points[-1].reviewed_by == "lite_reviewer"
+    assert updated.status == "needs_review"
+    assert updated.reviewer == "lite-test"
+    assert updated.extractor == review.extractor
+    assert updated.task == review.task
+    assert updated.genome.pressure_points[-1].id == "three_phase_impedance_formula"
+
+
+def _build_review(task_dir: Path) -> tuple[TaskGenomeReview, TaskSnapshotRef]:
+    snapshot = build_task_snapshot(
+        task=load_task_definition(task_dir, TASKS_ROOT),
+        tasks_root=TASKS_ROOT,
+    )
+    return build_task_genome_review(task_dir, TASKS_ROOT, task=snapshot), snapshot

--- a/tests/experimentation/task_ecology/test_benchmark.py
+++ b/tests/experimentation/task_ecology/test_benchmark.py
@@ -14,6 +14,7 @@ from aec_bench.experimentation.task_ecology.benchmark import (
     TemplateEntry,
     build_arm_config,
     load_pressure_task_patterns,
+    load_template_entries,
     materialise_suite,
     scaffold_workspace,
     select_benchmark_templates,
@@ -28,52 +29,52 @@ def _entries() -> list[TemplateEntry]:
         TemplateEntry(
             task_id="civil/bund-volume-calculation",
             domain="civil",
-            source_task_path="src/aec_bench/templates/builtin/civil/bund_volume_calculation",
+            template_path="src/aec_bench/templates/builtin/civil/bund_volume_calculation",
         ),
         TemplateEntry(
             task_id="civil/orifice-outlet-design",
             domain="civil",
-            source_task_path="src/aec_bench/templates/builtin/civil/orifice_outlet_design",
+            template_path="src/aec_bench/templates/builtin/civil/orifice_outlet_design",
         ),
         TemplateEntry(
             task_id="electrical/voltage-drop",
             domain="electrical",
-            source_task_path="src/aec_bench/templates/builtin/electrical/voltage_drop",
+            template_path="src/aec_bench/templates/builtin/electrical/voltage_drop",
         ),
         TemplateEntry(
             task_id="electrical/grid-resistance",
             domain="electrical",
-            source_task_path="src/aec_bench/templates/builtin/electrical/grid_resistance",
+            template_path="src/aec_bench/templates/builtin/electrical/grid_resistance",
         ),
         TemplateEntry(
             task_id="ground/consolidation-settlement",
             domain="ground",
-            source_task_path="src/aec_bench/templates/builtin/ground/consolidation_settlement",
+            template_path="src/aec_bench/templates/builtin/ground/consolidation_settlement",
         ),
         TemplateEntry(
             task_id="ground/wall-overturning",
             domain="ground",
-            source_task_path="src/aec_bench/templates/builtin/ground/wall_overturning",
+            template_path="src/aec_bench/templates/builtin/ground/wall_overturning",
         ),
         TemplateEntry(
             task_id="mechanical/npsh-available",
             domain="mechanical",
-            source_task_path="src/aec_bench/templates/builtin/mechanical/npsh_available",
+            template_path="src/aec_bench/templates/builtin/mechanical/npsh_available",
         ),
         TemplateEntry(
             task_id="mechanical/wave-speed-calculation",
             domain="mechanical",
-            source_task_path="src/aec_bench/templates/builtin/mechanical/wave_speed_calculation",
+            template_path="src/aec_bench/templates/builtin/mechanical/wave_speed_calculation",
         ),
         TemplateEntry(
             task_id="structural/gravity-base-stability",
             domain="structural",
-            source_task_path="src/aec_bench/templates/builtin/structural/gravity_base_stability",
+            template_path="src/aec_bench/templates/builtin/structural/gravity_base_stability",
         ),
         TemplateEntry(
             task_id="structural/thermal-movement-calc",
             domain="structural",
-            source_task_path="src/aec_bench/templates/builtin/structural/thermal_movement_calc",
+            template_path="src/aec_bench/templates/builtin/structural/thermal_movement_calc",
         ),
     ]
 
@@ -94,6 +95,36 @@ def test_select_benchmark_templates_keeps_anchors_out_of_population() -> None:
     assert len(selection.population) == 5
 
 
+def test_template_catalogue_owns_template_source_location(tmp_path: Path) -> None:
+    genome_path = tmp_path / "civil" / "bund-volume-calculation.yaml"
+    genome_path.parent.mkdir()
+    genome_path.write_text("task_id: civil/bund-volume-calculation\n", encoding="utf-8")
+    index_path = tmp_path / "index.yaml"
+    index_path.write_text(
+        yaml.safe_dump(
+            {
+                "entries": [
+                    {
+                        "task_id": "civil/bund-volume-calculation",
+                        "domain": "civil",
+                        "path": "civil/bund-volume-calculation.yaml",
+                        "template_path": "src/aec_bench/templates/builtin/civil/bund_volume_calculation",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert load_template_entries(index_path) == [
+        TemplateEntry(
+            task_id="civil/bund-volume-calculation",
+            domain="civil",
+            template_path="src/aec_bench/templates/builtin/civil/bund_volume_calculation",
+        )
+    ]
+
+
 def test_default_max_cycles_covers_population_once_at_default_batch_size() -> None:
     assert DEFAULT_DIFFICULTIES == ("easy", "medium", "hard")
     assert DEFAULT_MAX_CYCLES == 6
@@ -112,7 +143,7 @@ def test_materialise_suite_writes_one_replay_sidecar(tmp_path: Path) -> None:
             TemplateEntry(
                 task_id="civil/bund-volume-calculation",
                 domain="civil",
-                source_task_path=template.relative_to(tmp_path).as_posix(),
+                template_path=template.relative_to(tmp_path).as_posix(),
             )
         ],
         output_root=tmp_path / "generated",

--- a/tests/tasks/test_genome.py
+++ b/tests/tasks/test_genome.py
@@ -5,11 +5,19 @@ from pathlib import Path
 
 import yaml
 
+from aec_bench.contracts.run_bundle import TaskSnapshotRef
+from aec_bench.contracts.task_genome import TaskGenomeReview
+from aec_bench.harness.compilation.task_snapshot import build_task_snapshot
+from aec_bench.ledger.artifact_repository import ArtifactRepository
 from aec_bench.tasks.genome import (
-    build_task_genome_evidence,
+    build_task_genome_review,
     extract_task_genome,
+    load_task_genome_review,
+    publish_task_genome_review,
+    resolve_task_genome_evidence,
     task_genome_to_yaml,
 )
+from aec_bench.tasks.loader import load_task_definition
 
 TASKS_ROOT = Path(__file__).resolve().parents[2] / "tasks"
 
@@ -67,22 +75,19 @@ def test_task_genome_yaml_round_trips_to_plain_sidecar_payload() -> None:
     payload = yaml.safe_load(task_genome_to_yaml(manifest))
 
     assert payload["task_id"] == "electrical/voltage-drop"
-    assert payload["status"] == "extracted"
+    assert "status" not in payload
     assert payload["output_contract"]["format"] == "markdown_with_json_block"
     assert payload["extraction"]["reasoning_review_fields"]
 
 
-def test_builds_model_facing_evidence_packet() -> None:
-    packet = build_task_genome_evidence(
-        TASKS_ROOT / "mechanical" / "heat-load" / "audit-office-building" / "sydney-8rm",
-        TASKS_ROOT,
-    )
+def test_builds_snapshot_bound_review_without_source_copies() -> None:
+    task_dir = TASKS_ROOT / "mechanical" / "heat-load" / "audit-office-building" / "sydney-8rm"
+    review, snapshot = _build_review(task_dir)
 
-    assert packet.task_id == "mechanical/heat-load/audit-office-building/sydney-8rm"
-    assert "problem" in packet.instruction_sections
-    assert "available_tool" in packet.instruction_sections
-    assert "required" in packet.instruction_sections
-    assert packet.deterministic_manifest.output_contract.required_fields == [
+    assert review.task == snapshot
+    assert review.task.task_id == "mechanical/heat-load/audit-office-building/sydney-8rm"
+    assert review.extractor == "deterministic-task-genome"
+    assert review.genome.output_contract.required_fields == [
         "errors_found",
         "room_no",
         "field",
@@ -90,5 +95,45 @@ def test_builds_model_facing_evidence_packet() -> None:
         "correct_value",
         "explanation",
     ]
-    assert "tests/test.sh" in packet.verifier_files
-    assert "tests/verify.py" in packet.verifier_files
+    assert {span.path for span in review.evidence["verifier_contract"]} >= {
+        "tests/test.sh",
+        "tests/verify.py",
+    }
+    payload = review.model_dump(mode="json")
+    assert "task_toml" not in payload
+    assert "instruction_sections" not in payload
+    assert "verifier_files" not in payload
+    assert all(not hasattr(span, "sha256") for spans in review.evidence.values() for span in spans)
+
+
+def test_review_evidence_resolves_only_against_its_task_snapshot() -> None:
+    task_dir = TASKS_ROOT / "electrical" / "voltage-drop"
+    review, snapshot = _build_review(task_dir)
+
+    resolved = resolve_task_genome_evidence(review, task_dir=task_dir, current_task=snapshot)
+
+    assert any("## Constraints" in excerpt for excerpt in resolved["instructions"])
+    changed_snapshot = snapshot.model_copy(update={"package_sha256": "f" * 64})
+    try:
+        resolve_task_genome_evidence(review, task_dir=task_dir, current_task=changed_snapshot)
+    except ValueError as error:
+        assert str(error) == "task genome review is stale for the selected task snapshot"
+    else:
+        raise AssertionError("stale task genome evidence must not resolve")
+
+
+def test_retained_review_uses_one_verified_artifact_reference(tmp_path: Path) -> None:
+    task_dir = TASKS_ROOT / "electrical" / "voltage-drop"
+    review, _ = _build_review(task_dir)
+    repository = ArtifactRepository(tmp_path / "artifacts")
+
+    ref = publish_task_genome_review(review, repository)
+
+    assert load_task_genome_review(ref, repository) == review
+    assert len(list((tmp_path / "artifacts").rglob(ref.sha256))) == 1
+
+
+def _build_review(task_dir: Path) -> tuple[TaskGenomeReview, TaskSnapshotRef]:
+    task = load_task_definition(task_dir, TASKS_ROOT)
+    snapshot = build_task_snapshot(task=task, tasks_root=TASKS_ROOT)
+    return build_task_genome_review(task_dir, TASKS_ROOT, task=snapshot), snapshot

--- a/tests/templates/test_genome.py
+++ b/tests/templates/test_genome.py
@@ -48,6 +48,8 @@ def test_template_genome_yaml_round_trips() -> None:
     payload = yaml.safe_load(template_genome_to_yaml(manifest))
 
     assert payload["task_id"] == "mechanical/pump-head-calculation"
+    assert "source_task_path" not in payload
+    assert "status" not in payload
     assert payload["output_contract"]["required_fields"] == [
         "static_head_m",
         "pressure_head_differential_m",


### PR DESCRIPTION
## Summary

- Replace source-copying task-genome packets with TaskGenomeReview bound to one TaskSnapshotRef.
- Represent evidence as relative SourceSpan values, with snapshot-based staleness and no per-span hashes.
- Store independently retained reviews through one ArtifactRef and keep task/template discovery metadata outside the genome decomposition.

## Verification

- 41 focused task-genome, template, CLI, evolution, and task-ecology tests passed.
- Ruff check passed for all changed Python files.
- Ruff format check passed for all changed Python files.
- Mypy passed for all changed production modules.
- Provenance field audit passed with 0 violations.
- Documentation ownership checks: 9 passed, 1 unrelated local .DS_Store inventory check deselected.
- Package ownership checks: 26 passed, 1 unrelated existing adapters/harness cycle check deselected.

## Provenance

Does this change add a hash, commitment, fingerprint, version, revision,
timestamp, artifact reference, or attestation?

- [ ] No
- [x] Yes

If yes:

- Category: artifact_integrity, using the existing ArtifactRef contract.
- Authority: the task-genome review producer publishes through ArtifactRepository.
- Canonical payload: the complete TaskGenomeReview canonical JSON bytes.
- Consumer: load_task_genome_review reads through ArtifactRepository and then validates TaskGenomeReview.
- Mismatch behavior: artifact ID, size, digest, media type, or model validation failure rejects the review.