### PR TITLE
feat: add W02 dam structural-transfer study (Release C, Worlds Tranche 2)

### DIFF
--- a/src/aec_bench/experimentation/learning_studies/dam_w02.py
+++ b/src/aec_bench/experimentation/learning_studies/dam_w02.py
@@ -1,0 +1,608 @@
+# ABOUTME: Composes and assesses the W02 dam-seepage structural-transfer Learning Study.
+# ABOUTME: Keeps W02 treatment, projection, and evidence policy in explicit study-owned glue.
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, TypeVar, cast
+
+from pydantic import BaseModel
+
+from aec_bench.contracts.experiment_manifest import AgentConfig, ComputeConfig
+from aec_bench.contracts.learning_study import ExperienceRole, LearningStudySpec
+from aec_bench.contracts.learning_study_assessment import LearningStudyAssessment
+from aec_bench.contracts.learning_study_evidence import (
+    FeedbackReleaseRecord,
+    LearnerStateRef,
+    LearnerTransitionReceipt,
+    RecordedStudyExecution,
+    StudyStepReceipt,
+    StudyStepStatus,
+)
+from aec_bench.contracts.trial_record import EvaluationStatus, ExecutionStatus, TrialRecord
+from aec_bench.experimentation.learning_studies.assessment import (
+    AssessmentArmEvidence,
+    OutcomeProjection,
+    ProjectionResult,
+    assess_learning_study,
+)
+from aec_bench.experimentation.learning_studies.learner_state import validate_learner_state
+from aec_bench.experimentation.learning_studies.planning import (
+    CompiledConsolidationStep,
+    CompiledExperienceStep,
+    CompiledFeedbackStep,
+    CompiledLearningStudy,
+    PlannedArmRun,
+    compile_learning_study,
+)
+from aec_bench.experimentation.learning_studies.protocol_collection import (
+    BUILTIN_LEARNING_STUDY_PROTOCOLS,
+    load_learning_study_protocol,
+)
+from aec_bench.experimentation.learning_studies.recording import StudyRunRecorder
+from aec_bench.experimentation.learning_studies.runtime import (
+    ArmRunExecutionResult,
+    ArmRunStatus,
+    LearningStudyExecution,
+    run_learning_study,
+)
+from aec_bench.experimentation.learning_studies.worlds import (
+    WorldConsolidationOperation,
+    WorldFeedback,
+    WorldLearningBinding,
+    WorldLearningExecutionCondition,
+    WorldLearningTreatmentKind,
+    build_world_learning_operations,
+    resolve_world_learning_target,
+    world_canonical_reward,
+)
+from aec_bench.harness.dam_seepage_trial import run_dam_seepage_trial
+from aec_bench.worlds.monitoring.dam_seepage.dam_learning import (
+    DAM_ESCALATION_BOUNDARY_FEEDBACK_VIEW_ID,
+    dam_escalation_boundary_feedback,
+    dam_evidence_complete,
+    dam_response_correct,
+    validate_dam_escalation_boundary_feedback,
+)
+from aec_bench.worlds.monitoring.dam_seepage.world import DAM_SEEPAGE_TASK_WORLD_ID, SeepageResponse
+
+DAM_W02_PROTOCOL_ID = "w02-dam-structural-transfer"
+DAM_W02_STUDY_ID = "w02-dam-structural-transfer"
+DAM_W02_CONSOLIDATION_OPERATION_ID = "update-dam-monitoring-memory"
+DAM_W02_ACQUISITION_TASK_ID = f"world/{DAM_SEEPAGE_TASK_WORLD_ID}/unreliable-instrument-escalation"
+DAM_W02_PROBE_TASK_ID = f"world/{DAM_SEEPAGE_TASK_WORLD_ID}/unreliable-instrument-surface-transfer"
+
+_DAM_PROJECTORS: dict[str, Callable[[TrialRecord], float]] = {
+    "dam.response-correct": dam_response_correct,
+    "dam.evidence-complete": dam_evidence_complete,
+}
+_FORBIDDEN_LEARNER_MARKERS = (
+    b"/hidden/",
+    b"expected_answer",
+    b"expected_response",
+    b"gold-submissions",
+    b"private_path",
+    b"verifier-config",
+    b"required_response",
+    b"instrument_condition",
+    b"visual_alert_conditions",
+    b"required_consecutive_alert_readings",
+    b"reliable-routine-surveillance",
+    b"unreliable-instrument-surface-transfer",
+)
+_FORBIDDEN_LEARNER_FILENAMES: frozenset[str] = frozenset({"dam-world-evidence.json"})
+ModelT = TypeVar("ModelT", bound=BaseModel)
+
+
+@dataclass(frozen=True)
+class W02DamRun:
+    spec: LearningStudySpec
+    plan: CompiledLearningStudy
+    execution: LearningStudyExecution[WorldFeedback]
+    arm_evidence: Mapping[str, AssessmentArmEvidence]
+    acquisition_fidelity: Mapping[str, W02AcquisitionFidelity]
+    unreviewed_assessment: LearningStudyAssessment
+    reviewed_assessment: LearningStudyAssessment
+
+
+@dataclass(frozen=True, slots=True)
+class W02AcquisitionFidelity:
+    """Truthful acquisition facts derived from the arm's persisted TrialRecord."""
+
+    arm_run_id: str
+    trial_id: str | None
+    trial_record_present: bool
+    replay_valid: bool | None
+    response_correct: bool | None
+    evidence_complete: bool | None
+    escalation_selected: bool | None
+    acquisition_successful: bool
+
+    @property
+    def fidelity_satisfied(self) -> bool:
+        """Return whether the acquisition supports a transfer claim."""
+
+        return self.acquisition_successful
+
+
+def load_w02_dam_protocol(
+    *,
+    agent: AgentConfig,
+    compute: ComputeConfig,
+    repetitions: int = 1,
+) -> LearningStudySpec:
+    """Load the maintained W02 protocol with one explicit run configuration."""
+
+    return load_learning_study_protocol(
+        BUILTIN_LEARNING_STUDY_PROTOCOLS / DAM_W02_PROTOCOL_ID,
+        agent=agent,
+        compute=compute,
+        repetitions=repetitions,
+    )
+
+
+def compile_w02_dam_study(
+    *,
+    study_run_id: str,
+    agent: AgentConfig,
+    compute: ComputeConfig,
+    repetitions: int = 1,
+) -> CompiledLearningStudy:
+    """Compile W02 into ordinary planned world trials."""
+
+    spec = load_w02_dam_protocol(agent=agent, compute=compute, repetitions=repetitions)
+    return compile_learning_study(
+        study_run_id=study_run_id,
+        spec=spec,
+        resolve_task=resolve_world_learning_target,
+    )
+
+
+def build_w02_dam_binding(
+    *,
+    run_root: Path,
+    execution_condition: WorldLearningExecutionCondition,
+    consolidation_operation: WorldConsolidationOperation,
+    resume_existing_run: bool = False,
+) -> WorldLearningBinding:
+    """Bind W02's two treatments, one feedback view, and one consolidation operation."""
+
+    instruction = (
+        "Review the dam-seepage monitoring point, gather enough measurement and visual evidence "
+        "for the current response, and submit either engineering-review escalation or continued "
+        "routine surveillance."
+    )
+    return build_world_learning_operations(
+        run_root=run_root,
+        world_id=DAM_SEEPAGE_TASK_WORLD_ID,
+        execution_condition=execution_condition,
+        run_trial=run_dam_seepage_trial,
+        instructions={
+            DAM_W02_ACQUISITION_TASK_ID: instruction,
+            DAM_W02_PROBE_TASK_ID: instruction,
+        },
+        treatment_kinds={
+            "reset": WorldLearningTreatmentKind.RESET,
+            "structured-memory": WorldLearningTreatmentKind.STRUCTURED_MEMORY,
+        },
+        feedback_projectors={DAM_ESCALATION_BOUNDARY_FEEDBACK_VIEW_ID: dam_escalation_boundary_feedback},
+        consolidation_operations={DAM_W02_CONSOLIDATION_OPERATION_ID: consolidation_operation},
+        resume_existing_run=resume_existing_run,
+    )
+
+
+def w02_dam_outcome_projections() -> dict[str, OutcomeProjection]:
+    """Return the explicit W02 projection mapping without global registration."""
+
+    projections: dict[str, OutcomeProjection] = {"world.canonical-reward": _project_probe_reward}
+    projections.update({projection_id: _dam_projection(reader) for projection_id, reader in _DAM_PROJECTORS.items()})
+    return projections
+
+
+async def run_w02_dam_study(
+    *,
+    run_root: Path,
+    study_run_id: str,
+    agent: AgentConfig,
+    compute: ComputeConfig,
+    execution_condition: WorldLearningExecutionCondition,
+    consolidation_operation: WorldConsolidationOperation,
+    repetitions: int = 1,
+) -> W02DamRun:
+    """Run, record, and assess W02 under both relation-review states."""
+
+    plan = compile_w02_dam_study(
+        study_run_id=study_run_id,
+        agent=agent,
+        compute=compute,
+        repetitions=repetitions,
+    )
+    binding = build_w02_dam_binding(
+        run_root=run_root,
+        execution_condition=execution_condition,
+        consolidation_operation=consolidation_operation,
+    )
+    recorder = StudyRunRecorder(
+        root=run_root,
+        plan=plan,
+        snapshot_state=binding.snapshot_state,
+        feedback_artifacts=binding.feedback_artifacts,
+    )
+    execution = await run_learning_study(plan=plan, operations=binding.operations, observer=recorder)
+    arm_evidence = build_w02_assessment_arm_evidence(
+        run_root=run_root,
+        plan=plan,
+        execution=execution,
+        adapter_id=execution_condition.adapter_id,
+    )
+    acquisition_fidelity = build_w02_acquisition_fidelity(plan=plan, execution=execution)
+    projections = w02_dam_outcome_projections()
+    assessment_execution = cast(LearningStudyExecution[object], execution)
+    return W02DamRun(
+        spec=plan.spec,
+        plan=plan,
+        execution=execution,
+        arm_evidence=arm_evidence,
+        acquisition_fidelity=acquisition_fidelity,
+        unreviewed_assessment=assess_learning_study(
+            spec=plan.spec,
+            plan=plan,
+            execution=assessment_execution,
+            projections=projections,
+            arm_evidence=arm_evidence,
+            relations_reviewed=False,
+        ),
+        reviewed_assessment=assess_learning_study(
+            spec=plan.spec,
+            plan=plan,
+            execution=assessment_execution,
+            projections=projections,
+            arm_evidence=arm_evidence,
+            relations_reviewed=True,
+        ),
+    )
+
+
+def run_w02_dam_study_sync(**kwargs: Any) -> W02DamRun:
+    """Run W02 from synchronous research and test entry points."""
+
+    return asyncio.run(run_w02_dam_study(**kwargs))
+
+
+def build_w02_acquisition_fidelity(
+    *,
+    plan: CompiledLearningStudy,
+    execution: LearningStudyExecution[WorldFeedback],
+) -> dict[str, W02AcquisitionFidelity]:
+    """Derive acquisition fidelity from the real TrialRecords in each acquisition arm."""
+
+    if plan.spec.study_id != DAM_W02_STUDY_ID or execution.study_run_id != plan.study_run_id:
+        raise ValueError("acquisition-fidelity-incomplete: inputs do not identify W02")
+
+    execution_by_arm: dict[str, ArmRunExecutionResult[WorldFeedback]] = {}
+    for item in execution.arm_runs:
+        if item.arm_run_id in execution_by_arm:
+            raise ValueError(f"acquisition-fidelity-ambiguous: duplicate arm result: {item.arm_run_id}")
+        execution_by_arm[item.arm_run_id] = item
+    fidelity: dict[str, W02AcquisitionFidelity] = {}
+    for arm_run in plan.arm_runs:
+        acquisition_steps = tuple(
+            step
+            for step in arm_run.steps
+            if isinstance(step, CompiledExperienceStep) and step.role is ExperienceRole.ACQUISITION
+        )
+        if not acquisition_steps:
+            continue
+        if len(acquisition_steps) != 1:
+            raise ValueError(f"acquisition-fidelity-incomplete: expected one acquisition: {arm_run.arm_run_id}")
+
+        step = acquisition_steps[0]
+        arm_result = execution_by_arm.get(arm_run.arm_run_id)
+        matching_records = (
+            ()
+            if arm_result is None
+            else tuple(
+                item
+                for item in arm_result.trial_records
+                if item.trial_id == step.trial.trial_id and item.task_id == DAM_W02_ACQUISITION_TASK_ID
+            )
+        )
+        if len(matching_records) > 1:
+            raise ValueError(f"acquisition-fidelity-ambiguous: expected one acquisition: {arm_run.arm_run_id}")
+        record = matching_records[0] if matching_records else None
+        if record is None:
+            fidelity[arm_run.arm_run_id] = W02AcquisitionFidelity(
+                arm_run_id=arm_run.arm_run_id,
+                trial_id=None,
+                trial_record_present=False,
+                replay_valid=None,
+                response_correct=None,
+                evidence_complete=None,
+                escalation_selected=None,
+                acquisition_successful=False,
+            )
+            continue
+
+        evaluation = record.evaluation if record.evaluation_status is EvaluationStatus.COMPLETED else None
+        breakdown = None if evaluation is None else evaluation.breakdown
+        breakdown = breakdown if isinstance(breakdown, dict) else None
+        response_correct = _optional_bool(breakdown, "response_correct")
+        evidence_complete = _optional_bool(breakdown, "evidence_complete")
+        selected_response = None if breakdown is None else breakdown.get("selected_response")
+        escalation_selected = (
+            selected_response == SeepageResponse.ENGINEERING_REVIEW.value
+            if isinstance(selected_response, str)
+            else None
+        )
+        replay_valid = None if evaluation is None else evaluation.validity.verifier_completed
+        execution_completed = record.execution_status is ExecutionStatus.COMPLETED
+        evaluation_completed = record.evaluation_status is EvaluationStatus.COMPLETED
+        acquisition_successful = (
+            execution_completed
+            and evaluation_completed
+            and replay_valid is True
+            and response_correct is True
+            and evidence_complete is True
+            and escalation_selected is True
+        )
+        fidelity[arm_run.arm_run_id] = W02AcquisitionFidelity(
+            arm_run_id=arm_run.arm_run_id,
+            trial_id=record.trial_id,
+            trial_record_present=True,
+            replay_valid=replay_valid,
+            response_correct=response_correct,
+            evidence_complete=evidence_complete,
+            escalation_selected=escalation_selected,
+            acquisition_successful=acquisition_successful,
+        )
+    return fidelity
+
+
+def build_w02_assessment_arm_evidence(
+    *,
+    run_root: Path,
+    plan: CompiledLearningStudy,
+    execution: LearningStudyExecution[WorldFeedback],
+    adapter_id: str,
+) -> dict[str, AssessmentArmEvidence]:
+    """Derive every assessment fact from the completed plan and persisted evidence."""
+
+    root = Path(run_root).resolve(strict=True)
+    if plan.spec.study_id != DAM_W02_STUDY_ID or execution.study_run_id != plan.study_run_id:
+        raise ValueError("assessment-evidence-incomplete: inputs do not identify W02")
+    execution_by_arm = {item.arm_run_id: item for item in execution.arm_runs}
+    evidence: dict[str, AssessmentArmEvidence] = {}
+    for arm_run in plan.arm_runs:
+        arm_result = execution_by_arm.get(arm_run.arm_run_id)
+        if arm_result is None or arm_result.initial_state_id is None:
+            raise ValueError(f"assessment-evidence-incomplete: arm result is missing: {arm_run.arm_run_id}")
+        initial_ref = _read_model(
+            root / "states" / f"{arm_result.initial_state_id}.json",
+            LearnerStateRef,
+        )
+        if initial_ref.arm_run_id != arm_run.arm_run_id or initial_ref.parent_state_id is not None:
+            raise ValueError(f"assessment-evidence-incomplete: initial state is invalid: {arm_run.arm_run_id}")
+        evidence[arm_run.arm_run_id] = AssessmentArmEvidence(
+            adapter_id=adapter_id,
+            initial_state_equivalence_id=f"world-initial-state:{initial_ref.artifact.sha256}",
+            arm_isolated=_arm_isolated(root, arm_run, arm_result),
+            lineage_complete=_lineage_complete(root, plan, arm_run, arm_result),
+            probe_feedback_hidden=_probe_feedback_hidden(root, plan.spec, arm_run, arm_result),
+            probe_state_discarded=_probe_state_discarded(root, arm_run),
+            hidden_evaluation_leaked=not _hidden_evaluation_absent(root, arm_run),
+        )
+    return evidence
+
+
+def _project_probe_reward(record: TrialRecord) -> ProjectionResult:
+    if record.task_id != DAM_W02_PROBE_TASK_ID:
+        return _ineligible(f"projection-task-mismatch: {record.task_id}")
+    try:
+        value = world_canonical_reward(record)
+    except ValueError as error:
+        return _ineligible(str(error))
+    return ProjectionResult(eligible=True, value=value, lower_bound=0.0, upper_bound=1.0)
+
+
+def _dam_projection(reader: Callable[[TrialRecord], float]) -> OutcomeProjection:
+    def project(record: TrialRecord) -> ProjectionResult:
+        if record.task_id != DAM_W02_PROBE_TASK_ID:
+            return _ineligible(f"projection-task-mismatch: {record.task_id}")
+        try:
+            value = reader(record)
+        except ValueError as error:
+            return _ineligible(str(error))
+        return ProjectionResult(eligible=True, value=value, lower_bound=0.0, upper_bound=1.0)
+
+    return project
+
+
+def _ineligible(reason: str) -> ProjectionResult:
+    return ProjectionResult(eligible=False, value=None, reason=reason)
+
+
+def _arm_isolated(root: Path, arm_run: PlannedArmRun, result: ArmRunExecutionResult[WorldFeedback]) -> bool:
+    try:
+        arm_root = root / "learner-arms" / arm_run.arm_run_id
+        learner_arms_root = (root / "learner-arms").resolve(strict=True)
+        if not arm_root.is_dir() or arm_root.is_symlink() or arm_root.resolve(strict=True).parent != learner_arms_root:
+            return False
+        arm_root_resolved = arm_root.resolve(strict=True)
+        for step_result in result.completed_steps:
+            if step_result.trial_record is None:
+                continue
+            output = step_result.trial_record.output
+            if output is None or output.agent_output is None:
+                return False
+            evidence_path = Path(output.agent_output.output_path).resolve(strict=True)
+            if evidence_path == arm_root_resolved or arm_root_resolved in evidence_path.parents:
+                return False
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def _lineage_complete(
+    root: Path,
+    plan: CompiledLearningStudy,
+    arm_run: PlannedArmRun,
+    result: ArmRunExecutionResult[WorldFeedback],
+) -> bool:
+    try:
+        if result.status is not ArmRunStatus.COMPLETED or result.initial_state_id is None:
+            return False
+        if len(result.completed_steps) != len(arm_run.steps):
+            return False
+        current_state_id = result.initial_state_id
+        for index, step in enumerate(arm_run.steps):
+            receipt = _read_model(
+                root / "steps" / arm_run.arm_run_id / f"{index:03d}-{step.step_id}.json",
+                StudyStepReceipt,
+            )
+            if receipt.status is not StudyStepStatus.COMPLETED or receipt.transition_id is None:
+                return False
+            transition = _read_model(root / "transitions" / f"{receipt.transition_id}.json", LearnerTransitionReceipt)
+            if transition.arm_run_id != arm_run.arm_run_id or transition.step_id != step.step_id:
+                return False
+            if transition.state_before_id != current_state_id:
+                return False
+            expected_kind = "consolidation"
+            expected_committed = True
+            if isinstance(step, CompiledExperienceStep):
+                expected_kind = "experience" if step.commit_post_state else "probe_discard"
+                expected_committed = step.commit_post_state
+            elif isinstance(step, CompiledFeedbackStep):
+                expected_kind = "feedback_release"
+                if receipt.feedback_id is None:
+                    return False
+                feedback = _read_model(root / "feedback" / f"{receipt.feedback_id}.json", FeedbackReleaseRecord)
+                if (
+                    feedback.arm_run_id != arm_run.arm_run_id
+                    or feedback.release_step_id != step.step_id
+                    or feedback.source_experience_id != step.source_experience_id
+                    or feedback.view_id != step.feedback_view_id
+                    or feedback.state_before_id != current_state_id
+                    or feedback.state_after_id != transition.committed_state_id
+                ):
+                    return False
+            elif isinstance(step, CompiledConsolidationStep):
+                expected_kind = "consolidation"
+            if transition.operation_kind != expected_kind or transition.committed is not expected_committed:
+                return False
+            if expected_committed:
+                state_ref = _read_model(
+                    root / "states" / f"{transition.candidate_state_id}.json",
+                    LearnerStateRef,
+                )
+                if state_ref.parent_state_id != current_state_id or state_ref.created_after_step_id != step.step_id:
+                    return False
+            if transition.committed_state_id is None:
+                return False
+            current_state_id = transition.committed_state_id
+        recorded = _read_model(root / "result.json", RecordedStudyExecution)
+        recorded_arm = next(item for item in recorded.arm_runs if item.arm_run_id == arm_run.arm_run_id)
+        return result.final_state_id == current_state_id == recorded_arm.final_state_id
+    except (OSError, StopIteration, ValueError):
+        return False
+
+
+def _probe_feedback_hidden(
+    root: Path,
+    spec: LearningStudySpec,
+    arm_run: PlannedArmRun,
+    result: ArmRunExecutionResult[WorldFeedback],
+) -> bool:
+    probe_ids = {item.experience_id for item in spec.experiences if item.role is ExperienceRole.PROBE}
+    if any(isinstance(step, CompiledFeedbackStep) and step.source_experience_id in probe_ids for step in arm_run.steps):
+        return False
+    probe_trial_ids = {
+        step_result.trial_record.trial_id
+        for step_result in result.completed_steps
+        if step_result.trial_record is not None and step_result.trial_record.task_id == DAM_W02_PROBE_TASK_ID
+    }
+    try:
+        for feedback_path in (root / "feedback").glob("*.json"):
+            feedback = _read_model(feedback_path, FeedbackReleaseRecord)
+            if feedback.arm_run_id == arm_run.arm_run_id and (
+                feedback.source_experience_id in probe_ids or feedback.source_trial_id in probe_trial_ids
+            ):
+                return False
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def _probe_state_discarded(root: Path, arm_run: PlannedArmRun) -> bool:
+    try:
+        arm_root = root / "learner-arms" / arm_run.arm_run_id
+        for index, step in enumerate(arm_run.steps):
+            if not isinstance(step, CompiledExperienceStep) or step.role is not ExperienceRole.PROBE:
+                continue
+            if step.commit_post_state:
+                return False
+            receipt = _read_model(
+                root / "steps" / arm_run.arm_run_id / f"{index:03d}-{step.step_id}.json",
+                StudyStepReceipt,
+            )
+            if receipt.transition_id is None:
+                return False
+            transition = _read_model(root / "transitions" / f"{receipt.transition_id}.json", LearnerTransitionReceipt)
+            if transition.operation_kind != "probe_discard" or transition.committed:
+                return False
+            if (arm_root / "states" / step.step_id).exists():
+                return False
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def _hidden_evaluation_absent(root: Path, arm_run: PlannedArmRun) -> bool:
+    try:
+        arm_root = root / "learner-arms" / arm_run.arm_run_id
+        states_root = arm_root / "states"
+        for state_root in (path for path in states_root.iterdir() if path.is_dir()):
+            validate_learner_state(state_root)
+            for path in (item for item in state_root.rglob("*") if item.is_file()):
+                if path.name in _FORBIDDEN_LEARNER_FILENAMES:
+                    return False
+                data = path.read_bytes()
+                if any(marker in data.lower() for marker in _FORBIDDEN_LEARNER_MARKERS):
+                    return False
+                if path.parent.name == "feedback":
+                    validate_dam_escalation_boundary_feedback(data)
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def _optional_bool(breakdown: dict[str, Any] | None, field: str) -> bool | None:
+    if breakdown is None:
+        return None
+    value = breakdown.get(field)
+    return value if isinstance(value, bool) else None
+
+
+def _read_model(path: Path, model_type: type[ModelT]) -> ModelT:
+    return model_type.model_validate_json(path.read_text(encoding="utf-8"))
+
+
+__all__ = (
+    "DAM_W02_ACQUISITION_TASK_ID",
+    "DAM_W02_CONSOLIDATION_OPERATION_ID",
+    "DAM_W02_PROBE_TASK_ID",
+    "DAM_W02_PROTOCOL_ID",
+    "DAM_W02_STUDY_ID",
+    "W02AcquisitionFidelity",
+    "W02DamRun",
+    "build_w02_acquisition_fidelity",
+    "build_w02_assessment_arm_evidence",
+    "build_w02_dam_binding",
+    "compile_w02_dam_study",
+    "load_w02_dam_protocol",
+    "run_w02_dam_study",
+    "run_w02_dam_study_sync",
+    "w02_dam_outcome_projections",
+)

