### PR TITLE
feat: add lifecycle phase-evidence extension (Release B, Lifecycle Tranche 3, D1)

### DIFF
--- a/provenance-registry.toml
+++ b/provenance-registry.toml
@@ -2178,6 +2178,48 @@ artifact_boundary = "one immutable regular file below the descriptor-confined by
 read_verification = "ImmutableByteStore re-reads and rehashes the confined file and raises ImmutableArtifactIntegrityError on mismatch"
 
 [[field]]
+symbol = "aec_bench.lifecycles.stormwater_design.drainage_learning.DrainageLearningEvidence.evidence_schema"
+surface = "pydantic_model"
+wire_name = "evidence_schema"
+category = "compatibility"
+domain_owner = "stormwater_design"
+authority = "drainage_learning_evidence_protocol"
+authoritative = true
+exposure = "persisted"
+status = "current"
+payload_contract = "aec-bench/lifecycle/drainage/learning-evidence/1"
+canonicalization = "fixed schema literal serialized in the lifecycle learning evidence artefact"
+consumer = "phase evidence grouping and drainage learning-study analysis"
+validation_behavior = "Pydantic emits the fixed schema literal; lifecycle-owned readers reject malformed evidence payloads"
+mismatch_behavior = "reject_phase_evidence"
+retention = "trial_record_extension_lifetime"
+rationale = "The schema literal identifies the drainage-owned phase-evidence payload without promoting its fields to a common contract."
+duplication = "unique"
+compatibility_behavior = "reject unsupported drainage phase-evidence schemas"
+compatibility_kind = "external_schema"
+
+[[field]]
+symbol = "aec_bench.lifecycles.structural_review.facade_submittal.FacadeLearningEvidence.evidence_schema"
+surface = "pydantic_model"
+wire_name = "evidence_schema"
+category = "compatibility"
+domain_owner = "structural_review"
+authority = "facade_learning_evidence_protocol"
+authoritative = true
+exposure = "persisted"
+status = "current"
+payload_contract = "aec-bench/lifecycle/facade/learning-evidence/1"
+canonicalization = "fixed schema literal serialized in the lifecycle learning evidence artefact"
+consumer = "phase evidence grouping and facade learning-study analysis"
+validation_behavior = "Pydantic emits the fixed schema literal; lifecycle-owned readers reject malformed evidence payloads"
+mismatch_behavior = "reject_phase_evidence"
+retention = "trial_record_extension_lifetime"
+rationale = "The schema literal identifies the facade-owned phase-evidence payload without promoting its fields to a common contract."
+duplication = "unique"
+compatibility_behavior = "reject unsupported facade phase-evidence schemas"
+compatibility_kind = "external_schema"
+
+[[field]]
 symbol = "aec_bench.lifecycles.values.LifecycleExecution.tool_schema"
 surface = "dataclass"
 wire_name = "tool_schema"

--- a/src/aec_bench/experimentation/learning_studies/lifecycles.py
+++ b/src/aec_bench/experimentation/learning_studies/lifecycles.py
@@ -12,6 +12,8 @@ from enum import StrEnum
 from pathlib import Path, PurePosixPath
 from typing import Any
 
+from pydantic import BaseModel
+
 from aec_bench.contracts.artifacts import ArtifactRef
 from aec_bench.contracts.learning_study_evidence import FeedbackReleaseRecord, LearnerStateRef
 from aec_bench.contracts.trial_record import TrialRecord
@@ -116,6 +118,7 @@ class LifecycleConsolidationContext:
 
 
 type LifecycleFeedbackProjector = Callable[[TrialRecord], bytes]
+type LifecyclePhaseEvidenceExtractor = Callable[[TrialRecord], BaseModel | None]
 type LifecycleConsolidationOperation = Callable[[LifecycleConsolidationContext], None]
 
 
