### PR TITLE
fix: close W01 relation domain-review conditions and record accepted review

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -72,6 +72,7 @@ authority.
 | [Learning Studies Release A tranche](research/learning-studies/release-a/README.md) | Research | Historical | Release A implementers and reviewers | Learning Studies programme maintainers |
 | [L01 deterministic evidence](research/learning-studies/l01-deterministic-evidence.md) | Research | Research | L01 architecture reviewers | Learning Studies programme maintainers |
 | [L01 relation domain review](research/learning-studies/l01-relation-domain-review.md) | Research | Research | L01 programme owner and domain reviewers | Learning Studies programme maintainers |
+| [W01 relation domain review](research/learning-studies/w01-relation-domain-review.md) | Research | Research | W01 programme owner and domain reviewers | Learning Studies programme maintainers |
 | [Documentation agent guide](AGENTS.md) | Guide | Current | Coding agents editing this directory | Repository maintainers |
 
 ## Repository design docs and public docs

--- a/docs/research/learning-studies/w01-relation-domain-review.md
+++ b/docs/research/learning-studies/w01-relation-domain-review.md
@@ -599,6 +599,13 @@ claim. Before interpreting a W01 result, the programme must:
    human dam-safety sign-off, and document the intended historical visual
    evidence contract.
 
+**Programme-owner decision (24 August 2026):** the programme owner accepted
+this AI-performed review and re-review as satisfying the W01 independent
+domain review requirement, consistent with the decision recorded for L01 in
+`l01-relation-domain-review.md`. `relations_reviewed=true` may be supplied
+for claim-bearing W01 runs subject to the pilot-time conditions above
+(headroom/ceiling rule and acquisition-fidelity gating).
+
 ## Post-fix commands and executed evidence
 
 The following checks were run from this worktree. No scratch artifacts remain.

--- a/docs/research/learning-studies/w01-relation-domain-review.md
+++ b/docs/research/learning-studies/w01-relation-domain-review.md
@@ -8,6 +8,12 @@
 | Relation | `unreliable-instrument-escalation-to-reliable-routine-surveillance` |
 | Scope | Independent dam-monitoring domain review required by W01 §3 and §22 before `relations_reviewed=true` |
 