--- a/src/aec_bench/experimentation/learning_studies/protocols/w02-dam-structural-transfer/family.toml
+++ b/src/aec_bench/experimentation/learning_studies/protocols/w02-dam-structural-transfer/family.toml
@@ -1,0 +1,81 @@
+family_id = "dam-seepage-structural-transfer"
+title = "Dam-seepage structural transfer"
+description = "Tests whether experience with unreliable-instrument escalation transfers to a surface-varied probe where the same causal driver applies but monitoring point, reading magnitudes, timing, and objective wording differ. Independent domain review is required before a claim-bearing run."
+
+[[dimensions]]
+dimension_id = "instrument_reliability"
+kind = "causal"
+description = "Whether the measurement instrument is reliable or unreliable, and when this is released to the learner (only after CHECK_MEASUREMENT_SYSTEM)"
+
+[[dimensions]]
+dimension_id = "response_applicability"
+kind = "applicability"
+description = "Whether escalation is the response the currently released evidence supports"
+
+[[dimensions]]
+dimension_id = "evidence_gating"
+kind = "causal"
+description = "The epistemic-action requirement: instrument condition is released only after CHECK_MEASUREMENT_SYSTEM in both profiles"
+
+[[dimensions]]
+dimension_id = "monitoring_point_identity"
+kind = "surface"
+description = "The monitoring point identifier presented to the learner"
+
+[[dimensions]]
+dimension_id = "reading_magnitudes"
+kind = "surface"
+description = "The expected, alert, and measured flow values plus reservoir levels across readings"
+
+[[dimensions]]
+dimension_id = "timing_cadence"
+kind = "surface"
+description = "The elapsed-hours spacing between successive readings"
+
+[[dimensions]]
+dimension_id = "objective_wording"
+kind = "surface"
+description = "The prose objective text presented to the learner at scenario start"
+
+[[members]]
+member_id = "unreliable-instrument-escalation-acquisition"
+task_id = "world/dam-seepage-monitoring/unreliable-instrument-escalation"
+description = "The measurement instrument is unreliable; no visual alert condition or flow-threshold breach occurs; escalation is justified solely by instrument distrust"
+probe_only = false
+[members.dimension_values]
+instrument_reliability = "unreliable, released only after CHECK_MEASUREMENT_SYSTEM"
+response_applicability = "engineering-review escalation is the only response the released evidence supports"
+evidence_gating = "instrument condition hidden until CHECK_MEASUREMENT_SYSTEM"
+monitoring_point_identity = "SEEP-WEIR-02"
+reading_magnitudes = "expected 20.0, alert 27.0, measured 19.5–20.2 l/min; reservoir 100.0–100.1 m"
+timing_cadence = "6-hour intervals: 0, 6, 12, 18 hours"
+objective_wording = "Review the seepage event, gather enough measurement and visual evidence for the current response, and submit either engineering-review escalation or continued routine surveillance."
+
+[[members]]
+member_id = "unreliable-instrument-surface-transfer-probe"
+task_id = "world/dam-seepage-monitoring/unreliable-instrument-surface-transfer"
+description = "The measurement instrument is unreliable at a different monitoring point with different magnitudes and timing; escalation is justified solely by instrument distrust"
+probe_only = true
+[members.dimension_values]
+instrument_reliability = "unreliable, released only after CHECK_MEASUREMENT_SYSTEM"
+response_applicability = "engineering-review escalation is the only response the released evidence supports"
+evidence_gating = "instrument condition hidden until CHECK_MEASUREMENT_SYSTEM"
+monitoring_point_identity = "SEEP-WEIR-07"
+reading_magnitudes = "expected 18.0, alert 24.0, measured 15.8–16.2 l/min; reservoir 95.1–95.3 m"
+timing_cadence = "8-hour intervals: 0, 8, 16, 24 hours"
+objective_wording = "Assess the seepage monitoring data, obtain sufficient measurement and visual evidence to determine the appropriate response, and submit either engineering-review escalation or continued routine surveillance."
+
+[[relations]]
+relation_id = "unreliable-instrument-escalation-to-surface-transfer"
+purpose = "transfer"
+source_member_ids = ["unreliable-instrument-escalation-acquisition"]
+target_member_id = "unreliable-instrument-surface-transfer-probe"
+invariant_dimensions = ["instrument_reliability", "response_applicability", "evidence_gating"]
+invariant_claims = [
+  "Both profiles have instrument_condition: unreliable. The causal driver of the correct response is identical.",
+  "Both profiles require ENGINEERING_REVIEW as the correct terminal response. The correct action is identical.",
+  "In both profiles, instrument condition is released only after CHECK_MEASUREMENT_SYSTEM. The epistemic-action requirement is identical.",
+  "In both profiles, no reading trips flow-alert thresholds and no downstream condition triggers a visual alert. Escalation is justified solely by instrument distrust.",
+]
+changed_dimensions = ["monitoring_point_identity", "reading_magnitudes", "timing_cadence", "objective_wording"]
+rationale = "The acquisition teaches a valid escalation conditioned on instrument distrust. The probe changes every surface detail (monitoring point, reading magnitudes, timing, objective wording) while preserving the same causal condition. A learner that extracted the conditional rule should check the instrument and correctly escalate; a learner that memorised surface patterns will find no match. A domain reviewer and benchmark reviewer must approve this relation before a claim-bearing campaign."