@@ -184,6 +187,7 @@ def build_lifecycle_learning_operations(
     execution_condition: LifecycleExecutionCondition,
     treatment_kinds: Mapping[str, LifecycleLearningTreatmentKind],
     feedback_projectors: Mapping[str, LifecycleFeedbackProjector] | None = None,
+    phase_evidence_extractors: Mapping[str, Callable[[TrialRecord], BaseModel | None]] | None = None,
     consolidation_operations: Mapping[str, LifecycleConsolidationOperation] | None = None,
     initial_memory_root: Path | None = None,
     adapter_builder: Callable[..., Any] | None = None,
@@ -212,6 +216,7 @@ def build_lifecycle_learning_operations(
         execution_condition=execution_condition,
         treatment_kinds=treatment_kinds,
         feedback_projectors=feedback_projectors or {},
+        phase_evidence_extractors=phase_evidence_extractors or {},
         consolidation_operations=consolidation_operations or {},
         initial_memory_root=initial_memory_root,
         adapter_builder=adapter_builder,
@@ -239,6 +244,7 @@ class _LifecycleLearningCoordinator:
         execution_condition: LifecycleExecutionCondition,
         treatment_kinds: Mapping[str, LifecycleLearningTreatmentKind],
         feedback_projectors: Mapping[str, LifecycleFeedbackProjector],
+        phase_evidence_extractors: Mapping[str, LifecyclePhaseEvidenceExtractor],
         consolidation_operations: Mapping[str, LifecycleConsolidationOperation],
         initial_memory_root: Path | None,
         adapter_builder: Callable[..., Any] | None,
@@ -247,6 +253,7 @@ class _LifecycleLearningCoordinator:
         self._execution_condition = execution_condition
         self._treatment_kinds = dict(treatment_kinds)
         self._feedback_projectors = dict(feedback_projectors)
+        self._phase_evidence_extractors = dict(phase_evidence_extractors)
         self._consolidation_operations = dict(consolidation_operations)
         self._initial_memory_root = None if initial_memory_root is None else Path(initial_memory_root).resolve()
         self._adapter_builder = adapter_builder
@@ -367,6 +374,15 @@ class _LifecycleLearningCoordinator:
                         _validate_raw_history_context_projection(context_root, context_snapshot)
                     else:
                         validate_read_only_context_projection(context_root, context_snapshot)
+
+            extractor = self._phase_evidence_extractors.get(target.template_id)
+            if extractor is not None:
+                try:
+                    evidence = extractor(record)
+                except Exception:
+                    evidence = None
+                if evidence is not None:
+                    record.attach_extension("lifecycle_learning_evidence", evidence)
 
             expected_identity = (
                 request.step.trial.trial_id,

--- a/src/aec_bench/experimentation/learning_studies/phase_evidence.py
+++ b/src/aec_bench/experimentation/learning_studies/phase_evidence.py
@@ -1,0 +1,62 @@
+"""Group lifecycle phase-evidence extension artefacts by opaque phase ID."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from aec_bench.contracts.trial_record import TrialRecord
+from aec_bench.ledger.artifact_repository import ArtifactRepository
+
+PHASE_EVIDENCE_KIND = "lifecycle_learning_evidence"
+
+
+@dataclass(frozen=True)
+class PhaseEvidenceEntry:
+    trial_id: str
+    phase_id: str
+    raw_bytes: bytes
+
+
+def group_phase_evidence(
+    records: Iterable[TrialRecord],
+    *,
+    artifact_repository: ArtifactRepository,
+) -> dict[str, list[PhaseEvidenceEntry]]:
+    """Group extension phase records without interpreting their payloads."""
+
+    groups: dict[str, list[PhaseEvidenceEntry]] = {}
+    for record in records:
+        for extension in record.extension_refs:
+            if extension.extension_kind != PHASE_EVIDENCE_KIND:
+                continue
+            try:
+                payload = json.loads(artifact_repository.read_bytes(extension.artifact))
+            except (OSError, RuntimeError, ValueError, TypeError):
+                continue
+            if not isinstance(payload, dict) or not isinstance(payload.get("phase_records"), list):
+                continue
+            for phase in payload["phase_records"]:
+                if not isinstance(phase, dict):
+                    continue
+                phase_id = phase.get("phase_id")
+                if not isinstance(phase_id, str) or not phase_id:
+                    continue
+                raw_phase = json.dumps(
+                    phase,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    ensure_ascii=False,
+                ).encode("utf-8")
+                groups.setdefault(phase_id, []).append(
+                    PhaseEvidenceEntry(
+                        trial_id=record.trial_id,
+                        phase_id=phase_id,
+                        raw_bytes=raw_phase,
+                    )
+                )
+    return groups
+
+
+__all__ = ("PHASE_EVIDENCE_KIND", "PhaseEvidenceEntry", "group_phase_evidence")

--- a/src/aec_bench/lifecycles/stormwater_design/drainage_learning.py
+++ b/src/aec_bench/lifecycles/stormwater_design/drainage_learning.py
@@ -8,8 +8,11 @@ import math
 from pathlib import Path
 from typing import Any
 
+from pydantic import Field, ValidationError
+
 from aec_bench.contracts.evaluation_result import EvaluationResult
 from aec_bench.contracts.trial_record import EvaluationStatus, ExecutionStatus, TrialRecord
+from aec_bench.contracts.validators import NonEmptyStr, StrictModel
 from aec_bench.lifecycles.runtime.lifecycle import load_validated_lifecycle_submissions
 from aec_bench.lifecycles.stormwater_design.drainage_model import CHECKPOINT_IDS, GATE_IDS, TEMPLATE_ID
 
@@ -53,6 +56,165 @@ _TOP_LEVEL_FIELDS = {
     "checkpoint_submissions",
     "review_principles",
 }
+_DRAINAGE_SUBMISSION_FIELDS = {
+    "checkpoint_id",
+    "evidence_refs",
+    "review_matrix",
+    "transition_decision",
+    "findings",
+    "closure_evidence_requests",
+    "accepted_decisions",
+    "readiness_decision",
+    "claim_boundary_statement",
+}
+
+
+class DrainagePhaseEvidence(StrictModel):
+    phase_id: NonEmptyStr
+    checkpoint_ids: tuple[NonEmptyStr, ...]
+    phase_outcome: NonEmptyStr
+    evidence_requested: int | None = Field(default=None, ge=0)
+    evidence_released: int | None = Field(default=None, ge=0)
+    submissions_accepted: int | None = Field(default=None, ge=0)
+    submissions_rejected: int | None = Field(default=None, ge=0)
+    constraints_satisfied: int | None = Field(default=None, ge=0)
+    rework_events: int | None = Field(default=None, ge=0)
+    revisited_decisions: int | None = Field(default=None, ge=0)
+    recovery_actions: int | None = Field(default=None, ge=0)
+
+
+class DrainageLearningEvidence(StrictModel):
+    evidence_schema: str = "aec-bench/lifecycle/drainage/learning-evidence/1"
+    lifecycle_template_id: NonEmptyStr
+    variant_id: NonEmptyStr
+    phase_records: tuple[DrainagePhaseEvidence, ...]
+
+
+def extract_drainage_learning_evidence(record: TrialRecord) -> DrainageLearningEvidence | None:
+    """Extract phase evidence from one completed drainage lifecycle record.
+
+    The current drainage runtime does not record rejection, rework, or recovery
+    events. Those fields therefore remain explicitly unavailable rather than
+    being represented as fabricated zero counts.
+    """
+
+    try:
+        if not record.task_id.startswith(_DRAINAGE_TASK_PREFIX):
+            return None
+        evaluation = _completed_evaluation(record, category="phase-evidence-extraction-failed")
+        gates = _phase_evidence_gates(evaluation)
+        submissions = _phase_evidence_submissions(record)
+        variant_id = record.task_id.removeprefix(_DRAINAGE_TASK_PREFIX)
+        if not variant_id:
+            return None
+        phase_records = (
+            _drainage_phase(
+                phase_id="evidence_assessment",
+                checkpoint_ids=("initial_review",),
+                submissions=submissions,
+                gate_values=gates,
+                gate_ids=("checkpoint_contract", "staged_disclosure"),
+            ),
+            _drainage_phase(
+                phase_id="response_and_closeout",
+                checkpoint_ids=("response_review", "closeout_review"),
+                submissions=submissions,
+                gate_values=gates,
+                gate_ids=GATE_IDS,
+            ),
+        )
+        return DrainageLearningEvidence(
+            lifecycle_template_id=TEMPLATE_ID,
+            variant_id=variant_id,
+            phase_records=phase_records,
+        )
+    except (TypeError, ValueError, KeyError, ValidationError):
+        return None
+
+
+def _drainage_phase(
+    *,
+    phase_id: str,
+    checkpoint_ids: tuple[str, ...],
+    submissions: dict[str, dict[str, Any]],
+    gate_values: dict[str, dict[str, Any]],
+    gate_ids: tuple[str, ...],
+) -> DrainagePhaseEvidence:
+    selected = [submissions[checkpoint_id] for checkpoint_id in checkpoint_ids]
+    review_matrices = [submission["review_matrix"] for submission in selected]
+    if any(
+        not isinstance(matrix, dict) or any(not isinstance(value, str) for value in matrix.values())
+        for matrix in review_matrices
+    ):
+        raise ValueError("phase-evidence-extraction-failed: drainage review matrix is malformed")
+    accepted_decisions = [
+        decision
+        for submission in selected
+        for decision in submission["accepted_decisions"]
+        if isinstance(decision, dict) and isinstance(decision.get("decision_id"), str)
+    ]
+    decision_ids = [decision["decision_id"] for decision in accepted_decisions]
+    repeated_decisions = len(decision_ids) - len(set(decision_ids))
+    gate_complete = all(gate_values[gate_id]["passed"] for gate_id in gate_ids)
+    return DrainagePhaseEvidence(
+        phase_id=phase_id,
+        checkpoint_ids=checkpoint_ids,
+        phase_outcome="complete" if gate_complete else "incomplete",
+        evidence_requested=sum(len(submission["closure_evidence_requests"]) for submission in selected),
+        # The current TrialRecord retains cited references, not release-event
+        # counts, so this field remains explicitly unavailable.
+        evidence_released=None,
+        submissions_accepted=len(selected),
+        submissions_rejected=None,
+        constraints_satisfied=sum(sum(value == "pass" for value in matrix.values()) for matrix in review_matrices),
+        rework_events=None,
+        revisited_decisions=repeated_decisions,
+        recovery_actions=None,
+    )
+
+
+def _phase_evidence_gates(evaluation: EvaluationResult) -> dict[str, dict[str, Any]]:
+    breakdown = evaluation.breakdown
+    if not isinstance(breakdown, dict) or not isinstance(breakdown.get("lifecycle_gates"), dict):
+        raise ValueError("phase-evidence-extraction-failed: lifecycle gates are unavailable")
+    gates = breakdown["lifecycle_gates"]
+    selected: dict[str, dict[str, Any]] = {}
+    for gate_id in GATE_IDS:
+        gate = gates.get(gate_id)
+        if not isinstance(gate, dict) or not isinstance(gate.get("passed"), bool):
+            raise ValueError("phase-evidence-extraction-failed: lifecycle gate is malformed")
+        _bounded_number(gate.get("score"), category="phase-evidence-extraction-failed", label=gate_id)
+        selected[gate_id] = gate
+    return selected
+
+
+def _phase_evidence_submissions(record: TrialRecord) -> dict[str, dict[str, Any]]:
+    output = record.output
+    agent_output = None if output is None else output.agent_output
+    if agent_output is None:
+        raise ValueError("phase-evidence-extraction-failed: lifecycle run is unavailable")
+    run_dir = Path(agent_output.output_path)
+    if not run_dir.is_absolute() or not run_dir.is_dir() or run_dir.is_symlink():
+        raise ValueError("phase-evidence-extraction-failed: lifecycle run is unavailable")
+    run_dir = run_dir.resolve(strict=True)
+    submissions: dict[str, dict[str, Any]] = {}
+    for checkpoint_id in CHECKPOINT_IDS:
+        path = run_dir / "episodes" / checkpoint_id / "submission.json"
+        if not path.is_file() or path.is_symlink():
+            raise ValueError("phase-evidence-extraction-failed: checkpoint submission is unavailable")
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if (
+            not isinstance(payload, dict)
+            or payload.get("checkpoint_id") != checkpoint_id
+            or not _DRAINAGE_SUBMISSION_FIELDS.issubset(payload)
+            or not isinstance(payload.get("evidence_refs"), list)
+            or any(not isinstance(item, str) for item in payload["evidence_refs"])
+            or not isinstance(payload.get("closure_evidence_requests"), list)
+            or not isinstance(payload.get("accepted_decisions"), list)
+        ):
+            raise ValueError("phase-evidence-extraction-failed: checkpoint submission is malformed")
+        submissions[checkpoint_id] = payload
+    return submissions
 
 
 def drainage_staged_review_feedback(record: TrialRecord) -> bytes:

--- a/src/aec_bench/lifecycles/structural_review/facade_submittal.py
+++ b/src/aec_bench/lifecycles/structural_review/facade_submittal.py
@@ -16,6 +16,7 @@ from aec_bench.contracts.evidence_lifecycle import (
     LifecycleTaskMetadata,
 )
 from aec_bench.contracts.lifecycle_evaluation import LifecycleGateResult, LifecycleVerificationResult
+from aec_bench.contracts.trial_record import TrialRecord
 from aec_bench.contracts.validators import NonEmptyStr, StrictModel
 from aec_bench.lifecycles.runtime.lifecycle import load_validated_lifecycle_submissions
 from aec_bench.templates.builtin.structural.facade_submittal_source_policy_package import (
@@ -130,6 +131,118 @@ class FacadeReviewSubmission(StrictModel):
         if len(finding_ids) != len(set(finding_ids)):
             raise ValueError("finding ids must be unique")
         return value
+
+
+class FacadePhaseEvidence(StrictModel):
+    phase_id: NonEmptyStr
+    checkpoint_ids: tuple[NonEmptyStr, ...]
+    phase_outcome: NonEmptyStr
+    evidence_refs_cited: int = Field(ge=0)
+    evidence_refs_expected: int | None = Field(default=None, ge=0)
+    metric_accuracy_pass: bool
+    finding_continuity_pass: bool
+    review_decision_correct: bool
+
+
+class FacadeLearningEvidence(StrictModel):
+    evidence_schema: str = "aec-bench/lifecycle/facade/learning-evidence/1"
+    lifecycle_template_id: NonEmptyStr
+    phase_records: tuple[FacadePhaseEvidence, ...]
+
+
+def extract_facade_learning_evidence(record: TrialRecord) -> FacadeLearningEvidence | None:
+    """Extract phase evidence from one completed facade lifecycle record."""
+
+    try:
+        if record.task_id != f"lifecycle/{TEMPLATE_ID}":
+            return None
+        if record.evaluation is None or not record.evaluation.validity.verifier_completed:
+            return None
+        gates = _facade_phase_evidence_gates(record.evaluation.breakdown)
+        submissions = _facade_phase_evidence_submissions(record)
+        phase_records = (
+            _facade_phase(
+                phase_id="source_assessment",
+                checkpoint_ids=("source_review",),
+                submissions=submissions,
+                gates=gates,
+                gate_ids=("checkpoint_contract", "evidence_use", "metric_accuracy"),
+            ),
+            _facade_phase(
+                phase_id="review_and_response",
+                checkpoint_ids=("comment_review", "response_review"),
+                submissions=submissions,
+                gates=gates,
+                gate_ids=("finding_continuity", "review_decision", "claim_boundary"),
+            ),
+        )
+        return FacadeLearningEvidence(
+            lifecycle_template_id=TEMPLATE_ID,
+            phase_records=phase_records,
+        )
+    except (TypeError, ValueError, KeyError, ValidationError, json.JSONDecodeError):
+        return None
+
+
+def _facade_phase(
+    *,
+    phase_id: str,
+    checkpoint_ids: tuple[str, ...],
+    submissions: dict[str, FacadeReviewSubmission],
+    gates: dict[str, dict[str, Any]],
+    gate_ids: tuple[str, ...],
+) -> FacadePhaseEvidence:
+    phase_gates = {gate_id: gates[gate_id]["passed"] for gate_id in gate_ids}
+    return FacadePhaseEvidence(
+        phase_id=phase_id,
+        checkpoint_ids=checkpoint_ids,
+        phase_outcome="complete" if all(phase_gates.values()) else "incomplete",
+        evidence_refs_cited=sum(len(submissions[checkpoint_id].evidence_refs) for checkpoint_id in checkpoint_ids),
+        # The facade verifier does not retain expected reference counts in the
+        # TrialRecord; leaving this optional is the fail-closed representation.
+        evidence_refs_expected=None,
+        metric_accuracy_pass=gates["metric_accuracy"]["passed"],
+        finding_continuity_pass=gates["finding_continuity"]["passed"],
+        review_decision_correct=gates["review_decision"]["passed"],
+    )
+
+
+def _facade_phase_evidence_gates(breakdown: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
+    if not isinstance(breakdown, dict) or not isinstance(breakdown.get("lifecycle_gates"), dict):
+        raise ValueError("phase-evidence-extraction-failed: lifecycle gates are unavailable")
+    gates = breakdown["lifecycle_gates"]
+    selected: dict[str, dict[str, Any]] = {}
+    for gate_id in GATE_IDS:
+        gate = gates.get(gate_id)
+        if not isinstance(gate, dict) or not isinstance(gate.get("passed"), bool):
+            raise ValueError("phase-evidence-extraction-failed: lifecycle gate is malformed")
+        score = gate.get("score")
+        if isinstance(score, bool) or not isinstance(score, int | float) or not 0 <= score <= 1:
+            raise ValueError("phase-evidence-extraction-failed: lifecycle gate score is malformed")
+        selected[gate_id] = gate
+    return selected
+
+
+def _facade_phase_evidence_submissions(record: TrialRecord) -> dict[str, FacadeReviewSubmission]:
+    output = record.output
+    agent_output = None if output is None else output.agent_output
+    if agent_output is None:
+        raise ValueError("phase-evidence-extraction-failed: lifecycle run is unavailable")
+    run_dir = Path(agent_output.output_path)
+    if not run_dir.is_absolute() or not run_dir.is_dir() or run_dir.is_symlink():
+        raise ValueError("phase-evidence-extraction-failed: lifecycle run is unavailable")
+    run_dir = run_dir.resolve(strict=True)
+    submissions: dict[str, FacadeReviewSubmission] = {}
+    for checkpoint_id in CHECKPOINT_IDS:
+        path = run_dir / "episodes" / checkpoint_id / "submission.json"
+        if not path.is_file() or path.is_symlink():
+            raise ValueError("phase-evidence-extraction-failed: checkpoint submission is unavailable")
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        submission = FacadeReviewSubmission.model_validate(payload)
+        if submission.checkpoint_id != checkpoint_id:
+            raise ValueError("phase-evidence-extraction-failed: checkpoint identity is invalid")
+        submissions[checkpoint_id] = submission
+    return submissions
 
 
 def materialize_facade_submittal_lifecycle(output_dir: Path) -> Path:

--- a/tests/experimentation/learning_studies/test_phase_evidence.py
+++ b/tests/experimentation/learning_studies/test_phase_evidence.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from aec_bench.contracts.evaluation_result import EvaluationResult, ValidityCheck
+from aec_bench.contracts.learning_study import (
+    ExperienceRole,
+    LearningArmSpec,
+    LearningExperienceSpec,
+    LearningStudySpec,
+    RunExperienceStep,
+    StudyArmRole,
+)
+from aec_bench.contracts.trial_record import TrialExtensionRef, TrialRecord
+from aec_bench.experimentation.learning_studies.lifecycles import (
+    LifecycleExecutionCondition,
+    LifecycleLearningTreatmentKind,
+    build_lifecycle_learning_operations,
+    resolve_lifecycle_learning_target,
+)
+from aec_bench.experimentation.learning_studies.phase_evidence import group_phase_evidence
+from aec_bench.experimentation.learning_studies.planning import CompiledExperienceStep, compile_learning_study
+from aec_bench.experimentation.learning_studies.runtime import ExecuteExperienceRequest
+from aec_bench.ledger.artifact_repository import ArtifactRepository
+from aec_bench.ledger.reader import read_trial_record
+from aec_bench.ledger.writer import write_trial_record_at
+from aec_bench.lifecycles.runtime.episode import LifecycleExecutionMode, LifecycleVisibilityPolicy
+from aec_bench.lifecycles.stormwater_design.drainage_learning import (
+    DrainageLearningEvidence,
+    extract_drainage_learning_evidence,
+)
+from aec_bench.lifecycles.structural_review.facade_submittal import (
+    FacadeLearningEvidence,
+    extract_facade_learning_evidence,
+)
+from tests.support.trial_record_factories import make_trial_record
+
+_DRAINAGE_TASK = "lifecycle/drainage-model-evidence-lifecycle-review/staged_full_correction"
+_FACADE_TASK = "lifecycle/facade-submittal-review-lifecycle"
+_DRAINAGE_GATES = (
+    "checkpoint_contract",
+    "reviewer_self_consistency",
+    "staged_disclosure",
+    "finding_continuity",
+    "closure_evidence",
+    "accepted_decision_preservation",
+    "final_readiness",
+    "claim_boundary",
+)
+_FACADE_GATES = (
+    "checkpoint_contract",
+    "evidence_use",
+    "metric_accuracy",
+    "finding_continuity",
+    "review_decision",
+    "claim_boundary",
+)
+
+
+def _record_with_submissions(tmp_path: Path, *, task_id: str, checkpoints: tuple[str, ...]) -> TrialRecord:
+    run_dir = tmp_path / task_id.rsplit("/", 1)[-1] / "run"
+    for checkpoint_id in checkpoints:
+        path = run_dir / "episodes" / checkpoint_id / "submission.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if task_id == _DRAINAGE_TASK:
+            payload = {
+                "checkpoint_id": checkpoint_id,
+                "evidence_refs": ["evidence-a"],
+                "review_matrix": {"PRV-01": "pass"},
+                "transition_decision": {"design_claim": "supported"},
+                "findings": [],
+                "closure_evidence_requests": [],
+                "accepted_decisions": [],
+                "readiness_decision": "ready",
+                "claim_boundary_statement": "synthetic review only",
+            }
+        else:
+            payload = {
+                "checkpoint_id": checkpoint_id,
+                "evidence_refs": ["facade-source-index"],
+                "metrics": {"source_trace_score": 1.0},
+                "findings": [],
+                "review_decision": "continue_review",
+                "readiness": "review_in_progress",
+                "claim_boundary": {
+                    "evidence_class": "task_owned_synthetic_review",
+                    "authority_status": "no_authority_approval",
+                    "project_evidence_status": "not_project_evidence",
+                    "standards_status": "no_standards_compliance_claim",
+                },
+            }
+        path.write_text(json.dumps(payload), encoding="utf-8")
+    gates = _DRAINAGE_GATES if task_id == _DRAINAGE_TASK else _FACADE_GATES
+    evaluation = EvaluationResult(
+        reward=1.0,
+        validity=ValidityCheck(output_parseable=True, schema_valid=True, verifier_completed=True),
+        breakdown={"lifecycle_gates": {gate: {"passed": True, "score": 1.0} for gate in gates}},
+    )
+    return make_trial_record(
+        task_id=task_id,
+        outputs={
+            "agent_output": {
+                "status": "completed",
+                "output_path": str(run_dir.resolve()),
+                "output_format": "json",
+            }
+        },
+        evaluation=evaluation,
+    )
+
+
+def test_drainage_evidence_emits_the_declared_phase_mapping(tmp_path: Path) -> None:
+    evidence = extract_drainage_learning_evidence(
+        _record_with_submissions(
+            tmp_path,
+            task_id=_DRAINAGE_TASK,
+            checkpoints=("initial_review", "response_review", "closeout_review"),
+        )
+    )
+
+    assert isinstance(evidence, DrainageLearningEvidence)
+    assert [(item.phase_id, item.checkpoint_ids) for item in evidence.phase_records] == [
+        ("evidence_assessment", ("initial_review",)),
+        ("response_and_closeout", ("response_review", "closeout_review")),
+    ]
+    assert evidence.phase_records[0].submissions_accepted == 1
+    assert evidence.phase_records[0].rework_events is None
+
+
+def test_facade_evidence_emits_the_declared_phase_mapping(tmp_path: Path) -> None:
+    evidence = extract_facade_learning_evidence(
+        _record_with_submissions(
+            tmp_path,
+            task_id=_FACADE_TASK,
+            checkpoints=("source_review", "comment_review", "response_review"),
+        )
+    )
+
+    assert isinstance(evidence, FacadeLearningEvidence)
+    assert [(item.phase_id, item.checkpoint_ids) for item in evidence.phase_records] == [
+        ("source_assessment", ("source_review",)),
+        ("review_and_response", ("comment_review", "response_review")),
+    ]
+    assert evidence.phase_records[0].metric_accuracy_pass is True
+    assert evidence.phase_records[0].evidence_refs_expected is None
+
+
+def test_evidence_extractors_fail_closed_when_evidence_is_missing(tmp_path: Path) -> None:
+    drainage = make_trial_record(task_id=_DRAINAGE_TASK)
+    facade = make_trial_record(task_id=_FACADE_TASK)
+
+    assert extract_drainage_learning_evidence(drainage) is None
+    assert extract_facade_learning_evidence(facade) is None
+
+
+def _lifecycle_plan(task_id: str):
+    spec = LearningStudySpec(
+        study_id="phase-evidence-test",
+        title="phase evidence",
+        research_question="does the lifecycle adapter attach task evidence?",
+        agent={
+            "name": "phase-evidence-agent",
+            "adapter": "tool_loop",
+            "model": "fixed-test-model",
+            "parameters": {"max_turns_per_session": 1},
+        },
+        compute={"backend": "local", "resource_limits": {"memory_mb": 256}, "timeout_override": 30},
+        repetitions=1,
+        experiences=(LearningExperienceSpec(experience_id="probe", task_id=task_id, role=ExperienceRole.PROBE),),
+        arms=(
+            LearningArmSpec(
+                arm_id="cold",
+                role=StudyArmRole.CONTROL,
+                treatment_id="reset",
+                steps=(RunExperienceStep(step_id="probe-step", experience_id="probe", commit_post_state=False),),
+            ),
+        ),
+    )
+    return compile_learning_study(
+        study_run_id="phase-evidence-test-run",
+        spec=spec,
+        resolve_task=resolve_lifecycle_learning_target,
+    )
+
+
+def _fake_lifecycle_calls(monkeypatch: pytest.MonkeyPatch, task_id: str) -> None:
+    from aec_bench.experimentation.learning_studies import lifecycles as adapter
+
+    def compile_fake(template_id: str, package_dir: Path, *, variant_id: str | None = None):  # noqa: ANN202
+        package_dir.mkdir(parents=True)
+        return SimpleNamespace(
+            package_dir=package_dir,
+            envelope=SimpleNamespace(template_id=template_id, variant_id=variant_id),
+        )
+
+    def run_fake(*, trial, execute, verify, persist=None):  # noqa: ANN001, ANN202, ARG001
+        trial.run_dir.mkdir(parents=True)
+        return make_trial_record(
+            trial_id=trial.planned.trial_id,
+            experiment_id=trial.planned.experiment_id,
+            task_id=task_id,
+            attempt=trial.planned.repetition,
+        )
+
+    monkeypatch.setattr(adapter, "compile_lifecycle", compile_fake)
+    monkeypatch.setattr(adapter, "run_lifecycle_trial", run_fake)
+
+
+def _binding(tmp_path: Path, *, extractor=None):  # noqa: ANN001, ANN202
+    return build_lifecycle_learning_operations(
+        run_root=tmp_path / "study",
+        execution_condition=LifecycleExecutionCondition(
+            execution_mode=LifecycleExecutionMode.FRESH_CONTEXT,
+            visibility_policy=LifecycleVisibilityPolicy.ARTIFACT_MEMORY,
+        ),
+        treatment_kinds={"reset": LifecycleLearningTreatmentKind.RESET},
+        phase_evidence_extractors=(
+            None if extractor is None else {"drainage-model-evidence-lifecycle-review": extractor}
+        ),
+    )
+
+
+def test_coordinator_attaches_evidence_and_ledger_round_trips_it(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _fake_lifecycle_calls(monkeypatch, _DRAINAGE_TASK)
+    plan = _lifecycle_plan(_DRAINAGE_TASK)
+    evidence = DrainageLearningEvidence(
+        lifecycle_template_id="drainage-model-evidence-lifecycle-review",
+        variant_id="staged_full_correction",
+        phase_records=(
+            {
+                "phase_id": "evidence_assessment",
+                "checkpoint_ids": ("initial_review",),
+                "phase_outcome": "complete",
+            },
+        ),
+    )
+    binding = _binding(tmp_path, extractor=lambda record: evidence)
+    state = binding.operations.initialise_learner(plan.arm_runs[0])
+    step = plan.arm_runs[0].steps[0]
+    assert isinstance(step, CompiledExperienceStep)
+    record = binding.operations.execute_experience(
+        request=ExecuteExperienceRequest(arm_run=plan.arm_runs[0], step=step, state=state)
+    ).trial_record
+    assert record is not None
+    assert record.pending_extensions["lifecycle_learning_evidence"] == evidence
+
+    path = write_trial_record_at(path=tmp_path / "ledger" / "experiment" / "trial.json", record=record)
+    restored = read_trial_record(path, ledger_root=tmp_path / "ledger")
+    extension = next(item for item in restored.extension_refs if item.extension_kind == "lifecycle_learning_evidence")
+    raw = ArtifactRepository(tmp_path / "ledger" / "experiment" / "_artifacts").read_bytes(extension.artifact)
+    assert DrainageLearningEvidence.model_validate_json(raw) == evidence
+
+
+def test_coordinator_without_extractor_has_no_extension(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _fake_lifecycle_calls(monkeypatch, _DRAINAGE_TASK)
+    plan = _lifecycle_plan(_DRAINAGE_TASK)
+    binding = _binding(tmp_path)
+    state = binding.operations.initialise_learner(plan.arm_runs[0])
+    step = plan.arm_runs[0].steps[0]
+    assert isinstance(step, CompiledExperienceStep)
+    record = binding.operations.execute_experience(
+        ExecuteExperienceRequest(arm_run=plan.arm_runs[0], step=step, state=state)
+    ).trial_record
+    assert record is not None
+    assert record.extension_refs == ()
+    assert "lifecycle_learning_evidence" not in record.pending_extensions
+
+
+def test_facade_evidence_round_trips_through_the_ledger(tmp_path: Path) -> None:
+    record = _record_with_submissions(
+        tmp_path,
+        task_id=_FACADE_TASK,
+        checkpoints=("source_review", "comment_review", "response_review"),
+    )
+    evidence = extract_facade_learning_evidence(record)
+    assert evidence is not None
+    record.attach_extension("lifecycle_learning_evidence", evidence)
+
+    path = write_trial_record_at(path=tmp_path / "ledger" / "experiment" / "facade.json", record=record)
+    restored = read_trial_record(path, ledger_root=tmp_path / "ledger")
+    extension = next(item for item in restored.extension_refs if item.extension_kind == "lifecycle_learning_evidence")
+    raw = ArtifactRepository(tmp_path / "ledger" / "experiment" / "_artifacts").read_bytes(extension.artifact)
+
+    assert FacadeLearningEvidence.model_validate_json(raw) == evidence
+
+
+def test_phase_grouping_is_opaque_and_fail_closed(tmp_path: Path) -> None:
+    repository = ArtifactRepository(tmp_path / "artifacts")
+    drainage = make_trial_record(task_id=_DRAINAGE_TASK, trial_id="drainage-trial")
+    facade = make_trial_record(task_id=_FACADE_TASK, trial_id="facade-trial")
+    drainage_model = DrainageLearningEvidence(
+        lifecycle_template_id="drainage-model-evidence-lifecycle-review",
+        variant_id="staged_full_correction",
+        phase_records=(
+            {"phase_id": "evidence_assessment", "checkpoint_ids": ("initial_review",), "phase_outcome": "complete"},
+        ),
+    )
+    facade_model = FacadeLearningEvidence(
+        lifecycle_template_id="facade-submittal-review-lifecycle",
+        phase_records=(
+            {
+                "phase_id": "source_assessment",
+                "checkpoint_ids": ("source_review",),
+                "phase_outcome": "complete",
+                "evidence_refs_cited": 1,
+                "metric_accuracy_pass": True,
+                "finding_continuity_pass": True,
+                "review_decision_correct": True,
+            },
+        ),
+    )
+    drainage_ref = repository.publish_model(value=drainage_model, media_type="application/json")
+    facade_ref = repository.publish_model(value=facade_model, media_type="application/json")
+    malformed_ref = repository.publish_bytes(data=b"{", media_type="application/json")
+    missing_ref = repository.publish_bytes(data=b'{"phase_records":[{}]}', media_type="application/json")
+    unknown_ref = repository.publish_bytes(
+        data=b'{"phase_records":[{"phase_id":"ignored"}]}',
+        media_type="application/json",
+    )
+    drainage.extension_refs = (TrialExtensionRef(extension_kind="lifecycle_learning_evidence", artifact=drainage_ref),)
+    facade.extension_refs = (TrialExtensionRef(extension_kind="lifecycle_learning_evidence", artifact=facade_ref),)
+    malformed = make_trial_record(task_id=_FACADE_TASK, trial_id="malformed")
+    malformed.extension_refs = (
+        TrialExtensionRef(extension_kind="lifecycle_learning_evidence", artifact=malformed_ref),
+    )
+    missing = make_trial_record(task_id=_FACADE_TASK, trial_id="missing")
+    missing.extension_refs = (TrialExtensionRef(extension_kind="lifecycle_learning_evidence", artifact=missing_ref),)
+    unknown = make_trial_record(task_id=_FACADE_TASK, trial_id="unknown")
+    unknown.extension_refs = (TrialExtensionRef(extension_kind="other", artifact=unknown_ref),)
+
+    groups = group_phase_evidence([drainage, facade, malformed, missing, unknown], artifact_repository=repository)
+
+    assert {phase_id: [entry.trial_id for entry in entries] for phase_id, entries in groups.items()} == {
+        "evidence_assessment": ["drainage-trial"],
+        "source_assessment": ["facade-trial"],
+    }
+    source = Path("src/aec_bench/experimentation/learning_studies/phase_evidence.py").read_text()
+    assert "stormwater_design" not in source
+    assert "structural_review" not in source


### PR DESCRIPTION
## Summary

Implements D1 of Release B Lifecycle Tranche 3 (LS-07): task-owned phase-evidence emission for two lifecycle families, per `LS-07A-lifecycle-phase-evidence-extension.md`.

- `DrainageLearningEvidence` + `extract_drainage_learning_evidence` in `drainage_learning.py`, mapping the three drainage checkpoints (`initial_review` / `response_review` / `closeout_review`) to two phases (`evidence_assessment`; `response_and_closeout`).
- `FacadeLearningEvidence` + `extract_facade_learning_evidence` in `facade_submittal.py` -- **the first time `structural_review`'s facade submittal lifecycle participates in Learning Studies at all**, closing a gap that has existed since LS-06 (only drainage had ever run a study).
- A new caller-supplied `phase_evidence_extractors` mapping (keyed by `template_id`) on `build_lifecycle_learning_operations()`, following the existing `feedback_projectors` pattern exactly.
- The attach call sits in `_LifecycleLearningCoordinator.execute_experience()`, immediately after `run_lifecycle_trial()` returns the built `TrialRecord` -- **not** inside the lifecycle verifier, which only receives package/run paths and returns a plain dict, never a `TrialRecord`. Ordinary lifecycle callers with no extractor supplied are completely unaffected (covered by a dedicated test).
- Evidence is published via the existing generic `TrialRecord.attach_extension()`/`extension_refs` mechanism (already used for e.g. `attempt_selection`), so **no common contract, `TrialRecord`, ledger writer, or `ledger/reader.py` change was needed**. A coordinator-level test round-trips a real write/read through the ledger for both families.
- `phase_evidence.py` adds a study-owned grouping helper that reads only the opaque `phase_id` from each family's evidence via plain JSON parsing, with zero imports of `DrainageLearningEvidence`, `FacadeLearningEvidence`, or any lifecycle-specific module.
- Fields the current runtime genuinely cannot populate (rejection/rework/recovery counts for drainage; expected reference counts for facade) are left optional/`None` rather than fabricated as zero.

## Scope boundaries

No L03 study content, feedback views, or scaffolding variants in this PR (separate follow-ups, D2/D3, based on this branch). No changes to worlds, Gate C, harness-update, model weights, or common contracts.

## Testing

```
uv run pytest \
  tests/lifecycles/stormwater_design/test_drainage_lifecycle.py \
  tests/lifecycles/structural_review/test_facade_submittal.py \
  tests/experimentation/learning_studies/test_lifecycles.py \
  tests/experimentation/learning_studies/test_phase_evidence.py
```

65 passed, including a coordinator-level test that attaches evidence through the real `execute_experience` path and round-trips it through a real ledger write/read, and a dedicated test proving lifecycle execution is unchanged when no extractor is supplied.

`uv run ruff check` clean. `uv run python scripts/check_provenance_fields.py --check --base-revision main` passes with 0 violations.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
