### PR TITLE
feat: add L03 drainage scaffolding-transfer study (Release B, Lifecycle Tranche 3, D3)

### DIFF
--- a/src/aec_bench/experimentation/learning_studies/l03_drainage.py
+++ b/src/aec_bench/experimentation/learning_studies/l03_drainage.py
@@ -1,0 +1,552 @@
+# ABOUTME: Composes and assesses the first lifecycle-backed Learning Study vertical slice.
+# ABOUTME: Keeps L03 treatment, projection, and evidence policy in explicit study-owned glue.
+
+from __future__ import annotations
+
+import asyncio
+import math
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, TypeVar, cast
+
+from pydantic import BaseModel
+
+from aec_bench.contracts.experiment_manifest import AgentConfig, ComputeConfig
+from aec_bench.contracts.learning_study import ExperienceRole, LearningStudySpec
+from aec_bench.contracts.learning_study_assessment import LearningStudyAssessment
+from aec_bench.contracts.learning_study_evidence import (
+    FeedbackReleaseRecord,
+    LearnerStateRef,
+    LearnerTransitionReceipt,
+    RecordedStudyExecution,
+    StudyStepReceipt,
+    StudyStepStatus,
+)
+from aec_bench.contracts.trial_record import EvaluationStatus, TrialRecord
+from aec_bench.experimentation.learning_studies.assessment import (
+    AssessmentArmEvidence,
+    OutcomeProjection,
+    ProjectionResult,
+    assess_learning_study,
+)
+from aec_bench.experimentation.learning_studies.learner_state import (
+    validate_learner_state,
+)
+from aec_bench.experimentation.learning_studies.lifecycles import (
+    LifecycleConsolidationOperation,
+    LifecycleExecutionCondition,
+    LifecycleFeedback,
+    LifecycleLearningBinding,
+    LifecycleLearningTreatmentKind,
+    build_lifecycle_learning_operations,
+    resolve_lifecycle_learning_target,
+)
+from aec_bench.experimentation.learning_studies.planning import (
+    CompiledConsolidationStep,
+    CompiledExperienceStep,
+    CompiledFeedbackStep,
+    CompiledLearningStudy,
+    PlannedArmRun,
+    compile_learning_study,
+)
+from aec_bench.experimentation.learning_studies.protocol_collection import (
+    BUILTIN_LEARNING_STUDY_PROTOCOLS,
+    load_learning_study_protocol,
+)
+from aec_bench.experimentation.learning_studies.recording import StudyRunRecorder
+from aec_bench.experimentation.learning_studies.runtime import (
+    ArmRunExecutionResult,
+    ArmRunStatus,
+    LearningStudyExecution,
+    run_learning_study,
+)
+from aec_bench.lifecycles.runtime.episode import LifecycleExecutionMode, LifecycleVisibilityPolicy
+from aec_bench.lifecycles.stormwater_design.drainage_learning import (
+    DRAINAGE_CHECKPOINT_DETAILED_FEEDBACK_VIEW_ID,
+    drainage_checkpoint_detailed_feedback,
+    drainage_gate_score,
+    drainage_phase_completion,
+    extract_drainage_learning_evidence,
+    validate_drainage_checkpoint_detailed_feedback,
+)
+
+L03_DRAINAGE_PROTOCOL_ID = "l03-drainage-scaffolding-transfer"
+L03_DRAINAGE_STUDY_ID = "l03-drainage-scaffolding-transfer"
+L03_CONSOLIDATION_OPERATION_ID = "update-lifecycle-review-memory"
+L03_PROBE_TASK_ID = "lifecycle/drainage-model-evidence-lifecycle-review/staged_full_correction"
+L03_ACQUISITION_TASK_ID = "lifecycle/drainage-model-evidence-lifecycle-review/staged_full_correction"
+L03_EXECUTION_CONDITION = LifecycleExecutionCondition(
+    execution_mode=LifecycleExecutionMode.FRESH_CONTEXT,
+    visibility_policy=LifecycleVisibilityPolicy.ARTIFACT_MEMORY,
+)
+
+_GATE_PROJECTIONS = {
+    "drainage.staged-disclosure": "staged_disclosure",
+    "drainage.finding-continuity": "finding_continuity",
+    "drainage.closure-evidence": "closure_evidence",
+    "drainage.accepted-decision-preservation": "accepted_decision_preservation",
+    "drainage.claim-boundary": "claim_boundary",
+}
+_FORBIDDEN_LEARNER_MARKERS = (
+    b"/hidden/",
+    b"expected_answer",
+    b"gold-submissions",
+    b"private_path",
+    b"semantic_no_op_release",
+    b"verifier-config",
+)
+_FORBIDDEN_LEARNER_FILENAMES = {
+    "experiment-manifest.json",
+    "gold-submissions.json",
+    "metrics.json",
+    "verification.json",
+}
+ModelT = TypeVar("ModelT", bound=BaseModel)
+
+
+@dataclass(frozen=True)
+class L03DrainageRun:
+    spec: LearningStudySpec
+    plan: CompiledLearningStudy
+    execution: LearningStudyExecution[LifecycleFeedback]
+    arm_evidence: Mapping[str, AssessmentArmEvidence]
+    unreviewed_assessment: LearningStudyAssessment
+    reviewed_assessment: LearningStudyAssessment
+
+
+def load_l03_drainage_protocol(
+    *,
+    agent: AgentConfig,
+    compute: ComputeConfig,
+    repetitions: int = 1,
+) -> LearningStudySpec:
+    """Load the maintained L03 protocol with one explicit run configuration."""
+
+    return load_learning_study_protocol(
+        BUILTIN_LEARNING_STUDY_PROTOCOLS / L03_DRAINAGE_PROTOCOL_ID,
+        agent=agent,
+        compute=compute,
+        repetitions=repetitions,
+    )
+
+
+def compile_l03_drainage_study(
+    *,
+    study_run_id: str,
+    agent: AgentConfig,
+    compute: ComputeConfig,
+    repetitions: int = 1,
+) -> CompiledLearningStudy:
+    """Compile L03 into ordinary planned lifecycle trials."""
+
+    spec = load_l03_drainage_protocol(agent=agent, compute=compute, repetitions=repetitions)
+    return compile_learning_study(
+        study_run_id=study_run_id,
+        spec=spec,
+        resolve_task=resolve_lifecycle_learning_target,
+    )
+
+
+def build_l03_drainage_binding(
+    *,
+    run_root: Path,
+    consolidation_operation: LifecycleConsolidationOperation,
+    adapter_builder: Callable[..., Any] | None = None,
+    resume_existing_run: bool = False,
+) -> LifecycleLearningBinding:
+    """Bind L03's two treatments, one feedback view, and one consolidation operation."""
+
+    return build_lifecycle_learning_operations(
+        run_root=run_root,
+        execution_condition=L03_EXECUTION_CONDITION,
+        treatment_kinds={
+            "reset": LifecycleLearningTreatmentKind.RESET,
+            "structured-memory": LifecycleLearningTreatmentKind.STRUCTURED_MEMORY,
+        },
+        feedback_projectors={DRAINAGE_CHECKPOINT_DETAILED_FEEDBACK_VIEW_ID: drainage_checkpoint_detailed_feedback},
+        phase_evidence_extractors={"drainage-model-evidence-lifecycle-review": extract_drainage_learning_evidence},
+        consolidation_operations={L03_CONSOLIDATION_OPERATION_ID: consolidation_operation},
+        adapter_builder=adapter_builder,
+        resume_existing_run=resume_existing_run,
+    )
+
+
+def l03_drainage_outcome_projections() -> dict[str, OutcomeProjection]:
+    """Return the explicit L03 projection mapping without global registration."""
+
+    projections: dict[str, OutcomeProjection] = {
+        "lifecycle.canonical-reward": _project_probe_reward,
+        "drainage.phase-completion": _project_phase_completion,
+    }
+    projections.update(
+        {projection_id: _gate_projection(gate_id) for projection_id, gate_id in _GATE_PROJECTIONS.items()}
+    )
+    return projections
+
+
+async def run_l03_drainage_study(
+    *,
+    run_root: Path,
+    study_run_id: str,
+    agent: AgentConfig,
+    compute: ComputeConfig,
+    consolidation_operation: LifecycleConsolidationOperation,
+    adapter_builder: Callable[..., Any] | None = None,
+    repetitions: int = 1,
+) -> L03DrainageRun:
+    """Run, record, and assess L03 under both relation-review states."""
+
+    plan = compile_l03_drainage_study(
+        study_run_id=study_run_id,
+        agent=agent,
+        compute=compute,
+        repetitions=repetitions,
+    )
+    binding = build_l03_drainage_binding(
+        run_root=run_root,
+        consolidation_operation=consolidation_operation,
+        adapter_builder=adapter_builder,
+    )
+    recorder = StudyRunRecorder(
+        root=run_root,
+        plan=plan,
+        snapshot_state=binding.snapshot_state,
+        feedback_artifacts=binding.feedback_artifacts,
+    )
+    execution = await run_learning_study(plan=plan, operations=binding.operations, observer=recorder)
+    arm_evidence = build_l03_assessment_arm_evidence(
+        run_root=run_root,
+        plan=plan,
+        execution=execution,
+    )
+    projections = l03_drainage_outcome_projections()
+    assessment_execution = cast(LearningStudyExecution[object], execution)
+    return L03DrainageRun(
+        spec=plan.spec,
+        plan=plan,
+        execution=execution,
+        arm_evidence=arm_evidence,
+        unreviewed_assessment=assess_learning_study(
+            spec=plan.spec,
+            plan=plan,
+            execution=assessment_execution,
+            projections=projections,
+            arm_evidence=arm_evidence,
+            relations_reviewed=False,
+        ),
+        reviewed_assessment=assess_learning_study(
+            spec=plan.spec,
+            plan=plan,
+            execution=assessment_execution,
+            projections=projections,
+            arm_evidence=arm_evidence,
+            relations_reviewed=True,
+        ),
+    )
+
+
+def run_l03_drainage_study_sync(**kwargs: Any) -> L03DrainageRun:
+    """Run L03 from synchronous research and test entry points."""
+
+    return asyncio.run(run_l03_drainage_study(**kwargs))
+
+
+def build_l03_assessment_arm_evidence(
+    *,
+    run_root: Path,
+    plan: CompiledLearningStudy,
+    execution: LearningStudyExecution[LifecycleFeedback],
+) -> dict[str, AssessmentArmEvidence]:
+    """Derive every assessment fact from the completed plan and persisted evidence."""
+
+    root = Path(run_root).resolve(strict=True)
+    if plan.spec.study_id != L03_DRAINAGE_STUDY_ID or execution.study_run_id != plan.study_run_id:
+        raise ValueError("assessment-evidence-incomplete: inputs do not identify L03")
+    execution_by_arm = {item.arm_run_id: item for item in execution.arm_runs}
+    evidence: dict[str, AssessmentArmEvidence] = {}
+    for arm_run in plan.arm_runs:
+        arm_result = execution_by_arm.get(arm_run.arm_run_id)
+        if arm_result is None or arm_result.initial_state_id is None:
+            raise ValueError(f"assessment-evidence-incomplete: arm result is missing: {arm_run.arm_run_id}")
+        initial_ref = _read_model(
+            root / "states" / f"{arm_result.initial_state_id}.json",
+            LearnerStateRef,
+        )
+        if initial_ref.arm_run_id != arm_run.arm_run_id or initial_ref.parent_state_id is not None:
+            raise ValueError(f"assessment-evidence-incomplete: initial state is invalid: {arm_run.arm_run_id}")
+        evidence[arm_run.arm_run_id] = AssessmentArmEvidence(
+            adapter_id=L03_EXECUTION_CONDITION.adapter_id,
+            initial_state_equivalence_id=_initial_state(root / "learner-arms" / arm_run.arm_run_id, initial_ref),
+            arm_isolated=_arm_isolated(root, arm_run, arm_result),
+            lineage_complete=_lineage_complete(root, plan, arm_run, arm_result),
+            probe_feedback_hidden=_probe_feedback_hidden(root, plan.spec, arm_run, arm_result),
+            probe_state_discarded=_probe_state_discarded(root, arm_run),
+            hidden_evaluation_leaked=not _hidden_evaluation_absent(root, arm_run),
+        )
+    return evidence
+
+
+def _initial_state(arm_root: Path, initial_ref: LearnerStateRef) -> str:
+    """Use semantic empty-state equivalence across treatment-owned channel layouts."""
+
+    state_root = arm_root / "states" / "initial"
+    try:
+        top_level = {path.name: path for path in state_root.iterdir()}
+        if set(top_level) == {"history", "feedback", "memory"}:
+            if any(not path.is_dir() for path in top_level.values()):
+                raise ValueError("raw-history initial state channels are invalid")
+        else:
+            validate_learner_state(state_root)
+        if any(path.is_file() for path in state_root.rglob("*")):
+            raise ValueError("initial learner state contains committed content")
+    except (OSError, ValueError) as error:
+        raise ValueError(
+            f"assessment-evidence-incomplete: initial state is not empty: {initial_ref.state_id}"
+        ) from error
+    return "lifecycle-initial-state:empty"
+
+
+def _project_probe_reward(record: TrialRecord) -> ProjectionResult:
+    if record.task_id != L03_PROBE_TASK_ID:
+        return _ineligible(f"projection-task-mismatch: {record.task_id}")
+    if record.evaluation_status is not EvaluationStatus.COMPLETED or record.evaluation is None:
+        return _ineligible("projection-evaluation-missing: lifecycle evaluation is unavailable")
+    if not record.evaluation.validity.verifier_completed:
+        return _ineligible("projection-evaluation-missing: lifecycle verifier did not complete")
+    reward = record.evaluation.reward
+    if isinstance(reward, bool) or not isinstance(reward, int | float) or not math.isfinite(reward):
+        return _ineligible("projection-value-invalid: canonical reward is not finite")
+    value = float(reward)
+    if not 0.0 <= value <= 1.0:
+        return _ineligible("projection-value-out-of-bounds: canonical reward is outside [0, 1]")
+    return ProjectionResult(eligible=True, value=value, lower_bound=0.0, upper_bound=1.0)
+
+
+def _gate_projection(gate_id: str) -> OutcomeProjection:
+    def project(record: TrialRecord) -> ProjectionResult:
+        if record.task_id != L03_PROBE_TASK_ID:
+            return _ineligible(f"projection-task-mismatch: {record.task_id}")
+        try:
+            value = drainage_gate_score(record, gate_id)
+        except ValueError as error:
+            return _ineligible(str(error))
+        return ProjectionResult(eligible=True, value=value, lower_bound=0.0, upper_bound=1.0)
+
+    return project
+
+
+def _project_phase_completion(record: TrialRecord) -> ProjectionResult:
+    return drainage_phase_completion(record)
+
+
+def _ineligible(reason: str) -> ProjectionResult:
+    return ProjectionResult(eligible=False, value=None, reason=reason)
+
+
+def _arm_isolated(root: Path, arm_run: PlannedArmRun, result: ArmRunExecutionResult[LifecycleFeedback]) -> bool:
+    try:
+        arm_root = root / "learner-arms" / arm_run.arm_run_id
+        if (
+            not arm_root.is_dir()
+            or arm_root.is_symlink()
+            or arm_root.resolve(strict=True).parent != (root / "learner-arms")
+        ):
+            return False
+        for step_result in result.completed_steps:
+            if step_result.trial_record is None:
+                continue
+            expected = arm_root / "lifecycle-experiences" / step_result.step_id
+            package = expected / "package"
+            run = expected / "run"
+            output = step_result.trial_record.output
+            if (
+                not package.is_dir()
+                or package.is_symlink()
+                or not run.is_dir()
+                or run.is_symlink()
+                or output is None
+                or output.agent_output is None
+                or Path(output.agent_output.output_path).resolve(strict=True) != run.resolve(strict=True)
+            ):
+                return False
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def _lineage_complete(
+    root: Path,
+    plan: CompiledLearningStudy,
+    arm_run: PlannedArmRun,
+    result: ArmRunExecutionResult[LifecycleFeedback],
+) -> bool:
+    try:
+        if result.status is not ArmRunStatus.COMPLETED or result.initial_state_id is None:
+            return False
+        if len(result.completed_steps) != len(arm_run.steps):
+            return False
+        current_state_id = result.initial_state_id
+        for index, step in enumerate(arm_run.steps):
+            receipt = _read_model(
+                root / "steps" / arm_run.arm_run_id / f"{index:03d}-{step.step_id}.json",
+                StudyStepReceipt,
+            )
+            if receipt.status is not StudyStepStatus.COMPLETED or receipt.transition_id is None:
+                return False
+            transition = _read_model(root / "transitions" / f"{receipt.transition_id}.json", LearnerTransitionReceipt)
+            if transition.arm_run_id != arm_run.arm_run_id or transition.step_id != step.step_id:
+                return False
+            if transition.state_before_id != current_state_id:
+                return False
+            expected_kind = "consolidation"
+            expected_committed = True
+            if isinstance(step, CompiledExperienceStep):
+                expected_kind = "experience" if step.commit_post_state else "probe_discard"
+                expected_committed = step.commit_post_state
+            elif isinstance(step, CompiledFeedbackStep):
+                expected_kind = "feedback_release"
+                if receipt.feedback_id is None:
+                    return False
+                feedback = _read_model(root / "feedback" / f"{receipt.feedback_id}.json", FeedbackReleaseRecord)
+                if (
+                    feedback.arm_run_id != arm_run.arm_run_id
+                    or feedback.release_step_id != step.step_id
+                    or feedback.source_experience_id != step.source_experience_id
+                    or feedback.view_id != step.feedback_view_id
+                    or feedback.state_before_id != current_state_id
+                    or feedback.state_after_id != transition.committed_state_id
+                ):
+                    return False
+            elif isinstance(step, CompiledConsolidationStep):
+                expected_kind = "consolidation"
+            if transition.operation_kind != expected_kind or transition.committed is not expected_committed:
+                return False
+            if expected_committed:
+                state_ref = _read_model(
+                    root / "states" / f"{transition.candidate_state_id}.json",
+                    LearnerStateRef,
+                )
+                if state_ref.parent_state_id != current_state_id or state_ref.created_after_step_id != step.step_id:
+                    return False
+            if transition.committed_state_id is None:
+                return False
+            current_state_id = transition.committed_state_id
+        recorded = _read_model(root / "result.json", RecordedStudyExecution)
+        recorded_arm = next(item for item in recorded.arm_runs if item.arm_run_id == arm_run.arm_run_id)
+        return result.final_state_id == current_state_id == recorded_arm.final_state_id
+    except (OSError, StopIteration, ValueError):
+        return False
+
+
+def _probe_feedback_hidden(
+    root: Path,
+    spec: LearningStudySpec,
+    arm_run: PlannedArmRun,
+    result: ArmRunExecutionResult[LifecycleFeedback],
+) -> bool:
+    probe_ids = {item.experience_id for item in spec.experiences if item.role is ExperienceRole.PROBE}
+    if any(isinstance(step, CompiledFeedbackStep) and step.source_experience_id in probe_ids for step in arm_run.steps):
+        return False
+    probe_trial_ids = {
+        step_result.trial_record.trial_id
+        for step, step_result in zip(arm_run.steps, result.completed_steps, strict=False)
+        if (
+            isinstance(step, CompiledExperienceStep)
+            and step.role is ExperienceRole.PROBE
+            and step_result.trial_record is not None
+        )
+    }
+    try:
+        for feedback_path in (root / "feedback").glob("*.json"):
+            feedback = _read_model(feedback_path, FeedbackReleaseRecord)
+            if feedback.arm_run_id == arm_run.arm_run_id and (
+                feedback.source_experience_id in probe_ids or feedback.source_trial_id in probe_trial_ids
+            ):
+                return False
+        arm_root = root / "learner-arms" / arm_run.arm_run_id
+        for step in arm_run.steps:
+            if not isinstance(step, CompiledExperienceStep) or step.role is not ExperienceRole.PROBE:
+                continue
+            context = arm_root / "lifecycle-experiences" / step.step_id / "context"
+            if (
+                arm_run.treatment_id != "raw-history"
+                and context.exists()
+                and any("feedback" in path.relative_to(context).parts for path in context.rglob("*"))
+            ):
+                return False
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def _probe_state_discarded(root: Path, arm_run: PlannedArmRun) -> bool:
+    try:
+        arm_root = root / "learner-arms" / arm_run.arm_run_id
+        for index, step in enumerate(arm_run.steps):
+            if not isinstance(step, CompiledExperienceStep) or step.role is not ExperienceRole.PROBE:
+                continue
+            if step.commit_post_state:
+                return False
+            receipt = _read_model(
+                root / "steps" / arm_run.arm_run_id / f"{index:03d}-{step.step_id}.json",
+                StudyStepReceipt,
+            )
+            if receipt.transition_id is None:
+                return False
+            transition = _read_model(root / "transitions" / f"{receipt.transition_id}.json", LearnerTransitionReceipt)
+            if transition.operation_kind != "probe_discard" or transition.committed:
+                return False
+            if (arm_root / "states" / step.step_id).exists():
+                return False
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def _hidden_evaluation_absent(root: Path, arm_run: PlannedArmRun) -> bool:
+    try:
+        arm_root = root / "learner-arms" / arm_run.arm_run_id
+        states_root = arm_root / "states"
+        for state_root in (path for path in states_root.iterdir() if path.is_dir()):
+            validate_learner_state(state_root)
+            for path in (item for item in state_root.rglob("*") if item.is_file()):
+                if path.name in _FORBIDDEN_LEARNER_FILENAMES:
+                    return False
+                data = path.read_bytes()
+                if any(marker in data.lower() for marker in _FORBIDDEN_LEARNER_MARKERS):
+                    return False
+                if path.parent.name == "feedback":
+                    validate_drainage_checkpoint_detailed_feedback(data)
+        for context in (arm_root / "lifecycle-experiences").glob("*/context"):
+            for path in (item for item in context.rglob("*") if item.is_file()):
+                if path.name in _FORBIDDEN_LEARNER_FILENAMES:
+                    return False
+                data = path.read_bytes().lower()
+                if any(marker in data for marker in _FORBIDDEN_LEARNER_MARKERS):
+                    return False
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def _read_model(path: Path, model_type: type[ModelT]) -> ModelT:
+    return model_type.model_validate_json(path.read_text(encoding="utf-8"))
+
+
+__all__ = (
+    "L03_CONSOLIDATION_OPERATION_ID",
+    "L03_ACQUISITION_TASK_ID",
+    "L03_DRAINAGE_PROTOCOL_ID",
+    "L03_DRAINAGE_STUDY_ID",
+    "L03_EXECUTION_CONDITION",
+    "L03_PROBE_TASK_ID",
+    "L03DrainageRun",
+    "build_l03_assessment_arm_evidence",
+    "build_l03_drainage_binding",
+    "compile_l03_drainage_study",
+    "l03_drainage_outcome_projections",
+    "load_l03_drainage_protocol",
+    "run_l03_drainage_study",
+    "run_l03_drainage_study_sync",
+)