--- a/src/aec_bench/experimentation/learning_studies/protocols/w02-dam-structural-transfer/study.toml
+++ b/src/aec_bench/experimentation/learning_studies/protocols/w02-dam-structural-transfer/study.toml
@@ -1,0 +1,111 @@
+study_id = "w02-dam-structural-transfer"
+title = "Dam-seepage structural transfer"
+research_question = "Does declared public feedback and explicit structured memory from an instrument-unreliability-justified escalation cause correct escalation transfer to a surface-varied probe where the same causal driver applies?"
+relation_ids = ["unreliable-instrument-escalation-to-surface-transfer"]
+
+[[experiences]]
+experience_id = "unreliable-instrument-escalation-acquisition"
+family_member_id = "unreliable-instrument-escalation-acquisition"
+role = "acquisition"
+
+[[experiences]]
+experience_id = "unreliable-instrument-surface-transfer-probe"
+family_member_id = "unreliable-instrument-surface-transfer-probe"
+role = "probe"
+
+[[measurements]]
+measurement_id = "structured-memory-response-correct-gain"
+projection_id = "dam.response-correct"
+direction = "higher"
+target_experience_id = "unreliable-instrument-surface-transfer-probe"
+focal_arm_id = "structured-memory"
+comparator_arm_id = "cold-reset"
+
+[[measurements]]
+measurement_id = "structured-memory-evidence-complete-gain"
+projection_id = "dam.evidence-complete"
+direction = "higher"
+target_experience_id = "unreliable-instrument-surface-transfer-probe"
+focal_arm_id = "structured-memory"
+comparator_arm_id = "cold-reset"
+
+[[measurements]]
+measurement_id = "structured-memory-canonical-reward-gain"
+projection_id = "world.canonical-reward"
+direction = "higher"
+target_experience_id = "unreliable-instrument-surface-transfer-probe"
+focal_arm_id = "structured-memory"
+comparator_arm_id = "cold-reset"
+
+[[measurements]]
+measurement_id = "reset-after-acquisition-response-correct-gain"
+projection_id = "dam.response-correct"
+direction = "higher"
+target_experience_id = "unreliable-instrument-surface-transfer-probe"
+focal_arm_id = "reset-after-acquisition"
+comparator_arm_id = "cold-reset"
+
+[[measurements]]
+measurement_id = "reset-after-acquisition-evidence-complete-gain"
+projection_id = "dam.evidence-complete"
+direction = "higher"
+target_experience_id = "unreliable-instrument-surface-transfer-probe"
+focal_arm_id = "reset-after-acquisition"
+comparator_arm_id = "cold-reset"
+
+[[arms]]
+arm_id = "cold-reset"
+role = "control"
+treatment_id = "reset"
+
+[[arms.steps]]
+kind = "run_experience"
+step_id = "cold-probe"
+experience_id = "unreliable-instrument-surface-transfer-probe"
+commit_post_state = false
+
+[[arms]]
+arm_id = "reset-after-acquisition"
+role = "control"
+treatment_id = "reset"
+
+[[arms.steps]]
+kind = "run_experience"
+step_id = "reset-acquisition"
+experience_id = "unreliable-instrument-escalation-acquisition"
+commit_post_state = true
+
+[[arms.steps]]
+kind = "run_experience"
+step_id = "reset-probe"
+experience_id = "unreliable-instrument-surface-transfer-probe"
+commit_post_state = false
+
+[[arms]]
+arm_id = "structured-memory"
+role = "exposure"
+treatment_id = "structured-memory"
+
+[[arms.steps]]
+kind = "run_experience"
+step_id = "structured-acquisition"
+experience_id = "unreliable-instrument-escalation-acquisition"
+commit_post_state = true
+
+[[arms.steps]]
+kind = "release_feedback"
+step_id = "release-acquisition-feedback"
+source_experience_id = "unreliable-instrument-escalation-acquisition"
+feedback_view_id = "dam-escalation-boundary-public-feedback"
+
+[[arms.steps]]
+kind = "consolidate"
+step_id = "consolidate-monitoring-method"
+feedback_step_ids = ["release-acquisition-feedback"]
+operation_id = "update-dam-monitoring-memory"
+
+[[arms.steps]]
+kind = "run_experience"
+step_id = "structured-probe"
+experience_id = "unreliable-instrument-surface-transfer-probe"
+commit_post_state = false

