### PR TITLE
feat: add L02 drainage applicability-boundary study (Release B, Lifecycle Tranche 2, D2)

### DIFF
--- a/src/aec_bench/experimentation/learning_studies/l02_drainage.py
+++ b/src/aec_bench/experimentation/learning_studies/l02_drainage.py
@@ -1,0 +1,557 @@
+# ABOUTME: Composes and assesses the first lifecycle-backed Learning Study vertical slice.
+# ABOUTME: Keeps L02 treatment, projection, and evidence policy in explicit study-owned glue.
+
+from __future__ import annotations
+
+import asyncio
+import math
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, TypeVar, cast
+
+from pydantic import BaseModel
+
+from aec_bench.contracts.experiment_manifest import AgentConfig, ComputeConfig
+from aec_bench.contracts.learning_study import ExperienceRole, LearningStudySpec
+from aec_bench.contracts.learning_study_assessment import LearningStudyAssessment
+from aec_bench.contracts.learning_study_evidence import (
+    FeedbackReleaseRecord,
+    LearnerStateRef,
+    LearnerTransitionReceipt,
+    RecordedStudyExecution,
+    StudyStepReceipt,
+    StudyStepStatus,
+)
+from aec_bench.contracts.trial_record import EvaluationStatus, TrialRecord
+from aec_bench.experimentation.learning_studies.assessment import (
+    AssessmentArmEvidence,
+    OutcomeProjection,
+    ProjectionResult,
+    assess_learning_study,
+)
+from aec_bench.experimentation.learning_studies.learner_state import (
+    validate_learner_state,
+)
+from aec_bench.experimentation.learning_studies.lifecycles import (
+    LifecycleConsolidationOperation,
+    LifecycleExecutionCondition,
+    LifecycleFeedback,
+    LifecycleLearningBinding,
+    LifecycleLearningTreatmentKind,
+    _validate_raw_history_state,
+    build_lifecycle_learning_operations,
+    resolve_lifecycle_learning_target,
+)
+from aec_bench.experimentation.learning_studies.planning import (
+    CompiledConsolidationStep,
+    CompiledExperienceStep,
+    CompiledFeedbackStep,
+    CompiledLearningStudy,
+    PlannedArmRun,
+    compile_learning_study,
+)
+from aec_bench.experimentation.learning_studies.protocol_collection import (
+    BUILTIN_LEARNING_STUDY_PROTOCOLS,
+    load_learning_study_protocol,
+)
+from aec_bench.experimentation.learning_studies.recording import StudyRunRecorder
+from aec_bench.experimentation.learning_studies.runtime import (
+    ArmRunExecutionResult,
+    ArmRunStatus,
+    LearningStudyExecution,
+    run_learning_study,
+)
+from aec_bench.lifecycles.runtime.episode import LifecycleExecutionMode, LifecycleVisibilityPolicy
+from aec_bench.lifecycles.stormwater_design.drainage_learning import (
+    DRAINAGE_STAGED_REVIEW_FEEDBACK_VIEW_ID,
+    drainage_gate_score,
+    drainage_inappropriate_memo_closure,
+    drainage_staged_review_feedback,
+    validate_drainage_staged_review_feedback,
+)
+
+L02_DRAINAGE_PROTOCOL_ID = "l02-drainage-correction-applicability-boundary"
+L02_DRAINAGE_STUDY_ID = "l02-drainage-correction-applicability-boundary"
+L02_CONSOLIDATION_OPERATION_ID = "update-lifecycle-review-memory"
+L02_PROBE_TASK_ID = "lifecycle/drainage-model-evidence-lifecycle-review/memo_closeout_missing"
+L02_ACQUISITION_TASK_ID = "lifecycle/drainage-model-evidence-lifecycle-review/staged_full_correction"
+L02_EXECUTION_CONDITION = LifecycleExecutionCondition(
+    execution_mode=LifecycleExecutionMode.FRESH_CONTEXT,
+    visibility_policy=LifecycleVisibilityPolicy.ARTIFACT_MEMORY,
+)
+
+_GATE_PROJECTIONS = {
+    "drainage.staged-disclosure": "staged_disclosure",
+    "drainage.finding-continuity": "finding_continuity",
+    "drainage.closure-evidence": "closure_evidence",
+    "drainage.accepted-decision-preservation": "accepted_decision_preservation",
+    "drainage.claim-boundary": "claim_boundary",
+}
+_FORBIDDEN_LEARNER_MARKERS = (
+    b"/hidden/",
+    b"expected_answer",
+    b"gold-submissions",
+    b"private_path",
+    b"semantic_no_op_release",
+    b"verifier-config",
+)
+_FORBIDDEN_LEARNER_FILENAMES = {
+    "experiment-manifest.json",
+    "gold-submissions.json",
+    "metrics.json",
+    "verification.json",
+}
+ModelT = TypeVar("ModelT", bound=BaseModel)
+
+
+@dataclass(frozen=True)
+class L02DrainageRun:
+    spec: LearningStudySpec
+    plan: CompiledLearningStudy
+    execution: LearningStudyExecution[LifecycleFeedback]
+    arm_evidence: Mapping[str, AssessmentArmEvidence]
+    unreviewed_assessment: LearningStudyAssessment
+    reviewed_assessment: LearningStudyAssessment
+
+
+def load_l02_drainage_protocol(
+    *,
+    agent: AgentConfig,
+    compute: ComputeConfig,
+    repetitions: int = 1,
+) -> LearningStudySpec:
+    """Load the maintained L02 protocol with one explicit run configuration."""
+
+    return load_learning_study_protocol(
+        BUILTIN_LEARNING_STUDY_PROTOCOLS / L02_DRAINAGE_PROTOCOL_ID,
+        agent=agent,
+        compute=compute,
+        repetitions=repetitions,
+    )
+
+
+def compile_l02_drainage_study(
+    *,
+    study_run_id: str,
+    agent: AgentConfig,
+    compute: ComputeConfig,
+    repetitions: int = 1,
+) -> CompiledLearningStudy:
+    """Compile L02 into ordinary planned lifecycle trials."""
+
+    spec = load_l02_drainage_protocol(agent=agent, compute=compute, repetitions=repetitions)
+    return compile_learning_study(
+        study_run_id=study_run_id,
+        spec=spec,
+        resolve_task=resolve_lifecycle_learning_target,
+    )
+
+
+def build_l02_drainage_binding(
+    *,
+    run_root: Path,
+    consolidation_operation: LifecycleConsolidationOperation,
+    adapter_builder: Callable[..., Any] | None = None,
+    resume_existing_run: bool = False,
+) -> LifecycleLearningBinding:
+    """Bind L02's two treatments, one feedback view, and one consolidation operation."""
+
+    return build_lifecycle_learning_operations(
+        run_root=run_root,
+        execution_condition=L02_EXECUTION_CONDITION,
+        treatment_kinds={
+            "reset": LifecycleLearningTreatmentKind.RESET,
+            "raw-history": LifecycleLearningTreatmentKind.RAW_HISTORY,
+            "structured-memory": LifecycleLearningTreatmentKind.STRUCTURED_MEMORY,
+        },
+        feedback_projectors={DRAINAGE_STAGED_REVIEW_FEEDBACK_VIEW_ID: drainage_staged_review_feedback},
+        consolidation_operations={L02_CONSOLIDATION_OPERATION_ID: consolidation_operation},
+        adapter_builder=adapter_builder,
+        resume_existing_run=resume_existing_run,
+    )
+
+
+def l02_drainage_outcome_projections() -> dict[str, OutcomeProjection]:
+    """Return the explicit L02 projection mapping without global registration."""
+
+    projections: dict[str, OutcomeProjection] = {
+        "lifecycle.canonical-reward": _project_probe_reward,
+        "drainage.inappropriate-memo-closure": _project_inappropriate_memo_closure,
+    }
+    projections.update(
+        {projection_id: _gate_projection(gate_id) for projection_id, gate_id in _GATE_PROJECTIONS.items()}
+    )
+    return projections
+
+
+async def run_l02_drainage_study(
+    *,
+    run_root: Path,
+    study_run_id: str,
+    agent: AgentConfig,
+    compute: ComputeConfig,
+    consolidation_operation: LifecycleConsolidationOperation,
+    adapter_builder: Callable[..., Any] | None = None,
+    repetitions: int = 1,
+) -> L02DrainageRun:
+    """Run, record, and assess L02 under both relation-review states."""
+
+    plan = compile_l02_drainage_study(
+        study_run_id=study_run_id,
+        agent=agent,
+        compute=compute,
+        repetitions=repetitions,
+    )
+    binding = build_l02_drainage_binding(
+        run_root=run_root,
+        consolidation_operation=consolidation_operation,
+        adapter_builder=adapter_builder,
+    )
+    recorder = StudyRunRecorder(
+        root=run_root,
+        plan=plan,
+        snapshot_state=binding.snapshot_state,
+        feedback_artifacts=binding.feedback_artifacts,
+    )
+    execution = await run_learning_study(plan=plan, operations=binding.operations, observer=recorder)
+    arm_evidence = build_l02_assessment_arm_evidence(
+        run_root=run_root,
+        plan=plan,
+        execution=execution,
+    )
+    projections = l02_drainage_outcome_projections()
+    assessment_execution = cast(LearningStudyExecution[object], execution)
+    return L02DrainageRun(
+        spec=plan.spec,
+        plan=plan,
+        execution=execution,
+        arm_evidence=arm_evidence,
+        unreviewed_assessment=assess_learning_study(
+            spec=plan.spec,
+            plan=plan,
+            execution=assessment_execution,
+            projections=projections,
+            arm_evidence=arm_evidence,
+            relations_reviewed=False,
+        ),
+        reviewed_assessment=assess_learning_study(
+            spec=plan.spec,
+            plan=plan,
+            execution=assessment_execution,
+            projections=projections,
+            arm_evidence=arm_evidence,
+            relations_reviewed=True,
+        ),
+    )
+
+
+def run_l02_drainage_study_sync(**kwargs: Any) -> L02DrainageRun:
+    """Run L02 from synchronous research and test entry points."""
+
+    return asyncio.run(run_l02_drainage_study(**kwargs))
+
+
+def build_l02_assessment_arm_evidence(
+    *,
+    run_root: Path,
+    plan: CompiledLearningStudy,
+    execution: LearningStudyExecution[LifecycleFeedback],
+) -> dict[str, AssessmentArmEvidence]:
+    """Derive every assessment fact from the completed plan and persisted evidence."""
+
+    root = Path(run_root).resolve(strict=True)
+    if plan.spec.study_id != L02_DRAINAGE_STUDY_ID or execution.study_run_id != plan.study_run_id:
+        raise ValueError("assessment-evidence-incomplete: inputs do not identify L02")
+    execution_by_arm = {item.arm_run_id: item for item in execution.arm_runs}
+    evidence: dict[str, AssessmentArmEvidence] = {}
+    for arm_run in plan.arm_runs:
+        arm_result = execution_by_arm.get(arm_run.arm_run_id)
+        if arm_result is None or arm_result.initial_state_id is None:
+            raise ValueError(f"assessment-evidence-incomplete: arm result is missing: {arm_run.arm_run_id}")
+        initial_ref = _read_model(
+            root / "states" / f"{arm_result.initial_state_id}.json",
+            LearnerStateRef,
+        )
+        if initial_ref.arm_run_id != arm_run.arm_run_id or initial_ref.parent_state_id is not None:
+            raise ValueError(f"assessment-evidence-incomplete: initial state is invalid: {arm_run.arm_run_id}")
+        evidence[arm_run.arm_run_id] = AssessmentArmEvidence(
+            adapter_id=L02_EXECUTION_CONDITION.adapter_id,
+            initial_state_equivalence_id=_initial_state(root / "learner-arms" / arm_run.arm_run_id, initial_ref),
+            arm_isolated=_arm_isolated(root, arm_run, arm_result),
+            lineage_complete=_lineage_complete(root, plan, arm_run, arm_result),
+            probe_feedback_hidden=_probe_feedback_hidden(root, plan.spec, arm_run, arm_result),
+            probe_state_discarded=_probe_state_discarded(root, arm_run),
+            hidden_evaluation_leaked=not _hidden_evaluation_absent(root, arm_run),
+        )
+    return evidence
+
+
+def _initial_state(arm_root: Path, initial_ref: LearnerStateRef) -> str:
+    """Use semantic empty-state equivalence across treatment-owned channel layouts."""
+
+    state_root = arm_root / "states" / "initial"
+    try:
+        top_level = {path.name: path for path in state_root.iterdir()}
+        if set(top_level) == {"history", "feedback", "memory"}:
+            if any(not path.is_dir() for path in top_level.values()):
+                raise ValueError("raw-history initial state channels are invalid")
+        else:
+            validate_learner_state(state_root)
+        if any(path.is_file() for path in state_root.rglob("*")):
+            raise ValueError("initial learner state contains committed content")
+    except (OSError, ValueError) as error:
+        raise ValueError(
+            f"assessment-evidence-incomplete: initial state is not empty: {initial_ref.state_id}"
+        ) from error
+    return "lifecycle-initial-state:empty"
+
+
+def _project_probe_reward(record: TrialRecord) -> ProjectionResult:
+    if record.task_id != L02_PROBE_TASK_ID:
+        return _ineligible(f"projection-task-mismatch: {record.task_id}")
+    if record.evaluation_status is not EvaluationStatus.COMPLETED or record.evaluation is None:
+        return _ineligible("projection-evaluation-missing: lifecycle evaluation is unavailable")
+    if not record.evaluation.validity.verifier_completed:
+        return _ineligible("projection-evaluation-missing: lifecycle verifier did not complete")
+    reward = record.evaluation.reward
+    if isinstance(reward, bool) or not isinstance(reward, int | float) or not math.isfinite(reward):
+        return _ineligible("projection-value-invalid: canonical reward is not finite")
+    value = float(reward)
+    if not 0.0 <= value <= 1.0:
+        return _ineligible("projection-value-out-of-bounds: canonical reward is outside [0, 1]")
+    return ProjectionResult(eligible=True, value=value, lower_bound=0.0, upper_bound=1.0)
+
+
+def _gate_projection(gate_id: str) -> OutcomeProjection:
+    def project(record: TrialRecord) -> ProjectionResult:
+        if record.task_id != L02_PROBE_TASK_ID:
+            return _ineligible(f"projection-task-mismatch: {record.task_id}")
+        try:
+            value = drainage_gate_score(record, gate_id)
+        except ValueError as error:
+            return _ineligible(str(error))
+        return ProjectionResult(eligible=True, value=value, lower_bound=0.0, upper_bound=1.0)
+
+    return project
+
+
+def _project_inappropriate_memo_closure(record: TrialRecord) -> ProjectionResult:
+    if record.task_id != L02_PROBE_TASK_ID:
+        return _ineligible(f"projection-task-mismatch: {record.task_id}")
+    try:
+        value = drainage_inappropriate_memo_closure(record)
+    except ValueError as error:
+        return _ineligible(str(error))
+    return ProjectionResult(eligible=True, value=value, lower_bound=0.0, upper_bound=1.0)
+
+
+def _ineligible(reason: str) -> ProjectionResult:
+    return ProjectionResult(eligible=False, value=None, reason=reason)
+
+
+def _arm_isolated(root: Path, arm_run: PlannedArmRun, result: ArmRunExecutionResult[LifecycleFeedback]) -> bool:
+    try:
+        arm_root = root / "learner-arms" / arm_run.arm_run_id
+        if (
+            not arm_root.is_dir()
+            or arm_root.is_symlink()
+            or arm_root.resolve(strict=True).parent != (root / "learner-arms")
+        ):
+            return False
+        for step_result in result.completed_steps:
+            if step_result.trial_record is None:
+                continue
+            expected = arm_root / "lifecycle-experiences" / step_result.step_id
+            package = expected / "package"
+            run = expected / "run"
+            output = step_result.trial_record.output
+            if (
+                not package.is_dir()
+                or package.is_symlink()
+                or not run.is_dir()
+                or run.is_symlink()
+                or output is None
+                or output.agent_output is None
+                or Path(output.agent_output.output_path).resolve(strict=True) != run.resolve(strict=True)
+            ):
+                return False
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def _lineage_complete(
+    root: Path,
+    plan: CompiledLearningStudy,
+    arm_run: PlannedArmRun,
+    result: ArmRunExecutionResult[LifecycleFeedback],
+) -> bool:
+    try:
+        if result.status is not ArmRunStatus.COMPLETED or result.initial_state_id is None:
+            return False
+        if len(result.completed_steps) != len(arm_run.steps):
+            return False
+        current_state_id = result.initial_state_id
+        for index, step in enumerate(arm_run.steps):
+            receipt = _read_model(
+                root / "steps" / arm_run.arm_run_id / f"{index:03d}-{step.step_id}.json",
+                StudyStepReceipt,
+            )
+            if receipt.status is not StudyStepStatus.COMPLETED or receipt.transition_id is None:
+                return False
+            transition = _read_model(root / "transitions" / f"{receipt.transition_id}.json", LearnerTransitionReceipt)
+            if transition.arm_run_id != arm_run.arm_run_id or transition.step_id != step.step_id:
+                return False
+            if transition.state_before_id != current_state_id:
+                return False
+            expected_kind = "consolidation"
+            expected_committed = True
+            if isinstance(step, CompiledExperienceStep):
+                expected_kind = "experience" if step.commit_post_state else "probe_discard"
+                expected_committed = step.commit_post_state
+            elif isinstance(step, CompiledFeedbackStep):
+                expected_kind = "feedback_release"
+                if receipt.feedback_id is None:
+                    return False
+                feedback = _read_model(root / "feedback" / f"{receipt.feedback_id}.json", FeedbackReleaseRecord)
+                if (
+                    feedback.arm_run_id != arm_run.arm_run_id
+                    or feedback.release_step_id != step.step_id
+                    or feedback.source_experience_id != step.source_experience_id
+                    or feedback.view_id != step.feedback_view_id
+                    or feedback.state_before_id != current_state_id
+                    or feedback.state_after_id != transition.committed_state_id
+                ):
+                    return False
+            elif isinstance(step, CompiledConsolidationStep):
+                expected_kind = "consolidation"
+            if transition.operation_kind != expected_kind or transition.committed is not expected_committed:
+                return False
+            if expected_committed:
+                state_ref = _read_model(
+                    root / "states" / f"{transition.candidate_state_id}.json",
+                    LearnerStateRef,
+                )
+                if state_ref.parent_state_id != current_state_id or state_ref.created_after_step_id != step.step_id:
+                    return False
+            if transition.committed_state_id is None:
+                return False
+            current_state_id = transition.committed_state_id
+        recorded = _read_model(root / "result.json", RecordedStudyExecution)
+        recorded_arm = next(item for item in recorded.arm_runs if item.arm_run_id == arm_run.arm_run_id)
+        return result.final_state_id == current_state_id == recorded_arm.final_state_id
+    except (OSError, StopIteration, ValueError):
+        return False
+
+
+def _probe_feedback_hidden(
+    root: Path,
+    spec: LearningStudySpec,
+    arm_run: PlannedArmRun,
+    result: ArmRunExecutionResult[LifecycleFeedback],
+) -> bool:
+    probe_ids = {item.experience_id for item in spec.experiences if item.role is ExperienceRole.PROBE}
+    if any(isinstance(step, CompiledFeedbackStep) and step.source_experience_id in probe_ids for step in arm_run.steps):
+        return False
+    probe_trial_ids = {
+        step_result.trial_record.trial_id
+        for step_result in result.completed_steps
+        if step_result.trial_record is not None and step_result.trial_record.task_id == L02_PROBE_TASK_ID
+    }
+    try:
+        for feedback_path in (root / "feedback").glob("*.json"):
+            feedback = _read_model(feedback_path, FeedbackReleaseRecord)
+            if feedback.arm_run_id == arm_run.arm_run_id and (
+                feedback.source_experience_id in probe_ids or feedback.source_trial_id in probe_trial_ids
+            ):
+                return False
+        arm_root = root / "learner-arms" / arm_run.arm_run_id
+        for step in arm_run.steps:
+            if not isinstance(step, CompiledExperienceStep) or step.role is not ExperienceRole.PROBE:
+                continue
+            context = arm_root / "lifecycle-experiences" / step.step_id / "context"
+            if (
+                arm_run.treatment_id != "raw-history"
+                and context.exists()
+                and any("feedback" in path.relative_to(context).parts for path in context.rglob("*"))
+            ):
+                return False
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def _probe_state_discarded(root: Path, arm_run: PlannedArmRun) -> bool:
+    try:
+        arm_root = root / "learner-arms" / arm_run.arm_run_id
+        for index, step in enumerate(arm_run.steps):
+            if not isinstance(step, CompiledExperienceStep) or step.role is not ExperienceRole.PROBE:
+                continue
+            if step.commit_post_state:
+                return False
+            receipt = _read_model(
+                root / "steps" / arm_run.arm_run_id / f"{index:03d}-{step.step_id}.json",
+                StudyStepReceipt,
+            )
+            if receipt.transition_id is None:
+                return False
+            transition = _read_model(root / "transitions" / f"{receipt.transition_id}.json", LearnerTransitionReceipt)
+            if transition.operation_kind != "probe_discard" or transition.committed:
+                return False
+            if (arm_root / "states" / step.step_id).exists():
+                return False
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def _hidden_evaluation_absent(root: Path, arm_run: PlannedArmRun) -> bool:
+    try:
+        arm_root = root / "learner-arms" / arm_run.arm_run_id
+        states_root = arm_root / "states"
+        for state_root in (path for path in states_root.iterdir() if path.is_dir()):
+            if (state_root / "history").is_dir():
+                _validate_raw_history_state(state_root)
+            else:
+                validate_learner_state(state_root)
+            for path in (item for item in state_root.rglob("*") if item.is_file()):
+                if path.name in _FORBIDDEN_LEARNER_FILENAMES:
+                    return False
+                data = path.read_bytes()
+                if any(marker in data.lower() for marker in _FORBIDDEN_LEARNER_MARKERS):
+                    return False
+                if path.parent.name == "feedback":
+                    validate_drainage_staged_review_feedback(data)
+        for context in (arm_root / "lifecycle-experiences").glob("*/context"):
+            for path in (item for item in context.rglob("*") if item.is_file()):
+                if path.name in _FORBIDDEN_LEARNER_FILENAMES:
+                    return False
+                data = path.read_bytes().lower()
+                if any(marker in data for marker in _FORBIDDEN_LEARNER_MARKERS):
+                    return False
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def _read_model(path: Path, model_type: type[ModelT]) -> ModelT:
+    return model_type.model_validate_json(path.read_text(encoding="utf-8"))
+
+
+__all__ = (
+    "L02_CONSOLIDATION_OPERATION_ID",
+    "L02_ACQUISITION_TASK_ID",
+    "L02_DRAINAGE_PROTOCOL_ID",
+    "L02_DRAINAGE_STUDY_ID",
+    "L02_EXECUTION_CONDITION",
+    "L02_PROBE_TASK_ID",
+    "L02DrainageRun",
+    "build_l02_assessment_arm_evidence",
+    "build_l02_drainage_binding",
+    "compile_l02_drainage_study",
+    "l02_drainage_outcome_projections",
+    "load_l02_drainage_protocol",
+    "run_l02_drainage_study",
+    "run_l02_drainage_study_sync",
+)