--- a/src/aec_bench/experimentation/learning_studies/protocols/l03-drainage-scaffolding-transfer/family.toml
+++ b/src/aec_bench/experimentation/learning_studies/protocols/l03-drainage-scaffolding-transfer/family.toml
@@ -1,0 +1,75 @@
+# Maintained L03 family data. Keep this file aligned with the Learning Studies
+# family schema and the reviewed scaffolding-transfer relation.
+family_id = "drainage-lifecycle-scaffolding-transfer"
+title = "Drainage scaffolding transfer"
+description = "Tests whether structured scaffolding (checklists, worked examples) at acquisition transfers to independent performance after scaffold withdrawal. Independent drainage-domain review is required before a claim-bearing run."
+
+[[dimensions]]
+dimension_id = "review_contract"
+kind = "surface"
+description = "The three-checkpoint drainage review contract, stable finding and decision identities, readiness, and claim-boundary fields"
+
+[[dimensions]]
+dimension_id = "event_topology"
+kind = "surface"
+description = "The exact checkpoint event sequence: no controlled event at initial_review, release_corrected_model_chain at response_review, propagate_memo at closeout_review"
+
+[[dimensions]]
+dimension_id = "scaffolding_level"
+kind = "causal"
+description = "The level of instructional scaffolding: guided (full checklist and worked examples), reduced (brief prompts only), or independent (no additions)"
+
+[[dimensions]]
+dimension_id = "instructional_detail"
+kind = "parameter"
+description = "The amount of additional checkpoint instruction text beyond the base instruction"
+
+[[members]]
+member_id = "guided-acquisition"
+task_id = "lifecycle/drainage-model-evidence-lifecycle-review/staged_full_correction_guided"
+description = "Guided scaffolding: structured evidence-seeking checklist, explicit constraint verification, worked-example excerpts at each checkpoint"
+probe_only = false
+
+[members.dimension_values]
+review_contract = "initial_review, response_review, and closeout_review with cumulative evidence-backed submissions"
+event_topology = "no controlled event, release_corrected_model_chain, propagate_memo"
+scaffolding_level = "guided: full evidence-seeking checklist, constraint verification steps, and worked-example excerpts"
+instructional_detail = "full scaffolding additions appended to base checkpoint instructions"
+
+[[members]]
+member_id = "reduced-practice"
+task_id = "lifecycle/drainage-model-evidence-lifecycle-review/staged_full_correction_reduced"
+description = "Reduced guidance: brief evidence-seeking prompts only, no checklist or worked examples"
+probe_only = false
+
+[members.dimension_values]
+review_contract = "initial_review, response_review, and closeout_review with cumulative evidence-backed submissions"
+event_topology = "no controlled event, release_corrected_model_chain, propagate_memo"
+scaffolding_level = "reduced: brief evidence-seeking prompts only"
+instructional_detail = "minimal scaffolding additions appended to base checkpoint instructions"
+
+[[members]]
+member_id = "independent-probe"
+task_id = "lifecycle/drainage-model-evidence-lifecycle-review/staged_full_correction"
+description = "Independent: unmodified base instructions with no scaffolding additions"
+probe_only = true
+
+[members.dimension_values]
+review_contract = "initial_review, response_review, and closeout_review with cumulative evidence-backed submissions"
+event_topology = "no controlled event, release_corrected_model_chain, propagate_memo"
+scaffolding_level = "independent: no scaffolding additions"
+instructional_detail = "base checkpoint instructions only"
+
+[[relations]]
+relation_id = "scaffolding-guided-to-independent"
+purpose = "transfer"
+source_member_ids = ["guided-acquisition"]
+target_member_id = "independent-probe"
+invariant_dimensions = ["review_contract", "event_topology"]
+invariant_claims = [
+  "All members use the same three-checkpoint review contract, finding identities, accepted-decision identities, readiness vocabulary, and claim-boundary statement.",
+  "All members share the exact same event topology with no controlled event at initial_review, release_corrected_model_chain at response_review, and propagate_memo at closeout_review.",
+  "All members use the same gold expectations, verification gates, and claim-boundary requirements.",
+]
+changed_dimensions = ["scaffolding_level", "instructional_detail"]
+rationale = "The guided acquisition provides structured evidence-seeking scaffolding. The independent probe removes all scaffolding. Transfer is measured by whether the scaffolded learner outperforms a cold independent baseline on the unscaffolded probe."