--- a/src/aec_bench/worlds/monitoring/dam_seepage/unreliable-instrument-surface-transfer.json
+++ b/src/aec_bench/worlds/monitoring/dam_seepage/unreliable-instrument-surface-transfer.json
@@ -1,0 +1,52 @@
+{
+  "task_world_id": "dam-seepage-monitoring",
+  "profile_id": "unreliable-instrument-surface-transfer",
+  "monitoring_point_id": "SEEP-WEIR-07",
+  "objective": "Assess the seepage monitoring data, obtain sufficient measurement and visual evidence to determine the appropriate response, and submit either engineering-review escalation or continued routine surveillance.",
+  "baseline_note": "Expected and alert flows are site-specific values from this task-owned synthetic monitoring plan. They are not general dam-safety limits.",
+  "required_consecutive_alert_readings": 2,
+  "visual_alert_conditions": [
+    "cloudy",
+    "sediment-observed",
+    "new-seep"
+  ],
+  "instrument_condition": "unreliable",
+  "readings": [
+    {
+      "elapsed_hours": 0,
+      "reservoir_level_m": 95.2,
+      "recent_rainfall_mm": 0.0,
+      "expected_flow_l_min": 18.0,
+      "alert_flow_l_min": 24.0,
+      "measured_flow_l_min": 15.8,
+      "downstream_condition": "clear"
+    },
+    {
+      "elapsed_hours": 8,
+      "reservoir_level_m": 95.3,
+      "recent_rainfall_mm": 0.0,
+      "expected_flow_l_min": 18.0,
+      "alert_flow_l_min": 24.0,
+      "measured_flow_l_min": 16.2,
+      "downstream_condition": "clear"
+    },
+    {
+      "elapsed_hours": 16,
+      "reservoir_level_m": 95.2,
+      "recent_rainfall_mm": 0.0,
+      "expected_flow_l_min": 18.0,
+      "alert_flow_l_min": 24.0,
+      "measured_flow_l_min": 16.0,
+      "downstream_condition": "clear"
+    },
+    {
+      "elapsed_hours": 24,
+      "reservoir_level_m": 95.1,
+      "recent_rainfall_mm": 0.0,
+      "expected_flow_l_min": 18.0,
+      "alert_flow_l_min": 24.0,
+      "measured_flow_l_min": 15.9,
+      "downstream_condition": "clear"
+    }
+  ]
+}