--- a/src/aec_bench/experimentation/learning_studies/protocols/l02-drainage-correction-applicability-boundary/family.toml
+++ b/src/aec_bench/experimentation/learning_studies/protocols/l02-drainage-correction-applicability-boundary/family.toml
@@ -1,0 +1,73 @@
+family_id = "drainage-lifecycle-correction-boundary"
+title = "Drainage correction applicability boundary"
+description = "Tests whether a valid staged correction is applied to a closeout-only memo boundary where the required memo evidence is absent. Independent drainage-domain review is required before a claim-bearing run."
+
+[[dimensions]]
+dimension_id = "review_contract"
+kind = "surface"
+description = "The three-checkpoint drainage review contract, stable finding and decision identities, readiness, and claim-boundary fields"
+
+[[dimensions]]
+dimension_id = "evidence_governance"
+kind = "causal"
+description = "Current registered evidence, rather than assertions or unrelated releases, governs finding, closure, and readiness transitions"
+
+[[dimensions]]
+dimension_id = "response_release_form"
+kind = "surface"
+description = "The corrected model chain released at response_review"
+
+[[dimensions]]
+dimension_id = "closeout_release_form"
+kind = "surface"
+description = "A propagated design memo versus a memo-closure assertion without the revised memo"
+
+[[dimensions]]
+dimension_id = "closeout_evidence_applicability"
+kind = "applicability"
+description = "Whether the current closeout release supports closing the memo-governed finding and decision"
+
+[[dimensions]]
+dimension_id = "closeout_transition_timing"
+kind = "parameter"
+description = "The point at which memo evidence is available to the lifecycle review"
+
+[[members]]
+member_id = "staged-full-correction-acquisition"
+task_id = "lifecycle/drainage-model-evidence-lifecycle-review/staged_full_correction"
+description = "The corrected model chain arrives at response_review and the propagated design memo arrives at closeout_review"
+probe_only = false
+[members.dimension_values]
+review_contract = "initial_review, response_review, and closeout_review with cumulative evidence-backed submissions"
+evidence_governance = "current registered evidence and stable identities govern every status transition"
+response_release_form = "corrected manifest, rerun register, and model report"
+closeout_release_form = "propagated design memo"
+closeout_evidence_applicability = "memo-backed closure is applicable at closeout"
+closeout_transition_timing = "corrected chain at response; memo at closeout"
+
+[[members]]
+member_id = "memo-closeout-missing-probe"
+task_id = "lifecycle/drainage-model-evidence-lifecycle-review/memo_closeout_missing"
+description = "The corrected model chain still arrives at response_review, but closeout asserts memo closure without releasing the revised design memo"
+probe_only = true
+[members.dimension_values]
+review_contract = "initial_review, response_review, and closeout_review with cumulative evidence-backed submissions"
+evidence_governance = "current registered evidence and stable identities govern every status transition"
+response_release_form = "corrected manifest, rerun register, and model report"
+closeout_release_form = "memo-closure assertion without propagated design memo"
+closeout_evidence_applicability = "memo-backed closure is not applicable at closeout"
+closeout_transition_timing = "corrected chain at response; memo remains absent at closeout"
+
+[[relations]]
+relation_id = "staged-correction-to-memo-closeout-missing"
+purpose = "boundary"
+source_member_ids = ["staged-full-correction-acquisition"]
+target_member_id = "memo-closeout-missing-probe"
+invariant_dimensions = ["review_contract", "evidence_governance", "response_release_form"]
+invariant_claims = [
+  "Both members use the same three-checkpoint review contract, finding identities, accepted-decision identities, readiness vocabulary, and claim-boundary statement.",
+  "Both members require current registered evidence and stable identities for status transitions; assertions do not substitute for evidence.",
+  "Both members release the corrected model chain at response_review, with common response surfaces byte-identical unless a declared difference is recorded.",
+]
+changed_dimensions = ["closeout_release_form", "closeout_evidence_applicability", "closeout_transition_timing"]
+rationale = "The acquisition teaches a valid staged correction and memo-backed closeout. The probe preserves the corrected response chain but removes the closeout memo evidence, so repeating the acquisition closeout is inappropriate. The relation must be approved by an independent drainage-domain reviewer and a benchmark reviewer before a claim-bearing campaign."

