### PR TITLE
feat: add drainage feedback-schedule composition (Release B, Lifecycle Tranche 3, D2)

### DIFF
--- a/src/aec_bench/lifecycles/stormwater_design/drainage_learning.py
+++ b/src/aec_bench/lifecycles/stormwater_design/drainage_learning.py
@@ -17,6 +17,9 @@ from aec_bench.lifecycles.runtime.lifecycle import load_validated_lifecycle_subm
 from aec_bench.lifecycles.stormwater_design.drainage_model import CHECKPOINT_IDS, GATE_IDS, TEMPLATE_ID
 
 DRAINAGE_STAGED_REVIEW_FEEDBACK_VIEW_ID = "drainage-staged-review-public-feedback"
+DRAINAGE_CHECKPOINT_DETAILED_FEEDBACK_VIEW_ID = "drainage-checkpoint-detailed-feedback"
+DRAINAGE_PHASE_SUMMARY_FEEDBACK_VIEW_ID = "drainage-phase-summary-feedback"
+DRAINAGE_TERMINAL_FEEDBACK_VIEW_ID = "drainage-terminal-feedback"
 DRAINAGE_ACQUISITION_TASK_ID = f"lifecycle/{TEMPLATE_ID}/staged_full_correction"
 DRAINAGE_PROBE_TASK_ID = f"lifecycle/{TEMPLATE_ID}/semantic_no_op_release"
 
@@ -67,6 +70,9 @@ _DRAINAGE_SUBMISSION_FIELDS = {
     "readiness_decision",
     "claim_boundary_statement",
 }
+_REVIEW_MATRIX_IDS = tuple(f"PRV-0{index}" for index in range(1, 10))
+_REVIEW_MATRIX_STATUSES = frozenset({"pass", "fail", "not_applicable", "insufficient_data"})
+_DRAINAGE_PHASE_IDS = ("evidence_assessment", "response_and_closeout")
 
 
 class DrainagePhaseEvidence(StrictModel):
@@ -252,6 +258,273 @@ def drainage_staged_review_feedback(record: TrialRecord) -> bytes:
     data = (json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False) + "\n").encode()
     validate_drainage_staged_review_feedback(data)
     return data