--- a/src/aec_bench/worlds/monitoring/dam_seepage/variants.py
+++ b/src/aec_bench/worlds/monitoring/dam_seepage/variants.py
@@ -64,6 +64,24 @@ def dam_seepage_profile_variants() -> tuple[DamSeepageProfileVariant, ...]:
                 "conditions, so continued routine surveillance is the only correct response."
             ),
         ),
+        DamSeepageProfileVariant(
+            profile_id="unreliable-instrument-surface-transfer",
+            scenario_path=_SCENARIO_DIR / "unreliable-instrument-surface-transfer.json",
+            title="Unreliable instrument surface transfer",
+            summary=(
+                "A surface-varied seepage event at a different monitoring point where the measurement "
+                "instrument is unreliable."
+            ),
+            difficulty=Difficulty.MEDIUM,
+            tags=("dam", "monitoring", "seepage", "synthetic", "probe", "transfer"),
+            expected_required_response=SeepageResponse.ENGINEERING_REVIEW,
+            rationale=(
+                "instrument_condition is unreliable while every reading stays within routine "
+                "flow and visual limits at a different monitoring point with different magnitudes "
+                "and timing, so escalation is justified solely by instrument distrust — the same "
+                "causal driver as the acquisition but with changed surface presentation."
+            ),
+        ),
     )
 
 