--- a/src/aec_bench/experimentation/learning_studies/protocols/l03-drainage-scaffolding-transfer/study.toml
+++ b/src/aec_bench/experimentation/learning_studies/protocols/l03-drainage-scaffolding-transfer/study.toml
@@ -1,0 +1,253 @@
+# Maintained L03 study data. Keep this file aligned with the current study
+# schema and existing treatment, feedback, and projection identifiers.
+study_id = "l03-drainage-scaffolding-transfer"
+title = "Drainage scaffolding transfer"
+research_question = "Does guided scaffolding (structured checklists, worked examples) at acquisition transfer to independent performance after scaffold withdrawal, compared to a matched cold independent probe?"
+relation_ids = ["scaffolding-guided-to-independent"]
+
+[[experiences]]
+experience_id = "guided-acquisition"
+family_member_id = "guided-acquisition"
+role = "acquisition"
+
+[[experiences]]
+experience_id = "reduced-practice"
+family_member_id = "reduced-practice"
+role = "practice"
+
+[[experiences]]
+experience_id = "independent-acquisition"
+task_id = "lifecycle/drainage-model-evidence-lifecycle-review/staged_full_correction"
+role = "acquisition"
+
+[[experiences]]
+experience_id = "independent-practice"
+task_id = "lifecycle/drainage-model-evidence-lifecycle-review/staged_full_correction"
+role = "practice"
+
+[[experiences]]
+experience_id = "independent-probe"
+family_member_id = "independent-probe"
+role = "probe"
+
+[[measurements]]
+measurement_id = "scaffolded-withdrawal-canonical-reward-gain"
+projection_id = "lifecycle.canonical-reward"
+direction = "higher"
+target_experience_id = "independent-probe"
+focal_arm_id = "scaffolded-withdrawal"
+comparator_arm_id = "cold-independent"
+
+[[measurements]]
+measurement_id = "scaffolded-withdrawal-phase-completion-gain"
+projection_id = "drainage.phase-completion"
+direction = "higher"
+target_experience_id = "independent-probe"
+focal_arm_id = "scaffolded-withdrawal"
+comparator_arm_id = "cold-independent"
+
+[[measurements]]
+measurement_id = "scaffolded-withdrawal-finding-continuity-gain"
+projection_id = "drainage.finding-continuity"
+direction = "higher"
+target_experience_id = "independent-probe"
+focal_arm_id = "scaffolded-withdrawal"
+comparator_arm_id = "cold-independent"
+
+[[measurements]]
+measurement_id = "scaffolded-withdrawal-closure-evidence-gain"
+projection_id = "drainage.closure-evidence"
+direction = "higher"
+target_experience_id = "independent-probe"
+focal_arm_id = "scaffolded-withdrawal"
+comparator_arm_id = "cold-independent"
+
+[[measurements]]
+measurement_id = "scaffolded-withdrawal-claim-boundary-gain"
+projection_id = "drainage.claim-boundary"
+direction = "higher"
+target_experience_id = "independent-probe"
+focal_arm_id = "scaffolded-withdrawal"
+comparator_arm_id = "cold-independent"
+
+[[measurements]]
+measurement_id = "guided-only-canonical-reward-gain"
+projection_id = "lifecycle.canonical-reward"
+direction = "higher"
+target_experience_id = "independent-probe"
+focal_arm_id = "guided-only"
+comparator_arm_id = "cold-independent"
+
+[[measurements]]
+measurement_id = "guided-only-phase-completion-gain"
+projection_id = "drainage.phase-completion"
+direction = "higher"
+target_experience_id = "independent-probe"
+focal_arm_id = "guided-only"
+comparator_arm_id = "cold-independent"
+
+[[measurements]]
+measurement_id = "unscaffolded-practice-canonical-reward-gain"
+projection_id = "lifecycle.canonical-reward"
+direction = "higher"
+target_experience_id = "independent-probe"
+focal_arm_id = "unscaffolded-practice"
+comparator_arm_id = "cold-independent"
+
+[[measurements]]
+measurement_id = "scaffolded-versus-unscaffolded-canonical-reward"
+projection_id = "lifecycle.canonical-reward"
+direction = "higher"
+target_experience_id = "independent-probe"
+focal_arm_id = "scaffolded-withdrawal"
+comparator_arm_id = "unscaffolded-practice"
+
+[[measurements]]
+measurement_id = "scaffolded-versus-unscaffolded-phase-completion"
+projection_id = "drainage.phase-completion"
+direction = "higher"
+target_experience_id = "independent-probe"
+focal_arm_id = "scaffolded-withdrawal"
+comparator_arm_id = "unscaffolded-practice"
+
+[[measurements]]
+measurement_id = "scaffolded-versus-guided-only-canonical-reward"
+projection_id = "lifecycle.canonical-reward"
+direction = "higher"
+target_experience_id = "independent-probe"
+focal_arm_id = "scaffolded-withdrawal"
+comparator_arm_id = "guided-only"
+
+[[arms]]
+arm_id = "cold-independent"
+role = "control"
+treatment_id = "reset"
+
+[[arms.steps]]
+kind = "run_experience"
+step_id = "cold-probe"
+experience_id = "independent-probe"
+commit_post_state = false
+
+[[arms]]
+arm_id = "scaffolded-withdrawal"
+role = "exposure"
+treatment_id = "structured-memory"
+
+[[arms.steps]]
+kind = "run_experience"
+step_id = "guided-acq"
+experience_id = "guided-acquisition"
+commit_post_state = true
+
+[[arms.steps]]
+kind = "release_feedback"
+step_id = "guided-release"
+source_experience_id = "guided-acquisition"
+feedback_view_id = "drainage-checkpoint-detailed-feedback"
+
+[[arms.steps]]
+kind = "consolidate"
+step_id = "guided-consolidation"
+feedback_step_ids = ["guided-release"]
+operation_id = "update-lifecycle-review-memory"
+
+[[arms.steps]]
+kind = "run_experience"
+step_id = "reduced-prac"
+experience_id = "reduced-practice"
+commit_post_state = true
+
+[[arms.steps]]
+kind = "release_feedback"
+step_id = "reduced-release"
+source_experience_id = "reduced-practice"
+feedback_view_id = "drainage-checkpoint-detailed-feedback"
+
+[[arms.steps]]
+kind = "consolidate"
+step_id = "reduced-consolidation"
+feedback_step_ids = ["reduced-release"]
+operation_id = "update-lifecycle-review-memory"
+
+[[arms.steps]]
+kind = "run_experience"
+step_id = "scaffolded-probe"
+experience_id = "independent-probe"
+commit_post_state = false
+
+[[arms]]
+arm_id = "guided-only"
+role = "exposure"
+treatment_id = "structured-memory"
+
+[[arms.steps]]
+kind = "run_experience"
+step_id = "guided-only-acq"
+experience_id = "guided-acquisition"
+commit_post_state = true
+
+[[arms.steps]]
+kind = "release_feedback"
+step_id = "guided-only-release"
+source_experience_id = "guided-acquisition"
+feedback_view_id = "drainage-checkpoint-detailed-feedback"
+
+[[arms.steps]]
+kind = "consolidate"
+step_id = "guided-only-consolidation"
+feedback_step_ids = ["guided-only-release"]
+operation_id = "update-lifecycle-review-memory"
+
+[[arms.steps]]
+kind = "run_experience"
+step_id = "guided-only-probe"
+experience_id = "independent-probe"
+commit_post_state = false
+
+[[arms]]
+arm_id = "unscaffolded-practice"
+role = "exposure"
+treatment_id = "structured-memory"
+
+[[arms.steps]]
+kind = "run_experience"
+step_id = "unscaffolded-acq"
+experience_id = "independent-acquisition"
+commit_post_state = true
+
+[[arms.steps]]
+kind = "release_feedback"
+step_id = "unscaffolded-release-1"
+source_experience_id = "independent-acquisition"
+feedback_view_id = "drainage-checkpoint-detailed-feedback"
+
+[[arms.steps]]
+kind = "consolidate"
+step_id = "unscaffolded-consolidation-1"
+feedback_step_ids = ["unscaffolded-release-1"]
+operation_id = "update-lifecycle-review-memory"
+
+[[arms.steps]]
+kind = "run_experience"
+step_id = "unscaffolded-prac"
+experience_id = "independent-practice"
+commit_post_state = true
+
+[[arms.steps]]
+kind = "release_feedback"
+step_id = "unscaffolded-release-2"
+source_experience_id = "independent-practice"
+feedback_view_id = "drainage-checkpoint-detailed-feedback"
+
+[[arms.steps]]
+kind = "consolidate"
+step_id = "unscaffolded-consolidation-2"
+feedback_step_ids = ["unscaffolded-release-2"]
+operation_id = "update-lifecycle-review-memory"
+
+[[arms.steps]]
+kind = "run_experience"
+step_id = "unscaffolded-probe"
+experience_id = "independent-probe"
+commit_post_state = false