+
+
+def drainage_checkpoint_detailed_feedback(record: TrialRecord) -> bytes:
+    """Return safe per-checkpoint review detail for one completed acquisition."""
+
+    _require_completed_acquisition(record)
+    submissions = _archived_submissions(record)
+    checkpoints: dict[str, Any] = {}
+    for checkpoint_id in CHECKPOINT_IDS:
+        matrix = _public_review_matrix(submissions[checkpoint_id])
+        checkpoints[checkpoint_id] = {
+            "passed": all(status == "pass" for status in matrix.values()),
+            "gate_scores": {
+                gate_id: {"passed": status == "pass", "score": 1.0 if status == "pass" else 0.0}
+                for gate_id, status in matrix.items()
+            },
+            "review_matrix": matrix,
+        }
+    payload = {
+        "feedback_view_id": DRAINAGE_CHECKPOINT_DETAILED_FEEDBACK_VIEW_ID,
+        "trial_id": record.trial_id,
+        "task_id": record.task_id,
+        "execution_status": record.execution_status.value,
+        "checkpoints": checkpoints,
+        "overall_gates": {
+            gate_id: _public_gate(record, gate_id, category="feedback-projection-failed")
+            for gate_id in _SELECTED_FEEDBACK_GATE_IDS
+        },
+    }
+    data = _canonical_feedback_bytes(payload)
+    validate_drainage_checkpoint_detailed_feedback(data)
+    return data
+
+
+def validate_drainage_checkpoint_detailed_feedback(data: bytes) -> dict[str, Any]:
+    """Validate the bounded per-checkpoint drainage feedback projection."""
+
+    payload = _decode_feedback_object(data)
+    expected_fields = {"feedback_view_id", "trial_id", "task_id", "execution_status", "checkpoints", "overall_gates"}
+    if set(payload) != expected_fields:
+        raise ValueError("feedback-projection-unsafe: checkpoint feedback fields do not match the public view")
+    _validate_feedback_identity(
+        payload,
+        view_id=DRAINAGE_CHECKPOINT_DETAILED_FEEDBACK_VIEW_ID,
+        error_label="checkpoint feedback",
+    )
+    checkpoints = payload["checkpoints"]
+    if not isinstance(checkpoints, dict) or tuple(checkpoints) != tuple(sorted(CHECKPOINT_IDS)):
+        raise ValueError("feedback-projection-unsafe: checkpoint feedback checkpoint allowlist does not match")
+    for checkpoint_id in CHECKPOINT_IDS:
+        checkpoint = checkpoints[checkpoint_id]
+        if not isinstance(checkpoint, dict) or set(checkpoint) != {"passed", "gate_scores", "review_matrix"}:
+            raise ValueError(f"feedback-projection-unsafe: checkpoint feedback shape is invalid: {checkpoint_id}")
+        if not isinstance(checkpoint["passed"], bool):
+            raise ValueError(f"feedback-projection-unsafe: checkpoint status is invalid: {checkpoint_id}")
+        matrix = _validate_public_review_matrix(checkpoint["review_matrix"], checkpoint_id)
+        scores = checkpoint["gate_scores"]
+        if not isinstance(scores, dict) or tuple(scores) != _REVIEW_MATRIX_IDS:
+            raise ValueError(f"feedback-projection-unsafe: checkpoint gate allowlist is invalid: {checkpoint_id}")
+        for gate_id in _REVIEW_MATRIX_IDS:
+            score = scores[gate_id]
+            if (
+                not isinstance(score, dict)
+                or set(score) != {"passed", "score"}
+                or not isinstance(score["passed"], bool)
+            ):
+                raise ValueError(f"feedback-projection-unsafe: checkpoint gate shape is invalid: {gate_id}")
+            _bounded_number(score["score"], category="feedback-projection-unsafe", label=f"checkpoint gate {gate_id}")
+            if score["passed"] != (matrix[gate_id] == "pass"):
+                raise ValueError(f"feedback-projection-unsafe: checkpoint gate status is inconsistent: {gate_id}")
+        if checkpoint["passed"] != all(status == "pass" for status in matrix.values()):
+            raise ValueError(f"feedback-projection-unsafe: checkpoint status is inconsistent: {checkpoint_id}")
+    _validate_public_overall_gates(payload["overall_gates"])
+    return payload
+
+
+def drainage_phase_summary_feedback(record: TrialRecord) -> bytes:
+    """Return safe phase-level drainage feedback without checkpoint submissions."""
+
+    _require_completed_acquisition(record)
+    evidence = extract_drainage_learning_evidence(record)
+    if evidence is None:
+        raise ValueError("feedback-source-phase-evidence-missing: drainage phase evidence is unavailable")
+    phases = {phase.phase_id: phase.model_dump(mode="json") for phase in evidence.phase_records}
+    payload = {
+        "feedback_view_id": DRAINAGE_PHASE_SUMMARY_FEEDBACK_VIEW_ID,
+        "trial_id": record.trial_id,
+        "task_id": record.task_id,
+        "execution_status": record.execution_status.value,
+        "phases": phases,
+    }
+    data = _canonical_feedback_bytes(payload)
+    validate_drainage_phase_summary_feedback(data)
+    return data
+
+
+def validate_drainage_phase_summary_feedback(data: bytes) -> dict[str, Any]:
+    """Validate the bounded phase-summary drainage feedback projection."""
+
+    payload = _decode_feedback_object(data)
+    expected_fields = {"feedback_view_id", "trial_id", "task_id", "execution_status", "phases"}
+    if set(payload) != expected_fields:
+        raise ValueError("feedback-projection-unsafe: phase feedback fields do not match the public view")
+    _validate_feedback_identity(
+        payload,
+        view_id=DRAINAGE_PHASE_SUMMARY_FEEDBACK_VIEW_ID,
+        error_label="phase feedback",
+    )
+    phases = payload["phases"]
+    if not isinstance(phases, dict) or tuple(phases) != _DRAINAGE_PHASE_IDS:
+        raise ValueError("feedback-projection-unsafe: phase feedback phase allowlist does not match")
+    for phase_id, phase in phases.items():
+        if not isinstance(phase, dict):
+            raise ValueError(f"feedback-projection-unsafe: phase summary is invalid: {phase_id}")
+        expected = {
+            "phase_id",
+            "checkpoint_ids",
+            "phase_outcome",
+            "evidence_requested",
+            "evidence_released",
+            "submissions_accepted",
+            "submissions_rejected",
+            "constraints_satisfied",
+            "rework_events",
+            "revisited_decisions",
+            "recovery_actions",
+        }
+        if set(phase) != expected or phase["phase_id"] != phase_id:
+            raise ValueError(f"feedback-projection-unsafe: phase summary fields are invalid: {phase_id}")
+        if (
+            not isinstance(phase["checkpoint_ids"], list)
+            or any(not isinstance(item, str) or not item for item in phase["checkpoint_ids"])
+            or not isinstance(phase["phase_outcome"], str)
+            or not phase["phase_outcome"]
+        ):
+            raise ValueError(f"feedback-projection-unsafe: phase summary identity is invalid: {phase_id}")
+        for field in expected - {"phase_id", "checkpoint_ids", "phase_outcome"}:
+            value = phase[field]
+            if value is not None and (isinstance(value, bool) or not isinstance(value, int) or value < 0):
+                raise ValueError(f"feedback-projection-unsafe: phase summary count is invalid: {field}")
+    return payload
+
+
+def drainage_terminal_feedback(record: TrialRecord) -> bytes:
+    """Return terminal-only drainage feedback for a completed acquisition."""
+
+    _require_completed_acquisition(record)
+    evaluation = _completed_evaluation(record, category="feedback-source-evaluation-missing")
+    validity = evaluation.validity
+    payload = {
+        "feedback_view_id": DRAINAGE_TERMINAL_FEEDBACK_VIEW_ID,
+        "trial_id": record.trial_id,
+        "task_id": record.task_id,
+        "execution_status": record.execution_status.value,
+        "terminal_outcome": {
+            "canonical_reward": _bounded_number(
+                evaluation.reward,
+                category="feedback-projection-failed",
+                label="reward",
+            ),
+            "completion_status": record.execution_status.value,
+            "validity": {
+                "output_parseable": validity.output_parseable,
+                "schema_valid": validity.schema_valid,
+                "verifier_completed": validity.verifier_completed,
+            },
+        },
+        "overall_gates": {
+            gate_id: _public_gate(record, gate_id, category="feedback-projection-failed")
+            for gate_id in _SELECTED_FEEDBACK_GATE_IDS
+        },
+    }
+    data = _canonical_feedback_bytes(payload)
+    validate_drainage_terminal_feedback(data)
+    return data
+
+
+def validate_drainage_terminal_feedback(data: bytes) -> dict[str, Any]:
+    """Validate the bounded terminal-only drainage feedback projection."""
+
+    payload = _decode_feedback_object(data)
+    expected_fields = {
+        "feedback_view_id",
+        "trial_id",
+        "task_id",
+        "execution_status",
+        "terminal_outcome",
+        "overall_gates",
+    }
+    if set(payload) != expected_fields:
+        raise ValueError("feedback-projection-unsafe: terminal feedback fields do not match the public view")
+    _validate_feedback_identity(
+        payload,
+        view_id=DRAINAGE_TERMINAL_FEEDBACK_VIEW_ID,
+        error_label="terminal feedback",
+    )
+    terminal = payload["terminal_outcome"]
+    if not isinstance(terminal, dict) or set(terminal) != {"canonical_reward", "completion_status", "validity"}:
+        raise ValueError("feedback-projection-unsafe: terminal outcome fields do not match the public view")
+    _bounded_number(terminal["canonical_reward"], category="feedback-projection-unsafe", label="reward")
+    if terminal["completion_status"] != ExecutionStatus.COMPLETED.value:
+        raise ValueError("feedback-source-trial-missing: terminal feedback source is not complete")
+    validity = terminal["validity"]
+    if (
+        not isinstance(validity, dict)
+        or set(validity) != set(_PUBLIC_VALIDITY_FIELDS)
+        or any(not isinstance(validity[field], bool) for field in _PUBLIC_VALIDITY_FIELDS)
+    ):
+        raise ValueError("feedback-projection-unsafe: public validity fields are invalid")
+    _validate_public_overall_gates(payload["overall_gates"])
+    return payload
+
+
+def _require_completed_acquisition(record: TrialRecord) -> None:
+    if record.task_id != DRAINAGE_ACQUISITION_TASK_ID:
+        raise ValueError(f"feedback-source-task-mismatch: {record.task_id}")
+    if record.execution_status is not ExecutionStatus.COMPLETED:
+        raise ValueError("feedback-source-trial-missing: lifecycle execution is not complete")
+
+
+def _canonical_feedback_bytes(payload: dict[str, Any]) -> bytes:
+    return (json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False) + "\n").encode()
+
+
+def _decode_feedback_object(data: bytes) -> dict[str, Any]:
+    if not isinstance(data, bytes) or not data:
+        raise ValueError("feedback-projection-invalid-json: drainage feedback is not non-empty bytes")
+    try:
+        payload = json.loads(data.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError("feedback-projection-invalid-json: drainage feedback is not UTF-8 JSON") from error
+    if not isinstance(payload, dict):
+        raise ValueError("feedback-projection-invalid-json: drainage feedback must be a JSON object")
+    return payload
+
+
+def _validate_feedback_identity(payload: dict[str, Any], *, view_id: str, error_label: str) -> None:
+    if payload["feedback_view_id"] != view_id:
+        raise ValueError(f"feedback-projection-unsafe: {error_label} view identity does not match")
+    if payload["task_id"] != DRAINAGE_ACQUISITION_TASK_ID:
+        raise ValueError(f"feedback-source-task-mismatch: {error_label} source is not the acquisition task")
+    if payload["execution_status"] != ExecutionStatus.COMPLETED.value:
+        raise ValueError(f"feedback-source-trial-missing: {error_label} source is not complete")
+    if not isinstance(payload["trial_id"], str) or not payload["trial_id"]:
+        raise ValueError(f"feedback-projection-unsafe: {error_label} trial identity is missing")
+
+
+def _public_review_matrix(submission: dict[str, Any]) -> dict[str, str]:
+    matrix = submission.get("review_matrix")
+    return _validate_public_review_matrix(matrix, "checkpoint")
+
+
+def _validate_public_review_matrix(value: object, checkpoint_id: str) -> dict[str, str]:
+    if not isinstance(value, dict) or tuple(value) != _REVIEW_MATRIX_IDS:
+        raise ValueError(f"feedback-projection-unsafe: review matrix allowlist is invalid: {checkpoint_id}")
+    if any(not isinstance(status, str) or status not in _REVIEW_MATRIX_STATUSES for status in value.values()):
+        raise ValueError(f"feedback-projection-unsafe: review matrix status is invalid: {checkpoint_id}")
+    return dict(value)
+
+
+def _validate_public_overall_gates(value: object) -> None:
+    if not isinstance(value, dict) or tuple(value) != tuple(sorted(_SELECTED_FEEDBACK_GATE_IDS)):
+        raise ValueError("feedback-projection-unsafe: drainage feedback gate allowlist does not match")
+    for gate_id, gate in value.items():
+        if not isinstance(gate, dict) or set(gate) != {"passed", "score"} or not isinstance(gate["passed"], bool):
+            raise ValueError(f"feedback-projection-unsafe: public gate shape is invalid: {gate_id}")
+        _bounded_number(gate["score"], category="feedback-projection-unsafe", label=f"gate {gate_id}")
 
 
 def validate_drainage_staged_review_feedback(data: bytes) -> dict[str, Any]:
@@ -463,13 +736,22 @@ def _bounded_number(value: object, *, category: str, label: str) -> float:
 
 __all__ = (
     "DRAINAGE_ACQUISITION_TASK_ID",
+    "DRAINAGE_CHECKPOINT_DETAILED_FEEDBACK_VIEW_ID",
     "DRAINAGE_MEMO_CLOSURE_FAILURE_TOKENS",
     "DRAINAGE_MEMO_CLOSURE_REQUEST_ID",
     "DRAINAGE_MEMO_FINDING_ID",
+    "DRAINAGE_PHASE_SUMMARY_FEEDBACK_VIEW_ID",
     "DRAINAGE_PROBE_TASK_ID",
     "DRAINAGE_STAGED_REVIEW_FEEDBACK_VIEW_ID",
+    "DRAINAGE_TERMINAL_FEEDBACK_VIEW_ID",
+    "drainage_checkpoint_detailed_feedback",
     "drainage_gate_score",
     "drainage_inappropriate_memo_closure",
+    "drainage_phase_summary_feedback",
     "drainage_staged_review_feedback",
+    "drainage_terminal_feedback",
+    "validate_drainage_checkpoint_detailed_feedback",
+    "validate_drainage_phase_summary_feedback",
     "validate_drainage_staged_review_feedback",
+    "validate_drainage_terminal_feedback",
 )

--- a/tests/experimentation/learning_studies/test_d2_feedback_schedules.py
+++ b/tests/experimentation/learning_studies/test_d2_feedback_schedules.py
@@ -1,0 +1,424 @@
+"""Targeted proofs for LS-07 feedback views and composed schedules."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from aec_bench.contracts.agent_output import AgentOutput, AgentOutputStatus
+from aec_bench.contracts.evaluation_result import EvaluationResult, ValidityCheck
+from aec_bench.contracts.experiment_manifest import AgentConfig, ComputeConfig
+from aec_bench.contracts.learning_study import (
+    ConsolidateStep,
+    ExperienceRole,
+    LearningArmSpec,
+    LearningExperienceSpec,
+    LearningStudySpec,
+    ReleaseFeedbackStep,
+    RunExperienceStep,
+    StudyArmRole,
+)
+from aec_bench.contracts.trial_record import TrialInput, TrialOutput
+from aec_bench.experimentation.learning_studies.errors import LearningStudyOrderInvalid
+from aec_bench.experimentation.learning_studies.lifecycles import (
+    LifecycleExecutionCondition,
+    LifecycleLearningTreatmentKind,
+    build_lifecycle_learning_operations,
+    resolve_lifecycle_learning_target,
+)
+from aec_bench.experimentation.learning_studies.planning import (
+    CompiledExperienceStep,
+    CompiledFeedbackStep,
+    compile_learning_study,
+)
+from aec_bench.experimentation.learning_studies.runtime import ExecuteExperienceRequest, ReleaseFeedbackRequest
+from aec_bench.lifecycles.compiled import compile_lifecycle
+from aec_bench.lifecycles.runtime.episode import LifecycleExecutionMode, LifecycleVisibilityPolicy
+from aec_bench.lifecycles.runtime.lifecycle import run_lifecycle
+from aec_bench.lifecycles.stormwater_design.drainage_learning import (
+    DRAINAGE_ACQUISITION_TASK_ID,
+    DRAINAGE_CHECKPOINT_DETAILED_FEEDBACK_VIEW_ID,
+    DRAINAGE_PHASE_SUMMARY_FEEDBACK_VIEW_ID,
+    DRAINAGE_TERMINAL_FEEDBACK_VIEW_ID,
+    drainage_checkpoint_detailed_feedback,
+    drainage_phase_summary_feedback,
+    drainage_terminal_feedback,
+    validate_drainage_checkpoint_detailed_feedback,
+    validate_drainage_phase_summary_feedback,
+    validate_drainage_terminal_feedback,
+)
+from aec_bench.lifecycles.stormwater_design.drainage_model import (
+    TEMPLATE_ID,
+    verify_drainage_model_lifecycle,
+)
+from tests.support.lifecycle_episode import deterministic_episode_environment
+from tests.support.trial_record_factories import make_trial_record
+
+_PROBE_TASK_ID = f"lifecycle/{TEMPLATE_ID}/semantic_no_op_release"
+_CONDITION = LifecycleExecutionCondition(
+    execution_mode=LifecycleExecutionMode.FRESH_CONTEXT,
+    visibility_policy=LifecycleVisibilityPolicy.ARTIFACT_MEMORY,
+)
+_AGENT = AgentConfig(
+    name="d2-feedback-test-agent",
+    adapter="tool_loop",
+    model="fixed-test-model",
+    parameters={"max_turns_per_session": 5},
+)
+_COMPUTE = ComputeConfig(backend="local", resource_limits={"memory_mb": 512}, timeout_override=30)
+
+
+def _spec(
+    steps: tuple[object, ...],
+    *,
+    experiences: tuple[LearningExperienceSpec, ...] | None = None,
+) -> LearningStudySpec:
+    return LearningStudySpec(
+        study_id="d2-feedback-schedule",
+        title="D2 feedback schedule",
+        research_question="Can feedback schedules be composed from existing steps?",
+        agent=_AGENT,
+        compute=_COMPUTE,
+        experiences=experiences
+        or (
+            LearningExperienceSpec(
+                experience_id="acquisition",
+                task_id=DRAINAGE_ACQUISITION_TASK_ID,
+                role=ExperienceRole.ACQUISITION,
+            ),
+            LearningExperienceSpec(experience_id="probe", task_id=_PROBE_TASK_ID, role=ExperienceRole.PROBE),
+        ),
+        arms=(
+            LearningArmSpec(
+                arm_id="schedule",
+                role=StudyArmRole.EXPOSURE,
+                treatment_id="structured-memory",
+                steps=steps,
+            ),
+        ),
+    )
+
+
+def _compile(steps: tuple[object, ...], *, experiences: tuple[LearningExperienceSpec, ...] | None = None):
+    return compile_learning_study(
+        study_run_id="d2-schedule-test",
+        spec=_spec(steps, experiences=experiences),
+        resolve_task=resolve_lifecycle_learning_target,
+    )
+
+
+@pytest.mark.parametrize(
+    ("schedule", "steps"),
+    (
+        (
+            "no-feedback",
+            (
+                RunExperienceStep(step_id="acq", experience_id="acquisition"),
+                RunExperienceStep(step_id="probe", experience_id="probe", commit_post_state=False),
+            ),
+        ),
+        (
+            "terminal-only",
+            (
+                RunExperienceStep(step_id="acq", experience_id="acquisition"),
+                ReleaseFeedbackStep(
+                    step_id="release",
+                    source_experience_id="acquisition",
+                    feedback_view_id=DRAINAGE_TERMINAL_FEEDBACK_VIEW_ID,
+                ),
+                ConsolidateStep(step_id="consolidate", feedback_step_ids=("release",), operation_id="memory"),
+                RunExperienceStep(step_id="probe", experience_id="probe", commit_post_state=False),
+            ),
+        ),
+        (
+            "immediate-checkpoint",
+            (
+                RunExperienceStep(step_id="acq", experience_id="acquisition"),
+                ReleaseFeedbackStep(
+                    step_id="release",
+                    source_experience_id="acquisition",
+                    feedback_view_id=DRAINAGE_CHECKPOINT_DETAILED_FEEDBACK_VIEW_ID,
+                ),
+                ConsolidateStep(step_id="consolidate", feedback_step_ids=("release",), operation_id="memory"),
+                RunExperienceStep(step_id="probe", experience_id="probe", commit_post_state=False),
+            ),
+        ),
+        (
+            "summary-after-phase",
+            (
+                RunExperienceStep(step_id="acq", experience_id="acquisition"),
+                ReleaseFeedbackStep(
+                    step_id="release",
+                    source_experience_id="acquisition",
+                    feedback_view_id=DRAINAGE_PHASE_SUMMARY_FEEDBACK_VIEW_ID,
+                ),
+                ConsolidateStep(step_id="consolidate", feedback_step_ids=("release",), operation_id="memory"),
+                RunExperienceStep(step_id="probe", experience_id="probe", commit_post_state=False),
+            ),
+        ),
+    ),
+)
+def test_named_feedback_schedule_compiles_through_planner(schedule: str, steps: tuple[object, ...]) -> None:
+    plan = _compile(steps)
+    assert plan.arm_runs[0].steps
+    assert schedule in {"no-feedback", "terminal-only", "immediate-checkpoint", "summary-after-phase"}
+
+
+def test_delayed_checkpoint_feedback_compiles_after_multiple_acquisitions() -> None:
+    experiences = (
+        LearningExperienceSpec(
+            experience_id="acquisition-1",
+            task_id=DRAINAGE_ACQUISITION_TASK_ID,
+            role=ExperienceRole.ACQUISITION,
+        ),
+        LearningExperienceSpec(
+            experience_id="acquisition-2",
+            task_id=DRAINAGE_ACQUISITION_TASK_ID,
+            role=ExperienceRole.PRACTICE,
+        ),
+        LearningExperienceSpec(experience_id="probe", task_id=_PROBE_TASK_ID, role=ExperienceRole.PROBE),
+    )
+    plan = _compile(
+        (
+            RunExperienceStep(step_id="acq-1", experience_id="acquisition-1"),
+            RunExperienceStep(step_id="acq-2", experience_id="acquisition-2"),
+            ReleaseFeedbackStep(
+                step_id="release-1",
+                source_experience_id="acquisition-1",
+                feedback_view_id=DRAINAGE_CHECKPOINT_DETAILED_FEEDBACK_VIEW_ID,
+            ),
+            ReleaseFeedbackStep(
+                step_id="release-2",
+                source_experience_id="acquisition-2",
+                feedback_view_id=DRAINAGE_CHECKPOINT_DETAILED_FEEDBACK_VIEW_ID,
+            ),
+            ConsolidateStep(
+                step_id="consolidate",
+                feedback_step_ids=("release-1", "release-2"),
+                operation_id="memory",
+            ),
+            RunExperienceStep(step_id="probe", experience_id="probe", commit_post_state=False),
+        ),
+        experiences=experiences,
+    )
+    assert [step.step_id for step in plan.arm_runs[0].steps] == [
+        "acq-1",
+        "acq-2",
+        "release-1",
+        "release-2",
+        "consolidate",
+        "probe",
+    ]
+
+
+def test_planner_rejects_duplicate_source_and_feedback_view_pair() -> None:
+    steps = (
+        RunExperienceStep(step_id="acq", experience_id="acquisition"),
+        ReleaseFeedbackStep(
+            step_id="release-1",
+            source_experience_id="acquisition",
+            feedback_view_id=DRAINAGE_CHECKPOINT_DETAILED_FEEDBACK_VIEW_ID,
+        ),
+        ReleaseFeedbackStep(
+            step_id="release-2",
+            source_experience_id="acquisition",
+            feedback_view_id=DRAINAGE_CHECKPOINT_DETAILED_FEEDBACK_VIEW_ID,
+        ),
+    )
+    with pytest.raises(LearningStudyOrderInvalid, match="feedback view was already released"):
+        _compile(steps)
+
+
+def test_immediate_and_delayed_arms_use_same_tasks_but_different_release_timing() -> None:
+    experiences = (
+        LearningExperienceSpec(
+            experience_id="acquisition",
+            task_id=DRAINAGE_ACQUISITION_TASK_ID,
+            role=ExperienceRole.ACQUISITION,
+        ),
+        LearningExperienceSpec(
+            experience_id="acquisition-repeat",
+            task_id=DRAINAGE_ACQUISITION_TASK_ID,
+            role=ExperienceRole.PRACTICE,
+        ),
+        LearningExperienceSpec(experience_id="probe", task_id=_PROBE_TASK_ID, role=ExperienceRole.PROBE),
+    )
+    immediate = _compile(
+        (
+            RunExperienceStep(step_id="acq", experience_id="acquisition"),
+            ReleaseFeedbackStep(
+                step_id="release",
+                source_experience_id="acquisition",
+                feedback_view_id=DRAINAGE_CHECKPOINT_DETAILED_FEEDBACK_VIEW_ID,
+            ),
+            RunExperienceStep(step_id="probe", experience_id="probe", commit_post_state=False),
+        ),
+        experiences=experiences,
+    )
+    delayed = _compile(
+        (
+            RunExperienceStep(step_id="acq-1", experience_id="acquisition"),
+            RunExperienceStep(step_id="acq-2", experience_id="acquisition-repeat"),
+            ReleaseFeedbackStep(
+                step_id="release-1",
+                source_experience_id="acquisition",
+                feedback_view_id=DRAINAGE_CHECKPOINT_DETAILED_FEEDBACK_VIEW_ID,
+            ),
+            ReleaseFeedbackStep(
+                step_id="release-2",
+                source_experience_id="acquisition-repeat",
+                feedback_view_id=DRAINAGE_CHECKPOINT_DETAILED_FEEDBACK_VIEW_ID,
+            ),
+            RunExperienceStep(step_id="probe", experience_id="probe", commit_post_state=False),
+        ),
+        experiences=experiences,
+    )
+    immediate_steps = immediate.arm_runs[0].steps
+    delayed_steps = delayed.arm_runs[0].steps
+    assert [step.step_id for step in immediate_steps] == ["acq", "release", "probe"]
+    assert [step.step_id for step in delayed_steps] == ["acq-1", "acq-2", "release-1", "release-2", "probe"]
+    assert all(
+        isinstance(step, CompiledExperienceStep) and step.trial.task_id == DRAINAGE_ACQUISITION_TASK_ID
+        for step in delayed_steps[:2]
+    )
+    assert isinstance(immediate_steps[1], CompiledFeedbackStep)
+    assert isinstance(delayed_steps[2], CompiledFeedbackStep)
+
+
+def _completed_acquisition_record(tmp_path: Path):  # noqa: ANN202
+    package = compile_lifecycle(
+        TEMPLATE_ID,
+        tmp_path / "experience" / "package",
+        variant_id="staged_full_correction",
+    ).package_dir
+    run = tmp_path / "experience" / "run"
+    gold = json.loads((package / "hidden" / "gold-submissions.json").read_text(encoding="utf-8"))
+
+    def resolve(context: dict) -> dict:
+        output = Path(context["submission_path"])
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(gold[context["checkpoint_id"]]), encoding="utf-8")
+        return {"status": "completed"}
+
+    run_lifecycle(package, run, episode_environment=deterministic_episode_environment(resolve))
+    verification = verify_drainage_model_lifecycle(package, run)
+    record = make_trial_record(
+        task_id=DRAINAGE_ACQUISITION_TASK_ID,
+        input=TrialInput(
+            instruction="Complete the drainage review lifecycle.",
+            task_revision="test",
+            task_kind="lifecycle",
+        ),
+        output=TrialOutput(
+            agent_output=AgentOutput(
+                status=AgentOutputStatus.COMPLETED,
+                output_path=str(run),
+                output_format="evidence_lifecycle",
+            ),
+            terminated=True,
+            final_reason="completed",
+        ),
+        evaluation=EvaluationResult(
+            reward=verification["reward"],
+            validity=ValidityCheck(output_parseable=True, schema_valid=True, verifier_completed=True),
+            breakdown={"lifecycle_gates": verification["gates"]},
+        ),
+    )
+    return record
+
+
+def test_drainage_feedback_views_have_distinct_detail_levels_and_safe_allowlists(tmp_path: Path) -> None:
+    record = _completed_acquisition_record(tmp_path)
+    detailed = drainage_checkpoint_detailed_feedback(record)
+    phase = drainage_phase_summary_feedback(record)
+    terminal = drainage_terminal_feedback(record)
+
+    detailed_payload = validate_drainage_checkpoint_detailed_feedback(detailed)
+    phase_payload = validate_drainage_phase_summary_feedback(phase)
+    terminal_payload = validate_drainage_terminal_feedback(terminal)
+    assert set(detailed_payload["checkpoints"]) == {"initial_review", "response_review", "closeout_review"}
+    assert all("review_matrix" in item and "gate_scores" in item for item in detailed_payload["checkpoints"].values())
+    assert set(phase_payload["phases"]) == {"evidence_assessment", "response_and_closeout"}
+    assert "checkpoints" not in phase_payload
+    assert "checkpoints" not in terminal_payload
+    assert "canonical_reward" in terminal_payload["terminal_outcome"]
+    for data in (detailed, phase, terminal):
+        text = data.decode()
+        assert "gold-submissions" not in text
+        assert "verifier-config" not in text
+        assert "expected_answer" not in text
+        assert str(tmp_path) not in text
+
+    with pytest.raises(ValueError, match="fields do not match"):
+        validate_drainage_checkpoint_detailed_feedback(detailed.replace(b'"checkpoints":', b'"private_path":'))
+    with pytest.raises(ValueError, match="fields do not match"):
+        validate_drainage_phase_summary_feedback(phase.replace(b'"phases":', b'"gold":'))
+
+
+class _GoldLifecycleAdapterBuilder:
+    def __call__(self, **kwargs):  # noqa: ANN003, ANN202
+        package = Path(kwargs["workspace"]).parent.parent / "package"
+        gold = json.loads((package / "hidden" / "gold-submissions.json").read_text(encoding="utf-8"))
+
+        class _Adapter:
+            def execute(self, request):  # noqa: ANN001, ANN202
+                output = Path(request.output_path)
+                output.parent.mkdir(parents=True, exist_ok=True)
+                output.write_text(json.dumps(gold[output.stem]), encoding="utf-8")
+                return SimpleNamespace(
+                    adapter_name="tool_loop",
+                    resolved_model="fixed-test-model",
+                    configuration_record={"model": "fixed-test-model"},
+                    agent_output=SimpleNamespace(status=SimpleNamespace(value="completed")),
+                    transcript=[],
+                    raw_output_text=None,
+                    provider_error=None,
+                    failure_kind=None,
+                    usage_input_tokens=1,
+                    usage_output_tokens=1,
+                    usage_cache_read_tokens=0,
+                    usage_cache_write_tokens=0,
+                )
+
+        return _Adapter()
+
+
+def test_new_feedback_view_flows_through_coordinator_after_acquisition(tmp_path: Path) -> None:
+    plan = _compile(
+        (
+            RunExperienceStep(step_id="acq", experience_id="acquisition"),
+            ReleaseFeedbackStep(
+                step_id="release",
+                source_experience_id="acquisition",
+                feedback_view_id=DRAINAGE_CHECKPOINT_DETAILED_FEEDBACK_VIEW_ID,
+            ),
+        )
+    )
+    binding = build_lifecycle_learning_operations(
+        run_root=tmp_path / "study",
+        execution_condition=_CONDITION,
+        treatment_kinds={"structured-memory": LifecycleLearningTreatmentKind.STRUCTURED_MEMORY},
+        feedback_projectors={DRAINAGE_CHECKPOINT_DETAILED_FEEDBACK_VIEW_ID: drainage_checkpoint_detailed_feedback},
+        adapter_builder=_GoldLifecycleAdapterBuilder(),
+    )
+    arm_run = plan.arm_runs[0]
+    state = binding.operations.initialise_learner(arm_run)
+    experience_step, feedback_step = arm_run.steps
+    assert isinstance(experience_step, CompiledExperienceStep)
+    assert isinstance(feedback_step, CompiledFeedbackStep)
+    execution = binding.operations.execute_experience(
+        ExecuteExperienceRequest(arm_run=arm_run, step=experience_step, state=state)
+    )
+    released = binding.operations.release_feedback(
+        ReleaseFeedbackRequest(
+            arm_run=arm_run,
+            step=feedback_step,
+            state=execution.candidate_state,
+            source_trial_record=execution.trial_record,
+        )
+    )
+    assert released.feedback.value.path.read_bytes() == drainage_checkpoint_detailed_feedback(execution.trial_record)
+    assert released.feedback.value.artifact.size_bytes == released.feedback.value.path.stat().st_size


### PR DESCRIPTION
## Summary

Implements D2 of Release B Lifecycle Tranche 3 (LS-07): feedback-schedule composition, per `LS-07B-feedback-schedule-composition.md`. Depends on D1 (the phase-evidence extension).

- Three new task-owned drainage feedback views, each a different cross-experience detail level, alongside the existing `drainage-staged-review-public-feedback` (which already carries full checkpoint submissions and review principles):
  - `drainage-checkpoint-detailed-feedback` -- per-checkpoint pass/fail, bounded per-gate scores, review-matrix outcomes.
  - `drainage-phase-summary-feedback` -- phase-level summaries built from the D1 phase-evidence extension (a separate mechanism -- this is a between-lifecycle feedback view, not the observational extension artefact itself).
  - `drainage-terminal-feedback` -- reward, completion status, validity, and overall gates only -- the coarsest level.
- All three follow the existing `drainage_staged_review_feedback` projector/validator pattern and the existing feedback-safety discipline (bounded allowlisted fields, no hidden/gold/verifier/host-path material).
- The five named feedback schedules (no feedback, terminal-only, immediate-checkpoint, delayed-checkpoint, summary-after-phase) are composed entirely from the existing `RunExperienceStep`/`ReleaseFeedbackStep`/`ConsolidateStep` primitives and the planner's existing `(source_experience_id, feedback_view_id)` uniqueness rule -- **no common contract or planner change**.

## Scope decision carried from LS-07B

Per LS-07B §4, "checkpoint feedback timing" is interpreted as cross-experience release timing/detail level, not within-lifecycle checkpoint release timing (which remains lifecycle-runtime-owned and untouched). This is a deliberate, reviewed scope narrowing, not an oversight.

## Scope boundaries

No scaffolding variants or L03 study content in this PR (separate follow-up, D3, based on this branch). No changes to worlds, Gate C, harness-update, model weights, or common contracts.

## Testing

```
uv run pytest \
  tests/experimentation/learning_studies/test_planning.py \
  tests/experimentation/learning_studies/test_protocol_collection.py \
  tests/experimentation/learning_studies/test_lifecycles.py \
  tests/experimentation/learning_studies/test_l01_drainage.py \
  tests/experimentation/learning_studies/test_l02_drainage.py \
  tests/experimentation/learning_studies/test_phase_evidence.py \
  tests/experimentation/learning_studies/test_d2_feedback_schedules.py \
  tests/lifecycles/stormwater_design/test_drainage_lifecycle.py
```

96 passed, including tests compiling all five named schedule patterns through the real planner, a negative test proving the planner rejects a duplicate `(source, view)` release pair, a structural immediate-vs-delayed comparison, and a coordinator-level round trip (`execute_experience` -> `release_feedback`) for one of the new views.

`uv run ruff check` and `uv run ruff format --check` (including the CI-gated `stormwater_design/` path) both clean. `uv run python scripts/check_provenance_fields.py --check --base-revision main` passes with 0 violations.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