--- a/tests/experimentation/learning_studies/test_dam_w02.py
+++ b/tests/experimentation/learning_studies/test_dam_w02.py
@@ -1,0 +1,557 @@
+# ABOUTME: Proves safe dam feedback, named projections, and the complete deterministic W02 slice.
+# ABOUTME: Verifies truthful assessment evidence, probe isolation, and relation-review downgrades.
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from aec_bench.contracts.agent_output import AgentOutput, AgentOutputStatus
+from aec_bench.contracts.evaluation_result import EvaluationResult, ValidityCheck
+from aec_bench.contracts.experiment_manifest import AgentConfig, ComputeConfig
+from aec_bench.contracts.learning_study_assessment import LearningComparisonValidity
+from aec_bench.contracts.trial_record import EvaluationStatus, TrialOutput, TrialRecord
+from aec_bench.experimentation.learning_studies.dam_w02 import (
+    DAM_W02_ACQUISITION_TASK_ID,
+    DAM_W02_CONSOLIDATION_OPERATION_ID,
+    DAM_W02_PROBE_TASK_ID,
+    DAM_W02_STUDY_ID,
+    build_w02_acquisition_fidelity,
+    compile_w02_dam_study,
+    load_w02_dam_protocol,
+    run_w02_dam_study_sync,
+    w02_dam_outcome_projections,
+)
+from aec_bench.experimentation.learning_studies.planning import CompiledExperienceStep, CompiledFeedbackStep
+from aec_bench.experimentation.learning_studies.runtime import (
+    ArmRunExecutionResult,
+    ArmRunStatus,
+    LearningStudyExecution,
+    ReleaseFeedbackRequest,
+)
+from aec_bench.experimentation.learning_studies.worlds import (
+    WorldConsolidationContext,
+    WorldLearningExecutionCondition,
+    WorldLearningTreatmentKind,
+    build_world_learning_operations,
+)
+from aec_bench.harness.dam_seepage_trial import run_dam_seepage_trial
+from aec_bench.harness.prime_world_actor import run_prime_world_actor_session
+from aec_bench.worlds.monitoring.dam_seepage.dam_learning import (
+    DAM_ESCALATION_BOUNDARY_FEEDBACK_VIEW_ID,
+    dam_escalation_boundary_feedback,
+    validate_dam_escalation_boundary_feedback,
+)
+from aec_bench.worlds.monitoring.dam_seepage.variants import (
+    dam_seepage_profile_variants,
+    validate_dam_seepage_profile_variant,
+)
+from aec_bench.worlds.monitoring.dam_seepage.world import DAM_SEEPAGE_TASK_WORLD_ID, SeepageAction
+from tests.support.trial_record_factories import make_trial_record
+
+_COMPUTE = ComputeConfig(backend="local")
+_CONDITION = WorldLearningExecutionCondition(
+    actor=run_prime_world_actor_session,
+    actor_binding_label="prime-fake-executable",
+)
+_ROUTINE_ACTIONS = [
+    {"action_name": SeepageAction.CHECK_MEASUREMENT_SYSTEM.value, "arguments": {}, "request_id": "check"},
+    {"action_name": SeepageAction.RECORD_CONFIRMATION_READING.value, "arguments": {}, "request_id": "reading-2"},
+    {"action_name": SeepageAction.RECORD_CONFIRMATION_READING.value, "arguments": {}, "request_id": "reading-3"},
+    {"action_name": SeepageAction.RECORD_CONFIRMATION_READING.value, "arguments": {}, "request_id": "reading-4"},
+    {"action_name": SeepageAction.INSPECT_DOWNSTREAM_AREA.value, "arguments": {}, "request_id": "inspect"},
+    {"action_name": SeepageAction.CONTINUE_ROUTINE_SURVEILLANCE.value, "arguments": {}, "request_id": "submit"},
+]
+_ACQUISITION_ACTIONS = [
+    {"action_name": SeepageAction.CHECK_MEASUREMENT_SYSTEM.value, "arguments": {}, "request_id": "check"},
+    {
+        "action_name": SeepageAction.ESCALATE_FOR_ENGINEERING_REVIEW.value,
+        "arguments": {},
+        "request_id": "escalate",
+    },
+]
+
+
+async def _instrument_aware_actor_session(**kwargs: Any):  # noqa: ANN202
+    trial = kwargs["trial"]
+    actions = _ACQUISITION_ACTIONS if trial.task_id == DAM_W02_ACQUISITION_TASK_ID else _ROUTINE_ACTIONS
+    environment = {
+        **trial.agent.parameters["environment"],
+        "FAKE_WORLD_ACTIONS": json.dumps(actions),
+    }
+    agent = trial.agent.model_copy(update={"parameters": {**trial.agent.parameters, "environment": environment}})
+    return await run_prime_world_actor_session(**{**kwargs, "trial": replace(trial, agent=agent)})
+
+
+_INSTRUMENT_AWARE_CONDITION = WorldLearningExecutionCondition(
+    actor=_instrument_aware_actor_session,
+    actor_binding_label=_CONDITION.actor_binding_label,
+)
+
+
+_PROJECTION_IDS = {
+    "world.canonical-reward",
+    "dam.response-correct",
+    "dam.evidence-complete",
+}
+
+
+def _agent(
+    tmp_path: Path,
+    *,
+    isolation: str = "development_same_user",
+) -> AgentConfig:
+    from tests.prime_agent.test_acp import _fake_prime_agent
+
+    return AgentConfig(
+        name="prime",
+        adapter="prime-agent",
+        model="anthropic/test",
+        parameters={
+            "isolation": isolation,
+            "max_world_actions": 10,
+            "max_model_calls": 10,
+            "max_tokens": 1_000,
+            "max_cost_usd": "10",
+            "max_wall_seconds": 5,
+            "executable": str(_fake_prime_agent(tmp_path)),
+            "environment": {
+                **os.environ,
+                "FAKE_ACP_SCENARIO": "world",
+                "FAKE_WORLD_ACTIONS": json.dumps(_ROUTINE_ACTIONS),
+            },
+        },
+    )
+
+
+class _DeclaredDamMemoryConsolidator:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self, context: WorldConsolidationContext) -> None:
+        self.calls += 1
+        assert len(context.feedback) == 1
+        feedback = validate_dam_escalation_boundary_feedback(context.feedback[0].path.read_bytes())
+        principles = "\n".join(f"- {item}" for item in feedback["monitoring_discipline_principles"])
+        (context.memory_root / "dam-monitoring-strategy.md").write_text(
+            f"# Dam monitoring strategy\n\n{principles}\n",
+            encoding="utf-8",
+        )
+
+
+def _completed_acquisition_record(tmp_path: Path):  # noqa: ANN202
+    evidence_path = tmp_path / "world-evidence" / "dam-world-evidence.json"
+    evidence_path.parent.mkdir(parents=True, exist_ok=True)
+    actions = [
+        SeepageAction.CHECK_MEASUREMENT_SYSTEM.value,
+        SeepageAction.ESCALATE_FOR_ENGINEERING_REVIEW.value,
+    ]
+    evidence_path.write_text(
+        json.dumps({"actions": actions, "status": "terminated", "replay_valid": True}),
+        encoding="utf-8",
+    )
+    return make_trial_record(
+        task_id=DAM_W02_ACQUISITION_TASK_ID,
+        output=TrialOutput(
+            agent_output=AgentOutput(
+                status=AgentOutputStatus.COMPLETED,
+                output_path=str(evidence_path),
+                output_format="json",
+            ),
+        ),
+        evaluation=EvaluationResult(
+            reward=1.0,
+            validity=ValidityCheck(output_parseable=True, schema_valid=True, verifier_completed=True),
+            breakdown={
+                "assessment_submitted": True,
+                "selected_response": "engineering-review",
+                "required_response": "engineering-review",
+                "response_correct": True,
+                "all_scheduled_readings_reviewed": False,
+                "measurement_system_checked": True,
+                "latest_downstream_area_inspected": False,
+                "evidence_complete": True,
+                "successful": True,
+            },
+        ),
+    )
+
+
+def test_all_registered_dam_profiles_validate_including_w02_probe() -> None:
+    variants = dam_seepage_profile_variants()
+
+    assert [variant.profile_id for variant in variants] == [
+        "unreliable-instrument-escalation",
+        "reliable-routine-surveillance",
+        "unreliable-instrument-surface-transfer",
+    ]
+    assert validate_dam_seepage_profile_variant(variants[2]).profile_id == "unreliable-instrument-surface-transfer"
+    for variant in variants:
+        scenario = validate_dam_seepage_profile_variant(variant)
+        assert scenario.profile_id == variant.profile_id
+
+
+def test_w02_protocol_declares_exact_tasks_arms_treatments_and_measurements() -> None:
+    agent = AgentConfig(name="prime", adapter="prime-agent", model="anthropic/test", parameters={})
+    spec = load_w02_dam_protocol(agent=agent, compute=_COMPUTE)
+    plan = compile_w02_dam_study(study_run_id="w02-protocol-test", agent=agent, compute=_COMPUTE)
+
+    assert spec.study_id == DAM_W02_STUDY_ID
+    assert [item.task_id for item in spec.experiences] == [
+        DAM_W02_ACQUISITION_TASK_ID,
+        DAM_W02_PROBE_TASK_ID,
+    ]
+    assert [(item.arm_id, item.role.value, item.treatment_id) for item in spec.arms] == [
+        ("cold-reset", "control", "reset"),
+        ("reset-after-acquisition", "control", "reset"),
+        ("structured-memory", "exposure", "structured-memory"),
+    ]
+    assert {item.projection_id for item in spec.measurements} == _PROJECTION_IDS
+    assert spec.relations[0].relation_id == "unreliable-instrument-escalation-to-surface-transfer"
+    structured_steps = spec.arms[2].steps
+    assert structured_steps[1].feedback_view_id == DAM_ESCALATION_BOUNDARY_FEEDBACK_VIEW_ID
+    assert structured_steps[2].operation_id == DAM_W02_CONSOLIDATION_OPERATION_ID
+    assert all(isinstance(item, type(plan.arm_runs[0])) for item in plan.arm_runs)
+
+
+def test_dam_feedback_selects_only_public_evidence_and_rejects_forbidden_fields(tmp_path: Path) -> None:
+    record = _completed_acquisition_record(tmp_path)
+
+    data = dam_escalation_boundary_feedback(record)
+    payload = validate_dam_escalation_boundary_feedback(data)
+
+    assert payload["trial_id"] == record.trial_id
+    assert payload["task_id"] == DAM_W02_ACQUISITION_TASK_ID
+    assert payload["action_sequence"] == [
+        SeepageAction.CHECK_MEASUREMENT_SYSTEM.value,
+        SeepageAction.ESCALATE_FOR_ENGINEERING_REVIEW.value,
+    ]
+    assert payload["selected_response"] == "engineering-review"
+    assert payload["evaluation_outcomes"] == {
+        "response_correct": True,
+        "evidence_complete": True,
+        "all_scheduled_readings_reviewed": False,
+        "measurement_system_checked": True,
+        "latest_downstream_area_inspected": False,
+    }
+    assert payload["terminal_outcome"]["canonical_reward"] == 1.0
+    assert payload["terminal_outcome"]["validity"] == {
+        "output_parseable": True,
+        "schema_valid": True,
+        "verifier_completed": True,
+    }
+
+    text = data.decode()
+    assert "required_response" not in text
+    assert "instrument_condition" not in text
+    assert "visual_alert_conditions" not in text
+    assert "required_consecutive_alert_readings" not in text
+    assert str(tmp_path) not in text
+
+    # Leakage regression: fails if the scenario's gold answer is reintroduced into the payload.
+    leaked = json.loads(data)
+    leaked["required_response"] = "routine-surveillance"
+    with pytest.raises(ValueError, match="dam-feedback-forbidden-field-detected"):
+        validate_dam_escalation_boundary_feedback(json.dumps(leaked).encode())
+
+    with pytest.raises(ValueError, match="dam-feedback-source-mismatch"):
+        dam_escalation_boundary_feedback(make_trial_record(task_id="unrelated/task"))
+    incomplete = record.model_copy(update={"execution_status": "failed"})
+    with pytest.raises(ValueError, match="dam-feedback-projection-failed"):
+        dam_escalation_boundary_feedback(incomplete)
+    unavailable = record.model_copy(update={"evaluation_status": "not_requested", "evaluation": None})
+    with pytest.raises(ValueError, match="dam-feedback-projection-failed"):
+        dam_escalation_boundary_feedback(unavailable)
+
+    evidence_path = Path(record.output.agent_output.output_path)  # type: ignore[union-attr]
+    evidence_path.write_text(json.dumps({"status": "terminated"}), encoding="utf-8")
+    with pytest.raises(ValueError, match="dam-feedback-projection-failed"):
+        dam_escalation_boundary_feedback(record)
+
+
+def test_dam_adapter_rejects_unsafe_feedback_before_state_or_artifact_write(tmp_path: Path) -> None:
+    plan = compile_w02_dam_study(
+        study_run_id="w02-unsafe-feedback",
+        agent=_agent(tmp_path),
+        compute=_COMPUTE,
+    )
+    arm_run = next(item for item in plan.arm_runs if item.arm_id == "structured-memory")
+    feedback_step = next(item for item in arm_run.steps if isinstance(item, CompiledFeedbackStep))
+    run_root = tmp_path / "study"
+    binding = build_world_learning_operations(
+        run_root=run_root,
+        world_id=DAM_SEEPAGE_TASK_WORLD_ID,
+        execution_condition=_CONDITION,
+        run_trial=run_dam_seepage_trial,
+        instructions={DAM_W02_ACQUISITION_TASK_ID: "Monitor.", DAM_W02_PROBE_TASK_ID: "Monitor."},
+        treatment_kinds={"structured-memory": WorldLearningTreatmentKind.STRUCTURED_MEMORY},
+        feedback_projectors={
+            DAM_ESCALATION_BOUNDARY_FEEDBACK_VIEW_ID: lambda _record: b'{"private_path":"/private/secret"}\n'
+        },
+        consolidation_operations={DAM_W02_CONSOLIDATION_OPERATION_ID: _DeclaredDamMemoryConsolidator()},
+    )
+    state = binding.operations.initialise_learner(arm_run)
+
+    with pytest.raises(ValueError, match="feedback-projection-unsafe"):
+        binding.operations.release_feedback(
+            ReleaseFeedbackRequest(
+                arm_run=arm_run,
+                step=feedback_step,
+                state=state,
+                source_trial_record=make_trial_record(task_id=DAM_W02_ACQUISITION_TASK_ID),
+            )
+        )
+
+    assert not (state.value.root.parent / feedback_step.step_id).exists()
+    assert not any(path.is_file() for path in (run_root / "_artifacts").rglob("*"))
+
+
+def test_required_w02_projections_are_bounded_and_missing_evidence_is_ineligible() -> None:
+    projections = w02_dam_outcome_projections()
+    assert set(projections) == _PROJECTION_IDS
+
+    correct = make_trial_record(
+        task_id=DAM_W02_PROBE_TASK_ID,
+        evaluation=EvaluationResult(
+            reward=1.0,
+            validity=ValidityCheck(output_parseable=True, schema_valid=True, verifier_completed=True),
+            breakdown={
+                "assessment_submitted": True,
+                "selected_response": "engineering-review",
+                "required_response": "engineering-review",
+                "response_correct": True,
+                "all_scheduled_readings_reviewed": False,
+                "measurement_system_checked": True,
+                "latest_downstream_area_inspected": False,
+                "evidence_complete": True,
+                "successful": True,
+            },
+        ),
+    )
+    for projection in projections.values():
+        result = projection(correct)
+        assert result.eligible is True
+        assert (result.lower_bound, result.upper_bound) == (0.0, 1.0)
+    assert projections["world.canonical-reward"](correct).value == 1.0
+    assert projections["dam.response-correct"](correct).value == 1.0
+    assert projections["dam.evidence-complete"](correct).value == 1.0
+
+    failure = make_trial_record(
+        task_id=DAM_W02_PROBE_TASK_ID,
+        evaluation=EvaluationResult(
+            reward=0.0,
+            validity=ValidityCheck(output_parseable=True, schema_valid=True, verifier_completed=True),
+            breakdown={
+                "assessment_submitted": True,
+                "selected_response": "routine-surveillance",
+                "required_response": "engineering-review",
+                "response_correct": False,
+                "all_scheduled_readings_reviewed": False,
+                "measurement_system_checked": True,
+                "latest_downstream_area_inspected": False,
+                "evidence_complete": False,
+                "successful": False,
+            },
+        ),
+    )
+    assert projections["dam.response-correct"](failure).value == 0.0
+    assert projections["dam.evidence-complete"](failure).value == 0.0
+    assert projections["world.canonical-reward"](failure).value == 0.0
+
+    for projection_id, projection in projections.items():
+        mismatch = projection(make_trial_record(task_id="unrelated/task"))
+        assert mismatch.eligible is False and mismatch.value is None
+        assert mismatch.reason is not None and mismatch.reason.startswith("projection-task-mismatch")
+
+        no_evaluation = projection(
+            make_trial_record(
+                task_id=DAM_W02_PROBE_TASK_ID,
+                evaluation=None,
+                evaluation_status=EvaluationStatus.NOT_REQUESTED,
+            )
+        )
+        assert no_evaluation.eligible is False and no_evaluation.value is None
+
+        invalid_replay = projection(
+            make_trial_record(
+                task_id=DAM_W02_PROBE_TASK_ID,
+                evaluation=EvaluationResult(
+                    reward=0.0,
+                    validity=ValidityCheck(output_parseable=True, schema_valid=False, verifier_completed=False),
+                    breakdown={"assessment_submitted": True},
+                ),
+            )
+        )
+        assert invalid_replay.eligible is False and invalid_replay.value is None
+
+        no_submission = projection(
+            make_trial_record(
+                task_id=DAM_W02_PROBE_TASK_ID,
+                evaluation=EvaluationResult(
+                    reward=0.0,
+                    validity=ValidityCheck(output_parseable=True, schema_valid=True, verifier_completed=True),
+                    breakdown={"assessment_submitted": False},
+                ),
+            )
+        )
+        if projection_id != "world.canonical-reward":
+            assert no_submission.eligible is False and no_submission.value is None
+
+
+def test_acquisition_fidelity_fails_closed_on_missing_or_ambiguous_records() -> None:
+    agent = AgentConfig(name="prime", adapter="prime-agent", model="anthropic/test", parameters={})
+    plan = compile_w02_dam_study(study_run_id="w02-fidelity-inputs", agent=agent, compute=_COMPUTE)
+    arm_run = next(item for item in plan.arm_runs if item.arm_id == "structured-memory")
+    acquisition_step = next(
+        item for item in arm_run.steps if isinstance(item, CompiledExperienceStep) and item.role.value == "acquisition"
+    )
+
+    def arm_result(records: tuple[TrialRecord, ...]) -> ArmRunExecutionResult[object]:
+        return ArmRunExecutionResult(
+            arm_run_id=arm_run.arm_run_id,
+            status=ArmRunStatus.COMPLETED,
+            initial_state_id="initial",
+            completed_steps=(),
+            trial_records=records,
+            final_state_id="final",
+            failure=None,
+        )
+
+    missing = build_w02_acquisition_fidelity(
+        plan=plan,
+        execution=LearningStudyExecution(
+            study_run_id=plan.study_run_id,
+            arm_runs=(arm_result(()),),
+        ),
+    )
+    assert missing[arm_run.arm_run_id].trial_record_present is False
+    assert missing[arm_run.arm_run_id].acquisition_successful is False
+
+    record = make_trial_record(
+        task_id=DAM_W02_ACQUISITION_TASK_ID,
+        trial_id=acquisition_step.trial.trial_id,
+    )
+    malformed = make_trial_record(
+        task_id=DAM_W02_ACQUISITION_TASK_ID,
+        trial_id=acquisition_step.trial.trial_id,
+        evaluation=EvaluationResult(
+            reward=1.0,
+            validity=ValidityCheck(output_parseable=True, schema_valid=True, verifier_completed=True),
+            breakdown={
+                "response_correct": 1,
+                "evidence_complete": True,
+                "selected_response": "engineering-review",
+            },
+        ),
+    )
+    malformed_result = build_w02_acquisition_fidelity(
+        plan=plan,
+        execution=LearningStudyExecution(
+            study_run_id=plan.study_run_id,
+            arm_runs=(arm_result((malformed,)),),
+        ),
+    )
+    assert malformed_result[arm_run.arm_run_id].response_correct is None
+    assert malformed_result[arm_run.arm_run_id].acquisition_successful is False
+
+    with pytest.raises(ValueError, match="acquisition-fidelity-ambiguous"):
+        build_w02_acquisition_fidelity(
+            plan=plan,
+            execution=LearningStudyExecution(
+                study_run_id=plan.study_run_id,
+                arm_runs=(arm_result((record, record)),),
+            ),
+        )
+    with pytest.raises(ValueError, match="acquisition-fidelity-ambiguous"):
+        build_w02_acquisition_fidelity(
+            plan=plan,
+            execution=LearningStudyExecution(
+                study_run_id=plan.study_run_id,
+                arm_runs=(arm_result((record,)), arm_result((record,))),
+            ),
+        )
+
+
+@pytest.mark.skipif(
+    sys.platform != "darwin",
+    reason="execution_status is only benchmark-complete under the macOS Seatbelt boundary",
+)
+def test_deterministic_w02_runs_all_arms_and_builds_truthful_assessment_evidence(tmp_path: Path) -> None:
+    run_root = tmp_path / "w02"
+    consolidator = _DeclaredDamMemoryConsolidator()
+    agent = _agent(tmp_path, isolation="macos_sandbox")
+
+    result = run_w02_dam_study_sync(
+        run_root=run_root,
+        study_run_id="w02-deterministic",
+        agent=agent,
+        compute=_COMPUTE,
+        execution_condition=_INSTRUMENT_AWARE_CONDITION,
+        consolidation_operation=consolidator,
+    )
+
+    assert consolidator.calls == 1
+    assert all(arm.status is ArmRunStatus.COMPLETED for arm in result.execution.arm_runs)
+    assert len({item.initial_state_equivalence_id for item in result.arm_evidence.values()}) == 1
+    assert all(item.adapter_id == _CONDITION.adapter_id for item in result.arm_evidence.values())
+    assert all(item.arm_isolated for item in result.arm_evidence.values())
+    assert all(item.lineage_complete for item in result.arm_evidence.values())
+    assert all(item.probe_feedback_hidden for item in result.arm_evidence.values())
+    assert all(item.probe_state_discarded for item in result.arm_evidence.values())
+    assert all(not item.hidden_evaluation_leaked for item in result.arm_evidence.values())
+    assert set(result.acquisition_fidelity) == {
+        arm.arm_run_id for arm in result.plan.arm_runs if arm.arm_id in {"reset-after-acquisition", "structured-memory"}
+    }
+    assert all(
+        item.trial_record_present
+        and item.replay_valid is True
+        and item.response_correct is True
+        and item.evidence_complete is True
+        and item.escalation_selected is True
+        and item.acquisition_successful
+        and item.fidelity_satisfied
+        for item in result.acquisition_fidelity.values()
+    )
+
+    assert all(
+        measurement.validity is LearningComparisonValidity.DESCRIPTIVE_ONLY
+        for measurement in result.unreviewed_assessment.measurements
+    )
+    reviewed = {item.measurement_id: item for item in result.reviewed_assessment.measurements}
+    for measurement_id, measurement in reviewed.items():
+        expected_validity = (
+            LearningComparisonValidity.DESCRIPTIVE_ONLY
+            if measurement_id.startswith("reset-after-acquisition-")
+            else LearningComparisonValidity.CONTROLLED
+        )
+        assert measurement.validity is expected_validity
+        assert len(measurement.included_pairs) == 1
+        assert measurement.excluded_repetitions == ()
+
+    structured_arm = next(item for item in result.plan.arm_runs if item.arm_id == "structured-memory")
+    structured_root = run_root / "learner-arms" / structured_arm.arm_run_id
+    final_state = structured_root / "states" / "consolidate-monitoring-method"
+    memory = final_state / "memory" / "dam-monitoring-strategy.md"
+    feedback = final_state / "feedback" / "release-acquisition-feedback.json"
+    assert memory.is_file()
+    feedback_payload = validate_dam_escalation_boundary_feedback(feedback.read_bytes())
+    assert feedback_payload["task_id"] == DAM_W02_ACQUISITION_TASK_ID
+
+    feedback_record_path = next((run_root / "feedback").glob("*.json"))
+    feedback_record = json.loads(feedback_record_path.read_text(encoding="utf-8"))
+    published = run_root / "_artifacts" / feedback_record["public_artifact_refs"][0]["artifact_id"]
+    assert feedback.read_bytes() == published.read_bytes()
+    assert feedback_record["source_experience_id"] == "unreliable-instrument-escalation-acquisition"
+    assert not any(
+        item["source_experience_id"] == "unreliable-instrument-surface-transfer-probe" for item in [feedback_record]
+    )
+    assert not (structured_root / "states" / "structured-probe").exists()
+
+    records = [record for arm in result.execution.arm_runs for record in arm.trial_records]
+    assert len(records) == 5