--- a/src/aec_bench/lifecycles/stormwater_design/drainage_learning.py
+++ b/src/aec_bench/lifecycles/stormwater_design/drainage_learning.py
@@ -13,8 +13,10 @@ from pydantic import Field, ValidationError
 from aec_bench.contracts.evaluation_result import EvaluationResult
 from aec_bench.contracts.trial_record import EvaluationStatus, ExecutionStatus, TrialRecord
 from aec_bench.contracts.validators import NonEmptyStr, StrictModel
+from aec_bench.experimentation.learning_studies.assessment import ProjectionResult
 from aec_bench.lifecycles.runtime.lifecycle import load_validated_lifecycle_submissions
 from aec_bench.lifecycles.stormwater_design.drainage_model import CHECKPOINT_IDS, GATE_IDS, TEMPLATE_ID
+from aec_bench.lifecycles.stormwater_design.drainage_variants import get_drainage_model_variant
 
 DRAINAGE_STAGED_REVIEW_FEEDBACK_VIEW_ID = "drainage-staged-review-public-feedback"
 DRAINAGE_CHECKPOINT_DETAILED_FEEDBACK_VIEW_ID = "drainage-checkpoint-detailed-feedback"
@@ -22,8 +24,12 @@ DRAINAGE_PHASE_SUMMARY_FEEDBACK_VIEW_ID = "drainage-phase-summary-feedback"
 DRAINAGE_TERMINAL_FEEDBACK_VIEW_ID = "drainage-terminal-feedback"
 DRAINAGE_ACQUISITION_TASK_ID = f"lifecycle/{TEMPLATE_ID}/staged_full_correction"
 DRAINAGE_PROBE_TASK_ID = f"lifecycle/{TEMPLATE_ID}/semantic_no_op_release"
