### PR TITLE
Functional evolution architecture cutover

### DIFF
--- a/README.md
+++ b/README.md
@@ -901,6 +901,32 @@ Evolution workspaces use candidate IDs for lineage and full Git commits for
 source. Git tags are optional immutable labels. History displays the Git commit
 time; it does not create a new time when it reads old candidates.
 
+Evolution runs use one functional cycle. The host selects a parent and any
+inspirations, plans one shared evaluation batch, evaluates the exact parent,
+creates a child in scratch, evaluates the exact child against that same batch,
+then applies the search-specific acceptance and state transition. The
+canonical workspace changes only after acceptance. A one-shot variation is
+the current variation operator: it returns a child snapshot and mutation
+summary, or abstains when it makes no effective change. The operator seam is
+ready for future variation operators; this does not promise an AVO
+implementation.
+
+Hill-climb accepts a valid child when its trusted score clears the configured
+improvement threshold. QD accepts a valid child when it enters a new archive
+cell or improves an occupied cell; global-best improvement is not required.
+The QD host allocates mutation strategies with the strategy bandit and limits
+the archive agent to the host shortlist and chosen strategy. Bandit feedback is
+updated once from the archive outcome. Graveyard rescue uses only actual
+rejected candidate material with a matching candidate ID.
+
+Swarm agents receive exact `SwarmAssignment` values and return variation plus
+agent cost. They do not score candidates or update the archive. The host
+evaluates parent and child, binds exact `TrialRecord` evidence, and applies
+archive, graveyard, budget, and reducer effects. The async manager owns
+concurrency. Its immutable `SwarmState` owns decisions, while the event log
+reports them. Swarm state and candidate snapshots are persisted with the
+archive and graveyard so the recorded candidate material remains resolvable.
+
 ```bash
 # Create and run a workspace
 uv run aec-bench evolve init ./my-workspace --name "My Agent"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -107,38 +107,85 @@ meta-harness API.
 
 ### Agent evolution
 
-Evolution uses the same functional application shape as artifact-task
-execution:
+Evolution is one functional application path. `run_evolution()` composes task
+and attempt planning, evaluation, variation, search policy, and persistence;
+it does not create a second task executor or verifier. Its cycle is:
 
 ```text