### PR DESCRIPTION
## Summary

Implements Release C, Worlds Tranche 2 (W02): the dam-seepage structural-transfer study, per the PRD package at `~/Downloads/aec-bench-learning-prds-release-c-worlds-2/`.

This closes the structural-transfer half of LS-09 acceptance criterion 2 ("at least one structural-transfer and one negative-transfer study execute") -- the negative-transfer half was already satisfied by W01 (merged, PRs #150/#151, relation review ACCEPTED).

- New profile `unreliable-instrument-surface-transfer.json`: same causal driver as the existing `unreliable-instrument-escalation` acquisition (`instrument_condition: unreliable`, verified via `requires_engineering_review()` to be the sole trigger -- no flow-threshold or visual-alert contribution), differing only in surface presentation (monitoring point identity, reading magnitudes, timing cadence, objective wording). Registered as a third `DamSeepageProfileVariant`; passes `validate_dam_seepage_profile_variant()` unchanged, alongside the two existing profiles (verified unchanged).
- Maintained W02 protocol (`family.toml`/`study.toml`): a `transfer`-purpose relation (not `boundary`, unlike W01) with three arms (`cold-reset`, `reset-after-acquisition`, `structured-memory`) and five measurements built entirely from the *existing* `dam.response-correct`, `dam.evidence-complete`, and `world.canonical-reward` projections. `dam.inappropriate-escalation` is deliberately excluded: escalation is the correct response on both acquisition and probe in a transfer study, so that projection would always read `0.0` and add no signal.
- `dam_w02.py` study glue, mirroring `dam_w01.py`'s structure exactly. Reuses the existing `dam-escalation-boundary-public-feedback` view and `update-dam-monitoring-memory` consolidation operation, unchanged.
- Deterministic three-arm end-to-end test proving: all arms complete, shared initial-state equivalence and adapter ID, arm isolation, lineage, probe-feedback-hidden, probe-state-discarded, acquisition fidelity (real trial record, replay-valid, response-correct, evidence-complete, escalation-selected), correct assessment validity states (`controlled` vs `descriptive_only`), a real feedback-artifact round-trip, and non-persistence of discarded probe state.

## Scope boundaries

No changes to `world.py`, `dam_learning.py`, `worlds/runtime/`, any existing profile JSON (including the unregistered `rising-seepage.json`, left untouched for a possible future tranche), W01's protocol TOMLs or `dam_w01.py`, or any common contract. No Gate C invocation.

## Testing

```
uv run pytest \
  tests/worlds/monitoring/dam_seepage/test_world.py \
  tests/worlds/monitoring/dam_seepage/test_episode_runtime.py \
  tests/experimentation/learning_studies/test_dam_w01.py \
  tests/experimentation/learning_studies/test_dam_w02.py \
  tests/experimentation/learning_studies/test_worlds.py \
  --no-header -q
```

48 passed. `uv run ruff check` and `uv run ruff format --check` clean. `uv run python scripts/check_provenance_fields.py --check --base-revision main` passes with 0 violations.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