+_DRAINAGE_SCAFFOLDING_ACQUISITION_VARIANTS = frozenset(
+    {"staged_full_correction", "staged_full_correction_guided", "staged_full_correction_reduced"}
+)
 
 _DRAINAGE_TASK_PREFIX = f"lifecycle/{TEMPLATE_ID}/"
+_PHASE_EVIDENCE_EXTENSION_KIND = "lifecycle_learning_evidence"
 _SELECTED_FEEDBACK_GATE_IDS = (
     "checkpoint_contract",
     "staged_disclosure",
@@ -113,6 +119,7 @@ def extract_drainage_learning_evidence(record: TrialRecord) -> DrainageLearningE
         variant_id = record.task_id.removeprefix(_DRAINAGE_TASK_PREFIX)
         if not variant_id:
             return None
+        get_drainage_model_variant(variant_id)
         phase_records = (
             _drainage_phase(
                 phase_id="evidence_assessment",
@@ -136,6 +143,47 @@ def extract_drainage_learning_evidence(record: TrialRecord) -> DrainageLearningE
         )
     except (TypeError, ValueError, KeyError, ValidationError):
         return None
+
+
+def drainage_phase_completion(record: TrialRecord) -> ProjectionResult:
+    """Project completed drainage phase outcomes without scoring reflection text.
+
+    This is currently computable only for a record retained in the process that
+    executed the lifecycle. D1 deliberately does not register
+    ``lifecycle_learning_evidence`` in ``ledger.reader``'s typed-extension
+    hydration map, so a reloaded record has no pending extension value and
+    fails closed rather than fabricating a zero.
+    """
+
+    if not record.task_id.startswith(_DRAINAGE_TASK_PREFIX):
+        return ProjectionResult(eligible=False, value=None, reason=f"projection-task-mismatch: {record.task_id}")
+    if record.execution_status is not ExecutionStatus.COMPLETED:
+        return ProjectionResult(eligible=False, value=None, reason="phase-evidence-missing")
+    try:
+        _completed_evaluation(record, category="phase-evidence-parse-failed")
+    except ValueError as error:
+        return ProjectionResult(eligible=False, value=None, reason=str(error))
+    attached = record.pending_extensions.get(_PHASE_EVIDENCE_EXTENSION_KIND)
+    if attached is None:
+        return ProjectionResult(eligible=False, value=None, reason="phase-evidence-missing")
+    try:
+        evidence = (
+            attached
+            if isinstance(attached, DrainageLearningEvidence)
+            else DrainageLearningEvidence.model_validate(attached)
+        )
+        if evidence.lifecycle_template_id != TEMPLATE_ID or evidence.variant_id != record.task_id.removeprefix(
+            _DRAINAGE_TASK_PREFIX
+        ):
+            raise ValueError("phase evidence identity does not match the trial")
+        get_drainage_model_variant(evidence.variant_id)
+    except (TypeError, ValueError, ValidationError, KeyError):
+        return ProjectionResult(eligible=False, value=None, reason="phase-evidence-parse-failed")
+    if not evidence.phase_records:
+        return ProjectionResult(eligible=False, value=None, reason="no-phase-records")
+    completed = sum(phase.phase_outcome != "incomplete" for phase in evidence.phase_records)
+    value = completed / len(evidence.phase_records)
+    return ProjectionResult(eligible=True, value=value, lower_bound=0.0, upper_bound=1.0)
 
 
 def _drainage_phase(
@@ -226,7 +274,7 @@ def _phase_evidence_submissions(record: TrialRecord) -> dict[str, dict[str, Any]
 def drainage_staged_review_feedback(record: TrialRecord) -> bytes:
     """Return the declared public feedback view for one completed acquisition."""
 
-    if record.task_id != DRAINAGE_ACQUISITION_TASK_ID:
+    if not _is_acquisition_task(record.task_id):
         raise ValueError(f"feedback-source-task-mismatch: {record.task_id}")
     if record.execution_status is not ExecutionStatus.COMPLETED:
         raise ValueError("feedback-source-trial-missing: lifecycle execution is not complete")
@@ -472,7 +520,7 @@ def validate_drainage_terminal_feedback(data: bytes) -> dict[str, Any]:
 
 
 def _require_completed_acquisition(record: TrialRecord) -> None:
-    if record.task_id != DRAINAGE_ACQUISITION_TASK_ID:
+    if not _is_acquisition_task(record.task_id):
         raise ValueError(f"feedback-source-task-mismatch: {record.task_id}")
     if record.execution_status is not ExecutionStatus.COMPLETED:
         raise ValueError("feedback-source-trial-missing: lifecycle execution is not complete")
@@ -497,7 +545,7 @@ def _decode_feedback_object(data: bytes) -> dict[str, Any]:
 def _validate_feedback_identity(payload: dict[str, Any], *, view_id: str, error_label: str) -> None:
     if payload["feedback_view_id"] != view_id:
         raise ValueError(f"feedback-projection-unsafe: {error_label} view identity does not match")
-    if payload["task_id"] != DRAINAGE_ACQUISITION_TASK_ID:
+    if not _is_acquisition_task(payload["task_id"]):
         raise ValueError(f"feedback-source-task-mismatch: {error_label} source is not the acquisition task")
     if payload["execution_status"] != ExecutionStatus.COMPLETED.value:
         raise ValueError(f"feedback-source-trial-missing: {error_label} source is not complete")
@@ -538,7 +586,7 @@ def validate_drainage_staged_review_feedback(data: bytes) -> dict[str, Any]:
         raise ValueError("feedback-projection-unsafe: drainage feedback fields do not match the public view")
     if payload["feedback_view_id"] != DRAINAGE_STAGED_REVIEW_FEEDBACK_VIEW_ID:
         raise ValueError("feedback-projection-unsafe: drainage feedback view identity does not match")
-    if payload["task_id"] != DRAINAGE_ACQUISITION_TASK_ID:
+    if not _is_acquisition_task(payload["task_id"]):
         raise ValueError("feedback-source-task-mismatch: drainage feedback source is not the acquisition task")
     if payload["execution_status"] != ExecutionStatus.COMPLETED.value:
         raise ValueError("feedback-source-trial-missing: drainage feedback source is not complete")
@@ -725,6 +773,14 @@ def _require_drainage_task(record: TrialRecord, *, category: str) -> None:
         raise ValueError(f"{category}: {record.task_id}")
 
 
+def _is_acquisition_task(task_id: object) -> bool:
+    return (
+        isinstance(task_id, str)
+        and task_id.startswith(_DRAINAGE_TASK_PREFIX)
+        and task_id.removeprefix(_DRAINAGE_TASK_PREFIX) in _DRAINAGE_SCAFFOLDING_ACQUISITION_VARIANTS
+    )
+
+
 def _bounded_number(value: object, *, category: str, label: str) -> float:
     if isinstance(value, bool) or not isinstance(value, int | float) or not math.isfinite(value):
         raise ValueError(f"{category}-invalid: {label} must be finite")
@@ -747,6 +803,7 @@ __all__ = (
     "drainage_checkpoint_detailed_feedback",
     "drainage_gate_score",
     "drainage_inappropriate_memo_closure",
+    "drainage_phase_completion",
     "drainage_phase_summary_feedback",
     "drainage_staged_review_feedback",
     "drainage_terminal_feedback",

--- a/src/aec_bench/lifecycles/stormwater_design/drainage_model.py
+++ b/src/aec_bench/lifecycles/stormwater_design/drainage_model.py
@@ -120,7 +120,7 @@ def materialize_drainage_model_lifecycle(
     (output / "README.md").parent.mkdir(parents=True, exist_ok=True)
     (output / "README.md").write_text(_readme(), encoding="utf-8")
 
-    for checkpoint_id, instruction in _instructions().items():
+    for checkpoint_id, instruction in _instructions(variant.variant_id).items():
         path = output / "instructions" / f"{checkpoint_id}.md"
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(instruction, encoding="utf-8")
@@ -566,15 +566,31 @@ def _record_atoms(
             atoms[f"{prefix}.{field}"] = record.get(field)
 
 
-def _instructions() -> dict[str, str]:
-    return {
-        checkpoint_id: _instruction(checkpoint_id, purpose)
-        for checkpoint_id, purpose in {
-            "initial_review": "Review the initial registered model evidence and establish the cumulative review state.",
-            "response_review": "Review the newly released response evidence against the prior checkpoint state.",
-            "closeout_review": "Review the newly released closeout evidence and determine final readiness.",
-        }.items()
+def _instructions(variant_id: str = "staged_full_correction") -> dict[str, str]:
+    base = {
+        "initial_review": "Review the initial registered model evidence and establish the cumulative review state.",
+        "response_review": "Review the newly released response evidence against the prior checkpoint state.",
+        "closeout_review": "Review the newly released closeout evidence and determine final readiness.",
     }
+    if variant_id == "staged_full_correction_guided":
+        addition = (
+            "\n\nGuided evidence-seeking checklist:\n"
+            "- Identify each registered source before relying on a claim.\n"
+            "- Verify the governing constraint and its current value.\n"
+            "- Check that every transition is supported by the released evidence.\n"
+            "Constraint verification steps: confirm the source, constraint, and downstream consequence.\n"
+            "Worked-example excerpt: a corrected model chain supports a transition only when its manifest, "
+            "rerun, and report are traceable together.\n"
+        )
+    elif variant_id == "staged_full_correction_reduced":
+        addition = (
+            "\n\nEvidence-seeking prompts:\n"
+            "- Which registered evidence supports this decision?\n"
+            "- Which governing constraint must be verified before changing state?\n"
+        )
+    else:
+        addition = ""
+    return {checkpoint_id: _instruction(checkpoint_id, purpose) + addition for checkpoint_id, purpose in base.items()}
 
 
 def _instruction(checkpoint_id: str, purpose: str) -> str:

--- a/src/aec_bench/lifecycles/stormwater_design/drainage_variants.py
+++ b/src/aec_bench/lifecycles/stormwater_design/drainage_variants.py
@@ -458,6 +458,19 @@ _VARIANTS = {
             closeout_events=(DrainageEvidenceEvent.PROPAGATE_MEMO,),
         ),
         _variant(
+            "staged_full_correction_guided",
+            "A corrected staged review with guided evidence-seeking checklists, constraint verification, "
+            "and worked examples.",
+            response_events=(DrainageEvidenceEvent.RELEASE_CORRECTED_MODEL_CHAIN,),
+            closeout_events=(DrainageEvidenceEvent.PROPAGATE_MEMO,),
+        ),
+        _variant(
+            "staged_full_correction_reduced",
+            "A corrected staged review with brief evidence-seeking prompts after guided scaffolding is withdrawn.",
+            response_events=(DrainageEvidenceEvent.RELEASE_CORRECTED_MODEL_CHAIN,),
+            closeout_events=(DrainageEvidenceEvent.PROPAGATE_MEMO,),
+        ),
+        _variant(
             "semantic_no_op_release",
             "An unrelated administrative note arrives before the full corrected chain is released at closeout.",
             response_events=(DrainageEvidenceEvent.SEMANTIC_NO_OP,),

--- a/tests/experimentation/learning_studies/test_l03_drainage.py
+++ b/tests/experimentation/learning_studies/test_l03_drainage.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from aec_bench.contracts.experiment_manifest import AgentConfig, ComputeConfig
+from aec_bench.contracts.learning_study_assessment import LearningComparisonValidity
+from aec_bench.experimentation.learning_studies.families import load_learning_family
+from aec_bench.experimentation.learning_studies.l01_drainage import l01_drainage_outcome_projections
+from aec_bench.experimentation.learning_studies.l02_drainage import l02_drainage_outcome_projections
+from aec_bench.experimentation.learning_studies.l03_drainage import (
+    L03_EXECUTION_CONDITION,
+    l03_drainage_outcome_projections,
+    load_l03_drainage_protocol,
+    run_l03_drainage_study_sync,
+)
+from aec_bench.ledger.reader import read_trial_record
+from aec_bench.lifecycles.stormwater_design.drainage_learning import drainage_phase_completion
+from aec_bench.lifecycles.stormwater_design.drainage_model import TEMPLATE_ID
+
+_AGENT = AgentConfig(name="l03-deterministic-agent", adapter="tool_loop", model="fixed-test-model", parameters={})
+_COMPUTE = ComputeConfig(backend="local", resource_limits={"memory_mb": 512}, timeout_override=30)
+_SCAFFOLDING_MARKERS = (
+    b"guided evidence-seeking checklist",
+    b"constraint verification steps",
+    b"worked-example excerpt",
+    b"evidence-seeking prompts",
+)
+
+
+class _Consolidator:
+    calls = 0
+
+    def __call__(self, context):  # noqa: ANN001
+        type(self).calls += 1
+        (context.memory_root / f"review-{self.calls}.md").write_text(
+            "Reflection may be distinctive and misleading; it is not a score.\n", encoding="utf-8"
+        )
+
+
+class _GoldAdapterBuilder:
+    executions = 0
+    contexts: dict[str, list[set[str]]] = {}
+
+    def __call__(self, **kwargs):  # noqa: ANN003, ANN202
+        workspace = Path(kwargs["workspace"])
+        package = workspace.parent.parent / "package"
+        gold = json.loads((package / "hidden" / "gold-submissions.json").read_text(encoding="utf-8"))
+        builder = self
+
+        class Adapter:
+            def execute(self, request):  # noqa: ANN001
+                type(builder).executions += 1
+                context = workspace / "learner_context"
+                visible = (
+                    {path.relative_to(context).as_posix() for path in context.rglob("*") if path.is_file()}
+                    if context.exists()
+                    else set()
+                )
+                builder.contexts.setdefault(package.parent.parent.name, []).append(visible)
+                output = Path(request.output_path)
+                output.parent.mkdir(parents=True, exist_ok=True)
+                output.write_text(json.dumps(gold[output.stem]), encoding="utf-8")
+                return SimpleNamespace(
+                    adapter_name="tool_loop",
+                    resolved_model="fixed-test-model",
+                    configuration_record={"source": "deterministic-test"},
+                    agent_output=SimpleNamespace(status=SimpleNamespace(value="completed")),
+                    transcript=[],
+                    raw_output_text=None,
+                    provider_error=None,
+                    failure_kind=None,
+                    usage_input_tokens=1,
+                    usage_output_tokens=1,
+                    usage_cache_read_tokens=0,
+                    usage_cache_write_tokens=0,
+                )
+
+        return Adapter()
+
+
+def test_l03_protocol_schema_and_exact_task_resolution() -> None:
+    spec = load_l03_drainage_protocol(agent=_AGENT, compute=_COMPUTE)
+    assert spec.study_id == "l03-drainage-scaffolding-transfer"
+    assert [arm.arm_id for arm in spec.arms] == [
+        "cold-independent",
+        "scaffolded-withdrawal",
+        "guided-only",
+        "unscaffolded-practice",
+    ]
+    assert [experience.task_id for experience in spec.experiences] == [
+        f"lifecycle/{TEMPLATE_ID}/staged_full_correction_guided",
+        f"lifecycle/{TEMPLATE_ID}/staged_full_correction_reduced",
+        f"lifecycle/{TEMPLATE_ID}/staged_full_correction",
+        f"lifecycle/{TEMPLATE_ID}/staged_full_correction",
+        f"lifecycle/{TEMPLATE_ID}/staged_full_correction",
+    ]
+    assert L03_EXECUTION_CONDITION.adapter_id == "lifecycle-local:fresh_context:artifact_memory"
+    assert (
+        load_learning_family(
+            Path(__file__).parents[3]
+            / "src/aec_bench/experimentation/learning_studies/protocols/l03-drainage-scaffolding-transfer/family.toml"
+        ).family_id
+        == "drainage-lifecycle-scaffolding-transfer"
+    )
+
+
+def test_deterministic_l03_runs_all_arms_with_truthful_evidence_and_measurements(tmp_path: Path) -> None:
+    adapter = _GoldAdapterBuilder()
+    result = run_l03_drainage_study_sync(
+        run_root=tmp_path / "l03",
+        study_run_id="l03-deterministic",
+        agent=_AGENT,
+        compute=_COMPUTE,
+        consolidation_operation=_Consolidator(),
+        adapter_builder=adapter,
+    )
+    assert [arm.status.value for arm in result.execution.arm_runs] == ["completed"] * 4
+    assert [len(arm.trial_records) for arm in result.execution.arm_runs] == [1, 3, 2, 3]
+    assert len({item.initial_state_equivalence_id for item in result.arm_evidence.values()}) == 1
+    assert all(item.adapter_id == L03_EXECUTION_CONDITION.adapter_id for item in result.arm_evidence.values())
+    assert all(
+        item.arm_isolated
+        and item.lineage_complete
+        and item.probe_feedback_hidden
+        and item.probe_state_discarded
+        and not item.hidden_evaluation_leaked
+        for item in result.arm_evidence.values()
+    )
+    context_files = [path for path in (tmp_path / "l03").rglob("*") if path.is_file() and "context" in path.parts]
+    assert context_files and all(path.stat().st_mode & 0o222 == 0 for path in context_files)
+
+    projections = l03_drainage_outcome_projections()
+    for arm in result.execution.arm_runs:
+        for record in arm.trial_records:
+            phase = drainage_phase_completion(record)
+            assert phase.eligible and phase.value == 1.0
+            assert projections["drainage.phase-completion"](record).value == phase.value
+    measurements = {item.measurement_id: item for item in result.reviewed_assessment.measurements}
+    assert all(item.validity is not LearningComparisonValidity.INVALID for item in measurements.values())
+    assert (
+        measurements["scaffolded-versus-unscaffolded-canonical-reward"].validity
+        is LearningComparisonValidity.DESCRIPTIVE_ONLY
+    )
+    assert measurements["scaffolded-withdrawal-canonical-reward-gain"].validity is LearningComparisonValidity.CONTROLLED
+
+    # Every experience has a persisted phase-evidence extension and every probe
+    # remains uncommitted; the arm evidence above is derived from these records.
+    assert sum(len(arm.trial_records) for arm in result.execution.arm_runs) == 9
+    assert all(record.extension_refs for arm in result.execution.arm_runs for record in arm.trial_records)
+
+
+def test_l03_scaffolding_content_does_not_leak_to_feedback_memory_or_state(tmp_path: Path) -> None:
+    result = run_l03_drainage_study_sync(
+        run_root=tmp_path / "l03",
+        study_run_id="l03-leakage",
+        agent=_AGENT,
+        compute=_COMPUTE,
+        consolidation_operation=_Consolidator(),
+        adapter_builder=_GoldAdapterBuilder(),
+    )
+    root = tmp_path / "l03"
+    boundary_parts = {"feedback", "memory", "states", "context"}
+    for path in root.rglob("*"):
+        if path.is_file() and any(part in boundary_parts for part in path.parts):
+            assert not any(marker in path.read_bytes().lower() for marker in _SCAFFOLDING_MARKERS)
+    for trial_path in (root / "ledger").rglob("*.json"):
+        if "_artifacts" in trial_path.parts:
+            continue
+        for extension in json.loads(trial_path.read_text(encoding="utf-8")).get("extension_refs", ()):
+            if extension.get("extension_kind") == "lifecycle_learning_evidence":
+                artifact = root / "ledger" / "_artifacts" / extension["artifact"]["artifact_id"]
+                assert not any(marker in artifact.read_bytes().lower() for marker in _SCAFFOLDING_MARKERS)
+    assert result.arm_evidence
+
+
+def test_phase_completion_is_ineligible_not_zero_when_evidence_is_missing(tmp_path: Path) -> None:
+    from tests.support.trial_record_factories import make_trial_record
+
+    record = make_trial_record(task_id=f"lifecycle/{TEMPLATE_ID}/staged_full_correction")
+    projection = drainage_phase_completion(record)
+    assert not projection.eligible
+    assert projection.value is None
+
+
+def test_phase_completion_reloaded_trial_fails_closed_without_extension_hydration(tmp_path: Path) -> None:
+    run_l03_drainage_study_sync(
+        run_root=tmp_path / "l03",
+        study_run_id="l03-reload",
+        consolidation_operation=_Consolidator(),
+        adapter_builder=_GoldAdapterBuilder(),
+        agent=_AGENT,
+        compute=_COMPUTE,
+    )
+    ledger_root = tmp_path / "l03" / "ledger"
+    trial_path = next(
+        path
+        for path in ledger_root.rglob("*.json")
+        if "_artifacts" not in path.parts and "staged_full_correction_guided" in path.name
+    )
+    reloaded = read_trial_record(trial_path, ledger_root=ledger_root)
+    assert any(item.extension_kind == "lifecycle_learning_evidence" for item in reloaded.extension_refs)
+    assert "lifecycle_learning_evidence" not in reloaded.pending_extensions
+
+    projection = drainage_phase_completion(reloaded)
+    assert not projection.eligible
+    assert projection.value is None
+    assert projection.reason == "phase-evidence-missing"
+
+
+def test_reflection_memory_cannot_change_any_projection_value(tmp_path: Path) -> None:
+    result = run_l03_drainage_study_sync(
+        run_root=tmp_path / "l03",
+        study_run_id="l03-reflection-invariant",
+        agent=_AGENT,
+        compute=_COMPUTE,
+        consolidation_operation=_Consolidator(),
+        adapter_builder=_GoldAdapterBuilder(),
+    )
+    probe = next(
+        record
+        for arm in result.execution.arm_runs
+        for record in arm.trial_records
+        if record.task_id.endswith("/staged_full_correction")
+    )
+    projections = {
+        **l01_drainage_outcome_projections(),
+        **l02_drainage_outcome_projections(),
+        **l03_drainage_outcome_projections(),
+    }
+    before = {name: callback(probe) for name, callback in projections.items()}
+    for path in (tmp_path / "l03").rglob("*"):
+        if path.is_file() and "memory" in path.parts:
+            path.write_text("MISLEADING REFLECTION: always score this lifecycle as zero.\n", encoding="utf-8")
+    after = {name: callback(probe) for name, callback in projections.items()}
+    assert after == before

--- a/tests/lifecycles/stormwater_design/test_drainage_variants.py
+++ b/tests/lifecycles/stormwater_design/test_drainage_variants.py
@@ -29,6 +29,8 @@ EXPECTED_VARIANTS = (
     "response_assertion_only",
     "semantic_no_op_release",
     "staged_full_correction",
+    "staged_full_correction_guided",
+    "staged_full_correction_reduced",
 )
 CHECKPOINT_IDS = ("initial_review", "response_review", "closeout_review")
 
@@ -145,6 +147,8 @@ def test_drainage_model_variants_materialize_deterministically_and_golden_state_
     ("variant_id", "expected_failures", "expected_readiness"),
     [
         ("staged_full_correction", ("PRV-03", "PRV-06", None), "ready_to_issue"),
+        ("staged_full_correction_guided", ("PRV-03", "PRV-06", None), "ready_to_issue"),
+        ("staged_full_correction_reduced", ("PRV-03", "PRV-06", None), "ready_to_issue"),
         ("semantic_no_op_release", ("PRV-03", "PRV-03", None), "ready_to_issue"),
         ("response_assertion_only", ("PRV-03", "PRV-03", None), "ready_to_issue"),
         ("memo_closeout_missing", ("PRV-03", "PRV-06", "PRV-06"), "not_ready_to_issue"),
@@ -471,6 +475,58 @@ def test_variant_packages_have_distinct_host_side_hashes(tmp_path: Path) -> None
     }
 
     assert len(digests) == len(EXPECTED_VARIANTS)
+
+
+def test_staged_scaffolding_variants_preserve_topology_and_gold(tmp_path: Path) -> None:
+    specs = [
+        get_drainage_model_variant(variant_id)
+        for variant_id in ("staged_full_correction", "staged_full_correction_guided", "staged_full_correction_reduced")
+    ]
+    assert [tuple(checkpoint.events for checkpoint in spec.checkpoints) for spec in specs] == [
+        tuple(checkpoint.events for checkpoint in specs[0].checkpoints)
+    ] * 3
+    packages = {
+        variant_id: materialize_lifecycle(
+            "drainage-model-evidence-lifecycle-review",
+            tmp_path / variant_id,
+            variant_id=variant_id,
+        )
+        for variant_id in ("staged_full_correction", "staged_full_correction_guided", "staged_full_correction_reduced")
+    }
+    gold = [_load_json(package / "hidden" / "gold-submissions.json") for package in packages.values()]
+    assert gold[0] == gold[1] == gold[2]
+    assert [_load_json(package / "hidden" / "variant.json")["variant_id"] for package in packages.values()] == list(
+        packages
+    )
+    for checkpoint_id in CHECKPOINT_IDS:
+        assert (
+            _instruction_without_scaffolding(
+                (packages["staged_full_correction_guided"] / "instructions" / f"{checkpoint_id}.md").read_text()
+            )
+            == (packages["staged_full_correction"] / "instructions" / f"{checkpoint_id}.md").read_text()
+        )
+        assert (
+            _instruction_without_scaffolding(
+                (packages["staged_full_correction_reduced"] / "instructions" / f"{checkpoint_id}.md").read_text()
+            )
+            == (packages["staged_full_correction"] / "instructions" / f"{checkpoint_id}.md").read_text()
+        )
+    assert _package_files(packages["staged_full_correction"]) != _package_files(
+        packages["staged_full_correction_guided"]
+    )
+    for root in ("releases",):
+        for path in (packages["staged_full_correction"] / root).rglob("*"):
+            if path.is_file():
+                relative = path.relative_to(packages["staged_full_correction"])
+                assert path.read_bytes() == (packages["staged_full_correction_guided"] / relative).read_bytes()
+                assert path.read_bytes() == (packages["staged_full_correction_reduced"] / relative).read_bytes()
+
+
+def _instruction_without_scaffolding(text: str) -> str:
+    for marker in ("\n\nGuided evidence-seeking checklist:", "\n\nEvidence-seeking prompts:"):
+        if marker in text:
+            return text.split(marker, 1)[0].rstrip() + "\n"
+    return text
 
 
 @pytest.mark.parametrize("variant_id", EXPECTED_VARIANTS)


### PR DESCRIPTION
## Summary

Implements D3 (the final tranche) of Release B Lifecycle Tranche 3 (LS-07): scaffolding variants and the L03 drainage scaffolding-transfer study, per `LS-07C-scaffolding-study-and-measurements.md` and `studies/L03-drainage-scaffolding-transfer.md`. Depends on D1 (phase-evidence extension) and D2 (feedback-schedule composition), both already merged.

- Two new drainage variants, `staged_full_correction_guided` and `staged_full_correction_reduced`, sharing the exact event topology of `staged_full_correction` and differing only in checkpoint instruction text. Verified byte-identical gold submissions, releases, and verifier outcomes across all three variants.
- Maintained L03 protocol (`family.toml`/`study.toml`) with four arms: `cold-independent` (control), `scaffolded-withdrawal`, `guided-only`, and `unscaffolded-practice` (a practice-effect control reusing the *existing* `staged_full_correction` variant -- no new variant needed there). Every arm's probe resolves to the unmodified, existing `staged_full_correction` variant.
- `drainage.phase-completion` projection reading D1's attached phase evidence, following the existing ineligible-not-zero discipline.
- A no-reflection-scoring invariant test and a scaffolding-leakage scan (instruction content confirmed absent from feedback, memory, learner state, context, and the persisted phase-evidence extension artifact bytes).
- A deterministic four-arm end-to-end test with truthful `AssessmentArmEvidence`.

## Honest limitation, tested and documented

`drainage.phase-completion` is same-process-only: since D1 deliberately excludes `lifecycle_learning_evidence` from `ledger/reader.py`'s typed-extension hydration map (to keep zero common-substrate changes), a trial record reloaded from a persisted ledger correctly and safely returns `ineligible` rather than a fabricated zero. This was found during my own review of the first draft (which only proved the same-process path) and the implementer added a dedicated test (`test_phase_completion_reloaded_trial_fails_closed_without_extension_hydration`) plus an explicit code comment documenting it.

## Validity discipline

The reviewed assessment reports 8 controlled cold-control comparisons and 3 `descriptive_only` exposure-to-exposure comparisons. Canonical reward and phase completion are both at a ceiling (1.0) under the deterministic gold adapter, so **no causal transfer claim is made** -- only the assessor's actual decision states are reported.

## Scope boundaries

No changes to worlds, Gate C, LS-09, harness-update, model weights, or common contracts. The architecture-review package (`REVIEW-LS07-phase-evidence-and-scaffolding.md`) and independent relation/domain review remain pending before any real-model pilot.

## Testing

```
uv run pytest \
  tests/lifecycles/stormwater_design/test_drainage_variants.py \
  tests/lifecycles/stormwater_design/test_drainage_lifecycle.py \
  tests/experimentation/learning_studies/test_l01_drainage.py \
  tests/experimentation/learning_studies/test_l02_drainage.py \
  tests/experimentation/learning_studies/test_phase_evidence.py \
  tests/experimentation/learning_studies/test_d2_feedback_schedules.py \
  tests/experimentation/learning_studies/test_planning.py \
  tests/experimentation/learning_studies/test_protocol_collection.py \
  tests/experimentation/learning_studies/test_l03_drainage.py
```

133 passed. `uv run ruff check` clean. `uv run ruff format --check` (including the CI-gated `stormwater_design/` path) clean. `uv run python scripts/check_provenance_fields.py --check --base-revision main` passes with 0 violations.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