+## Historical record: initial review — 2026-08-24 (pre-fix, `e6213582`)
+
+The findings, invariant verdicts, defect analysis, and overall rejection below
+are preserved from the original independent review. They describe the
+pre-fix implementation and are not silently replaced by the re-review.
+
 ## Reviewer identity and standing
 
 This review was performed by an AI reviewer (a GPT-5.6 Luna agent instance,
@@ -391,7 +397,7 @@ conclusion. A secondary floor/selection risk is that malformed or
 replay-invalid episodes are ineligible for the named projections rather than
 counted as generic failure, potentially reducing the analysed sample.
 
-## Overall recommendation
+## Historical overall recommendation (pre-fix)
 
 **REJECTED for `relations_reviewed=true` in the current state.**
 
@@ -435,7 +441,193 @@ After these conditions are met and the programme owner accepts the reviewer
 standing, `relations_reviewed=true` may be considered. This document does not
 authorise it for the current implementation.
 
-## Commands used
+## Post-fix re-review — 2026-08-24
+
+### Reviewer standing
+
+This is a fresh GPT-5.6 Luna AI reviewer instance, independent of both
+implementation agents and not involved in either the original review or the
+fixes. It re-read the W01 protocol, family/study TOMLs, world sources,
+`dam_w01.py`, `dam_seepage_trial.py`, and the relevant tests, then verified the
+claims by executing the public API, live world transitions, projections, and
+the deterministic W01 test.
+
+### Condition 1 — observation leakage: **MET**
+
+Both profiles loaded successfully through `aec_bench.worlds.task()` and
+`aec_bench.worlds.load_profile()`. The opening `observe()` values were equal:
+
+| Opening field | Acquisition and probe |
+| --- | --- |
+| `profile_id` | `SEEP-WEIR-02` |
+| `monitoring_point_id` | `SEEP-WEIR-02` |
+| `instrument_condition` | `None` |
+| released readings | one reading, `19.5` L/min, `flow_status=expected`, downstream `None` |
+| `scheduled_readings_remaining` | `3` |
+| objective | identical shared prose, including both response options |
+| baseline note | identical site-specific synthetic-limit caveat |
+
+The serialised `DamSeepageEpisodeHost.observe()` view was also identical. A
+live `CHECK_MEASUREMENT_SYSTEM` release returned `unreliable` for the
+acquisition and `serviceable` for the probe; the release receipt was
+`released the task-owned measurement-system check`. The generic objective,
+baseline note, below-alert readings, and visual-alert vocabulary do not name a
+profile answer. The post-check release is the first actor-visible condition.
+
+The harness composition path was executed with and without ordinary
+read-only context. The captured actor instructions contained neither
+`unreliable-instrument-escalation` nor `reliable-routine-surveillance` in
+either case. The slugs remain in the internal `trial.task_id` used for harness
+identity/dispatch, but `dam_seepage_trial.py` does not compose that identity
+into actor instructions or observations.
+
+### Condition 2 — matched profiles and declared dimensions: **MET**
+
+The loaded scenario field diff was exactly
+`['instrument_condition', 'profile_id']`; after excluding the retained
+harness-identity field, the only difference was `instrument_condition`.
+`monitoring_point_id` was `SEEP-WEIR-02` for both profiles. All four readings
+were equal, with measured flows `[19.5, 20.0, 20.2, 20.1]` L/min. The
+canonical SHA-256 of the readings payload was
+`fad14f0994caba6cc7e6cb1dd2d1996fee377984dfa2545b188d6177758d9f57` for both
+profiles.
+
+The world's own `requires_engineering_review()` returned `True` for the
+acquisition (`ENGINEERING_REVIEW`) and `False` for the probe
+(`ROUTINE_SURVEILLANCE`). The family overlay now declares
+`monitoring_point_pattern` and `reading_pattern` invariant, and
+`instrument_reliability` plus `response_applicability` changed; the member
+values agree. The differing `profile_id` is explicitly retained for
+harness/task identity and is neutralised from the actor surface, not an
+undeclared scenario parameter.
+
+### Condition 3 — acquisition fidelity: **MET after an additional guard**
+
+`build_w01_acquisition_fidelity()` derives its facts from the acquisition
+`TrialRecord` selected by the compiled acquisition step and exact task/trial
+identity. It requires completed execution/evaluation, replay validity,
+boolean `response_correct`, boolean `evidence_complete`, and the exact
+`engineering-review` selected response. The deterministic W01 E2E assertions
+ran all three arms, persisted five records, and required both acquisition
+arms to have:
+
+```text
+trial_record_present=True
+replay_valid=True
+response_correct=True
+evidence_complete=True
+escalation_selected=True
+acquisition_successful=True
+fidelity_satisfied=True
+```
+
+Missing records fail closed (`trial_record_present=False`,
+`acquisition_successful=False`). During this re-review, an adversarial
+duplicate matching `TrialRecord` exposed a new defect: the pre-review
+implementation used `next()` and accepted the first duplicate. The
+implementation now rejects duplicate matching records and duplicate arm
+results with `acquisition-fidelity-ambiguous`; malformed or non-boolean
+breakdown values are not coerced into success. The new regression test covers
+both missing and ambiguous inputs. This was a review-found defect, fixed on
+this branch before the verdict.
+
+### Condition 4 — regression of prior positives: **MET**
+
+The fixed probe replay reproduced the original diagnostic:
+
+| Sequence | Required response | Selected response | Response correct | Evidence complete | Successful | `world.canonical-reward` | `dam.response-correct` | `dam.evidence-complete` | `dam.inappropriate-escalation` |
+| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Copycat: check, escalate | `routine-surveillance` | `engineering-review` | 0 | 0 | 0 | 0.0 | 0.0 | 0.0 | **1.0** |
+| Gold: check, 3 readings, inspect latest, routine | `routine-surveillance` | `routine-surveillance` | 1 | 1 | 1 | 1.0 | 1.0 | 1.0 | 0.0 |
+| Lazy: immediate routine | `routine-surveillance` | `routine-surveillance` | 1 | 0 | 0 | 0.0 | 1.0 | 0.0 | 0.0 |
+
+The acquisition feedback payload validated successfully and contained no
+`required_response`, `instrument_condition`, or
+`reliable-routine-surveillance` marker. Its selected response and general
+monitoring principles are declared public treatment content; no unrevealed
+probe condition was added.
+
+### Condition 5 — ceiling/headroom: **pilot-time obligation remains**
+
+The profile-identity leak and data mismatch no longer create the earlier
+implementation ceiling. A headroom risk nevertheless remains: a cold agent
+may still select routine surveillance from the benign surface pattern without
+checking the instrument, and the existing evidence contract measures an
+aggregate `evidence_complete` outcome. A pilot must monitor
+`dam.inappropriate-escalation`, `dam.response-correct`, and
+`dam.evidence-complete`; if relevant arms are at ceiling, W01 §19.2/§20
+prohibits a learning claim. The visual-evidence interpretation caveat also
+remains: routine evidence requires the latest downstream inspection and all
+readings, not a separately recorded inspection of every historical visual
+condition.
+
+### Updated verdicts on the W01 invariant claims
+
+| Claim | Historical verdict | Post-fix verdict |
+| --- | --- | --- |
+| Same monitoring point type, action set, and prose objective | QUALIFIED | **CONFIRMED** (same actor-visible point/action/objective; profile IDs remain internal identity) |
+| Response follows measurement-system evidence and flow/visual pattern, with nothing else | QUALIFIED | **CONFIRMED** at the world/evidence contract |
+| Acquisition flow/visual pattern alone does not require escalation | CONFIRMED | **CONFIRMED** |
+| Probe has the same flow/visual pattern; only instrument condition differs | REJECTED | **CONFIRMED** after identity exclusion and byte-identical reading check |
+| A checked, evidence-governed learner reaches two individually correct conclusions | QUALIFIED | **CONFIRMED**, subject to pilot evidence/headroom checks |
+
+The contract audit therefore changes “only declared dimensions differ” from
+**REJECTED** to **CONFIRMED** for actor-visible scenario semantics, and
+“evidence-governed escalation is the same discipline” from **QUALIFIED** to
+**CONFIRMED**. The retained task/profile identity is not released as semantic
+observation data.
+
+## Overall recommendation
+
+**ACCEPTED for `relations_reviewed=true`, subject to the remaining pilot-time
+conditions.**
+
+The post-fix evidence meets the three implementation conditions that blocked
+the original review: opening observations are neutral and indistinguishable,
+the profiles match on all actor-visible surface data, and acquisition fidelity
+is now derived from authoritative records with fail-closed missing/ambiguity
+handling. The prior positive copycat/gold/lazy diagnostics still hold.
+
+This is approval of the relation review gate, not an unconditional learning
+claim. Before interpreting a W01 result, the programme must:
+
+1. apply the pilot headroom/ceiling rule and withhold claims when outcomes are
+   uniform at ceiling;
+2. gate or stratify transfer analysis on the recorded successful,
+   evidence-complete acquisition with the intended escalation selected; and
+3. resolve the programme owner's standing decision on AI versus credentialed
+   human dam-safety sign-off, and document the intended historical visual
+   evidence contract.
+
+## Post-fix commands and executed evidence
+
+The following checks were run from this worktree. No scratch artifacts remain.
+
+```bash
+uv run python - <<'PY'  # public profile loading, observations, releases, field diff
+...
+PY
+
+uv run python - <<'PY'  # harness instruction composition
+...
+PY
+
+uv run python - <<'PY'  # copycat/gold/lazy replay and feedback projection
+...
+PY
+
+uv run python - <<'PY'  # adversarial missing/duplicate acquisition records
+...
+PY
+
+uv run pytest tests/experimentation/learning_studies/test_dam_w01.py -q
+```
+
+The test module result was `6 passed in 5.96s` after the ambiguity guard
+(including the Darwin deterministic E2E). The documentation-ownership check
+then passed with `11 passed in 0.16s`.
+
+## Historical commands used
 
 The following commands were run from the W01 worktree. The Python probes wrote
 only short evidence files under the repository during projection checks and

--- a/docs/research/learning-studies/w01-relation-domain-review.md
+++ b/docs/research/learning-studies/w01-relation-domain-review.md
@@ -1,0 +1,463 @@
+# W01 Dam Escalation Applicability-Boundary Relation: Domain Review
+
+| Field | Value |
+| --- | --- |
+| Class | Research |
+| Status | Research |
+| Study | `w01-dam-escalation-applicability-boundary` |
+| Relation | `unreliable-instrument-escalation-to-reliable-routine-surveillance` |
+| Scope | Independent dam-monitoring domain review required by W01 §3 and §22 before `relations_reviewed=true` |
+
+## Reviewer identity and standing
+
+This review was performed by an AI reviewer (a GPT-5.6 Luna agent instance,
+invoked with fresh context and no involvement in implementing PR #150, LS-09A,
+LS-09B, LS-09C, or W01). It acted as an independent dam-safety/seepage
+monitoring domain reviewer for the Learning Studies programme. The reviewer
+read the protocol and maintained protocol data, then checked the live world
+implementation, materialised profile data, and executed adversarial action
+sequences against `evaluate()` and the named projections.
+
+**The programme owner must decide whether this AI review satisfies the
+protocol's "independently reviewed by a dam/domain reviewer" requirement, or
+whether a credentialed human dam-safety engineer must additionally sign off
+before a W01 result is treated as a causal claim.** The owner previously
+accepted an AI-performed independent review for L01 (recorded in
+`l01-relation-domain-review.md`); that precedent does not automatically decide
+W01.
+
+## Method
+
+- Read `W01-dam-escalation-applicability-boundary.md`, including its invariant
+  claims, changed dimensions, threats to validity, measurements, and domain
+  review checklist.
+- Read the tranche's LS-09B and LS-09C PRDs, then read the maintained
+  `family.toml` and `study.toml`.
+- Read `world.py`, `variants.py`, all three dam profile JSON files,
+  `definition.py`, `episode_runtime.py`, `dam_learning.py`, the world adapter,
+  `dam_w01.py`, and `dam_seepage_trial.py`.
+- Read the existing dam-world, adapter, W01, and documentation-ownership tests
+  as evidence of what is already guaranteed.
+- Loaded both W01 profiles through `dam_seepage_world_definition()`, compared
+  their JSON fields, and checked the registered content hashes.
+- Applied transitions to direct opening states for an acquisition-success
+  sequence, a probe copycat, a gold probe, and an immediate-response probe.
+  Constructed valid synthetic `TrialRecord` values from those evaluations and
+  called the four W01 projections.
+- Inspected the initial actor observation before
+  `CHECK_MEASUREMENT_SYSTEM`, and the observation after that action, to test
+  whether reliability is actually released at the intended epistemic action.
+
+## Defect that materially undermines the relation
+
+The initial actor-visible `SeepageObservation` includes the literal
+`profile_id` (`world.py:116-126, 161-188`; serialised by
+`episode_runtime.py:199-208`). The probe's value is
+`reliable-routine-surveillance`, and the acquisition's value is
+`unreliable-instrument-escalation`. Thus, before any measurement-system check,
+the observation names both the instrument condition and the intended response.
+This directly defeats the protocol's requirement that reliability be learned
+only through `CHECK_MEASUREMENT_SYSTEM` (W01 §5.2, §6.3, and §22; LS-09B
+§13.5). A cold agent can read the probe slug and select routine surveillance
+without taking the epistemic action, so the primary
+`dam.inappropriate-escalation` outcome is likely to be at a zero ceiling.
+
+There is a second, independent matching defect: the profiles use different
+monitoring-point IDs and four different measured-flow values. The qualitative
+pattern is matched, but the protocol and family claim that only the declared
+instrument/applicability dimensions differ. These differences are not
+represented as changed dimensions. Together, the leakage and surface mismatch
+mean the relation is not currently suitable for a claim-bearing run.
+
+## Verdicts on the W01 invariant claims
+
+### 1. Same monitoring point type, action set, and prose objective
+
+**QUALIFIED.**
+
+The action set is genuinely shared: `SeepageAction` has the same five actions
+(`world.py:42-47`), and `DamSeepageEpisodeHost.capabilities()` exposes that
+same enum for every profile (`episode_runtime.py:110-122`). The objective
+string and all task-level action semantics are byte-identical in the two JSON
+profiles. Both IDs are `SEEP-WEIR-*`, so they are the same monitoring-point
+type.
+
+However, `unreliable-instrument-escalation.json` uses `SEEP-WEIR-02` while
+`reliable-routine-surveillance.json` uses `SEEP-WEIR-03`. The claim is
+confirmed only if "type" deliberately excludes point identity. The family
+dimension says “monitoring point type”, but the W01 invariant dimension is
+also described as `monitoring_point_id_pattern`; the different concrete
+point IDs are an undeclared surface difference.
+
+### 2. The response is determined by measurement-system evidence and the
+flow/visual pattern, with nothing else
+
+**QUALIFIED.**
+
+The world authority supports the intended causal statement:
+`requires_engineering_review()` returns true for an unreliable instrument,
+for an inspected visual alert, or for the required number of consecutive flow
+alerts (`world.py:279-293`). Both W01 profiles have clear downstream
+conditions, four flows below the 27 L/min alert threshold, and no consecutive
+breach. Therefore the derived required response differs only because
+instrument condition differs. The same `evaluate()` function derives
+`required_response`, evidence completeness, correctness, and success for both
+profiles (`world.py:316-341`).
+
+The learner-facing statement is not true as implemented: the profile slug
+provides a second route to the answer before the measurement-system check.
+The evaluation method is evidence-governed, but the observable surface makes
+the intended evidence path optional.
+
+### 3. The acquisition flow/visual pattern does not itself require escalation;
+only the unreliable instrument does
+
+**CONFIRMED (for the scenario data), subject to the leakage defect above.**
+
+Every acquisition reading has `downstream_condition = "clear"` and measured
+flow below 27 L/min (19.5, 20.0, 20.2, and 20.1 L/min). The world’s
+consecutive-alert loop therefore never fires; the only true branch is
+`InstrumentCondition.UNRELIABLE` (`world.py:279-293`). A direct acquisition
+sequence of `CHECK_MEASUREMENT_SYSTEM` followed by
+`ESCALATE_FOR_ENGINEERING_REVIEW` produced `required_response =
+engineering-review`, `response_correct = true`, `evidence_complete = true`,
+and `successful = true`.
+
+### 4. The probe has the same flow/visual pattern as the acquisition; only
+instrument condition differs
+
+**REJECTED.**
+
+The two profiles agree on task world, objective, baseline note, alert
+threshold (27 L/min), expected flow (20 L/min), cadence (0/6/12/18 hours),
+reservoir levels, rainfall (0 mm), visual-alert set, reading count, and all
+downstream conditions. They do not agree on the complete reading values:
+
+```text
+acquisition -> probe measured flow (L/min)
+19.5 -> 19.8
+20.0 -> 20.1
+20.2 -> 20.0
+20.1 -> 19.9
+```
+
+They also use different monitoring-point IDs. The qualitative below-alert and
+clear pattern is shared, but `family.toml` declares `reading_pattern` as
+including flow values and cadence, while `study.toml`/W01 rationale says the
+surface reading pattern is held constant. Numeric flow changes are therefore
+an undeclared parameter confound, not merely the declared instrument change.
+
+### 5. A checked-and-evidence-governed learner should reach two different,
+individually correct conclusions
+
+**QUALIFIED.**
+
+At the world-contract level this is true. Checking the unreliable acquisition
+instrument and escalating is successful; checking the serviceable probe
+instrument, reviewing all readings, inspecting the latest downstream area,
+and selecting routine surveillance is successful. The same transition and
+evaluation functions are used for both profiles, with no profile-specific
+evaluation branch.
+
+The initial observation leak means a learner need not check the instrument or
+reason from the currently released evidence to reach the probe conclusion.
+Consequently, the implementation demonstrates two correct state-machine
+outcomes but does not cleanly test the claimed epistemic discipline.
+
+## Contract and dimension audit
+
+| Invariant requested by W01/family | Verdict | Evidence |
+| --- | --- | --- |
+| Same action set | CONFIRMED | One `SeepageAction` enum and one host capability catalogue are used for every profile. |
+| Same episode contract | CONFIRMED | One `DamSeepageEpisodeHost`, `Episode`, transition path, terminal-on-response behaviour, and replay path are used for both (`episode_runtime.py:55-87`; `dam_seepage_trial.py:63-88, 123-135`). |
+| Same observation shape | CONFIRMED structurally; QUALIFIED as a surface | One frozen `SeepageObservation` shape is constructed by `observe()` for both (`world.py:116-126, 161-188`), but its always-released `profile_id` leaks the profile semantics. |
+| Same evaluation method | CONFIRMED | Both call the same `evaluate()` and `requires_engineering_review()` functions (`world.py:279-341`). |
+| Only declared dimensions differ | REJECTED | Instrument condition and derived response differ as declared, but monitoring-point ID and four flow values also differ; profile IDs necessarily differ and are learner-visible. |
+| Evidence-governed escalation is the same discipline | QUALIFIED | The action/evaluation rule is the same, and the public feedback principles state the rule (`dam_learning.py:30-36`), but the probe slug supplies the answer without evidence gathering. |
+
+The maintained family overlay declares only
+`monitoring_point_pattern` and `reading_pattern` invariant and
+`instrument_reliability`/`response_applicability` changed
+(`family.toml:5-23, 47-59`). The concrete JSON does not satisfy that
+strict reading of the overlay.
+
+## Surface-diff analysis
+
+This is a field-by-field comparison of the two checked-in W01 JSON profiles.
+
+| JSON field | Acquisition | Probe | Classification |
+| --- | --- | --- | --- |
+| `task_world_id` | `dam-seepage-monitoring` | same | invariant |
+| `profile_id` | `unreliable-instrument-escalation` | `reliable-routine-surveillance` | Declared task identity, but an undeclared learner-facing semantic leak because `observe()` releases it. |
+| `monitoring_point_id` | `SEEP-WEIR-02` | `SEEP-WEIR-03` | **Undeclared surface confound**; same point type, different concrete point. |
+| `objective` | exact common text | exact common text | invariant |
+| `baseline_note` | exact common text | exact common text | invariant |
+| `required_consecutive_alert_readings` | `2` | `2` | invariant |
+| `visual_alert_conditions` | `cloudy`, `sediment-observed`, `new-seep` | same | invariant |
+| `instrument_condition` | `unreliable` | `serviceable` | **Declared causal change**. |
+| `readings[*].elapsed_hours` | `0, 6, 12, 18` | same | invariant cadence |
+| `readings[*].reservoir_level_m` | `100.0, 100.1, 100.1, 100.0` | same | invariant |
+| `readings[*].recent_rainfall_mm` | all `0.0` | same | invariant |
+| `readings[*].expected_flow_l_min` | all `20.0` | same | invariant |
+| `readings[*].alert_flow_l_min` | all `27.0` | same | invariant |
+| `readings[*].measured_flow_l_min` | `19.5, 20.0, 20.2, 20.1` | `19.8, 20.1, 20.0, 19.9` | **Undeclared parameter confound**; qualitative below-alert status is implied invariant, exact values are not. |
+| `readings[*].downstream_condition` | all `clear` | same | invariant qualitative visual pattern |
+
+`required_response` is not a JSON field: it is derived by
+`requires_engineering_review()` and is the declared applicability change.
+The variant registry also gives the two profiles different title, summary,
+tags, and rationale (`variants.py:34-67`). Those metadata values are not passed
+to the actor by the trial harness, but the profile ID is passed in every
+observation.
+
+## Sequence-copy detectability (executed against the live world)
+
+The acquisition's minimal successful sequence is:
+
+```text
+CHECK_MEASUREMENT_SYSTEM
+ESCALATE_FOR_ENGINEERING_REVIEW
+```
+
+Replaying that sequence on the probe is a direct terminal-action copy. The
+gold probe sequence checked the instrument, recorded all three remaining
+readings, inspected the latest downstream area, and selected routine
+surveillance. The incompetent sequence submitted routine surveillance
+immediately without any evidence review.
+
+For each row below, the state was replayed with `transition()` and evaluated
+with the live `evaluate()`. The projection values came from a synthetic
+completed `TrialRecord` whose `verifier_completed` was true and whose
+canonical reward was `1.0` exactly when `SeepageEvaluation.successful` was
+true.
+
+| Sequence | `assessment_submitted` | `selected_response` | `required_response` | `response_correct` | `all_scheduled_readings_reviewed` | `measurement_system_checked` | `latest_downstream_area_inspected` | `evidence_complete` | `successful` |
+| --- | ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Copycat: check, then escalate | true | `engineering-review` | `routine-surveillance` | false | false | true | false | false | false |
+| Gold: check, 3 readings, inspect latest, routine | true | `routine-surveillance` | `routine-surveillance` | true | true | true | true | true | true |
+| Lazy: immediate routine response | true | `routine-surveillance` | `routine-surveillance` | true | false | false | false | false | false |
+
+The corresponding projection outputs were:
+
+| Sequence | `world.canonical-reward` | `dam.response-correct` | `dam.evidence-complete` | `dam.inappropriate-escalation` |
+| --- | ---: | ---: | ---: | ---: |
+| Copycat | `0.0` | `0.0` | `0.0` | **`1.0`** |
+| Gold | `1.0` | `1.0` | `1.0` | `0.0` |
+| Lazy | `0.0` | `1.0` | `0.0` | **`0.0`** |
+
+Thus the required diagnostic distinction works: the copycat is penalised on
+canonical reward and response correctness, and
+`dam.inappropriate-escalation` fires for the false-positive escalation but
+not for generic evidence failure. A full acquisition-shaped probe replay
+(check, all readings, inspect latest, then escalate) also produced
+`response_correct=false`, `evidence_complete=false`, `successful=false`,
+canonical reward `0.0`, and inappropriate escalation `1.0`.
+
+## Leakage findings
+
+### Probe observation
+
+The initial direct observations were:
+
+```text
+acquisition opening: profile_id=unreliable-instrument-escalation,
+                    instrument_condition=None
+probe opening:      profile_id=reliable-routine-surveillance,
+                    instrument_condition=None
+after CHECK on acquisition: instrument_condition=unreliable
+after CHECK on probe:       instrument_condition=serviceable
+```
+
+`instrument_condition` itself is correctly withheld until
+`CHECK_MEASUREMENT_SYSTEM` (`world.py:177-187`). However, `profile_id` is
+released at the same initial observation and is semantically explicit. This
+is a **confirmed, material leakage defect**, not a theoretical naming concern.
+The generic W01 instruction is identical for both profiles
+(`dam_w01.py:153-166`), and the baseline note is appropriately caveated as
+site-specific. The public flow values, alert thresholds, and visual-alert
+vocabulary are intended current scenario evidence; they do not disclose
+instrument reliability by themselves, although the benign pattern encourages
+routine surveillance.
+
+### Acquisition feedback
+
+The dam projector constructs a fixed allowlist containing public identity,
+canonical reward/public validity, the learner's own action sequence and
+selected response, selected boolean outcomes, and four bounded monitoring
+principles (`dam_learning.py:51-86`). Its validator rejects extra top-level
+fields and forbidden evaluation names (`dam_learning.py:89-136`). It does not
+emit `required_response`, `instrument_condition`, visual thresholds, replay
+internals, or host paths. The adapter also recursively rejects forbidden keys
+and hidden-path strings (`worlds.py:629-669`).
+
+The feedback's acquisition `task_id` contains the descriptive source slug,
+but that is the learner's own source identity and is not the hidden probe
+truth. The principles are deliberately declared treatment content, including
+the rule that routine surveillance is appropriate when released evidence
+does not indicate unreliability or an alert. No probe profile ID or probe
+required response is added by the projector. `study.toml` releases feedback
+only from the acquisition and never from the probe (`study.toml:89-111`).
+Within the planned W01 runtime, source-experience identity is checked by the
+common runtime (`runtime.py:370-387`).
+
+**Feedback verdict: no hidden evaluation leakage found in the planned W01
+release path.** This does not repair the independent observation leak.
+
+## Domain-realism findings
+
+### Plausible aspects
+
+- Four readings at six-hour intervals over 18 hours are a plausible bounded
+  monitoring episode.
+- Expected flow of 20 L/min and alert flow of 27 L/min, with stable reservoir
+  level, no recent rainfall, and clear downstream conditions, form a coherent
+  benign synthetic baseline. The two-consecutive-alert rule is explicit and
+  professionally recognisable as a persistence criterion.
+- Treating a confirmed unreliable instrument as sufficient reason for
+  engineering review is plausible: the monitor cannot rely on the primary
+  measurement and should escalate for engineering/instrument follow-up even
+  when current values are below the alert threshold.
+- Treating a serviceable instrument plus stable below-alert flow and clear
+  visual evidence as routine surveillance is professionally plausible within
+  this bounded action set. The baseline note correctly says its limits are
+  task-owned synthetic values, not general dam-safety limits.
+
+### Domain and interpretation caveats
+
+- The descriptive profile IDs are not realistic operational observations and
+  expose the answer. A real monitor would see a monitoring-point identifier,
+  not a task slug saying “reliable routine surveillance”.
+- `INSPECT_DOWNSTREAM_AREA` releases only the condition for the current
+  reading, and `evaluate()` marks routine evidence complete when the latest
+  reading is inspected (`world.py:254-264, 323-340`). It does not require
+  inspection of each historical reading. A competent dam monitor may accept a
+  current downstream inspection plus the recorded history, but the protocol's
+  wording “no visual alert condition ever occurs” is stronger than the
+  learner-visible evidence contract. This weakens `evidence-complete` as a
+  professional measure, although it is held constant across profiles.
+- The small numeric flow perturbations remain below the threshold and are not
+  implausible, but they can create model-facing surface differences unrelated
+  to applicability. They should not be retained while claiming an otherwise
+  exact match.
+- This is a synthetic decision-support task, not authority to make a real
+  dam-safety determination. The source comments and profile baseline make that
+  boundary clear.
+
+## Measurement sufficiency and ceiling/floor risks
+
+The five maintained measurements (`study.toml:16-54`) cover the intended
+probe-level outcomes:
+
+1. structured-memory versus cold `dam.inappropriate-escalation`;
+2. reset-after-acquisition versus cold inappropriate escalation;
+3. structured-memory versus cold response correctness;
+4. structured-memory versus cold evidence completeness; and
+5. structured-memory versus cold canonical reward.
+
+They are sufficient to score the state-machine distinction demonstrated above,
+including the required separate false-positive diagnostic. The reset control
+also addresses ordering/provider contamination. The named projections are
+bounded and ineligibility-safe: the dam projections require a completed,
+replay-valid evaluation and a submitted response, while canonical reward reads
+the completed replay-valid evaluation.
+
+Important blind spots remain:
+
+- There is no registered acquisition-quality measurement or gate. A real
+  structured-memory arm can fail the acquisition response and still receive
+  the declared feedback/principles and consolidate memory. The resulting
+  effect is the bundle “acquisition attempt + feedback + consolidation”, not
+  specifically transfer from a correctly learned escalation. Acquisition
+  success, selected response, and feedback eligibility must be reported and
+  stratified or gated before attributing a result to prior correct escalation.
+- `dam.evidence-complete` is an aggregate boolean; it does not separately
+  measure whether the learner checked the instrument, reviewed all readings,
+  and inspected the relevant visual evidence. The existing fields can report
+  those components, but W01 does not register them as separate measurements.
+- The projections detect the outcome of copying escalation but cannot establish
+  whether a model reasoned conditionally versus read the leaked profile slug.
+  Removing the slug is therefore a prerequisite for interpreting the causal
+  mechanism.
+- The treatment bundles declared public principles, feedback, and
+  consolidation. W01 cannot isolate which of those components caused a probe
+  effect, as the protocol acknowledges.
+
+The dominant ceiling risk is the profile-ID leak: a cold agent can identify the
+probe's intended answer from the initial observation, so
+`dam.inappropriate-escalation = 0.0` and `dam.response-correct = 1.0` may be
+uniform across arms without testing negative transfer. The protocol's own
+“all arms at ceiling” rule (§19.2 and §20) would then prohibit a learning
+conclusion. A secondary floor/selection risk is that malformed or
+replay-invalid episodes are ineligible for the named projections rather than
+counted as generic failure, potentially reducing the analysed sample.
+
+## Overall recommendation
+
+**REJECTED for `relations_reviewed=true` in the current state.**
+
+The world rule and the copycat diagnostic are sound, and the dam scenario is
+reasonable as a bounded synthetic exercise. Nevertheless, the relation is not
+currently a clean causal applicability boundary because:
+
+1. the initial observation literally names `reliable-routine-surveillance`
+   (and the acquisition slug names its own answer) before the epistemic check;
+2. the two profiles differ in concrete monitoring-point ID and measured flows
+   despite those differences not being declared; and
+3. acquisition success is not gated or measured, which weakens any statement
+   specifically about transfer from a correctly acquired escalation.
+
+Before any claim-bearing W01 run, require:
+
+1. **Remove or neutralise the semantic profile slug from actor-visible
+   observations.** Keep the task/profile identity available to the harness,
+   but expose only a non-semantic monitoring-point identifier or another
+   neutral actor-facing value. Add a regression test showing that the opening
+   probe observation does not disclose reliability or the required response;
+   retain the post-`CHECK_MEASUREMENT_SYSTEM` release test.
+2. **Make the matched profiles actually matched.** Prefer the same
+   `monitoring_point_id` and byte-identical readings (including measured
+   values), with only `instrument_condition` changed and the required response
+   derived accordingly. Alternatively, explicitly re-author the family and
+   study to declare and justify each remaining surface/parameter difference,
+   then obtain a new relation review.
+3. **Record acquisition fidelity.** Require or report a successful,
+   evidence-complete acquisition with the intended escalation before calling a
+   result transfer from prior escalation experience; otherwise label the
+   estimand as the full declared treatment bundle.
+4. **Pilot for headroom and visual-evidence interpretation.** If cold and
+   exposed probes are at ceiling on inappropriate escalation, response
+   correctness, or evidence completeness, apply W01 §20 and make no learning
+   claim. Clarify whether one current downstream inspection is the intended
+   professional evidence contract or require historical visual checks.
+5. **Repeat this relation review after the observation and matching fixes.**
+
+After these conditions are met and the programme owner accepts the reviewer
+standing, `relations_reviewed=true` may be considered. This document does not
+authorise it for the current implementation.
+
+## Commands used
+
+The following commands were run from the W01 worktree. The Python probes wrote
+only short evidence files under the repository during projection checks and
+removed them before completion; no scratch artifacts remain.
+
+```bash
+uv run python - <<'PY'  # load profiles, field-diff JSON, evaluate sequences
+...
+PY
+
+uv run python - <<'PY'  # build synthetic TrialRecords and call four projections
+...
+PY
+
+uv run python - <<'PY'  # inspect opening and post-check observations
+...
+PY
+```
+
+The final documentation-ownership validation is recorded after registering
+this document:
+
+```bash
+uv run pytest tests/docs/test_documentation_ownership.py -q
+```

--- a/src/aec_bench/experimentation/learning_studies/dam_w01.py
+++ b/src/aec_bench/experimentation/learning_studies/dam_w01.py
@@ -22,7 +22,7 @@ from aec_bench.contracts.learning_study_evidence import (
     StudyStepReceipt,
     StudyStepStatus,
 )
-from aec_bench.contracts.trial_record import TrialRecord
+from aec_bench.contracts.trial_record import EvaluationStatus, ExecutionStatus, TrialRecord
 from aec_bench.experimentation.learning_studies.assessment import (
     AssessmentArmEvidence,
     OutcomeProjection,
@@ -68,7 +68,7 @@ from aec_bench.worlds.monitoring.dam_seepage.dam_learning import (
     dam_response_correct,
     validate_dam_escalation_boundary_feedback,
 )
-from aec_bench.worlds.monitoring.dam_seepage.world import DAM_SEEPAGE_TASK_WORLD_ID
+from aec_bench.worlds.monitoring.dam_seepage.world import DAM_SEEPAGE_TASK_WORLD_ID, SeepageResponse
 
 DAM_W01_PROTOCOL_ID = "w01-dam-escalation-applicability-boundary"
 DAM_W01_STUDY_ID = "w01-dam-escalation-applicability-boundary"
@@ -104,8 +104,29 @@ class W01DamRun:
     plan: CompiledLearningStudy
     execution: LearningStudyExecution[WorldFeedback]
     arm_evidence: Mapping[str, AssessmentArmEvidence]
+    acquisition_fidelity: Mapping[str, W01AcquisitionFidelity]
     unreviewed_assessment: LearningStudyAssessment
     reviewed_assessment: LearningStudyAssessment
+
+
+@dataclass(frozen=True, slots=True)
+class W01AcquisitionFidelity:
+    """Truthful acquisition facts derived from the arm's persisted TrialRecord."""
+
+    arm_run_id: str
+    trial_id: str | None
+    trial_record_present: bool
+    replay_valid: bool | None
+    response_correct: bool | None
+    evidence_complete: bool | None
+    escalation_selected: bool | None
+    acquisition_successful: bool
+
+    @property
+    def fidelity_satisfied(self) -> bool:
+        """Return whether the acquisition supports a transfer claim."""
+
+        return self.acquisition_successful
 
 
 def load_w01_dam_protocol(
@@ -220,6 +241,7 @@ async def run_w01_dam_study(
         execution=execution,
         adapter_id=execution_condition.adapter_id,
     )
+    acquisition_fidelity = build_w01_acquisition_fidelity(plan=plan, execution=execution)
     projections = w01_dam_outcome_projections()
     assessment_execution = cast(LearningStudyExecution[object], execution)
     return W01DamRun(
@@ -227,6 +249,7 @@ async def run_w01_dam_study(
         plan=plan,
         execution=execution,
         arm_evidence=arm_evidence,
+        acquisition_fidelity=acquisition_fidelity,
         unreviewed_assessment=assess_learning_study(
             spec=plan.spec,
             plan=plan,
@@ -250,6 +273,91 @@ def run_w01_dam_study_sync(**kwargs: Any) -> W01DamRun:
     """Run W01 from synchronous research and test entry points."""
 
     return asyncio.run(run_w01_dam_study(**kwargs))
+
+
+def build_w01_acquisition_fidelity(
+    *,
+    plan: CompiledLearningStudy,
+    execution: LearningStudyExecution[WorldFeedback],
+) -> dict[str, W01AcquisitionFidelity]:
+    """Derive acquisition fidelity from the real TrialRecords in each acquisition arm."""
+
+    if plan.spec.study_id != DAM_W01_STUDY_ID or execution.study_run_id != plan.study_run_id:
+        raise ValueError("acquisition-fidelity-incomplete: inputs do not identify W01")
+
+    execution_by_arm = {item.arm_run_id: item for item in execution.arm_runs}
+    fidelity: dict[str, W01AcquisitionFidelity] = {}
+    for arm_run in plan.arm_runs:
+        acquisition_steps = tuple(
+            step
+            for step in arm_run.steps
+            if isinstance(step, CompiledExperienceStep) and step.role is ExperienceRole.ACQUISITION
+        )
+        if not acquisition_steps:
+            continue
+        if len(acquisition_steps) != 1:
+            raise ValueError(f"acquisition-fidelity-incomplete: expected one acquisition: {arm_run.arm_run_id}")
+
+        step = acquisition_steps[0]
+        arm_result = execution_by_arm.get(arm_run.arm_run_id)
+        record = (
+            None
+            if arm_result is None
+            else next(
+                (
+                    item
+                    for item in arm_result.trial_records
+                    if item.trial_id == step.trial.trial_id and item.task_id == DAM_W01_ACQUISITION_TASK_ID
+                ),
+                None,
+            )
+        )
+        if record is None:
+            fidelity[arm_run.arm_run_id] = W01AcquisitionFidelity(
+                arm_run_id=arm_run.arm_run_id,
+                trial_id=None,
+                trial_record_present=False,
+                replay_valid=None,
+                response_correct=None,
+                evidence_complete=None,
+                escalation_selected=None,
+                acquisition_successful=False,
+            )
+            continue
+
+        evaluation = record.evaluation if record.evaluation_status is EvaluationStatus.COMPLETED else None
+        breakdown = None if evaluation is None else evaluation.breakdown
+        breakdown = breakdown if isinstance(breakdown, dict) else None
+        response_correct = _optional_bool(breakdown, "response_correct")
+        evidence_complete = _optional_bool(breakdown, "evidence_complete")
+        selected_response = None if breakdown is None else breakdown.get("selected_response")
+        escalation_selected = (
+            selected_response == SeepageResponse.ENGINEERING_REVIEW.value
+            if isinstance(selected_response, str)
+            else None
+        )
+        replay_valid = None if evaluation is None else evaluation.validity.verifier_completed
+        execution_completed = record.execution_status is ExecutionStatus.COMPLETED
+        evaluation_completed = record.evaluation_status is EvaluationStatus.COMPLETED
+        acquisition_successful = (
+            execution_completed
+            and evaluation_completed
+            and replay_valid is True
+            and response_correct is True
+            and evidence_complete is True
+            and escalation_selected is True
+        )
+        fidelity[arm_run.arm_run_id] = W01AcquisitionFidelity(
+            arm_run_id=arm_run.arm_run_id,
+            trial_id=record.trial_id,
+            trial_record_present=True,
+            replay_valid=replay_valid,
+            response_correct=response_correct,
+            evidence_complete=evidence_complete,
+            escalation_selected=escalation_selected,
+            acquisition_successful=acquisition_successful,
+        )
+    return fidelity
 
 
 def build_w01_assessment_arm_evidence(
@@ -469,6 +577,13 @@ def _hidden_evaluation_absent(root: Path, arm_run: PlannedArmRun) -> bool:
         return False
 
 
+def _optional_bool(breakdown: dict[str, Any] | None, field: str) -> bool | None:
+    if breakdown is None:
+        return None
+    value = breakdown.get(field)
+    return value if isinstance(value, bool) else None
+
+
 def _read_model(path: Path, model_type: type[ModelT]) -> ModelT:
     return model_type.model_validate_json(path.read_text(encoding="utf-8"))
 
@@ -479,7 +594,9 @@ __all__ = (
     "DAM_W01_PROBE_TASK_ID",
     "DAM_W01_PROTOCOL_ID",
     "DAM_W01_STUDY_ID",
+    "W01AcquisitionFidelity",
     "W01DamRun",
+    "build_w01_acquisition_fidelity",
     "build_w01_assessment_arm_evidence",
     "build_w01_dam_binding",
     "compile_w01_dam_study",

--- a/src/aec_bench/experimentation/learning_studies/dam_w01.py
+++ b/src/aec_bench/experimentation/learning_studies/dam_w01.py
@@ -285,7 +285,11 @@ def build_w01_acquisition_fidelity(
     if plan.spec.study_id != DAM_W01_STUDY_ID or execution.study_run_id != plan.study_run_id:
         raise ValueError("acquisition-fidelity-incomplete: inputs do not identify W01")
 
-    execution_by_arm = {item.arm_run_id: item for item in execution.arm_runs}
+    execution_by_arm: dict[str, ArmRunExecutionResult[WorldFeedback]] = {}
+    for item in execution.arm_runs:
+        if item.arm_run_id in execution_by_arm:
+            raise ValueError(f"acquisition-fidelity-ambiguous: duplicate arm result: {item.arm_run_id}")
+        execution_by_arm[item.arm_run_id] = item
     fidelity: dict[str, W01AcquisitionFidelity] = {}
     for arm_run in plan.arm_runs:
         acquisition_steps = tuple(
@@ -300,18 +304,18 @@ def build_w01_acquisition_fidelity(
 
         step = acquisition_steps[0]
         arm_result = execution_by_arm.get(arm_run.arm_run_id)
-        record = (
-            None
+        matching_records = (
+            ()
             if arm_result is None
-            else next(
-                (
-                    item
-                    for item in arm_result.trial_records
-                    if item.trial_id == step.trial.trial_id and item.task_id == DAM_W01_ACQUISITION_TASK_ID
-                ),
-                None,
+            else tuple(
+                item
+                for item in arm_result.trial_records
+                if item.trial_id == step.trial.trial_id and item.task_id == DAM_W01_ACQUISITION_TASK_ID
             )
         )
+        if len(matching_records) > 1:
+            raise ValueError(f"acquisition-fidelity-ambiguous: expected one acquisition: {arm_run.arm_run_id}")
+        record = matching_records[0] if matching_records else None
         if record is None:
             fidelity[arm_run.arm_run_id] = W01AcquisitionFidelity(
                 arm_run_id=arm_run.arm_run_id,

--- a/src/aec_bench/experimentation/learning_studies/protocols/w01-dam-escalation-applicability-boundary/family.toml
+++ b/src/aec_bench/experimentation/learning_studies/protocols/w01-dam-escalation-applicability-boundary/family.toml
@@ -1,3 +1,5 @@
+# Profile slugs remain stable harness/task identity; the world observation
+# deliberately exposes only the neutral monitoring-point identifier.
 family_id = "dam-seepage-escalation-applicability"
 title = "Dam-seepage escalation applicability boundary"
 description = "Tests whether escalation experience justified solely by instrument unreliability incorrectly transfers to a surface-similar profile where the instrument is reliable and escalation is not supported by evidence. Independent domain review is required before a claim-bearing run."
@@ -5,12 +7,12 @@ description = "Tests whether escalation experience justified solely by instrumen
 [[dimensions]]
 dimension_id = "monitoring_point_pattern"
 kind = "surface"
-description = "The monitoring point type, action set, and prose objective presented to the learner"
+description = "The monitoring point type, action set, and prose objective presented to the learner; the matched profiles use the same point."
 
 [[dimensions]]
 dimension_id = "reading_pattern"
 kind = "parameter"
-description = "The flow, rainfall, and reservoir reading values and cadence across the episode"
+description = "The byte-identical flow, rainfall, reservoir, threshold, condition, and cadence readings across the episode"
 
 [[dimensions]]
 dimension_id = "instrument_reliability"
@@ -52,7 +54,7 @@ target_member_id = "reliable-routine-surveillance-probe"
 invariant_dimensions = ["monitoring_point_pattern", "reading_pattern"]
 invariant_claims = [
   "Both profiles present the same monitoring point type, action set, and prose objective.",
-  "In both profiles, flow stays below alert thresholds and no visual alert condition ever occurs, so the correct response is fully determined by the instrument-reliability finding.",
+  "Both profiles use byte-identical readings: flow stays below alert thresholds and no visual alert condition ever occurs, so the correct response is fully determined by the instrument-reliability finding.",
   "The correct response in each profile follows only from checking the measurement system, never from the surface reading pattern alone.",
 ]
 changed_dimensions = ["instrument_reliability", "response_applicability"]

--- a/src/aec_bench/worlds/monitoring/dam_seepage/reliable-routine-surveillance.json
+++ b/src/aec_bench/worlds/monitoring/dam_seepage/reliable-routine-surveillance.json
@@ -1,7 +1,7 @@
 {
   "task_world_id": "dam-seepage-monitoring",
   "profile_id": "reliable-routine-surveillance",
-  "monitoring_point_id": "SEEP-WEIR-03",
+  "monitoring_point_id": "SEEP-WEIR-02",
   "objective": "Review the seepage event, gather enough measurement and visual evidence for the current response, and submit either engineering-review escalation or continued routine surveillance.",
   "baseline_note": "Expected and alert flows are site-specific values from this task-owned synthetic monitoring plan. They are not general dam-safety limits.",
   "required_consecutive_alert_readings": 2,
@@ -18,7 +18,7 @@
       "recent_rainfall_mm": 0.0,
       "expected_flow_l_min": 20.0,
       "alert_flow_l_min": 27.0,
-      "measured_flow_l_min": 19.8,
+      "measured_flow_l_min": 19.5,
       "downstream_condition": "clear"
     },
     {
@@ -27,7 +27,7 @@
       "recent_rainfall_mm": 0.0,
       "expected_flow_l_min": 20.0,
       "alert_flow_l_min": 27.0,
-      "measured_flow_l_min": 20.1,
+      "measured_flow_l_min": 20.0,
       "downstream_condition": "clear"
     },
     {
@@ -36,7 +36,7 @@
       "recent_rainfall_mm": 0.0,
       "expected_flow_l_min": 20.0,
       "alert_flow_l_min": 27.0,
-      "measured_flow_l_min": 20.0,
+      "measured_flow_l_min": 20.2,
       "downstream_condition": "clear"
     },
     {
@@ -45,7 +45,7 @@
       "recent_rainfall_mm": 0.0,
       "expected_flow_l_min": 20.0,
       "alert_flow_l_min": 27.0,
-      "measured_flow_l_min": 19.9,
+      "measured_flow_l_min": 20.1,
       "downstream_condition": "clear"
     }
   ]

--- a/src/aec_bench/worlds/monitoring/dam_seepage/world.py
+++ b/src/aec_bench/worlds/monitoring/dam_seepage/world.py
@@ -175,7 +175,9 @@ def observe(state: SeepageState) -> SeepageObservation:
         for index, reading in enumerate(state.scenario.readings[: state.reading_index + 1])
     )
     return SeepageObservation(
-        profile_id=state.scenario.profile_id,
+        # Preserve the observation wire shape while keeping the registered
+        # profile identity out of the actor-visible view.
+        profile_id=state.scenario.monitoring_point_id,
         monitoring_point_id=state.scenario.monitoring_point_id,
         objective=state.scenario.objective,
         baseline_note=state.scenario.baseline_note,

--- a/tests/docs/test_documentation_ownership.py
+++ b/tests/docs/test_documentation_ownership.py
@@ -34,6 +34,7 @@ EXPECTED_REPOSITORY_DOCS = {
     "research/learning-studies/l01-deterministic-evidence.md",
     "research/learning-studies/l01-relation-domain-review.md",
     "research/learning-studies/programme.md",
+    "research/learning-studies/w01-relation-domain-review.md",
     "research/learning-studies/release-a/GATE-A-artifact-substrate-extraction.md",
     "research/learning-studies/release-a/LS-00-programme-boundary-and-semantic-cleanup.md",
     "research/learning-studies/release-a/LS-01A-study-contracts-and-compilation.md",

--- a/tests/experimentation/learning_studies/test_dam_w01.py
+++ b/tests/experimentation/learning_studies/test_dam_w01.py
@@ -16,19 +16,25 @@ from aec_bench.contracts.agent_output import AgentOutput, AgentOutputStatus
 from aec_bench.contracts.evaluation_result import EvaluationResult, ValidityCheck
 from aec_bench.contracts.experiment_manifest import AgentConfig, ComputeConfig
 from aec_bench.contracts.learning_study_assessment import LearningComparisonValidity
-from aec_bench.contracts.trial_record import EvaluationStatus, TrialOutput
+from aec_bench.contracts.trial_record import EvaluationStatus, TrialOutput, TrialRecord
 from aec_bench.experimentation.learning_studies.dam_w01 import (
     DAM_W01_ACQUISITION_TASK_ID,
     DAM_W01_CONSOLIDATION_OPERATION_ID,
     DAM_W01_PROBE_TASK_ID,
     DAM_W01_STUDY_ID,
+    build_w01_acquisition_fidelity,
     compile_w01_dam_study,
     load_w01_dam_protocol,
     run_w01_dam_study_sync,
     w01_dam_outcome_projections,
 )
-from aec_bench.experimentation.learning_studies.planning import CompiledFeedbackStep
-from aec_bench.experimentation.learning_studies.runtime import ArmRunStatus, ReleaseFeedbackRequest
+from aec_bench.experimentation.learning_studies.planning import CompiledExperienceStep, CompiledFeedbackStep
+from aec_bench.experimentation.learning_studies.runtime import (
+    ArmRunExecutionResult,
+    ArmRunStatus,
+    LearningStudyExecution,
+    ReleaseFeedbackRequest,
+)
 from aec_bench.experimentation.learning_studies.worlds import (
     WorldConsolidationContext,
     WorldLearningExecutionCondition,
@@ -400,6 +406,59 @@ def test_required_w01_projections_are_bounded_and_missing_evidence_is_ineligible
         )
         if projection_id != "world.canonical-reward":
             assert no_submission.eligible is False and no_submission.value is None
+
+
+def test_acquisition_fidelity_fails_closed_on_missing_or_ambiguous_records() -> None:
+    agent = AgentConfig(name="prime", adapter="prime-agent", model="anthropic/test", parameters={})
+    plan = compile_w01_dam_study(study_run_id="w01-fidelity-inputs", agent=agent, compute=_COMPUTE)
+    arm_run = next(item for item in plan.arm_runs if item.arm_id == "structured-memory")
+    acquisition_step = next(
+        item
+        for item in arm_run.steps
+        if isinstance(item, CompiledExperienceStep) and item.role.value == "acquisition"
+    )
+
+    def arm_result(records: tuple[TrialRecord, ...]) -> ArmRunExecutionResult[object]:
+        return ArmRunExecutionResult(
+            arm_run_id=arm_run.arm_run_id,
+            status=ArmRunStatus.COMPLETED,
+            initial_state_id="initial",
+            completed_steps=(),
+            trial_records=records,
+            final_state_id="final",
+            failure=None,
+        )
+
+    missing = build_w01_acquisition_fidelity(
+        plan=plan,
+        execution=LearningStudyExecution(
+            study_run_id=plan.study_run_id,
+            arm_runs=(arm_result(()),),
+        ),
+    )
+    assert missing[arm_run.arm_run_id].trial_record_present is False
+    assert missing[arm_run.arm_run_id].acquisition_successful is False
+
+    record = make_trial_record(
+        task_id=DAM_W01_ACQUISITION_TASK_ID,
+        trial_id=acquisition_step.trial.trial_id,
+    )
+    with pytest.raises(ValueError, match="acquisition-fidelity-ambiguous"):
+        build_w01_acquisition_fidelity(
+            plan=plan,
+            execution=LearningStudyExecution(
+                study_run_id=plan.study_run_id,
+                arm_runs=(arm_result((record, record)),),
+            ),
+        )
+    with pytest.raises(ValueError, match="acquisition-fidelity-ambiguous"):
+        build_w01_acquisition_fidelity(
+            plan=plan,
+            execution=LearningStudyExecution(
+                study_run_id=plan.study_run_id,
+                arm_runs=(arm_result((record,)), arm_result((record,))),
+            ),
+        )
 
 
 @pytest.mark.skipif(

--- a/tests/experimentation/learning_studies/test_dam_w01.py
+++ b/tests/experimentation/learning_studies/test_dam_w01.py
@@ -443,6 +443,29 @@ def test_acquisition_fidelity_fails_closed_on_missing_or_ambiguous_records() -> 
         task_id=DAM_W01_ACQUISITION_TASK_ID,
         trial_id=acquisition_step.trial.trial_id,
     )
+    malformed = make_trial_record(
+        task_id=DAM_W01_ACQUISITION_TASK_ID,
+        trial_id=acquisition_step.trial.trial_id,
+        evaluation=EvaluationResult(
+            reward=1.0,
+            validity=ValidityCheck(output_parseable=True, schema_valid=True, verifier_completed=True),
+            breakdown={
+                "response_correct": 1,
+                "evidence_complete": True,
+                "selected_response": "engineering-review",
+            },
+        ),
+    )
+    malformed_result = build_w01_acquisition_fidelity(
+        plan=plan,
+        execution=LearningStudyExecution(
+            study_run_id=plan.study_run_id,
+            arm_runs=(arm_result((malformed,)),),
+        ),
+    )
+    assert malformed_result[arm_run.arm_run_id].response_correct is None
+    assert malformed_result[arm_run.arm_run_id].acquisition_successful is False
+
     with pytest.raises(ValueError, match="acquisition-fidelity-ambiguous"):
         build_w01_acquisition_fidelity(
             plan=plan,

--- a/tests/experimentation/learning_studies/test_dam_w01.py
+++ b/tests/experimentation/learning_studies/test_dam_w01.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 import json
 import os
 import sys
+from dataclasses import replace
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -56,6 +58,33 @@ _ROUTINE_ACTIONS = [
     {"action_name": SeepageAction.INSPECT_DOWNSTREAM_AREA.value, "arguments": {}, "request_id": "inspect"},
     {"action_name": SeepageAction.CONTINUE_ROUTINE_SURVEILLANCE.value, "arguments": {}, "request_id": "submit"},
 ]
+_ACQUISITION_ACTIONS = [
+    {"action_name": SeepageAction.CHECK_MEASUREMENT_SYSTEM.value, "arguments": {}, "request_id": "check"},
+    {
+        "action_name": SeepageAction.ESCALATE_FOR_ENGINEERING_REVIEW.value,
+        "arguments": {},
+        "request_id": "escalate",
+    },
+]
+
+
+async def _instrument_aware_actor_session(**kwargs: Any):  # noqa: ANN202
+    trial = kwargs["trial"]
+    actions = _ACQUISITION_ACTIONS if trial.task_id == DAM_W01_ACQUISITION_TASK_ID else _ROUTINE_ACTIONS
+    environment = {
+        **trial.agent.parameters["environment"],
+        "FAKE_WORLD_ACTIONS": json.dumps(actions),
+    }
+    agent = trial.agent.model_copy(update={"parameters": {**trial.agent.parameters, "environment": environment}})
+    return await run_prime_world_actor_session(**{**kwargs, "trial": replace(trial, agent=agent)})
+
+
+_INSTRUMENT_AWARE_CONDITION = WorldLearningExecutionCondition(
+    actor=_instrument_aware_actor_session,
+    actor_binding_label=_CONDITION.actor_binding_label,
+)
+
+
 _PROJECTION_IDS = {
     "world.canonical-reward",
     "dam.response-correct",
@@ -64,7 +93,11 @@ _PROJECTION_IDS = {
 }
 
 
-def _agent(tmp_path: Path, *, isolation: str = "development_same_user") -> AgentConfig:
+def _agent(
+    tmp_path: Path,
+    *,
+    isolation: str = "development_same_user",
+) -> AgentConfig:
     from tests.prime_agent.test_acp import _fake_prime_agent
 
     return AgentConfig(
@@ -383,7 +416,7 @@ def test_deterministic_w01_runs_all_arms_and_builds_truthful_assessment_evidence
         study_run_id="w01-deterministic",
         agent=agent,
         compute=_COMPUTE,
-        execution_condition=_CONDITION,
+        execution_condition=_INSTRUMENT_AWARE_CONDITION,
         consolidation_operation=consolidator,
     )
 
@@ -396,6 +429,19 @@ def test_deterministic_w01_runs_all_arms_and_builds_truthful_assessment_evidence
     assert all(item.probe_feedback_hidden for item in result.arm_evidence.values())
     assert all(item.probe_state_discarded for item in result.arm_evidence.values())
     assert all(not item.hidden_evaluation_leaked for item in result.arm_evidence.values())
+    assert set(result.acquisition_fidelity) == {
+        arm.arm_run_id for arm in result.plan.arm_runs if arm.arm_id in {"reset-after-acquisition", "structured-memory"}
+    }
+    assert all(
+        item.trial_record_present
+        and item.replay_valid is True
+        and item.response_correct is True
+        and item.evidence_complete is True
+        and item.escalation_selected is True
+        and item.acquisition_successful
+        and item.fidelity_satisfied
+        for item in result.acquisition_fidelity.values()
+    )
 
     assert all(
         measurement.validity is LearningComparisonValidity.DESCRIPTIVE_ONLY

--- a/tests/worlds/monitoring/dam_seepage/test_episode_runtime.py
+++ b/tests/worlds/monitoring/dam_seepage/test_episode_runtime.py
@@ -54,6 +54,8 @@ def test_dam_episode_host_preserves_exact_retry_stale_decision_and_external_eval
     assert catalogue.task_world_id == "dam-seepage-monitoring"
     assert {action.name for action in catalogue.actions} == {action.value for action in SeepageAction}
     assert all(action.input_schema["additionalProperties"] is False for action in catalogue.actions)
+    assert opening.view["profile_id"] == opening.view["monitoring_point_id"] == "SEEP-WEIR-01"
+    assert opening.view["instrument_condition"] is None
     assert "required_response" not in opening.view
 
     checked_request = WorldActorActionRequest(

--- a/tests/worlds/monitoring/dam_seepage/test_world.py
+++ b/tests/worlds/monitoring/dam_seepage/test_world.py
@@ -19,6 +19,7 @@ from aec_bench.worlds.monitoring.dam_seepage.world import (
     evaluate,
     initial_state,
     observe,
+    requires_engineering_review,
     transition,
 )
 from aec_bench.worlds.runtime.episode import (
@@ -35,8 +36,12 @@ _BASE_PROFILE_ID = "synthetic-rising-seepage"
 
 
 def _profile() -> DamSeepageProfile:
+    return _profile_by_id(_BASE_PROFILE_ID)
+
+
+def _profile_by_id(profile_id: str) -> DamSeepageProfile:
     definition = dam_seepage_world_definition()
-    reference = next(profile for profile in definition.profiles if profile.profile_id == _BASE_PROFILE_ID)
+    reference = next(profile for profile in definition.profiles if profile.profile_id == profile_id)
     loaded = definition.load_profile(reference)
     assert isinstance(loaded.value, DamSeepageProfile)
     return loaded.value
@@ -99,6 +104,38 @@ def test_observation_reveals_only_requested_monitoring_evidence() -> None:
     inspected_view = observe(inspected.state)
     assert inspected_view.readings[0].downstream_condition is None
     assert inspected_view.readings[1].downstream_condition is DownstreamCondition.CLEAR
+
+
+def test_opening_probe_observation_uses_a_neutral_identifier() -> None:
+    profile = _profile_by_id("reliable-routine-surveillance")
+
+    opening = observe(profile.opening_state)
+
+    assert opening.profile_id == profile.scenario.monitoring_point_id == "SEEP-WEIR-02"
+    assert opening.profile_id not in {
+        "unreliable-instrument-escalation",
+        "reliable-routine-surveillance",
+    }
+    assert opening.instrument_condition is None
+    assert not hasattr(opening, "required_response")
+
+
+def test_w01_profiles_are_matched_except_declared_instrument_condition() -> None:
+    acquisition = _profile_by_id("unreliable-instrument-escalation").scenario
+    probe = _profile_by_id("reliable-routine-surveillance").scenario
+
+    acquisition_fields = acquisition.model_dump(mode="json")
+    probe_fields = probe.model_dump(mode="json")
+    acquisition_fields.pop("profile_id")
+    probe_fields.pop("profile_id")
+
+    differing_fields = {field for field in acquisition_fields if acquisition_fields[field] != probe_fields[field]}
+
+    assert differing_fields == {"instrument_condition"}
+    assert acquisition_fields["monitoring_point_id"] == probe_fields["monitoring_point_id"]
+    assert acquisition_fields["readings"] == probe_fields["readings"]
+    assert requires_engineering_review(acquisition)
+    assert not requires_engineering_review(probe)
 
 
 def test_world_accepts_judgment_then_evaluation_checks_it() -> None:


### PR DESCRIPTION
## Summary

Fixes the three defects found by the independent W01 relation domain review, and carries the full review record (original rejection preserved as history + post-fix re-review) to its **ACCEPTED** conclusion. With this merged, `relations_reviewed=true` may be supplied for claim-bearing W01 runs, subject to the recorded pilot-time conditions.

## The defects and fixes

1. **Observation identity leakage (critical).** The opening `SeepageObservation` exposed the registered profile slug (`reliable-routine-surveillance` / `unreliable-instrument-escalation`) — naming the hidden instrument condition and the required response before the `CHECK_MEASUREMENT_SYSTEM` epistemic action. Fixed: the actor-visible identity slot now carries the neutral monitoring-point identifier; the registered profile identity remains available to the harness only. Regression tests assert the opening observations of both profiles are indistinguishable and `instrument_condition` stays hidden until checked.
2. **Undeclared profile differences.** The probe differed from the acquisition in monitoring-point ID (`SEEP-WEIR-03` vs `-02`) and four measured-flow values. Fixed: the probe now shares the monitoring point and byte-identical readings; only `instrument_condition` differs, with the required response derived by the world's own `requires_engineering_review` logic. A field-diff test enforces this, and `family.toml` claims now state the byte-identical match.
3. **No acquisition-fidelity recording.** Claim-bearing transfer analysis needs evidence the acquisition actually demonstrated the intended behaviour. Fixed: study-owned `W01AcquisitionFidelity` derived from the real acquisition `TrialRecord`s (fail-closed `acquisition-fidelity-incomplete` / `acquisition-fidelity-ambiguous` on missing or duplicate records; no coercion), asserted by the deterministic E2E test.

## Review record

`docs/research/learning-studies/w01-relation-domain-review.md` contains the complete governance lineage: the original review (verdicts including the REJECTED overall recommendation, simulated copycat/gold/lazy diagnostics, surface-diff analysis) and the post-fix re-review by a fresh reviewer instance, which verified every condition by execution and updated the recommendation to ACCEPTED. The re-review also found and fixed one additional defect (duplicate acquisition records were silently accepted; now rejected as ambiguous). The programme-owner acceptance decision is recorded in the document, consistent with the L01 precedent.

Remaining pilot-time obligations (recorded, not blockers to this PR): headroom/ceiling monitoring per W01 §20, and gating transfer analysis on recorded acquisition fidelity.

## Testing

- Targeted suites: dam world, W01 study, worlds adapter, world trials, docs ownership — all passing (43 + follow-up modules; 26 in final verification run; 6 new fidelity-guard tests; 11 docs ownership)
- Ruff format/check, scoped mypy (`src/aec_bench/worlds/`), and the provenance policy gate against base — all clean