-run_trial() -> run_experiment() -> run_evolution()
+functional application shell
+        ↓
+explicit selection state
+        ↓
+exact parent evaluation
+        ↓
+isolated variation
+        ↓
+exact child evaluation
+        ↓
+pure policy and state transition
+        ↓
+explicit commit/archive/graveyard effects
 ```
 
-`run_evolution()` owns the evolution cycle loop. It receives an explicit
-`Workspace`, `EvolutionConfig`, `CandidateEvaluator`, batch planner, variation
-operator, observation enricher, and selection strategy. The evaluator receives
-one `WorkspaceSnapshot` and one candidate-independent `CandidateEvaluationBatch`.
-It returns `TrialRecord` values through the normal `run_experiment()` path.
-The loop binds each candidate snapshot to its own `EvaluatedCandidate`, compares
-parent and child assessments from the same planned cases, applies pure gate and
-state functions, persists cycle evidence, saves archive and graveyard state,
-and returns `EvolutionResult` directly. The canonical workspace changes only
-after an accepted child; rejected child material remains in the graveyard.
+The shell receives an explicit `Workspace`, `EvolutionConfig`, candidate batch
+planner, candidate evaluator, variation operator, and observation enricher.
+The planner creates one candidate-independent `CandidateEvaluationBatch` for a
+cycle. Parent and child records are produced by the evaluator for that exact
+batch, then `bind_candidate_evaluation()` creates separate
+`EvaluatedCandidate` values. A child is evaluated before any gate or workspace
+write can accept it. Parent and child evidence are never combined.
 
-`EvolutionState` is the sole owner of active candidate, best candidate, score,
-and stagnation state. The application coordinator is the only owner of cycle
-effects. Swarm execution uses a private single-cycle call into that coordinator
-until its later redesign; it does not maintain a second evolution lifecycle.
+`EvolutionState` is the sole owner of the hill-climb active candidate, best
+candidate, score, and stagnation state. Pure transition functions decide the
+next state. The shell applies a canonical workspace commit only after an
+accepted child. Rejected or invalid child material is written to the
+graveyard. A one-shot variation call operates on a scratch workspace and
+returns either a complete `VariationResult` or an explicit abstention.
 
-`run_evolution_from_config()` is the repository composition root. It loads the
-workspace and configured model clients, selects the local or Harbor candidate
-evaluator, builds the batch planner, variation operator, and strategy, and calls
-`run_evolution()`. The
-`aec-bench evolve run` command is a thin caller of this function.
+Quality-diversity runs keep explicit `QDState` for cell-selection and strategy
+bandit feedback. The host selects the mutation strategy and shortlist. The
+archive agent may select a parent and inspirations only within those host
+constraints; it cannot change the strategy. An archive insertion is accepted
+when it enters a new cell or improves a cell, even when it does not improve the
+global score. Bandit and cell feedback updates once from that archive outcome.
+Graveyard rescue is allowed only when the entry contains a resolvable
+`rejected_snapshot` with the exact candidate ID.
+
+Swarm execution uses `SwarmManager` as an asynchronous shell over the same
+candidate/evidence boundary. Each `SwarmAssignment` contains exact parent and
+inspiration snapshots. An agent returns a `SwarmAgentResult` containing only a
+variation result and its agent cost; it does not submit a score, descriptor, or
+archive decision. The manager evaluates the assigned parent and submitted child
+through the host evaluator outside the shared-state lock. Archive and
+graveyard effects, budget accounting, pure reduction, and `SwarmState` updates
+are applied in one short locked section. `SwarmState` is immutable and is the
+decision authority; the event log reports those decisions and is not state.
+The manager persists `swarm_state.json`, exact candidate snapshots, archive,
+graveyard, budget, lineage, notes, and events as separate owned outputs.
+
+The durable ownership boundaries are:
+
+| Concern | Owner |
+| --- | --- |
+| Task and attempt planning | Evaluation composition |
+| Validity and score meaning | Evaluation |
+| Candidate/evidence binding | Evolution functional core |
+| Parent and inspiration selection | Search policy |
+| Variation | Variation operator |
+| Acceptance | Search-specific trusted policy |
+| Candidate persistence | Workspace/application shell |
+| QD insertion | Archive adapter |
+| Graveyard projection | Functional core |
+| Swarm concurrency | Async manager shell |
+| Swarm decisions | Functional reducer |
+
+`run_evolution_from_config()` is the composition root. It loads the workspace
+and model clients, selects the local or Harbor evaluator, builds the batch
+planner, variation operator, and enrichment path, and calls `run_evolution()`.
+The `aec-bench evolve run` command is a thin caller of this function.
 
 Best-of-K attempts stay inside one scored trial. Evolution cycles stay outside
-the trial and use the returned records as fitness evidence. Evolution does not
-own a separate task executor, verifier, artifact collector, or trial builder.
+the trial and use returned `TrialRecord` values as fitness evidence.
 
 Deterministic templates and suite generation live with authoring and generation.
 Generated instances remain derived artifacts. Runnable task directories contain

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -36,6 +36,7 @@ readable.
 | Experiment manifest | Experiment orchestration | User configuration becomes an executable plan | Internal, except documented CLI/config behavior | [`ExperimentManifest`](../src/aec_bench/contracts/experiment_manifest.py) | Persisted configuration |
 | Learning Study design and evidence | Experimentation | An authored protocol composes exact task members and family relations, then compiles to existing trials; committed state and explicit comparison-validity evidence stay outside `TrialRecord` | Internal Release A persisted contracts | [`LearningStudyProtocolSpec`, `LearningStudySpec`](../src/aec_bench/contracts/learning_study.py), [`LearningFamilySpec`](../src/aec_bench/contracts/learning_family.py), [`learning_study_evidence.py`](../src/aec_bench/contracts/learning_study_evidence.py), [`learning_study_assessment.py`](../src/aec_bench/contracts/learning_study_assessment.py), and the [Gate A decision](adr/learning-studies-gate-a.md) | Maintained or caller-selected protocol directory, compiled plan, append-only receipts and sequenced events, ordinary trial ledger, and pair-level paired-difference assessment |
 | Evolution workspace candidate lineage | Experimentation and feedback | Mutable workspace files become exact Git source and explicit candidate lineage | Workspace manifest schema 1; legacy labels require an explicit migration plan | [`WorkspaceCandidateVersion`, `WorkspaceManifest`, and `WorkspaceMigrationPlan`](../src/aec_bench/contracts/evolution.py) plus [`Workspace`](../src/aec_bench/evolution/workspace.py) | Persisted workspace Git metadata and manifest |
+| Evolution functional search and swarm coordination | Evolution application and swarm manager | Exact candidate material is paired with its own evaluation evidence before policy or shared effects use it | Internal pre-1.0 values; no new public schema promise | [`EvaluatedCandidate`, `CandidateEvaluationBatch`, `VariationResult`, `SwarmAssignment`, `SwarmAgentResult`, and `SwarmState`](../src/aec_bench/evolution/core.py), [`evaluation.py`](../src/aec_bench/evolution/evaluation.py), and [`swarm/core.py`](../src/aec_bench/evolution/swarm/core.py) | In-process functional values and swarm state outputs |
 | Run plan and published run package | Harness and ledger | One internal execution plan and its trial records become one portable retained package | Internal `RunPlan`; published package schema 1 | [`RunPlan` and `PublishedRunPackage`](../src/aec_bench/contracts/run_bundle.py), [`TaskSnapshotRef`](../src/aec_bench/contracts/task_snapshot.py), and [`run_package.py`](../src/aec_bench/ledger/run_package.py) | Internal plan; persisted and exportable package |
 | Trial and episode record | Harness and ledger | Execution, verifier, and authority evidence becomes reportable benchmark evidence | Protected schema 2; no historical reader | [`RunManifest` and `TrialRecord`](../src/aec_bench/contracts/trial_record.py) plus the owning episode or world protocol | Persisted and exportable |
 | Evaluation regime | Evaluation | Observable evaluation policy becomes one independently published compatibility identity | Envelope schema 1; legacy component plans migrate only when all inputs resolve | [`EvaluationRegimeEnvelope`](../src/aec_bench/contracts/evaluation_plane.py), `EvaluationRegimeRef`, and [`regime.py`](../src/aec_bench/evaluation/regime.py) | Persisted and independently publishable |
@@ -428,6 +429,39 @@ moved label, an unknown parent, duplicate source assignment, or a missing
 confirmed revision. It also replaces legacy label fields in `archive.json` and
 `graveyard.json`. It registers no candidate and writes no sidecar when the plan
 is ambiguous.
+
+## Evolution candidate and evidence contracts
+
+`WorkspaceSnapshot.candidate_id` identifies one exact candidate material. It is
+distinct from `trial_id` and from an attempt ID. A `CandidateEvaluationBatch`
+contains the candidate-independent task and planned trial cases for one cycle.
+The evaluator returns `TrialRecord` values for that exact batch. The evolution
+application binds those records to the snapshot as one `EvaluatedCandidate`,
+whose `CandidateAssessment` is an evolution-owned projection of the evidence.
+
+Parent and child are separate `EvaluatedCandidate` values. They MUST use the
+same ordered `evaluation_case_ids` for comparison, and a parent record MUST NOT
+be used as child evidence or vice versa. `TrialRecord` remains the evidence
+authority for execution and evaluation facts; `CandidateAssessment` does not
+replace it.
+
+Variation changes scratch material only. A submitted `VariationResult` carries
+the exact child snapshot and mutation summary, or an explicit abstention carries
+no child. The application applies a canonical workspace commit only after the
+trusted search policy accepts the evaluated child. QD archive entries and
+graveyard entries MUST resolve to the exact candidate snapshot they name.
+Archive insertion distinguishes a new cell, an improved cell, and rejection.
+The archive agent and strategy bandit are search-policy inputs and feedback;
+they do not own candidate scores or evaluation validity.
+
+`SwarmAssignment` contains exact parent and inspiration snapshots. A swarm
+agent returns `SwarmAgentResult` with variation and agent cost only. The host
+evaluates both parent and submitted child and binds the resulting `TrialRecord`
+values before archive, graveyard, budget, or reducer effects. `SwarmState` is
+immutable decision state. The manager owns concurrency and effect application;
+the event log is a report of those effects, not an alternative state authority.
+These internal selector and swarm values are not new public compatibility
+promises.
 
 ## Provider request and result envelopes
 

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -76,6 +76,21 @@ result.
 A report, dashboard, provider adapter, or persistence layer must not invent a
 second metric definition or repair an invalid result into a valid one.
 
+## Candidate evidence is exact
+
+Any score, descriptor, gate decision, archive outcome, graveyard entry, or
+lineage update that names a candidate MUST derive from evidence produced by
+that exact candidate. Candidate identity MUST remain distinct from trial and
+attempt identity. Parent and child evidence MUST remain separate, and a
+comparison MUST use the same ordered evaluation cases for both candidates.
+
+`TrialRecord` remains the evidence authority. Evolution-owned assessments,
+archive entries, graveyard projections, and swarm decisions may summarise that
+evidence, but they MUST NOT invent a score, descriptor, validity result, or
+candidate snapshot. A rejected or invalid candidate MUST NOT become an
+accepted archive or global-best candidate through an event, placeholder, or
+agent-owned score.
+
 ## Public and holdout material remain separate
 
 Visibility is explicit. Public catalogues, examples, training exports,

--- a/src/aec_bench/cli/commands/swarm.py
+++ b/src/aec_bench/cli/commands/swarm.py
@@ -1,4 +1,4 @@
-# ABOUTME: CLI commands for multi-agent swarm evolution — run, resume, stop, status, history.
+# ABOUTME: CLI commands for multi-agent swarm evolution — run, status, and history.
 # ABOUTME: Manages swarm lifecycle via the SwarmManager.
 
 from __future__ import annotations
@@ -126,42 +126,27 @@ def swarm_run(
         factory.cleanup()
 
 
-@app.command("resume")
-def swarm_resume(
-    run_id: str = typer.Argument(help="Run ID to resume"),
-    state_dir: str = typer.Option(".", "--state-dir", help="Directory containing swarm state"),
-) -> None:
-    """Resume a swarm run from its event log."""
-    require_optional_extra("Swarm execution support", "evolution,local-agents", ("numpy", "ribs", "pydantic_ai"))
-    event_log = Path(state_dir) / run_id / "events.jsonl"
-    if not event_log.exists():
-        print_error(f"Event log not found: {event_log}")
-        raise typer.Exit(1)
-    console.print(f"[bold green]Resuming swarm:[/bold green] {run_id}")
-
-
-@app.command("stop")
-def swarm_stop(
-    run_id: str = typer.Argument(help="Run ID to stop"),
-) -> None:
-    """Gracefully stop a running swarm (agents finish current eval)."""
-    console.print(f"[yellow]Stopping swarm:[/yellow] {run_id}")
-
-
 @app.command("status")
 def swarm_status(
     run_id: str = typer.Argument(help="Run ID to check"),
     state_dir: str = typer.Option(".", "--state-dir", help="Directory containing swarm state"),
 ) -> None:
     """Show current status of a swarm run."""
-    event_log = Path(state_dir) / "events.jsonl"
-    if not event_log.exists():
+    run_path = Path(state_dir)
+    if not (run_path / "swarm_state.json").is_file():
         print_error(f"No swarm state found for {run_id}")
         raise typer.Exit(1)
 
-    from aec_bench.evolution.swarm.resume import rebuild_state
+    from aec_bench.evolution.swarm.resume import load_resumed_state
 
-    state = rebuild_state(event_log)
+    try:
+        state = load_resumed_state(run_path)
+    except ValueError as exc:
+        print_error(str(exc))
+        raise typer.Exit(1) from exc
+    if state.run_id != run_id:
+        print_error(f"Swarm state run ID is {state.run_id!r}, not {run_id!r}")
+        raise typer.Exit(1)
     console.print(f"[bold]Run:[/bold] {state.run_id}")
     console.print(f"  Evals: {state.total_evals}")
     console.print(f"  Best score: {state.best_score:.2f}")
@@ -175,10 +160,13 @@ def swarm_history(
     """List past swarm runs."""
     state_path = Path(state_dir)
     runs: list[dict[str, Any]] = []
-    for event_file in sorted(state_path.glob("**/events.jsonl")):
-        from aec_bench.evolution.swarm.resume import rebuild_state
+    for run_path in sorted(path for path in state_path.glob("**/swarm_state.json") if path.is_file()):
+        try:
+            from aec_bench.evolution.swarm.resume import load_resumed_state
 
-        state = rebuild_state(event_file)
+            state = load_resumed_state(run_path.parent)
+        except ValueError:
+            continue
         if state.run_id:
             runs.append(
                 {

--- a/src/aec_bench/evolution/swarm/resume.py
+++ b/src/aec_bench/evolution/swarm/resume.py
@@ -187,9 +187,3 @@ def load_resumed_state(state_dir: Path) -> ResumedState:
         initial_candidate_id,
         next_sequence,
     )
-
-
-def rebuild_state(state_path: Path) -> ResumedState:
-    """Load explicit state for callers that historically passed an event path."""
-    state_dir = state_path if state_path.is_dir() else state_path.parent
-    return load_resumed_state(state_dir)

--- a/tests/evolution/swarm/test_cli.py
+++ b/tests/evolution/swarm/test_cli.py
@@ -78,12 +78,6 @@ def test_swarm_history_no_runs(tmp_path: Path) -> None:
     assert "No swarm runs found" in result.output
 
 
-def test_swarm_resume_missing_log(tmp_path: Path) -> None:
-    result = runner.invoke(app, ["swarm", "resume", "sw-missing", "--state-dir", str(tmp_path)])
+def test_swarm_status_requires_explicit_run_state(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["swarm", "status", "sw-missing", "--state-dir", str(tmp_path)])
     assert result.exit_code != 0
-
-
-def test_swarm_stop_outputs_run_id() -> None:
-    result = runner.invoke(app, ["swarm", "stop", "sw-test-123"])
-    assert result.exit_code == 0
-    assert "sw-test-123" in result.output

--- a/tests/evolution/swarm/test_manager.py
+++ b/tests/evolution/swarm/test_manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import threading
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -46,8 +47,6 @@ class FakeEvolverFactory:
         self._state_dir = state_dir or Path("/private/tmp/aec-bench-swarm-test")
         self._scores = scores_per_agent
         self._scores_by_candidate: dict[str, float] = {}
-        self.lock_probe: asyncio.Lock | None = None
-        self.lock_probe_states: list[bool] = []
 
     def create(self, agent_id: str, model_override: str | None = None):
         scores = self._scores.get(agent_id, [0.5])
@@ -94,8 +93,6 @@ class FakeEvolverFactory:
         return CandidateEvaluationBatch((resolved,), (planned,), (f"case-{cycle}",), cycle=cycle)
 
     def evaluate(self, snapshot: WorkspaceSnapshot, batch: CandidateEvaluationBatch):
-        if self.lock_probe is not None:
-            self.lock_probe_states.append(self.lock_probe.locked())
         score = self._scores_by_candidate.get(snapshot.candidate_id, 0.5)
         return tuple(
             make_trial_record(
@@ -136,13 +133,10 @@ async def test_concurrent_completions_reduce_without_lost_state(tmp_path: Path) 
     config = _make_config(agent_count=2, max_cost=1.0)
     factory = FakeEvolverFactory({"agent-0": [0.6], "agent-1": [0.7]})
     manager = SwarmManager(config=config, state_dir=tmp_path, evolver_factory=factory)
-    factory.lock_probe = manager._lock
     result = await manager.run()
 
     assert result.total_evals >= 2
     assert result.total_cost_usd == pytest.approx(result.total_evals * 0.5)
-    assert len(factory.lock_probe_states) == result.total_evals * 2
-    assert not any(factory.lock_probe_states)
     eval_events = [
         event
         for event in SwarmEventReader(tmp_path / "events.jsonl").read_all()
@@ -151,6 +145,35 @@ async def test_concurrent_completions_reduce_without_lost_state(tmp_path: Path) 
     assert len(eval_events) == result.total_evals
     persisted = json.loads((tmp_path / "swarm_state.json").read_text())
     assert persisted["total_evaluations"] == result.total_evals
+
+
+@pytest.mark.asyncio
+async def test_host_evaluation_does_not_hold_shared_state_lock(tmp_path: Path) -> None:
+    evaluation_started = threading.Event()
+    release_evaluation = threading.Event()
+
+    class BlockingEvaluationFactory(FakeEvolverFactory):
+        def evaluate(self, snapshot: WorkspaceSnapshot, batch: CandidateEvaluationBatch):
+            evaluation_started.set()
+            if not release_evaluation.wait(timeout=5):
+                raise TimeoutError("test did not release host evaluation")
+            return super().evaluate(snapshot, batch)
+
+    factory = BlockingEvaluationFactory({"agent-0": [0.6]})
+    manager = SwarmManager(
+        config=_make_config(agent_count=1, max_cost=0.5),
+        state_dir=tmp_path,
+        evolver_factory=factory,
+    )
+    run_task = asyncio.create_task(manager.run())
+    try:
+        started = await asyncio.wait_for(asyncio.to_thread(evaluation_started.wait, 5), timeout=6)
+        assert started
+        await asyncio.wait_for(manager._lock.acquire(), timeout=1)
+        manager._lock.release()
+    finally:
+        release_evaluation.set()
+    await run_task
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- make the functional evolution architecture authoritative in the README and core documentation
- remove the fake swarm resume and stop commands and the obsolete state-loader alias
- make swarm status and history read explicit persisted state
- retire completed evolution plans and confirm no obsolete engine or strategy paths remain
- replace a flaky lock probe with a deterministic test that proves host evaluation runs outside the shared-state lock

## Focused verification

- 172 focused evolution, swarm, CLI, and documentation tests passed
- Ruff check passed on changed Python files
- Ruff format check passed on changed Python files
- mypy passed on changed source files
- documentation ownership and relative-link checks passed
- exact obsolete-symbol audit found only the unrelated `ContextSelectionStrategy` harness contract
- offline source distribution and wheel build passed

The full local test suite was intentionally not run because it takes about one hour. CI provides the broader repository checks for this merge boundary.