--- a/src/aec_bench/experimentation/learning_studies/protocols/l02-drainage-correction-applicability-boundary/study.toml
+++ b/src/aec_bench/experimentation/learning_studies/protocols/l02-drainage-correction-applicability-boundary/study.toml
@@ -1,0 +1,196 @@
+study_id = "l02-drainage-correction-applicability-boundary"
+title = "Drainage correction applicability boundary"
+research_question = "Does public feedback from a valid staged correction cause raw-history or structured-memory learners to apply memo-backed closeout on a probe where the corrected model chain is present but the required design memo is missing?"
+relation_ids = ["staged-correction-to-memo-closeout-missing"]
+
+[[experiences]]
+experience_id = "staged-full-correction-acquisition"
+family_member_id = "staged-full-correction-acquisition"
+role = "acquisition"
+
+[[experiences]]
+experience_id = "memo-closeout-missing-probe"
+family_member_id = "memo-closeout-missing-probe"
+role = "probe"
+
+[[measurements]]
+measurement_id = "raw-history-canonical-reward-gain"
+projection_id = "lifecycle.canonical-reward"
+direction = "higher"
+target_experience_id = "memo-closeout-missing-probe"
+focal_arm_id = "raw-history"
+comparator_arm_id = "cold-reset"
+
+[[measurements]]
+measurement_id = "raw-history-closure-evidence-gain"
+projection_id = "drainage.closure-evidence"
+direction = "higher"
+target_experience_id = "memo-closeout-missing-probe"
+focal_arm_id = "raw-history"
+comparator_arm_id = "cold-reset"
+
+[[measurements]]
+measurement_id = "raw-history-accepted-decision-preservation-gain"
+projection_id = "drainage.accepted-decision-preservation"
+direction = "higher"
+target_experience_id = "memo-closeout-missing-probe"
+focal_arm_id = "raw-history"
+comparator_arm_id = "cold-reset"
+
+[[measurements]]
+measurement_id = "raw-history-claim-boundary-gain"
+projection_id = "drainage.claim-boundary"
+direction = "higher"
+target_experience_id = "memo-closeout-missing-probe"
+focal_arm_id = "raw-history"
+comparator_arm_id = "cold-reset"
+
+[[measurements]]
+measurement_id = "raw-history-inappropriate-memo-closure-effect"
+projection_id = "drainage.inappropriate-memo-closure"
+direction = "lower"
+target_experience_id = "memo-closeout-missing-probe"
+focal_arm_id = "raw-history"
+comparator_arm_id = "cold-reset"
+
+[[measurements]]
+measurement_id = "structured-memory-canonical-reward-gain"
+projection_id = "lifecycle.canonical-reward"
+direction = "higher"
+target_experience_id = "memo-closeout-missing-probe"
+focal_arm_id = "structured-memory"
+comparator_arm_id = "cold-reset"
+
+[[measurements]]
+measurement_id = "structured-memory-staged-disclosure-gain"
+projection_id = "drainage.staged-disclosure"
+direction = "higher"
+target_experience_id = "memo-closeout-missing-probe"
+focal_arm_id = "structured-memory"
+comparator_arm_id = "cold-reset"
+
+[[measurements]]
+measurement_id = "structured-memory-finding-continuity-gain"
+projection_id = "drainage.finding-continuity"
+direction = "higher"
+target_experience_id = "memo-closeout-missing-probe"
+focal_arm_id = "structured-memory"
+comparator_arm_id = "cold-reset"
+
+[[measurements]]
+measurement_id = "structured-memory-closure-evidence-gain"
+projection_id = "drainage.closure-evidence"
+direction = "higher"
+target_experience_id = "memo-closeout-missing-probe"
+focal_arm_id = "structured-memory"
+comparator_arm_id = "cold-reset"
+
+[[measurements]]
+measurement_id = "structured-memory-accepted-decision-preservation-gain"
+projection_id = "drainage.accepted-decision-preservation"
+direction = "higher"
+target_experience_id = "memo-closeout-missing-probe"
+focal_arm_id = "structured-memory"
+comparator_arm_id = "cold-reset"
+
+[[measurements]]
+measurement_id = "structured-memory-claim-boundary-gain"
+projection_id = "drainage.claim-boundary"
+direction = "higher"
+target_experience_id = "memo-closeout-missing-probe"
+focal_arm_id = "structured-memory"
+comparator_arm_id = "cold-reset"
+
+[[measurements]]
+measurement_id = "structured-memory-inappropriate-memo-closure-effect"
+projection_id = "drainage.inappropriate-memo-closure"
+direction = "lower"
+target_experience_id = "memo-closeout-missing-probe"
+focal_arm_id = "structured-memory"
+comparator_arm_id = "cold-reset"
+
+[[measurements]]
+measurement_id = "reset-after-acquisition-inappropriate-memo-closure-effect"
+projection_id = "drainage.inappropriate-memo-closure"
+direction = "lower"
+target_experience_id = "memo-closeout-missing-probe"
+focal_arm_id = "reset-after-acquisition"
+comparator_arm_id = "cold-reset"
+
+[[measurements]]
+measurement_id = "structured-memory-versus-raw-history-inappropriate-closure"
+projection_id = "drainage.inappropriate-memo-closure"
+direction = "lower"
+target_experience_id = "memo-closeout-missing-probe"
+focal_arm_id = "structured-memory"
+comparator_arm_id = "raw-history"
+
+[[arms]]
+arm_id = "cold-reset"
+role = "control"
+treatment_id = "reset"
+[[arms.steps]]
+kind = "run_experience"
+step_id = "cold-probe"
+experience_id = "memo-closeout-missing-probe"
+commit_post_state = false
+
+[[arms]]
+arm_id = "reset-after-acquisition"
+role = "control"
+treatment_id = "reset"
+[[arms.steps]]
+kind = "run_experience"
+step_id = "reset-acquisition"
+experience_id = "staged-full-correction-acquisition"
+commit_post_state = true
+[[arms.steps]]
+kind = "run_experience"
+step_id = "reset-probe"
+experience_id = "memo-closeout-missing-probe"
+commit_post_state = false
+
+[[arms]]
+arm_id = "raw-history"
+role = "exposure"
+treatment_id = "raw-history"
+[[arms.steps]]
+kind = "run_experience"
+step_id = "raw-acquisition"
+experience_id = "staged-full-correction-acquisition"
+commit_post_state = true
+[[arms.steps]]
+kind = "release_feedback"
+step_id = "raw-release"
+source_experience_id = "staged-full-correction-acquisition"
+feedback_view_id = "drainage-staged-review-public-feedback"
+[[arms.steps]]
+kind = "run_experience"
+step_id = "raw-probe"
+experience_id = "memo-closeout-missing-probe"
+commit_post_state = false
+
+[[arms]]
+arm_id = "structured-memory"
+role = "exposure"
+treatment_id = "structured-memory"
+[[arms.steps]]
+kind = "run_experience"
+step_id = "structured-acquisition"
+experience_id = "staged-full-correction-acquisition"
+commit_post_state = true
+[[arms.steps]]
+kind = "release_feedback"
+step_id = "structured-release"
+source_experience_id = "staged-full-correction-acquisition"
+feedback_view_id = "drainage-staged-review-public-feedback"
+[[arms.steps]]
+kind = "consolidate"
+step_id = "structured-consolidation"
+feedback_step_ids = ["structured-release"]
+operation_id = "update-lifecycle-review-memory"
+[[arms.steps]]
+kind = "run_experience"
+step_id = "structured-probe"
+experience_id = "memo-closeout-missing-probe"
+commit_post_state = false

--- a/src/aec_bench/lifecycles/stormwater_design/drainage_learning.py
+++ b/src/aec_bench/lifecycles/stormwater_design/drainage_learning.py
@@ -27,6 +27,15 @@ _SELECTED_FEEDBACK_GATE_IDS = (
     "final_readiness",
     "claim_boundary",
 )
+DRAINAGE_MEMO_FINDING_ID = "F-PRV06-001"
+DRAINAGE_MEMO_CLOSURE_REQUEST_ID = "CER-002"
+DRAINAGE_MEMO_CLOSURE_FAILURE_TOKENS = frozenset(
+    {
+        f"closeout_review:{DRAINAGE_MEMO_FINDING_ID}:closure_evidence",
+        f"closeout_review:{DRAINAGE_MEMO_CLOSURE_REQUEST_ID}:status",
+        f"closeout_review:{DRAINAGE_MEMO_CLOSURE_REQUEST_ID}:response_refs",
+    }
+)
 _PUBLIC_VALIDITY_FIELDS = ("output_parseable", "schema_valid", "verifier_completed")
 _REVIEW_PRINCIPLES = (
     "Current registered evidence controls finding, closure, and readiness status transitions.",
@@ -141,6 +150,75 @@ def drainage_gate_score(record: TrialRecord, gate_id: str) -> float:
     return float(_public_gate(record, gate_id, category="projection")["score"])
 
 
+def drainage_inappropriate_memo_closure(record: TrialRecord) -> float:
+    """Measure an unsupported closeout assertion separately from generic failure."""
+
+    _require_drainage_task(record, category="projection-task-mismatch")
+    _completed_evaluation(record, category="projection-evaluation-missing")
+    evaluation = record.evaluation
+    if evaluation is None or not isinstance(evaluation.breakdown, dict):
+        raise ValueError("projection-ineligible: lifecycle evaluation breakdown is unavailable")
+    gates = evaluation.breakdown.get("lifecycle_gates")
+    if not isinstance(gates, dict):
+        raise ValueError("projection-ineligible: lifecycle gates are unavailable")
+    closure_gate = gates.get("closure_evidence")
+    if not isinstance(closure_gate, dict):
+        raise ValueError("projection-ineligible: closure evidence gate is unavailable")
+    if not isinstance(closure_gate.get("passed"), bool):
+        raise ValueError("projection-ineligible: closure evidence gate status is invalid")
+    _bounded_number(closure_gate.get("score"), category="projection-ineligible", label="closure evidence gate")
+    failures = closure_gate.get("failures")
+    if not isinstance(failures, list) or any(not isinstance(item, str) for item in failures):
+        raise ValueError("projection-ineligible: closure evidence gate failures are malformed")
+
+    submissions = _archived_submissions(record)
+    closeout = submissions.get("closeout_review")
+    if not isinstance(closeout, dict):
+        raise ValueError("projection-ineligible: closeout submission is malformed")
+    finding = _identified_record(closeout.get("findings"), DRAINAGE_MEMO_FINDING_ID, "finding", "finding_id")
+    request = _identified_record(
+        closeout.get("closure_evidence_requests"),
+        DRAINAGE_MEMO_CLOSURE_REQUEST_ID,
+        "closure request",
+        "request_id",
+    )
+    if finding.get("status") not in {"open", "closed"} or request.get("status") not in {"open", "closed"}:
+        raise ValueError("projection-ineligible: memo closure status is malformed")
+    _string_list(finding.get("closure_evidence"), "finding closure evidence")
+    _string_list(request.get("response_refs"), "closure response references")
+
+    identified_attempt = (
+        closure_gate["passed"] is False
+        and finding["status"] == "closed"
+        and request["status"] == "closed"
+        and DRAINAGE_MEMO_CLOSURE_FAILURE_TOKENS.issubset(set(failures))
+    )
+    return 1.0 if identified_attempt else 0.0
+
+
+def _identified_record(value: Any, record_id: str, label: str, identity_key: str) -> dict[str, Any]:
+    if not isinstance(value, list):
+        raise ValueError(f"projection-ineligible: {label} records are malformed")
+    if any(
+        not isinstance(item, dict) or not isinstance(item.get(identity_key), str) or not item[identity_key]
+        for item in value
+    ):
+        raise ValueError(f"projection-ineligible: {label} records are malformed")
+    identities = [item[identity_key] for item in value]
+    if len(set(identities)) != len(identities):
+        raise ValueError(f"projection-ineligible: {label} identities are ambiguous")
+    matches = [item for item in value if isinstance(item, dict) and item.get(identity_key) == record_id]
+    if len(matches) != 1:
+        raise ValueError(f"projection-ineligible: {label} identity is missing or ambiguous")
+    return matches[0]
+
+
+def _string_list(value: Any, label: str) -> list[str]:
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise ValueError(f"projection-ineligible: {label} is malformed")
+    return value
+
+
 def _completed_evaluation(record: TrialRecord, *, category: str) -> EvaluationResult:
     if record.evaluation_status is not EvaluationStatus.COMPLETED or record.evaluation is None:
         raise ValueError(f"{category}: lifecycle evaluation is unavailable")
@@ -223,9 +301,13 @@ def _bounded_number(value: object, *, category: str, label: str) -> float:
 
 __all__ = (
     "DRAINAGE_ACQUISITION_TASK_ID",
+    "DRAINAGE_MEMO_CLOSURE_FAILURE_TOKENS",
+    "DRAINAGE_MEMO_CLOSURE_REQUEST_ID",
+    "DRAINAGE_MEMO_FINDING_ID",
     "DRAINAGE_PROBE_TASK_ID",
     "DRAINAGE_STAGED_REVIEW_FEEDBACK_VIEW_ID",
     "drainage_gate_score",
+    "drainage_inappropriate_memo_closure",
     "drainage_staged_review_feedback",
     "validate_drainage_staged_review_feedback",
 )

--- a/tests/experimentation/learning_studies/test_l02_drainage.py
+++ b/tests/experimentation/learning_studies/test_l02_drainage.py
@@ -1,0 +1,273 @@
+# ABOUTME: Proves the deterministic four-arm L02 drainage applicability-boundary campaign.
+# ABOUTME: Covers treatment isolation, matched surfaces, acquisition fidelity, and bounded projections.
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from aec_bench.contracts.evaluation_result import EvaluationResult, ValidityCheck
+from aec_bench.contracts.experiment_manifest import AgentConfig, ComputeConfig
+from aec_bench.contracts.learning_study_assessment import LearningComparisonValidity
+from aec_bench.contracts.trial_record import EvaluationStatus
+from aec_bench.experimentation.learning_studies.l02_drainage import (
+    L02_ACQUISITION_TASK_ID,
+    L02_CONSOLIDATION_OPERATION_ID,
+    L02_DRAINAGE_STUDY_ID,
+    L02_EXECUTION_CONDITION,
+    L02_PROBE_TASK_ID,
+    compile_l02_drainage_study,
+    l02_drainage_outcome_projections,
+    load_l02_drainage_protocol,
+    run_l02_drainage_study_sync,
+)
+from aec_bench.experimentation.learning_studies.lifecycles import LifecycleConsolidationContext
+from aec_bench.lifecycles.catalogue import materialize_lifecycle
+from aec_bench.lifecycles.compiled import compile_lifecycle
+from aec_bench.lifecycles.runtime.lifecycle import run_lifecycle
+from aec_bench.lifecycles.stormwater_design import drainage_learning
+from aec_bench.lifecycles.stormwater_design.drainage_model import verify_drainage_model_lifecycle
+from tests.support.lifecycle_episode import deterministic_episode_environment
+from tests.support.trial_record_factories import make_trial_record
+
+_AGENT = AgentConfig(name="l02-deterministic-agent", adapter="tool_loop", model="fixed-test-model", parameters={})
+_COMPUTE = ComputeConfig(backend="local", resource_limits={"memory_mb": 512}, timeout_override=30)
+
+
+class _Consolidator:
+    calls = 0
+
+    def __call__(self, context: LifecycleConsolidationContext) -> None:
+        type(self).calls += 1
+        (context.memory_root / "review-strategy.md").write_text("Use current registered evidence.\n", encoding="utf-8")
+
+
+class _GoldAdapterBuilder:
+    executions = 0
+    contexts: dict[tuple[str, str], list[set[str]]] = {}
+
+    def __call__(self, **kwargs):  # noqa: ANN003, ANN202
+        workspace = Path(kwargs["workspace"])
+        package = workspace.parent.parent / "package"
+        arm_id = package.parents[2].name
+        variant = json.loads((package / "hidden" / "variant.json").read_text())["variant_id"]
+        gold = json.loads((package / "hidden" / "gold-submissions.json").read_text())
+        builder = self
+
+        class Adapter:
+            def execute(self, request):  # noqa: ANN001, ANN202
+                type(builder).executions += 1
+                context = workspace / "learner_context"
+                visible = (
+                    {path.relative_to(context).as_posix() for path in context.rglob("*") if path.is_file()}
+                    if context.exists()
+                    else set()
+                )
+                builder.contexts.setdefault((arm_id, variant), []).append(visible)
+                output = Path(request.output_path)
+                output.parent.mkdir(parents=True, exist_ok=True)
+                output.write_text(json.dumps(gold[output.stem]), encoding="utf-8")
+                return SimpleNamespace(
+                    adapter_name="tool_loop",
+                    resolved_model="fixed-test-model",
+                    configuration_record={"source": "deterministic-test"},
+                    agent_output=SimpleNamespace(status=SimpleNamespace(value="completed")),
+                    transcript=[],
+                    raw_output_text=None,
+                    provider_error=None,
+                    failure_kind=None,
+                    usage_input_tokens=1,
+                    usage_output_tokens=1,
+                    usage_cache_read_tokens=0,
+                    usage_cache_write_tokens=0,
+                )
+
+        return Adapter()
+
+
+def test_l02_protocol_and_matched_surfaces(tmp_path: Path) -> None:
+    spec = load_l02_drainage_protocol(agent=_AGENT, compute=_COMPUTE)
+    plan = compile_l02_drainage_study(study_run_id="l02-protocol", agent=_AGENT, compute=_COMPUTE)
+    assert spec.study_id == L02_DRAINAGE_STUDY_ID
+    assert [item.task_id for item in spec.experiences] == [L02_ACQUISITION_TASK_ID, L02_PROBE_TASK_ID]
+    assert [(item.arm_id, item.role.value, item.treatment_id) for item in spec.arms] == [
+        ("cold-reset", "control", "reset"),
+        ("reset-after-acquisition", "control", "reset"),
+        ("raw-history", "exposure", "raw-history"),
+        ("structured-memory", "exposure", "structured-memory"),
+    ]
+    assert L02_EXECUTION_CONDITION.adapter_id == "lifecycle-local:fresh_context:artifact_memory"
+    assert any(getattr(item, "operation_id", None) == L02_CONSOLIDATION_OPERATION_ID for item in spec.arms[-1].steps)
+    assert all(step.trial.extensions == {} for arm in plan.arm_runs for step in arm.steps if hasattr(step, "trial"))
+
+    packages = {
+        variant: compile_lifecycle(
+            "drainage-model-evidence-lifecycle-review", tmp_path / variant, variant_id=variant
+        ).package_dir
+        for variant in ("staged_full_correction", "memo_closeout_missing")
+    }
+    for filename in ("initial_review.md", "response_review.md", "closeout_review.md"):
+        assert (packages["staged_full_correction"] / "instructions" / filename).read_bytes() == (
+            packages["memo_closeout_missing"] / "instructions" / filename
+        ).read_bytes()
+    for filename in (
+        "document-register-rev-f.md",
+        "response-cover.md",
+        "model-input-manifest-rev-b.md",
+        "run-register-rev-f.md",
+        "hydraulic-report-043.md",
+    ):
+        assert (packages["staged_full_correction"] / "releases" / "response_review" / filename).read_bytes() == (
+            packages["memo_closeout_missing"] / "releases" / "response_review" / filename
+        ).read_bytes()
+    assert not (
+        packages["memo_closeout_missing"] / "releases" / "closeout_review" / "drainage-design-memo-rev-e.md"
+    ).exists()
+
+
+def test_deterministic_l02_runs_all_arms_and_preserves_fidelity(tmp_path: Path) -> None:
+    adapter = _GoldAdapterBuilder()
+    consolidator = _Consolidator()
+    result = run_l02_drainage_study_sync(
+        run_root=tmp_path / "l02",
+        study_run_id="l02-deterministic",
+        agent=_AGENT,
+        compute=_COMPUTE,
+        consolidation_operation=consolidator,
+        adapter_builder=adapter,
+    )
+    assert [arm.status.value for arm in result.execution.arm_runs] == ["completed"] * 4
+    assert type(adapter).executions == 21
+    assert _Consolidator.calls == 1
+    assert len({item.initial_state_equivalence_id for item in result.arm_evidence.values()}) == 1
+    assert all(item.adapter_id == L02_EXECUTION_CONDITION.adapter_id for item in result.arm_evidence.values())
+    assert all(item.arm_isolated and item.lineage_complete for item in result.arm_evidence.values())
+    assert all(item.probe_feedback_hidden and item.probe_state_discarded for item in result.arm_evidence.values())
+    assert all(not item.hidden_evaluation_leaked for item in result.arm_evidence.values())
+
+    measurements = {item.measurement_id: item for item in result.reviewed_assessment.measurements}
+    assert (
+        measurements["structured-memory-versus-raw-history-inappropriate-closure"].validity
+        is LearningComparisonValidity.DESCRIPTIVE_ONLY
+    )
+    for measurement in measurements.values():
+        assert measurement.validity is not LearningComparisonValidity.INVALID
+    projections = l02_drainage_outcome_projections()
+    probe_records = [
+        record
+        for arm in result.execution.arm_runs
+        for record in arm.trial_records
+        if record.task_id == L02_PROBE_TASK_ID
+    ]
+    assert len(probe_records) == 4
+    for record in probe_records:
+        assert projections["drainage.inappropriate-memo-closure"](record).value == 0.0
+
+    raw_arm = next(arm for arm in result.plan.arm_runs if arm.arm_id == "raw-history")
+    structured_arm = next(arm for arm in result.plan.arm_runs if arm.arm_id == "structured-memory")
+    raw_final = tmp_path / "l02" / "learner-arms" / raw_arm.arm_run_id / "states" / "raw-acquisition"
+    structured_final = (
+        tmp_path / "l02" / "learner-arms" / structured_arm.arm_run_id / "states" / "structured-consolidation"
+    )
+    assert (
+        (raw_final / "history").is_dir()
+        and (raw_final / "feedback").is_dir()
+        and (raw_final / "memory").is_dir()
+        and not any((raw_final / "memory").iterdir())
+    )
+    assert (
+        (structured_final / "memory").is_dir()
+        and (structured_final / "feedback").is_dir()
+        and not (structured_final / "history").exists()
+    )
+    raw_result = next(arm for arm in result.execution.arm_runs if arm.arm_run_id == raw_arm.arm_run_id)
+    acquisition = next(record for record in raw_result.trial_records if record.task_id == L02_ACQUISITION_TASK_ID)
+    feedback_record = next(
+        json.loads(path.read_text())
+        for path in (tmp_path / "l02" / "feedback").glob("*.json")
+        if json.loads(path.read_text())["arm_run_id"] == raw_arm.arm_run_id
+    )
+    assert feedback_record["source_experience_id"] == "staged-full-correction-acquisition"
+    assert feedback_record["source_trial_id"] == acquisition.trial_id
+    assert feedback_record["state_after_id"] != feedback_record["state_before_id"]
+    acquisition_package = (
+        tmp_path / "l02" / "learner-arms" / raw_arm.arm_run_id / "lifecycle-experiences" / "raw-acquisition" / "package"
+    )
+    assert (
+        json.loads((acquisition_package / "hidden" / "variant.json").read_text())["variant_id"]
+        == "staged_full_correction"
+    )
+
+
+def test_inappropriate_projection_separates_identified_closure_from_generic_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    closeout = {
+        "findings": [{"finding_id": "F-PRV06-001", "status": "closed", "closure_evidence": ["unsupported"]}],
+        "closure_evidence_requests": [{"request_id": "CER-002", "status": "closed", "response_refs": ["unsupported"]}],
+    }
+    gate = {
+        "passed": False,
+        "score": 0.5,
+        "failures": sorted(drainage_learning.DRAINAGE_MEMO_CLOSURE_FAILURE_TOKENS),
+    }
+    record = make_trial_record(
+        task_id=L02_PROBE_TASK_ID,
+        evaluation_status=EvaluationStatus.COMPLETED,
+        evaluation=EvaluationResult(
+            reward=0.0,
+            validity=ValidityCheck(output_parseable=True, schema_valid=True, verifier_completed=True),
+            breakdown={"lifecycle_gates": {"closure_evidence": gate}},
+        ),
+    )
+    monkeypatch.setattr(drainage_learning, "_archived_submissions", lambda _record: {"closeout_review": closeout})
+    assert drainage_learning.drainage_inappropriate_memo_closure(record) == 1.0
+    gate["failures"] = ["closeout_review:F-PRV03-001:closure_evidence"]
+    assert drainage_learning.drainage_inappropriate_memo_closure(record) == 0.0
+
+
+def test_real_memo_closeout_copycat_triggers_declared_projection_tokens(tmp_path: Path) -> None:
+    template = "drainage-model-evidence-lifecycle-review"
+    memo_package = materialize_lifecycle(template, tmp_path / "memo" / "package", variant_id="memo_closeout_missing")
+    staged_package = materialize_lifecycle(
+        template, tmp_path / "staged" / "package", variant_id="staged_full_correction"
+    )
+    memo_gold = json.loads((memo_package / "hidden" / "gold-submissions.json").read_text())
+    staged_gold = json.loads((staged_package / "hidden" / "gold-submissions.json").read_text())
+
+    def resolve(context: dict) -> dict:
+        output = Path(context["submission_path"])
+        output.parent.mkdir(parents=True, exist_ok=True)
+        source = staged_gold if context["checkpoint_id"] == "closeout_review" else memo_gold
+        output.write_text(json.dumps(source[context["checkpoint_id"]]), encoding="utf-8")
+        return {"status": "completed"}
+
+    run_dir = tmp_path / "memo" / "run"
+    run_lifecycle(memo_package, run_dir, episode_environment=deterministic_episode_environment(resolve))
+    verification = verify_drainage_model_lifecycle(memo_package, run_dir)
+    closure_gate = verification["gates"]["closure_evidence"]
+    assert not closure_gate["passed"]
+    assert set(drainage_learning.DRAINAGE_MEMO_CLOSURE_FAILURE_TOKENS).issubset(set(closure_gate["failures"]))
+
+    record = make_trial_record(
+        task_id=L02_PROBE_TASK_ID,
+        output={
+            "agent_output": {
+                "status": "completed",
+                "output_path": str(run_dir.resolve()),
+                "output_format": "evidence_lifecycle",
+            },
+            "raw_output_path": str(run_dir.resolve()),
+            "conversation_path": str(run_dir.resolve()),
+            "agent_result": {"completion_status": "completed"},
+        },
+        evaluation=EvaluationResult(
+            reward=verification["reward"],
+            validity=ValidityCheck(output_parseable=True, schema_valid=True, verifier_completed=True),
+            breakdown={"lifecycle_gates": verification["gates"]},
+        ),
+    )
+    assert drainage_learning.drainage_inappropriate_memo_closure(record) == 1.0


### PR DESCRIPTION
## Summary

Implements D2 of Release B Lifecycle Tranche 2: the L02 drainage correction applicability-boundary study, per `studies/L02-drainage-correction-applicability-boundary.md`. Depends on D1 (the `raw-history` treatment).

- Maintained L02 protocol (`family.toml`/`study.toml`) using the existing `staged_full_correction` acquisition and `memo_closeout_missing` probe. No new drainage variant.
- Four arms under the fixed `lifecycle-local:fresh_context:artifact_memory` binding: `cold-reset`, `reset-after-acquisition`, `raw-history`, `structured-memory`.
- Task-owned `drainage.inappropriate-memo-closure` projection in `drainage_learning.py`: reads the existing `closure_evidence` gate and archived checkpoint submissions (no new lifecycle evidence contract). Returns `1.0` only for an identified unsupported closure attempt on finding `F-PRV06-001` / request `CER-002`, `0.0` for eligible generic failure, and `ineligible` for missing/malformed evidence.
- `l02_drainage.py` study glue: protocol loading, compilation, deterministic run/assessment helpers.

## Validity notes

- The declared failure tokens for the inappropriate-closure projection were verified against a *real* adversarial submission (the `staged_full_correction` gold closeout pattern copied onto the `memo_closeout_missing` probe) run through the actual verifier, not just a hand-authored fixture.
- The deterministic gold-adapter four-arm run produces a ceiling (every eligible arm's inappropriate-closure value is `0.0`), which is reported as a ceiling -- not as evidence that any treatment avoids negative transfer.
- The `structured-memory` vs `raw-history` comparison remains `descriptive_only` under the existing assessor.

## Scope boundaries

No changes to worlds, LS-07, Gate C, harness-update, model weights, or common contracts. No changes to the D1 raw-history mechanism itself.

## Testing

```
uv run pytest \
  tests/experimentation/learning_studies/test_lifecycle_memory.py \
  tests/experimentation/learning_studies/test_lifecycles.py \
  tests/experimentation/learning_studies/test_l01_drainage.py \
  tests/experimentation/learning_studies/test_protocol_collection.py \
  tests/experimentation/learning_studies/test_lifecycle_raw_history.py \
  tests/experimentation/learning_studies/test_l02_drainage.py \
  tests/lifecycles/stormwater_design/test_drainage_lifecycle.py \
  tests/lifecycles/stormwater_design/test_drainage_variants.py
```

134 passed, including a real adversarial-submission test (`test_real_memo_closeout_copycat_triggers_declared_projection_tokens`) added after review.

`uv run ruff check` clean. `uv run python scripts/check_provenance_fields.py --check --base-revision main` passes with 0 violations.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
