### PR TITLE
Add bounded conditional AVO supervision

### DIFF
--- a/src/aec_bench/contracts/evolution.py
+++ b/src/aec_bench/contracts/evolution.py
@@ -45,6 +45,8 @@ class VariationUsage:
     tool_calls: int = 0
     development_evaluations: int = 0
     supervisor_interventions: int = 0
+    input_tokens: int | None = None
+    output_tokens: int | None = None
     model_cost_usd: float | None = None
     development_evaluation_cost_usd: float | None = None
     elapsed_seconds: float = 0.0
@@ -57,6 +59,10 @@ class VariationUsage:
             "supervisor_interventions",
         ):
             _require_usage_integer(getattr(self, field_name), field_name)
+        for field_name in ("input_tokens", "output_tokens"):
+            tokens = getattr(self, field_name)
+            if tokens is not None:
+                _require_usage_integer(tokens, field_name)
         _require_usage_number(self.elapsed_seconds, "elapsed_seconds")
         for field_name in ("model_cost_usd", "development_evaluation_cost_usd"):
             cost = getattr(self, field_name)

--- a/src/aec_bench/evolution/agent_loop.py
+++ b/src/aec_bench/evolution/agent_loop.py
@@ -347,6 +347,15 @@ class _LoopController:
                 return self._terminal_result()
             if self.resume_checkpoint is not None:
                 self._restore_checkpoint()
+                if self.terminal_status is None:
+                    try:
+                        # A crash can occur after a deterministic trigger was
+                        # checkpointed but before the normal post-command
+                        # supervision turn. Resolve that trigger first so the
+                        # next main-agent context contains the outcome.
+                        self._maybe_run_supervision()
+                    except AgentToolBudgetExceeded as exc:
+                        return self._exhausted(exc.limit)
             else:
                 self._start_new_call()
 
@@ -502,6 +511,10 @@ class _LoopController:
 
     def _finish_cancellation(self, reason: AVOCancellationReason) -> VariationResult:
         """Publish a truthful cancellation result before propagating it."""
+        # A pending host request is a trigger, not a terminal outcome. Clear
+        # it before publishing cancellation so the terminal checkpoint is a
+        # valid consumed state even when cancellation wins before supervision.
+        self.state = replace(self.state, exhausted_direction_requested=False)
         self.cancellation_reason = reason
         self.terminal_status = VariationStatus.CANCELLED
         self.terminal_message = reason.detail
@@ -889,6 +902,8 @@ class _LoopController:
             if not isinstance(result, AVOSupervisionResult):
                 raise TypeError("supervisor runner must return AVOSupervisionResult")
             reconciled_usage = reconcile_supervision_usage(usage_before, self.budget, result.usage)
+            self._model_cost_known = reconciled_usage.model_cost_usd is not None
+            self._model_cost_total = reconciled_usage.model_cost_usd or 0.0
             if isinstance(result.output, AVOSupervisionAdvice):
                 record = AVOSupervisionRecord(trigger_reason=trigger_reason, advice=result.output)
             else:

--- a/src/aec_bench/evolution/agent_loop.py
+++ b/src/aec_bench/evolution/agent_loop.py
@@ -360,8 +360,9 @@ class _LoopController:
                     # accepted. Leave the marker for explicit reconciliation.
                     raise AVOIncompleteExternalEffectError(effect, exc) from exc
                 try:
-                    command, model_cost = _normalise_response(response)
+                    command, model_cost, input_tokens, output_tokens = _normalise_response(response)
                     self._record_model_cost(model_cost)
+                    self._record_model_tokens(input_tokens, output_tokens)
                 finally:
                     # The provider returned, so the marker can be cleared only
                     # after its usage has been recorded durably.
@@ -842,6 +843,25 @@ class _LoopController:
             self._model_cost_total += cost
             self._set_usage(model_cost_usd=self._model_cost_total)
 
+    def _record_model_tokens(self, input_tokens: int | None, output_tokens: int | None) -> None:
+        """Aggregate one response's token counts, retaining unknown values."""
+        usage = self.state.usage
+        previous_requests = usage.model_requests - 1
+
+        def merge(previous: int | None, added: int | None) -> int | None:
+            if added is None:
+                return None
+            if previous_requests == 0:
+                return added
+            if previous is None:
+                return None
+            return previous + added
+
+        self._set_usage(
+            input_tokens=merge(usage.input_tokens, input_tokens),
+            output_tokens=merge(usage.output_tokens, output_tokens),
+        )
+
     def _set_usage(self, **updates: int | float | None) -> None:
         usage = self.state.usage
         self.state = replace(
@@ -851,6 +871,8 @@ class _LoopController:
                 tool_calls=_as_int(updates.get("tool_calls"), usage.tool_calls),
                 development_evaluations=_as_int(updates.get("development_evaluations"), usage.development_evaluations),
                 supervisor_interventions=usage.supervisor_interventions,
+                input_tokens=_as_optional_int(updates.get("input_tokens", usage.input_tokens)),
+                output_tokens=_as_optional_int(updates.get("output_tokens", usage.output_tokens)),
                 model_cost_usd=updates.get("model_cost_usd", usage.model_cost_usd),
                 development_evaluation_cost_usd=updates.get(
                     "development_evaluation_cost_usd", usage.development_evaluation_cost_usd
@@ -897,6 +919,9 @@ class _LoopController:
             raise AgentToolBudgetExceeded("max_tool_calls")
         if usage.elapsed_seconds >= self.budget.max_elapsed_seconds:
             raise AgentToolBudgetExceeded("max_elapsed_seconds")
+        limit = self._known_token_limit()
+        if limit is not None:
+            raise AgentToolBudgetExceeded(limit)
         limit = self._known_cost_limit()
         if limit is not None:
             raise AgentToolBudgetExceeded(limit)
@@ -926,7 +951,25 @@ class _LoopController:
             return "max_tool_calls"
         if usage.elapsed_seconds >= self.budget.max_elapsed_seconds:
             return "max_elapsed_seconds"
+        token_limit = self._known_token_limit()
+        if token_limit is not None:
+            return token_limit
         return self._known_cost_limit()
+
+    def _known_token_limit(self) -> str | None:
+        usage = self.state.usage
+        if usage.model_requests == 0:
+            return None
+        for name, observed, limit in (
+            ("max_input_tokens", usage.input_tokens, self.budget.max_input_tokens),
+            ("max_output_tokens", usage.output_tokens, self.budget.max_output_tokens),
+        ):
+            if limit is not None:
+                if observed is None:
+                    return f"{name}_unknown"
+                if observed >= limit:
+                    return name
+        return None
 
     def _known_cost_limit(self) -> str | None:
         if self.budget.max_cost_usd is None:
@@ -974,11 +1017,13 @@ class _LoopController:
         return result
 
 
-def _normalise_response(response: AgentCommand | AgentResponse) -> tuple[AgentCommand, float | None]:
+def _normalise_response(
+    response: AgentCommand | AgentResponse,
+) -> tuple[AgentCommand, float | None, int | None, int | None]:
     if isinstance(response, AgentResponse):
-        return response.command, response.model_cost_usd
+        return response.command, response.model_cost_usd, response.input_tokens, response.output_tokens
     if isinstance(response, AgentCommand):
-        return response, None
+        return response, None, None, None
     raise TypeError("agent runner must return AgentCommand or AgentResponse")
 
 
@@ -1122,6 +1167,10 @@ def _as_int(value: int | float | None, default: int) -> int:
 
 def _as_float(value: int | float | None, default: float) -> float:
     return default if value is None else float(value)
+
+
+def _as_optional_int(value: int | float | None) -> int | None:
+    return None if value is None else int(value)
 
 
 __all__ = (

--- a/src/aec_bench/evolution/agent_loop.py
+++ b/src/aec_bench/evolution/agent_loop.py
@@ -62,6 +62,17 @@ from aec_bench.evolution.resume import (
     terminal_result_from_checkpoint,
 )
 from aec_bench.evolution.sanitiser import CompactionLLM, sanitise_workspace
+from aec_bench.evolution.supervision import (
+    AVOSupervisionAdvice,
+    AVOSupervisionRecord,
+    AVOSupervisionRequest,
+    AVOSupervisionResult,
+    SupervisorRunner,
+    project_remaining_budget,
+    reconcile_supervision_usage,
+    reserve_supervision_usage,
+    supervision_trigger_reason,
+)
 from aec_bench.evolution.workspace import Workspace, scratch_workspace_from
 
 _TOOL_NAMES = (
@@ -148,6 +159,7 @@ def run_agentic_variation(
     *,
     development_boundary: DevelopmentEvaluationBoundary,
     agent_runner: AgentRunner,
+    supervisor_runner: SupervisorRunner | None = None,
     budget: AVOBudget | None = None,
     knowledge_source: ApprovedKnowledgeSource | None = None,
     compaction_llm: CompactionLLM | None = None,
@@ -173,6 +185,8 @@ def run_agentic_variation(
         raise TypeError("development_boundary must be a DevelopmentEvaluationBoundary")
     if not callable(agent_runner):
         raise TypeError("agent_runner must be callable")
+    if supervisor_runner is not None and not callable(supervisor_runner):
+        raise TypeError("supervisor_runner must be callable")
     if cancellation_signal is None:
         cancellation_signal = AVOCancellationSignal()
     if not isinstance(cancellation_signal, AVOCancellationSignal):
@@ -181,6 +195,8 @@ def run_agentic_variation(
         budget = AVOBudget()
     if not isinstance(budget, AVOBudget):
         raise TypeError("budget must be an AVOBudget")
+    if supervisor_runner is None and budget.max_supervisor_interventions > 0:
+        raise ValueError("supervisor_runner is required when supervisor interventions are enabled")
     if development_evaluation_cost_usd is not None and development_evaluation_cost_usd < 0:
         raise ValueError("development_evaluation_cost_usd must be non-negative")
     if checkpoint_path is not None:
@@ -258,6 +274,7 @@ def run_agentic_variation(
             configuration_identity=effective_configuration_identity,
             resume_checkpoint=resume_checkpoint,
             cancellation_signal=cancellation_signal,
+            supervisor_runner=supervisor_runner,
         )
         return controller.run(agent_runner)
 
@@ -282,6 +299,7 @@ class _LoopController:
         configuration_identity: AVOConfigurationIdentity | None,
         resume_checkpoint: AVOCheckpoint | None,
         cancellation_signal: AVOCancellationSignal,
+        supervisor_runner: SupervisorRunner | None,
     ) -> None:
         self.request = request
         self.scratch = scratch
@@ -316,6 +334,7 @@ class _LoopController:
         self.configuration_identity = configuration_identity
         self.resume_checkpoint = resume_checkpoint
         self.cancellation_signal = cancellation_signal
+        self.supervisor_runner = supervisor_runner
         self.incomplete_external_effects: tuple[AVOIncompleteExternalEffect, ...] = ()
 
     def run(self, runner: AgentRunner) -> VariationResult:
@@ -333,8 +352,8 @@ class _LoopController:
 
             if self.terminal_status is not None:
                 return self._terminal_result()
-            tools = MappingProxyType(self._build_tools())
             while self.terminal_status is None:
+                tools = MappingProxyType(self._build_tools())
                 self._refresh_elapsed()
                 limit = self._loop_limit_reason()
                 if limit is not None:
@@ -374,6 +393,11 @@ class _LoopController:
                     self._dispatch(command, tools)
                 except AgentToolBudgetExceeded as exc:
                     return self._exhausted(exc.limit)
+                if self.terminal_status is None:
+                    try:
+                        self._maybe_run_supervision()
+                    except AgentToolBudgetExceeded as exc:
+                        return self._exhausted(exc.limit)
             return self._terminal_result()
         except AVOCancellationError as exc:
             return self._finish_cancellation(exc.reason)
@@ -443,9 +467,12 @@ class _LoopController:
         self,
         operation: AVOExternalEffectOperation,
         effect_id_suffix: str,
+        *,
+        check_cancellation: bool = True,
     ) -> AVOIncompleteExternalEffect:
         """Durably mark one provider or evaluator call before invoking it."""
-        self._check_cancellation()
+        if check_cancellation:
+            self._check_cancellation()
         effect = AVOIncompleteExternalEffect(
             effect_id=f"{self.state.variation_id}:{effect_id_suffix}",
             operation=operation,
@@ -551,7 +578,13 @@ class _LoopController:
             "submit_current_revision": guarded("submit_current_revision", self.submit_current_revision),
             "abstain": guarded("abstain", self.abstain),
         }
-        if tuple(tools) != _TOOL_NAMES:
+        if (
+            self.supervisor_runner is not None
+            and self.budget.max_supervisor_interventions > self.state.usage.supervisor_interventions
+        ):
+            tools["request_supervision"] = guarded("request_supervision", self.request_supervision)
+        expected_names = _TOOL_NAMES + (("request_supervision",) if "request_supervision" in tools else ())
+        if tuple(tools) != expected_names:
             raise AssertionError("agent tool surface does not match the approved AVO contract")
         return tools
 
@@ -798,9 +831,20 @@ class _LoopController:
         self.terminal_message = self.explicit_reasoning
         return AbstentionToolResult(True, self.explicit_reasoning)
 
+    def request_supervision(self) -> str:
+        """Persist the main agent's request for a new direction."""
+        if (
+            self.supervisor_runner is None
+            or self.state.usage.supervisor_interventions >= self.budget.max_supervisor_interventions
+        ):
+            return "Supervisor intervention is unavailable within the configured budget."
+        self.state = replace(self.state, exhausted_direction_requested=True)
+        self._write_checkpoint()
+        return "The exhausted-direction request was recorded for host supervision."
+
     def _dispatch(self, command: AgentCommand, tools: Mapping[str, Callable[..., object]]) -> None:
-        function = tools[command.tool.value]
         try:
+            function = tools[command.tool.value]
             function(**command.arguments)
         except AgentToolBudgetExceeded:
             raise
@@ -808,6 +852,69 @@ class _LoopController:
             # Typed argument errors are returned to the next model request.
             # Provider and evaluation failures use their own propagation rules.
             return
+
+    def _maybe_run_supervision(self) -> None:
+        """Run one host-owned intervention after a completed main-agent outcome."""
+        trigger_reason = supervision_trigger_reason(
+            self.state,
+            self.budget,
+            exhausted_direction_requested=self.state.exhausted_direction_requested,
+        )
+        if trigger_reason is None or self.supervisor_runner is None:
+            return
+
+        self._check_cancellation()
+        usage_before = self.state.usage
+        try:
+            reserved_usage = reserve_supervision_usage(usage_before, self.budget)
+        except ValueError as exc:
+            raise AgentToolBudgetExceeded(str(exc)) from exc
+        reserved_state = replace(self.state, usage=reserved_usage)
+        request = AVOSupervisionRequest(
+            goal=self.request.selection.goal,
+            selected_parent_id=reserved_state.parent_candidate_id,
+            strategy=self.request.selection.strategy,
+            attempt_summaries=reserved_state.memory,
+            remaining_budget=project_remaining_budget(self.budget, reserved_state),
+            trigger_reason=trigger_reason,
+        )
+        self.state = reserved_state
+        effect = self._begin_external_effect(
+            "supervisor_request",
+            f"supervisor-{reserved_usage.supervisor_interventions}",
+            check_cancellation=False,
+        )
+        try:
+            result = self.supervisor_runner(request)
+            if not isinstance(result, AVOSupervisionResult):
+                raise TypeError("supervisor runner must return AVOSupervisionResult")
+            reconciled_usage = reconcile_supervision_usage(usage_before, self.budget, result.usage)
+            if isinstance(result.output, AVOSupervisionAdvice):
+                record = AVOSupervisionRecord(trigger_reason=trigger_reason, advice=result.output)
+            else:
+                record = AVOSupervisionRecord(trigger_reason=trigger_reason, failure=result.output)
+            self.state = replace(
+                self.state,
+                usage=reconciled_usage,
+                supervision_records=(*self.state.supervision_records, record),
+                exhausted_direction_requested=False,
+                consecutive_without_progress=0,
+                consecutive_evaluation_errors=0,
+            )
+            # Publish the confirmed outcome, exact usage, and marker removal in
+            # one atomic checkpoint replacement. A crash before this write
+            # retains the prior incomplete marker and therefore fails closed.
+            self.incomplete_external_effects = tuple(
+                item for item in self.incomplete_external_effects if item.effect_id != effect.effect_id
+            )
+            self._write_checkpoint()
+        except AVOIncompleteExternalEffectError:
+            raise
+        except Exception as exc:
+            # A provider, transport, malformed adapter, or reconciliation
+            # failure is not safe to retry because completion is unknown.
+            raise AVOIncompleteExternalEffectError(effect, exc) from exc
+        self._check_cancellation()
 
     def _best_score(self) -> float:
         if self.state.best_attempt_id is None:

--- a/src/aec_bench/evolution/agent_protocol.py
+++ b/src/aec_bench/evolution/agent_protocol.py
@@ -17,6 +17,11 @@ from aec_bench.evolution.cancellation import AVOCancellationSignal
 from aec_bench.evolution.core import AVOState, EvaluatedCandidate, VariationRequest
 from aec_bench.evolution.memory import AVOMemoryEntry
 from aec_bench.evolution.mutation import MutationAction
+from aec_bench.evolution.supervision import (
+    AVOSupervisionAdvice,
+    AVOSupervisionFailure,
+    AVOSupervisionRecord,
+)
 
 
 class AgentToolName(StrEnum):
@@ -33,6 +38,7 @@ class AgentToolName(StrEnum):
     RESTORE_ATTEMPT = "restore_attempt"
     SUBMIT_CURRENT_REVISION = "submit_current_revision"
     ABSTAIN = "abstain"
+    REQUEST_SUPERVISION = "request_supervision"
 
 
 class MutationInput(StrictModel):
@@ -128,6 +134,21 @@ class AgentContext:
         self.previous_tool_error = previous_tool_error
         self.cancellation_signal = cancellation_signal
         self.memory: tuple[AVOMemoryEntry, ...] = state.memory
+        self.supervision_records: tuple[AVOSupervisionRecord, ...] = state.supervision_records
+
+    @property
+    def latest_supervision_advice(self) -> AVOSupervisionAdvice | None:
+        """Return the latest advice, without treating it as an instruction."""
+        if not self.supervision_records:
+            return None
+        return self.supervision_records[-1].advice
+
+    @property
+    def latest_supervision_failure(self) -> AVOSupervisionFailure | None:
+        """Return the latest confirmed supervisor failure, when present."""
+        if not self.supervision_records:
+            return None
+        return self.supervision_records[-1].failure
 
 
 class AgentRunner(Protocol):
@@ -205,6 +226,37 @@ def _render_agent_prompt(context: AgentContext) -> str:
         ensure_ascii=True,
         sort_keys=True,
     )
+    supervision = "No confirmed supervisor outcome is available."
+    if context.latest_supervision_advice is not None:
+        supervision = json.dumps(
+            {
+                "directions": context.latest_supervision_advice.directions,
+                "reasoning": context.latest_supervision_advice.reasoning,
+                "authority": (
+                    "optional advisory guidance only; it does not itself perform or authorize workspace edits, "
+                    "evaluation, or submission, or alter selection, parent, strategy, goal, or budgets; use it only "
+                    "through existing bounded tools and authority"
+                ),
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        )
+    elif context.latest_supervision_failure is not None:
+        supervision = json.dumps(
+            {
+                "failure_code": context.latest_supervision_failure.code.value,
+                "detail": context.latest_supervision_failure.detail,
+                "authority": "confirmed fact only; do not retry supervision",
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+        )
+    host_command = (
+        "The host command `request_supervision` takes no arguments and records that the current direction "
+        "is exhausted. "
+        if "request_supervision" in context.tools
+        else ""
+    )
     return (
         f"Goal: {request.selection.goal}\n"
         f"Strategy: {request.selection.strategy.value}\n"
@@ -214,11 +266,13 @@ def _render_agent_prompt(context: AgentContext) -> str:
         f"development evaluations {context.state.usage.development_evaluations}.\n"
         f"Structured memory (bounded facts only): {memory}\n"
         f"Approved tools: {names}. Each command uses `tool` plus an `arguments` object. "
+        f"{host_command}"
         "For apply_mutation, arguments are {mutation: {type, name, description, discipline, body, or content}}. "
         "For evaluate_current_revision, arguments are {hypothesis: string}. For restore_attempt, "
         "arguments are {attempt_id: string} or {revision: integer}. For submit_current_revision and "
         "abstain, arguments are {reasoning: string}.\n"
         f"{previous}\n"
+        f"Latest supervisor outcome (advisory guidance or confirmed fact only): {supervision}\n"
         "Return the next AgentCommand."
     )
 

--- a/src/aec_bench/evolution/agent_protocol.py
+++ b/src/aec_bench/evolution/agent_protocol.py
@@ -10,7 +10,7 @@ from enum import StrEnum
 from importlib import import_module
 from typing import Any, Literal, Protocol
 
-from pydantic import ConfigDict, Field, model_validator
+from pydantic import ConfigDict, Field, field_validator, model_validator
 
 from aec_bench.contracts.validators import NonEmptyStr, StrictModel
 from aec_bench.evolution.cancellation import AVOCancellationSignal
@@ -85,12 +85,21 @@ class AgentResponse(StrictModel):
 
     command: AgentCommand
     model_cost_usd: float | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
 
     @model_validator(mode="after")
     def validate_cost(self) -> AgentResponse:
         if self.model_cost_usd is not None and (not math.isfinite(self.model_cost_usd) or self.model_cost_usd < 0):
             raise ValueError("model_cost_usd must be finite and non-negative")
         return self
+
+    @field_validator("input_tokens", "output_tokens")
+    @classmethod
+    def validate_tokens(cls, value: int | None) -> int | None:
+        if value is not None and (isinstance(value, bool) or not isinstance(value, int) or value < 0):
+            raise ValueError("token counts must be non-negative integers")
+        return value
 
 
 class AgentContext:
@@ -161,7 +170,13 @@ class PydanticAIStructuredRunner:
             retries=0,
         )
         result = agent.run_sync(_render_agent_prompt(context), usage_limits=usage_module.UsageLimits(request_limit=1))
-        return AgentResponse(command=result.output, model_cost_usd=None)
+        usage = result.usage()
+        return AgentResponse(
+            command=result.output,
+            model_cost_usd=None,
+            input_tokens=usage.input_tokens,
+            output_tokens=usage.output_tokens,
+        )
 
 
 def _render_agent_prompt(context: AgentContext) -> str:

--- a/src/aec_bench/evolution/application.py
+++ b/src/aec_bench/evolution/application.py
@@ -32,7 +32,6 @@ from aec_bench.evolution.archive import ArchiveBatchOutcome, ArchiveView, QDArch
 from aec_bench.evolution.archive_agent import run_archive_selection
 from aec_bench.evolution.checkpoint import AVOConfigurationIdentity
 from aec_bench.evolution.core import (
-    AVOBudget,
     CycleOutcome,
     EvaluatedCandidate,
     EvolutionState,
@@ -497,13 +496,15 @@ def run_evolution_from_config(
         development_batch_planner = _empty_batch_planner
         development_evaluate = make_stub_candidate_evaluator(())
 
+    evolver_model = build_pydantic_model(config.models.evolver)
     variation = build_agentic_variation_operator(
-        agent_model=build_pydantic_model(config.models.evolver),
+        agent_model=evolver_model,
+        supervisor_model=evolver_model,
+        supervisor_model_identity=avo_configuration_identity.supervisor_model_identity,
         development_batch_planner=development_batch_planner,
         development_evaluator=development_evaluate,
         development_batch_size=config.batch_size,
         development_experiment_prefix=development_experiment_id,
-        budget=AVOBudget(),
         compaction_llm=classifier_llm,
         checkpoint_root=workspace.root,
         configuration_identity=avo_configuration_identity,

--- a/src/aec_bench/evolution/application.py
+++ b/src/aec_bench/evolution/application.py
@@ -451,6 +451,7 @@ def run_evolution_from_config(
     ).hexdigest()
     avo_configuration_identity = AVOConfigurationIdentity(
         model_identity=config.models.evolver,
+        supervisor_model_identity=config.models.evolver,
         tool_identity="avo-tools:1",
         development_evaluator_identity=(
             f"{config.backend}:{development_experiment_id}:{adapter}:{model}:timeout-{config.timeout}"

--- a/src/aec_bench/evolution/checkpoint.py
+++ b/src/aec_bench/evolution/checkpoint.py
@@ -40,12 +40,13 @@ from aec_bench.evolution.core import (
     VariationStatus,
 )
 from aec_bench.evolution.memory import AVO_MEMORY_LIMIT, AVOMemoryEntry, validate_memory_entries
+from aec_bench.evolution.supervision import AVOSupervisionRecord
 from aec_bench.ledger.durability import mkdir_durable, replace_file_bytes_durable
 
 AVO_CHECKPOINT_SCHEMA_VERSION: Literal[1] = 1
 """The only persisted checkpoint schema currently accepted by the reader."""
 
-AVOExternalEffectOperation = Literal["model_request", "development_evaluation", "compaction"]
+AVOExternalEffectOperation = Literal["model_request", "development_evaluation", "compaction", "supervisor_request"]
 """External operations that require durable incomplete-effect reconciliation."""
 
 
@@ -347,9 +348,11 @@ class AVOCheckpoint(StrictModel):
     best_attempt_id: NonEmptyStr | None = None
     consecutive_without_progress: int = 0
     consecutive_evaluation_errors: int = 0
+    exhausted_direction_requested: bool = False
     budget: AVOBudgetSnapshot
     usage: AVOUsageSnapshot
     structured_memory: tuple[AVOMemoryEntry, ...] = ()
+    supervision_records: tuple[AVOSupervisionRecord, ...] = ()
     incomplete_external_effects: tuple[AVOIncompleteExternalEffect, ...] = ()
     terminal_result: AVOCheckpointTerminalResult | None = None
 
@@ -358,6 +361,13 @@ class AVOCheckpoint(StrictModel):
     def validate_counters(cls, value: int) -> int:
         if isinstance(value, bool) or not isinstance(value, int) or value < 0:
             raise ValueError("checkpoint state counters must be non-negative integers")
+        return value
+
+    @field_validator("exhausted_direction_requested")
+    @classmethod
+    def validate_direction_request(cls, value: bool) -> bool:
+        if not isinstance(value, bool):
+            raise TypeError("checkpoint exhausted_direction_requested must be a boolean")
         return value
 
     @field_validator("development_case_ids")
@@ -400,6 +410,17 @@ class AVOCheckpoint(StrictModel):
             raise ValueError("checkpoint current_snapshot must match final_child_candidate_id")
         if self.terminal_result is not None and self.incomplete_external_effects:
             raise ValueError("terminal checkpoint must not retain incomplete external effects")
+        in_flight_supervisions = tuple(
+            effect for effect in self.incomplete_external_effects if effect.operation == "supervisor_request"
+        )
+        if len(in_flight_supervisions) > 1:
+            raise ValueError("checkpoint may contain at most one incomplete supervisor request")
+        if len(self.supervision_records) > self.budget.max_supervisor_interventions:
+            raise ValueError("checkpoint supervision_records exceed the configured supervisor intervention budget")
+        if len(self.supervision_records) + len(in_flight_supervisions) != self.usage.supervisor_interventions:
+            raise ValueError("checkpoint supervision_records and incomplete requests must match supervisor usage")
+        if self.terminal_result is not None and self.exhausted_direction_requested:
+            raise ValueError("terminal checkpoint cannot retain a pending exhausted-direction request")
 
         # Parent development evidence is absent only before the first baseline
         # evaluation. This shape is needed to durably represent cancellation or
@@ -654,9 +675,11 @@ class AVOCheckpoint(StrictModel):
             best_attempt_id=state.best_attempt_id,
             consecutive_without_progress=state.consecutive_without_progress,
             consecutive_evaluation_errors=state.consecutive_evaluation_errors,
+            exhausted_direction_requested=state.exhausted_direction_requested,
             budget=AVOBudgetSnapshot.from_budget(budget),
             usage=AVOUsageSnapshot.from_usage(state.usage),
             structured_memory=structured_memory,
+            supervision_records=tuple(state.supervision_records),
             incomplete_external_effects=incomplete_external_effects,
             terminal_result=terminal_result,
         )
@@ -673,6 +696,8 @@ class AVOCheckpoint(StrictModel):
             best_attempt_id=self.best_attempt_id,
             consecutive_without_progress=self.consecutive_without_progress,
             consecutive_evaluation_errors=self.consecutive_evaluation_errors,
+            exhausted_direction_requested=self.exhausted_direction_requested,
+            supervision_records=self.supervision_records,
             memory=self.structured_memory,
             usage=self.usage.to_usage(),
             terminal_status=self.terminal_result.status if self.terminal_result is not None else None,
@@ -735,6 +760,7 @@ __all__ = (
     "AVOExternalEffectOperation",
     "AVOIncompleteExternalEffect",
     "AVOIncompleteExternalEffectError",
+    "AVOSupervisionRecord",
     "AVOUsageSnapshot",
     "read_checkpoint",
     "write_checkpoint",

--- a/src/aec_bench/evolution/checkpoint.py
+++ b/src/aec_bench/evolution/checkpoint.py
@@ -43,7 +43,7 @@ from aec_bench.evolution.memory import AVO_MEMORY_LIMIT, AVOMemoryEntry, validat
 from aec_bench.evolution.supervision import AVOSupervisionRecord
 from aec_bench.ledger.durability import mkdir_durable, replace_file_bytes_durable
 
-AVO_CHECKPOINT_SCHEMA_VERSION: Literal[1] = 1
+AVO_CHECKPOINT_SCHEMA_VERSION: Literal[2] = 2
 """The only persisted checkpoint schema currently accepted by the reader."""
 
 AVOExternalEffectOperation = Literal["model_request", "development_evaluation", "compaction", "supervisor_request"]
@@ -330,7 +330,7 @@ class AVOCheckpointTerminalResult(StrictModel):
 class AVOCheckpoint(StrictModel):
     """The sole validated resume authority for one durable AVO call."""
 
-    schema_version: Literal[1] = AVO_CHECKPOINT_SCHEMA_VERSION
+    schema_version: Literal[2] = AVO_CHECKPOINT_SCHEMA_VERSION
     run_id: NonEmptyStr
     variation_id: NonEmptyStr
     parent_candidate_id: NonEmptyStr
@@ -419,6 +419,14 @@ class AVOCheckpoint(StrictModel):
             raise ValueError("checkpoint supervision_records exceed the configured supervisor intervention budget")
         if len(self.supervision_records) + len(in_flight_supervisions) != self.usage.supervisor_interventions:
             raise ValueError("checkpoint supervision_records and incomplete requests must match supervisor usage")
+        if (
+            self.exhausted_direction_requested
+            and self.usage.supervisor_interventions >= self.budget.max_supervisor_interventions
+            and not in_flight_supervisions
+        ):
+            raise ValueError(
+                "checkpoint exhausted_direction_requested cannot remain after supervisor budget is consumed"
+            )
         if self.terminal_result is not None and self.exhausted_direction_requested:
             raise ValueError("terminal checkpoint cannot retain a pending exhausted-direction request")
 

--- a/src/aec_bench/evolution/checkpoint.py
+++ b/src/aec_bench/evolution/checkpoint.py
@@ -201,7 +201,7 @@ class AVOBudgetSnapshot(StrictModel):
     max_elapsed_seconds: float = 1800.0
     max_consecutive_evaluation_errors: int = 2
     max_stagnant_evaluations: int = 3
-    max_supervisor_interventions: int = 1
+    max_supervisor_interventions: int = 0
     max_cost_usd: float | None = None
 
     @field_validator(

--- a/src/aec_bench/evolution/checkpoint.py
+++ b/src/aec_bench/evolution/checkpoint.py
@@ -141,11 +141,18 @@ class AVOUsageSnapshot(StrictModel):
     tool_calls: int = 0
     development_evaluations: int = 0
     supervisor_interventions: int = 0
+    input_tokens: int | None = None
+    output_tokens: int | None = None
     model_cost_usd: float | None = None
     development_evaluation_cost_usd: float | None = None
     elapsed_seconds: float = 0.0
 
-    @field_validator("model_requests", "tool_calls", "development_evaluations", "supervisor_interventions")
+    @field_validator(
+        "model_requests",
+        "tool_calls",
+        "development_evaluations",
+        "supervisor_interventions",
+    )
     @classmethod
     def validate_counters(cls, value: int) -> int:
         if isinstance(value, bool) or not isinstance(value, int) or value < 0:
@@ -159,6 +166,13 @@ class AVOUsageSnapshot(StrictModel):
             return None
         if isinstance(value, bool) or not isinstance(value, int | float) or not math.isfinite(value) or value < 0:
             raise ValueError("checkpoint usage values must be finite and non-negative")
+        return value
+
+    @field_validator("input_tokens", "output_tokens")
+    @classmethod
+    def validate_token_counts(cls, value: int | None) -> int | None:
+        if value is not None and (isinstance(value, bool) or not isinstance(value, int) or value < 0):
+            raise ValueError("checkpoint token counts must be non-negative integers")
         return value
 
     @classmethod
@@ -181,10 +195,12 @@ class AVOBudgetSnapshot(StrictModel):
     max_model_requests: int = 12
     max_tool_calls: int = 40
     max_development_evaluations: int = 7
+    max_input_tokens: int | None = None
+    max_output_tokens: int | None = None
     max_elapsed_seconds: float = 1800.0
     max_consecutive_evaluation_errors: int = 2
     max_stagnant_evaluations: int = 3
-    max_supervisor_interventions: int = 0
+    max_supervisor_interventions: int = 1
     max_cost_usd: float | None = None
 
     @field_validator(
@@ -216,6 +232,13 @@ class AVOBudgetSnapshot(StrictModel):
             raise ValueError("checkpoint active budget values must be finite and positive")
         return value
 
+    @field_validator("max_input_tokens", "max_output_tokens")
+    @classmethod
+    def validate_token_limits(cls, value: int | None) -> int | None:
+        if value is not None and (isinstance(value, bool) or not isinstance(value, int) or value <= 0):
+            raise ValueError("checkpoint token limits must be positive integers")
+        return value
+
     @classmethod
     def from_budget(cls, budget: AVOBudget) -> AVOBudgetSnapshot:
         """Convert one runtime budget."""
@@ -234,6 +257,7 @@ class AVOConfigurationIdentity(StrictModel):
     """Explicit behavior-affecting identity required for checkpoint compatibility."""
 
     model_identity: NonEmptyStr
+    supervisor_model_identity: NonEmptyStr
     tool_identity: NonEmptyStr
     development_evaluator_identity: NonEmptyStr
     configuration_identity: NonEmptyStr

--- a/src/aec_bench/evolution/core.py
+++ b/src/aec_bench/evolution/core.py
@@ -8,7 +8,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from aec_bench.contracts.evolution import (
     CandidateAssessment,
@@ -25,6 +25,9 @@ from aec_bench.contracts.evolution import (
 from aec_bench.evolution.analysis import EvolutionAnalysis, GraduatedScope
 from aec_bench.evolution.graveyard import GraveyardEntry
 from aec_bench.evolution.memory import AVO_MEMORY_LIMIT, AVOMemoryEntry, validate_memory_entries
+
+if TYPE_CHECKING:
+    from aec_bench.evolution.supervision import AVOSupervisionRecord
 
 
 def _require_text(value: str, field_name: str) -> None:
@@ -271,6 +274,8 @@ class AVOState:
     best_attempt_id: str | None = None
     consecutive_without_progress: int = 0
     consecutive_evaluation_errors: int = 0
+    exhausted_direction_requested: bool = False
+    supervision_records: tuple[AVOSupervisionRecord, ...] = ()
     memory: tuple[AVOMemoryEntry, ...] = ()
     usage: VariationUsage = VariationUsage()
     terminal_status: VariationStatus | None = None
@@ -282,6 +287,25 @@ class AVOState:
         _require_non_negative_integer(self.current_revision, "current_revision")
         _require_non_negative_integer(self.consecutive_without_progress, "consecutive_without_progress")
         _require_non_negative_integer(self.consecutive_evaluation_errors, "consecutive_evaluation_errors")
+        if not isinstance(self.exhausted_direction_requested, bool):
+            raise TypeError("exhausted_direction_requested must be a boolean")
+        if not isinstance(self.usage, VariationUsage):
+            raise TypeError("usage must be a VariationUsage")
+        records = tuple(self.supervision_records)
+        if any(record is None for record in records):
+            raise TypeError("supervision_records must not contain None")
+        if records:
+            # Keep the foundational core independent from the supervision
+            # adapter while still rejecting untyped state at this boundary.
+            from aec_bench.evolution.supervision import AVOSupervisionRecord
+
+            if any(not isinstance(record, AVOSupervisionRecord) for record in records):
+                raise TypeError("supervision_records must contain AVOSupervisionRecord values")
+        if len(records) > self.usage.supervisor_interventions:
+            raise ValueError("supervision_records cannot exceed supervisor_interventions usage")
+        if self.terminal_status is not None and self.exhausted_direction_requested:
+            raise ValueError("terminal AVO state cannot retain a pending exhausted-direction request")
+        object.__setattr__(self, "supervision_records", records)
         attempts = tuple(self.attempts)
         if any(not isinstance(attempt, DevelopmentAttempt) for attempt in attempts):
             raise TypeError("attempts must contain DevelopmentAttempt values")
@@ -301,8 +325,6 @@ class AVOState:
             raise ValueError("development attempt trial IDs must be unique")
         if self.best_attempt_id is not None and self.best_attempt_id not in attempt_ids:
             raise ValueError("best_attempt_id must reference an attempt")
-        if not isinstance(self.usage, VariationUsage):
-            raise TypeError("usage must be a VariationUsage")
         memory = validate_memory_entries(self.memory)
         if len(memory) > AVO_MEMORY_LIMIT:
             raise ValueError(f"AVO state memory must contain at most {AVO_MEMORY_LIMIT} entries")

--- a/src/aec_bench/evolution/core.py
+++ b/src/aec_bench/evolution/core.py
@@ -63,10 +63,12 @@ class AVOBudget:
     max_model_requests: int = 12
     max_tool_calls: int = 40
     max_development_evaluations: int = 7
+    max_input_tokens: int | None = None
+    max_output_tokens: int | None = None
     max_elapsed_seconds: float = 1800.0
     max_consecutive_evaluation_errors: int = 2
     max_stagnant_evaluations: int = 3
-    max_supervisor_interventions: int = 0
+    max_supervisor_interventions: int = 1
     max_cost_usd: float | None = None
 
     def __post_init__(self) -> None:
@@ -80,6 +82,10 @@ class AVOBudget:
             _require_positive_integer(getattr(self, field_name), field_name)
         _require_finite_positive(self.max_elapsed_seconds, "max_elapsed_seconds")
         _require_non_negative_integer(self.max_supervisor_interventions, "max_supervisor_interventions")
+        for field_name in ("max_input_tokens", "max_output_tokens"):
+            limit = getattr(self, field_name)
+            if limit is not None:
+                _require_positive_integer(limit, field_name)
         if self.max_cost_usd is not None:
             _require_finite_positive(self.max_cost_usd, "max_cost_usd")
 
@@ -368,6 +374,16 @@ def budget_exhaustion_reason(budget: AVOBudget, state: AVOState) -> str | None:
     for name, observed, limit in limits:
         if limit > 0 and observed >= limit:
             return name
+    token_limits: tuple[tuple[str, int | None, int | None], ...] = (
+        ("max_input_tokens", usage.input_tokens, budget.max_input_tokens),
+        ("max_output_tokens", usage.output_tokens, budget.max_output_tokens),
+    )
+    for token_name, token_observed, token_limit in token_limits:
+        if token_limit is not None:
+            if token_observed is None and usage.model_requests > 0:
+                return f"{token_name}_unknown"
+            if token_observed is not None and token_observed >= token_limit:
+                return token_name
     if budget.max_cost_usd is not None:
         total_cost = usage.total_cost_usd
         if total_cost is None:

--- a/src/aec_bench/evolution/core.py
+++ b/src/aec_bench/evolution/core.py
@@ -71,7 +71,7 @@ class AVOBudget:
     max_elapsed_seconds: float = 1800.0
     max_consecutive_evaluation_errors: int = 2
     max_stagnant_evaluations: int = 3
-    max_supervisor_interventions: int = 1
+    max_supervisor_interventions: int = 0
     max_cost_usd: float | None = None
 
     def __post_init__(self) -> None:
@@ -391,7 +391,6 @@ def budget_exhaustion_reason(budget: AVOBudget, state: AVOState) -> str | None:
             state.consecutive_without_progress,
             budget.max_stagnant_evaluations,
         ),
-        ("max_supervisor_interventions", usage.supervisor_interventions, budget.max_supervisor_interventions),
     )
     for name, observed, limit in limits:
         if limit > 0 and observed >= limit:

--- a/src/aec_bench/evolution/supervision.py
+++ b/src/aec_bench/evolution/supervision.py
@@ -9,7 +9,7 @@ import time
 from dataclasses import asdict, dataclass
 from enum import StrEnum
 from importlib import import_module
-from typing import Any
+from typing import Any, Protocol
 
 from pydantic import model_validator
 
@@ -218,6 +218,12 @@ class AVOSupervisionBudgetError(ValueError):
     """Raised when a supervisor reservation or reconciliation exceeds AVO authority."""
 
 
+class SupervisorRunner(Protocol):
+    """Narrow provider boundary for one non-recursive supervisor request."""
+
+    def __call__(self, request: AVOSupervisionRequest) -> AVOSupervisionResult: ...
+
+
 def _validate_usage_within_budget(
     usage: VariationUsage,
     budget: AVOBudget,
@@ -327,7 +333,6 @@ def reconcile_supervision_usage(
         development_evaluation_cost_usd=usage_before.development_evaluation_cost_usd,
         elapsed_seconds=reserved.elapsed_seconds + supervisor_usage.elapsed_seconds,
     )
-    _validate_usage_within_budget(reconciled, budget)
     return reconciled
 
 
@@ -566,6 +571,7 @@ __all__ = (
     "AVOSupervisionRequest",
     "AVOSupervisionTrigger",
     "PydanticAISupervisionRunner",
+    "SupervisorRunner",
     "build_supervision_composition",
     "project_remaining_budget",
     "reconcile_supervision_usage",

--- a/src/aec_bench/evolution/supervision.py
+++ b/src/aec_bench/evolution/supervision.py
@@ -1,0 +1,244 @@
+# ABOUTME: Defines bounded, read-only contracts for conditional AVO supervision.
+# ABOUTME: Computes deterministic intervention triggers and projects existing AVO budget only.
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import StrEnum
+
+from aec_bench.contracts.evolution import MutationStrategy
+from aec_bench.evolution.core import AVOBudget, AVOState
+from aec_bench.evolution.memory import AVO_MEMORY_LIMIT, AVOMemoryEntry, validate_memory_entries
+
+_VALID_STAGNATION_THRESHOLD = 3
+_INVALID_OR_FAILED_THRESHOLD = 2
+
+
+def _require_text(value: str, field_name: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must not be blank")
+
+
+def _require_non_negative_integer(value: int, field_name: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{field_name} must be a non-negative integer")
+
+
+def _require_finite_non_negative(value: float, field_name: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int | float) or not math.isfinite(value) or value < 0:
+        raise ValueError(f"{field_name} must be a finite non-negative number")
+
+
+class AVOSupervisionTrigger(StrEnum):
+    """Stable reasons that can admit one bounded supervisor intervention."""
+
+    VALID_DEVELOPMENT_STAGNATION = "three_valid_development_evaluations_without_progress"
+    CONSECUTIVE_INVALID_OR_FAILED_EVALUATIONS = "two_consecutive_invalid_or_failed_development_evaluations"
+    EXHAUSTED_DIRECTION_REQUEST = "main_agent_exhausted_direction_request"
+
+
+@dataclass(frozen=True)
+class AVORemainingBudget:
+    """Read-only remaining allowance projected from one AVO call's budget.
+
+    ``cost_limit_usd`` distinguishes an unbounded cost plane from a bounded
+    plane whose remaining cost is unknown. ``None`` for ``remaining_cost_usd``
+    does not mean that the supervisor may spend without a limit. This value is
+    a projection for supervisor context; it cannot grant authority to use a
+    resource that the AVO budget does not permit.
+    """
+
+    remaining_model_requests: int
+    remaining_tool_calls: int
+    remaining_development_evaluations: int
+    remaining_elapsed_seconds: float
+    remaining_supervisor_interventions: int
+    cost_limit_usd: float | None
+    remaining_cost_usd: float | None
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "model_requests",
+            "tool_calls",
+            "development_evaluations",
+            "supervisor_interventions",
+        ):
+            _require_non_negative_integer(getattr(self, f"remaining_{field_name}"), f"remaining_{field_name}")
+        _require_finite_non_negative(self.remaining_elapsed_seconds, "remaining_elapsed_seconds")
+        if self.cost_limit_usd is not None:
+            _require_finite_non_negative(self.cost_limit_usd, "cost_limit_usd")
+        if self.remaining_cost_usd is not None:
+            _require_finite_non_negative(self.remaining_cost_usd, "remaining_cost_usd")
+            if self.cost_limit_usd is None:
+                raise ValueError("remaining_cost_usd requires a bounded cost_limit_usd")
+            if self.remaining_cost_usd > self.cost_limit_usd:
+                raise ValueError("remaining_cost_usd cannot exceed cost_limit_usd")
+
+
+@dataclass(frozen=True)
+class AVOSupervisionRequest:
+    """Structured, read-only input supplied to one supervisor invocation."""
+
+    goal: str
+    selected_parent_id: str
+    strategy: MutationStrategy
+    attempt_summaries: tuple[AVOMemoryEntry, ...]
+    remaining_budget: AVORemainingBudget
+    trigger_reason: AVOSupervisionTrigger
+
+    def __post_init__(self) -> None:
+        _require_text(self.goal, "goal")
+        _require_text(self.selected_parent_id, "selected_parent_id")
+        try:
+            strategy = MutationStrategy(self.strategy)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"unsupported mutation strategy: {self.strategy!r}") from exc
+        object.__setattr__(self, "strategy", strategy)
+
+        summaries = validate_memory_entries(self.attempt_summaries)
+        if len(summaries) > AVO_MEMORY_LIMIT:
+            raise ValueError(f"attempt_summaries must contain at most {AVO_MEMORY_LIMIT} entries")
+        object.__setattr__(self, "attempt_summaries", summaries)
+
+        if not isinstance(self.remaining_budget, AVORemainingBudget):
+            raise TypeError("remaining_budget must be an AVORemainingBudget")
+        try:
+            trigger_reason = AVOSupervisionTrigger(self.trigger_reason)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"unsupported supervision trigger reason: {self.trigger_reason!r}") from exc
+        object.__setattr__(self, "trigger_reason", trigger_reason)
+
+
+@dataclass(frozen=True)
+class AVOSupervisionAdvice:
+    """Validated guidance that cannot mutate AVO or outer evolution state."""
+
+    directions: tuple[str, ...]
+    reasoning: str
+
+    def __post_init__(self) -> None:
+        directions = tuple(self.directions)
+        if not 1 <= len(directions) <= 3:
+            raise ValueError("supervision advice must contain one to three directions")
+        normalised: list[str] = []
+        for direction in directions:
+            if not isinstance(direction, str):
+                raise TypeError("supervision advice directions must be strings")
+            value = direction.strip()
+            if not value:
+                raise ValueError("supervision advice directions must not be blank")
+            normalised.append(value)
+        if len(normalised) != len(set(normalised)):
+            raise ValueError("supervision advice directions must be unique")
+        object.__setattr__(self, "directions", tuple(normalised))
+        _require_text(self.reasoning, "reasoning")
+
+
+def project_remaining_budget(budget: AVOBudget, state: AVOState) -> AVORemainingBudget:
+    """Project non-negative remaining AVO allowances without adding authority."""
+    if not isinstance(budget, AVOBudget):
+        raise TypeError("budget must be an AVOBudget")
+    if not isinstance(state, AVOState):
+        raise TypeError("state must be an AVOState")
+
+    usage = state.usage
+    total_cost = usage.total_cost_usd
+    remaining_cost = None
+    if budget.max_cost_usd is not None and total_cost is not None:
+        remaining_cost = max(0.0, budget.max_cost_usd - total_cost)
+    return AVORemainingBudget(
+        remaining_model_requests=max(0, budget.max_model_requests - usage.model_requests),
+        remaining_tool_calls=max(0, budget.max_tool_calls - usage.tool_calls),
+        remaining_development_evaluations=max(0, budget.max_development_evaluations - usage.development_evaluations),
+        remaining_elapsed_seconds=max(0.0, budget.max_elapsed_seconds - usage.elapsed_seconds),
+        remaining_supervisor_interventions=max(0, budget.max_supervisor_interventions - usage.supervisor_interventions),
+        cost_limit_usd=budget.max_cost_usd,
+        remaining_cost_usd=remaining_cost,
+    )
+
+
+def supervision_trigger_reason(
+    state: AVOState,
+    budget: AVOBudget,
+    *,
+    exhausted_direction_requested: bool = False,
+) -> AVOSupervisionTrigger | None:
+    """Return the deterministic trigger reason admitted by explicit AVO state.
+
+    Valid stagnation uses the explicit ``consecutive_without_progress``
+    counter, and confirms that its latest three development attempts are valid
+    evidence. Invalid attempts and evaluator failures use their respective
+    explicit state counters. Trigger order is stable when more than one
+    condition is true. Reaching the hard intervention limit always suppresses
+    a trigger, including an explicit main-agent request.
+    """
+    if not isinstance(state, AVOState):
+        raise TypeError("state must be an AVOState")
+    if not isinstance(budget, AVOBudget):
+        raise TypeError("budget must be an AVOBudget")
+    if not isinstance(exhausted_direction_requested, bool):
+        raise TypeError("exhausted_direction_requested must be a boolean")
+    if state.terminal_status is not None:
+        return None
+    if state.usage.supervisor_interventions >= budget.max_supervisor_interventions:
+        return None
+
+    if _has_valid_stagnation(state):
+        return AVOSupervisionTrigger.VALID_DEVELOPMENT_STAGNATION
+    if _has_consecutive_invalid_or_failed_evaluations(state):
+        return AVOSupervisionTrigger.CONSECUTIVE_INVALID_OR_FAILED_EVALUATIONS
+    if exhausted_direction_requested:
+        return AVOSupervisionTrigger.EXHAUSTED_DIRECTION_REQUEST
+    return None
+
+
+def should_trigger_supervision(
+    state: AVOState,
+    budget: AVOBudget,
+    *,
+    exhausted_direction_requested: bool = False,
+) -> bool:
+    """Return whether one supervisor intervention is currently admitted."""
+    return (
+        supervision_trigger_reason(
+            state,
+            budget,
+            exhausted_direction_requested=exhausted_direction_requested,
+        )
+        is not None
+    )
+
+
+def _has_valid_stagnation(state: AVOState) -> bool:
+    """Require the explicit stagnation count and three latest valid attempts."""
+    if state.consecutive_without_progress < _VALID_STAGNATION_THRESHOLD:
+        return False
+    if state.consecutive_evaluation_errors:
+        return False
+    latest_attempts = state.attempts[-_VALID_STAGNATION_THRESHOLD:]
+    return len(latest_attempts) == _VALID_STAGNATION_THRESHOLD and all(
+        attempt.evaluated.assessment.valid for attempt in latest_attempts
+    )
+
+
+def _has_consecutive_invalid_or_failed_evaluations(state: AVOState) -> bool:
+    """Recognise two evaluator failures or two latest invalid attempts."""
+    if state.consecutive_evaluation_errors >= _INVALID_OR_FAILED_THRESHOLD:
+        return True
+    required_invalid_attempts = _INVALID_OR_FAILED_THRESHOLD - state.consecutive_evaluation_errors
+    latest_attempts = state.attempts[-required_invalid_attempts:]
+    return len(latest_attempts) == required_invalid_attempts and all(
+        not attempt.evaluated.assessment.valid for attempt in latest_attempts
+    )
+
+
+__all__ = (
+    "AVORemainingBudget",
+    "AVOSupervisionAdvice",
+    "AVOSupervisionRequest",
+    "AVOSupervisionTrigger",
+    "project_remaining_budget",
+    "should_trigger_supervision",
+    "supervision_trigger_reason",
+)

--- a/src/aec_bench/evolution/supervision.py
+++ b/src/aec_bench/evolution/supervision.py
@@ -3,11 +3,15 @@
 
 from __future__ import annotations
 
+import json
 import math
-from dataclasses import dataclass
+import time
+from dataclasses import asdict, dataclass
 from enum import StrEnum
+from importlib import import_module
+from typing import Any
 
-from aec_bench.contracts.evolution import MutationStrategy
+from aec_bench.contracts.evolution import MutationStrategy, VariationUsage
 from aec_bench.evolution.core import AVOBudget, AVOState
 from aec_bench.evolution.memory import AVO_MEMORY_LIMIT, AVOMemoryEntry, validate_memory_entries
 
@@ -56,6 +60,10 @@ class AVORemainingBudget:
     remaining_supervisor_interventions: int
     cost_limit_usd: float | None
     remaining_cost_usd: float | None
+    remaining_input_tokens: int | None = None
+    remaining_output_tokens: int | None = None
+    input_token_limit: int | None = None
+    output_token_limit: int | None = None
 
     def __post_init__(self) -> None:
         for field_name in (
@@ -66,6 +74,20 @@ class AVORemainingBudget:
         ):
             _require_non_negative_integer(getattr(self, f"remaining_{field_name}"), f"remaining_{field_name}")
         _require_finite_non_negative(self.remaining_elapsed_seconds, "remaining_elapsed_seconds")
+        for field_name in ("remaining_input_tokens", "remaining_output_tokens"):
+            tokens = getattr(self, field_name)
+            if tokens is not None:
+                _require_non_negative_integer(tokens, field_name)
+        for field_name, remaining_name in (
+            ("input_token_limit", "remaining_input_tokens"),
+            ("output_token_limit", "remaining_output_tokens"),
+        ):
+            limit = getattr(self, field_name)
+            if limit is not None:
+                _require_non_negative_integer(limit, field_name)
+                remaining = getattr(self, remaining_name)
+                if remaining is not None and remaining > limit:
+                    raise ValueError(f"{remaining_name} cannot exceed {field_name}")
         if self.cost_limit_usd is not None:
             _require_finite_non_negative(self.cost_limit_usd, "cost_limit_usd")
         if self.remaining_cost_usd is not None:
@@ -135,6 +157,268 @@ class AVOSupervisionAdvice:
         _require_text(self.reasoning, "reasoning")
 
 
+class AVOSupervisionFailureCode(StrEnum):
+    """Confirmed supervisor failures that do not represent provider failure."""
+
+    OUTPUT_VALIDATION_REJECTED = "output_validation_rejected"
+
+
+@dataclass(frozen=True)
+class AVOSupervisionFailure:
+    """One confirmed failure produced by supervisor output validation."""
+
+    code: AVOSupervisionFailureCode
+    detail: str
+
+    def __post_init__(self) -> None:
+        try:
+            code = AVOSupervisionFailureCode(self.code)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"unsupported supervisor failure code: {self.code!r}") from exc
+        object.__setattr__(self, "code", code)
+        _require_text(self.detail, "detail")
+
+
+@dataclass(frozen=True)
+class AVOSupervisionResult:
+    """Immutable supervisor output and the usage delta for that one call."""
+
+    output: AVOSupervisionAdvice | AVOSupervisionFailure
+    usage: VariationUsage
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.output, AVOSupervisionAdvice | AVOSupervisionFailure):
+            raise TypeError("output must be AVOSupervisionAdvice or AVOSupervisionFailure")
+        if not isinstance(self.usage, VariationUsage):
+            raise TypeError("usage must be a VariationUsage")
+        if self.usage.model_requests != 1 or self.usage.supervisor_interventions != 1:
+            raise ValueError("supervision result usage must describe exactly one request and intervention")
+        if self.usage.tool_calls or self.usage.development_evaluations:
+            raise ValueError("supervision result usage must not include tools or development evaluations")
+
+
+class AVOSupervisionBudgetError(ValueError):
+    """Raised when a supervisor reservation or reconciliation exceeds AVO authority."""
+
+
+def _validate_usage_within_budget(
+    usage: VariationUsage,
+    budget: AVOBudget,
+    *,
+    allow_reserved_unknown_tokens: bool = False,
+    allow_reserved_unknown_cost: bool = False,
+) -> None:
+    """Fail closed when known usage exceeds a configured hard limit."""
+    if usage.model_requests > budget.max_model_requests:
+        raise AVOSupervisionBudgetError("max_model_requests")
+    if usage.supervisor_interventions > budget.max_supervisor_interventions:
+        raise AVOSupervisionBudgetError("max_supervisor_interventions")
+    if usage.elapsed_seconds > budget.max_elapsed_seconds:
+        raise AVOSupervisionBudgetError("max_elapsed_seconds")
+    for name, observed, limit in (
+        ("max_input_tokens", usage.input_tokens, budget.max_input_tokens),
+        ("max_output_tokens", usage.output_tokens, budget.max_output_tokens),
+    ):
+        if limit is not None:
+            if observed is None:
+                if allow_reserved_unknown_tokens and usage.model_requests == 1:
+                    continue
+                raise AVOSupervisionBudgetError(f"{name}_unknown")
+            if observed > limit:
+                raise AVOSupervisionBudgetError(name)
+    if budget.max_cost_usd is not None:
+        total_cost = usage.total_cost_usd
+        if total_cost is None:
+            if allow_reserved_unknown_cost and usage.model_requests == 1:
+                return
+            raise AVOSupervisionBudgetError("max_cost_usd_unknown")
+        if total_cost > budget.max_cost_usd:
+            raise AVOSupervisionBudgetError("max_cost_usd")
+
+
+def reserve_supervision_usage(usage: VariationUsage, budget: AVOBudget) -> VariationUsage:
+    """Reserve one model request and intervention before a supervisor call."""
+    if not isinstance(usage, VariationUsage):
+        raise TypeError("usage must be a VariationUsage")
+    if not isinstance(budget, AVOBudget):
+        raise TypeError("budget must be an AVOBudget")
+    if usage.model_requests >= budget.max_model_requests:
+        raise AVOSupervisionBudgetError("max_model_requests")
+    if usage.supervisor_interventions >= budget.max_supervisor_interventions:
+        raise AVOSupervisionBudgetError("max_supervisor_interventions")
+    if usage.elapsed_seconds >= budget.max_elapsed_seconds:
+        raise AVOSupervisionBudgetError("max_elapsed_seconds")
+    reserved = VariationUsage(
+        model_requests=usage.model_requests + 1,
+        tool_calls=usage.tool_calls,
+        development_evaluations=usage.development_evaluations,
+        supervisor_interventions=usage.supervisor_interventions + 1,
+        input_tokens=usage.input_tokens,
+        output_tokens=usage.output_tokens,
+        model_cost_usd=usage.model_cost_usd,
+        development_evaluation_cost_usd=usage.development_evaluation_cost_usd,
+        elapsed_seconds=usage.elapsed_seconds,
+    )
+    _validate_usage_within_budget(
+        reserved,
+        budget,
+        allow_reserved_unknown_tokens=usage.model_requests == 0,
+        allow_reserved_unknown_cost=usage.model_requests == 0 and usage.total_cost_usd is not None,
+    )
+    return reserved
+
+
+def reconcile_supervision_usage(
+    usage_before: VariationUsage,
+    budget: AVOBudget,
+    supervisor_usage: VariationUsage,
+) -> VariationUsage:
+    """Merge one validated supervisor usage delta into the shared AVO usage."""
+    reserved = reserve_supervision_usage(usage_before, budget)
+    if not isinstance(supervisor_usage, VariationUsage):
+        raise TypeError("supervisor_usage must be a VariationUsage")
+    if (
+        supervisor_usage.model_requests != 1
+        or supervisor_usage.supervisor_interventions != 1
+        or supervisor_usage.tool_calls != 0
+        or supervisor_usage.development_evaluations != 0
+    ):
+        raise ValueError("supervisor usage must describe exactly one request and intervention")
+
+    def merge_tokens(previous: int | None, added: int | None) -> int | None:
+        if usage_before.model_requests == 0:
+            return added
+        if previous is None or added is None:
+            return None
+        return previous + added
+
+    def merge_cost(previous: float | None, added: float | None) -> float | None:
+        if usage_before.model_requests == 0:
+            return added
+        if previous is None or added is None:
+            return None
+        return previous + added
+
+    reconciled = VariationUsage(
+        model_requests=reserved.model_requests,
+        tool_calls=reserved.tool_calls,
+        development_evaluations=reserved.development_evaluations,
+        supervisor_interventions=reserved.supervisor_interventions,
+        input_tokens=merge_tokens(usage_before.input_tokens, supervisor_usage.input_tokens),
+        output_tokens=merge_tokens(usage_before.output_tokens, supervisor_usage.output_tokens),
+        model_cost_usd=merge_cost(usage_before.model_cost_usd, supervisor_usage.model_cost_usd),
+        development_evaluation_cost_usd=usage_before.development_evaluation_cost_usd,
+        elapsed_seconds=reserved.elapsed_seconds + supervisor_usage.elapsed_seconds,
+    )
+    _validate_usage_within_budget(reconciled, budget)
+    return reconciled
+
+
+class PydanticAISupervisionRunner:
+    """Provider adapter with only one typed, read-only supervisor request."""
+
+    def __init__(self, model: Any, *, model_identity: str, system_prompt: str = "") -> None:
+        if model is None:
+            raise ValueError("supervisor model must be explicit")
+        _require_text(model_identity, "model_identity")
+        if system_prompt and not isinstance(system_prompt, str):
+            raise TypeError("system_prompt must be a string")
+        self.model = model
+        self.model_identity = model_identity.strip()
+        self.system_prompt = system_prompt.strip() or _DEFAULT_SUPERVISOR_SYSTEM_PROMPT
+
+    def __call__(self, request: AVOSupervisionRequest) -> AVOSupervisionResult:
+        if not isinstance(request, AVOSupervisionRequest):
+            raise TypeError("request must be an AVOSupervisionRequest")
+        pydantic_ai = import_module("pydantic_ai")
+        usage_module = import_module("pydantic_ai.usage")
+        started_at = time.monotonic()
+        agent = pydantic_ai.Agent(
+            self.model,
+            system_prompt=self.system_prompt,
+            output_type=AVOSupervisionAdvice,
+            retries=0,
+        )
+        result = agent.run_sync(
+            _render_supervision_prompt(request),
+            usage_limits=usage_module.UsageLimits(request_limit=1),
+        )
+
+        usage = result.usage()
+        if usage.requests != 1:
+            raise RuntimeError("supervisor provider request count must be exactly one")
+        return AVOSupervisionResult(
+            output=result.output,
+            usage=VariationUsage(
+                model_requests=1,
+                supervisor_interventions=1,
+                input_tokens=usage.input_tokens,
+                output_tokens=usage.output_tokens,
+                elapsed_seconds=max(0.0, time.monotonic() - started_at),
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class AVOSupervisionComposition:
+    """Immutable pairing of an isolated supervisor runner and exact identity."""
+
+    runner: PydanticAISupervisionRunner
+    model_identity: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.runner, PydanticAISupervisionRunner):
+            raise TypeError("runner must be a PydanticAISupervisionRunner")
+        _require_text(self.model_identity, "model_identity")
+        identity = self.model_identity.strip()
+        if self.runner.model_identity != identity:
+            raise ValueError("supervisor runner identity must match composition identity")
+        object.__setattr__(self, "model_identity", identity)
+
+
+def build_supervision_composition(
+    model: Any,
+    *,
+    model_identity: str,
+    system_prompt: str = "",
+) -> AVOSupervisionComposition:
+    """Build one explicit supervisor runner without composing loop state or tools."""
+    runner = PydanticAISupervisionRunner(model, model_identity=model_identity, system_prompt=system_prompt)
+    return AVOSupervisionComposition(runner=runner, model_identity=runner.model_identity)
+
+
+_DEFAULT_SUPERVISOR_SYSTEM_PROMPT = (
+    "You are a bounded AEC-Bench supervisor. Return only validated advice with one to three distinct directions. "
+    "You cannot edit workspaces, call tools, evaluate candidates, or change budgets."
+)
+
+
+def _render_supervision_prompt(request: AVOSupervisionRequest) -> str:
+    """Render only immutable request facts for the isolated supervisor."""
+    summaries = [
+        {
+            "source_variation_id": entry.source_variation_id,
+            "source_attempt_id": entry.source_attempt_id,
+            "hypothesis": entry.hypothesis,
+            "change_summary": entry.change_summary,
+            "evidence_summary": entry.evidence_summary,
+            "outcome": entry.outcome.value,
+            "failure_category": entry.failure_category,
+            "next_direction": entry.next_direction,
+        }
+        for entry in request.attempt_summaries
+    ]
+    payload = {
+        "goal": request.goal,
+        "selected_parent_id": request.selected_parent_id,
+        "strategy": request.strategy.value,
+        "attempt_summaries": summaries,
+        "remaining_budget": asdict(request.remaining_budget),
+        "trigger_reason": request.trigger_reason.value,
+    }
+    return json.dumps(payload, ensure_ascii=True, sort_keys=True)
+
+
 def project_remaining_budget(budget: AVOBudget, state: AVOState) -> AVORemainingBudget:
     """Project non-negative remaining AVO allowances without adding authority."""
     if not isinstance(budget, AVOBudget):
@@ -155,6 +439,26 @@ def project_remaining_budget(budget: AVOBudget, state: AVOState) -> AVORemaining
         remaining_supervisor_interventions=max(0, budget.max_supervisor_interventions - usage.supervisor_interventions),
         cost_limit_usd=budget.max_cost_usd,
         remaining_cost_usd=remaining_cost,
+        remaining_input_tokens=(
+            budget.max_input_tokens
+            if budget.max_input_tokens is not None and usage.model_requests == 0 and usage.input_tokens is None
+            else (
+                None
+                if budget.max_input_tokens is None or usage.input_tokens is None
+                else max(0, budget.max_input_tokens - usage.input_tokens)
+            )
+        ),
+        remaining_output_tokens=(
+            budget.max_output_tokens
+            if budget.max_output_tokens is not None and usage.model_requests == 0 and usage.output_tokens is None
+            else (
+                None
+                if budget.max_output_tokens is None or usage.output_tokens is None
+                else max(0, budget.max_output_tokens - usage.output_tokens)
+            )
+        ),
+        input_token_limit=budget.max_input_tokens,
+        output_token_limit=budget.max_output_tokens,
     )
 
 
@@ -234,11 +538,20 @@ def _has_consecutive_invalid_or_failed_evaluations(state: AVOState) -> bool:
 
 
 __all__ = (
+    "AVOSupervisionBudgetError",
+    "AVOSupervisionComposition",
+    "AVOSupervisionFailure",
+    "AVOSupervisionFailureCode",
+    "AVOSupervisionResult",
     "AVORemainingBudget",
     "AVOSupervisionAdvice",
     "AVOSupervisionRequest",
     "AVOSupervisionTrigger",
+    "PydanticAISupervisionRunner",
+    "build_supervision_composition",
     "project_remaining_budget",
+    "reconcile_supervision_usage",
+    "reserve_supervision_usage",
     "should_trigger_supervision",
     "supervision_trigger_reason",
 )

--- a/src/aec_bench/evolution/supervision.py
+++ b/src/aec_bench/evolution/supervision.py
@@ -212,6 +212,8 @@ class AVOSupervisionResult:
             raise ValueError("supervision result usage must describe exactly one request and intervention")
         if self.usage.tool_calls or self.usage.development_evaluations:
             raise ValueError("supervision result usage must not include tools or development evaluations")
+        if self.usage.development_evaluation_cost_usd is not None:
+            raise ValueError("supervision result usage must not include development evaluation cost")
 
 
 class AVOSupervisionBudgetError(ValueError):
@@ -305,6 +307,7 @@ def reconcile_supervision_usage(
         or supervisor_usage.supervisor_interventions != 1
         or supervisor_usage.tool_calls != 0
         or supervisor_usage.development_evaluations != 0
+        or supervisor_usage.development_evaluation_cost_usd is not None
     ):
         raise ValueError("supervisor usage must describe exactly one request and intervention")
 

--- a/src/aec_bench/evolution/supervision.py
+++ b/src/aec_bench/evolution/supervision.py
@@ -11,7 +11,10 @@ from enum import StrEnum
 from importlib import import_module
 from typing import Any
 
+from pydantic import model_validator
+
 from aec_bench.contracts.evolution import MutationStrategy, VariationUsage
+from aec_bench.contracts.validators import FrozenStrictModel
 from aec_bench.evolution.core import AVOBudget, AVOState
 from aec_bench.evolution.memory import AVO_MEMORY_LIMIT, AVOMemoryEntry, validate_memory_entries
 
@@ -177,6 +180,20 @@ class AVOSupervisionFailure:
             raise ValueError(f"unsupported supervisor failure code: {self.code!r}") from exc
         object.__setattr__(self, "code", code)
         _require_text(self.detail, "detail")
+
+
+class AVOSupervisionRecord(FrozenStrictModel):
+    """One confirmed intervention outcome retained in AVO state."""
+
+    trigger_reason: AVOSupervisionTrigger
+    advice: AVOSupervisionAdvice | None = None
+    failure: AVOSupervisionFailure | None = None
+
+    @model_validator(mode="after")
+    def validate_outcome(self) -> AVOSupervisionRecord:
+        if (self.advice is None) == (self.failure is None):
+            raise ValueError("supervision record requires advice or confirmed failure, but not both")
+        return self
 
 
 @dataclass(frozen=True)
@@ -542,6 +559,7 @@ __all__ = (
     "AVOSupervisionComposition",
     "AVOSupervisionFailure",
     "AVOSupervisionFailureCode",
+    "AVOSupervisionRecord",
     "AVOSupervisionResult",
     "AVORemainingBudget",
     "AVOSupervisionAdvice",

--- a/src/aec_bench/evolution/swarm/evolver.py
+++ b/src/aec_bench/evolution/swarm/evolver.py
@@ -31,7 +31,7 @@ from aec_bench.evolution.cancellation import (
     AVOCancellationSignal,
 )
 from aec_bench.evolution.checkpoint import AVOConfigurationIdentity
-from aec_bench.evolution.core import AVOBudget, EvolutionState, VariationRequest, VariationResult
+from aec_bench.evolution.core import EvolutionState, VariationRequest, VariationResult
 from aec_bench.evolution.enrichment import enrich_observations
 from aec_bench.evolution.evaluation import CandidateBatchPlanner, CandidateEvaluationBatch, bind_candidate_evaluation
 from aec_bench.evolution.graveyard import MutationGraveyard
@@ -297,13 +297,15 @@ class SwarmEvolverFactory:
             candidate_identity=False,
         )
         cancellation_signal = AVOCancellationSignal()
+        evolver_model = build_pydantic_model(evolver_model_name)
         variation_operator = build_agentic_variation_operator(
-            agent_model=build_pydantic_model(evolver_model_name),
+            agent_model=evolver_model,
+            supervisor_model=evolver_model,
+            supervisor_model_identity=evolver_model_name,
             development_batch_planner=development_batch_planner,
             development_evaluator=development_evaluator,
             development_batch_size=self._batch_size,
             development_experiment_prefix=development_experiment_id,
-            budget=AVOBudget(),
             compaction_llm=classifier_llm,
             # Agent workspaces are disposable copies. Keep the checkpoint in
             # the factory's source workspace so cleanup cannot remove the

--- a/src/aec_bench/evolution/swarm/evolver.py
+++ b/src/aec_bench/evolution/swarm/evolver.py
@@ -311,6 +311,7 @@ class SwarmEvolverFactory:
             checkpoint_root=self._workspace_source,
             configuration_identity=AVOConfigurationIdentity(
                 model_identity=evolver_model_name,
+                supervisor_model_identity=evolver_model_name,
                 tool_identity="avo-tools:1",
                 development_evaluator_identity=(
                     f"local:{development_experiment_id}:{self._adapter}:{solver_model}:timeout-{self._timeout}"

--- a/src/aec_bench/evolution/variation_operator.py
+++ b/src/aec_bench/evolution/variation_operator.py
@@ -24,6 +24,7 @@ from aec_bench.evolution.development import (
 from aec_bench.evolution.evaluation import CandidateEvaluationBatch
 from aec_bench.evolution.resume import checkpoint_path
 from aec_bench.evolution.sanitiser import CompactionLLM
+from aec_bench.evolution.supervision import build_supervision_composition
 from aec_bench.evolution.workspace import Workspace
 from aec_bench.trials import build_trial_id
 
@@ -31,6 +32,8 @@ from aec_bench.trials import build_trial_id
 def build_agentic_variation_operator(
     *,
     agent_model: Any,
+    supervisor_model: Any,
+    supervisor_model_identity: str,
     development_batch_planner: DevelopmentBatchPlanner,
     development_evaluator: DevelopmentEvaluator,
     development_batch_size: int,
@@ -59,14 +62,27 @@ def build_agentic_variation_operator(
         raise ValueError("development_batch_size must be positive")
     if not isinstance(development_experiment_prefix, str) or not development_experiment_prefix.strip():
         raise ValueError("development_experiment_prefix must not be blank")
-    selected_budget = budget if budget is not None else AVOBudget()
+    selected_budget = budget if budget is not None else AVOBudget(max_supervisor_interventions=1)
     if not isinstance(selected_budget, AVOBudget):
         raise TypeError("budget must be an AVOBudget")
+    if supervisor_model is None:
+        raise ValueError("supervisor_model must be explicit")
+    if not isinstance(supervisor_model_identity, str) or not supervisor_model_identity.strip():
+        raise ValueError("supervisor_model_identity must not be blank")
     if checkpoint_root is not None and not isinstance(checkpoint_root, Path):
         raise TypeError("checkpoint_root must be a Path")
     if checkpoint_root is not None and configuration_identity is None:
         raise ValueError("configuration_identity is required when checkpointing is enabled")
+    if (
+        configuration_identity is not None
+        and supervisor_model_identity.strip() != configuration_identity.supervisor_model_identity
+    ):
+        raise ValueError("supervisor_model_identity must match configuration_identity.supervisor_model_identity")
     runner = PydanticAIStructuredRunner(agent_model)
+    supervisor_runner = build_supervision_composition(
+        supervisor_model,
+        model_identity=supervisor_model_identity,
+    ).runner
 
     def vary(request: VariationRequest, source: Workspace, child_candidate_id: str) -> VariationResult:
         if not isinstance(request, VariationRequest):
@@ -117,6 +133,7 @@ def build_agentic_variation_operator(
             child_candidate_id,
             development_boundary=boundary,
             agent_runner=runner,
+            supervisor_runner=supervisor_runner,
             budget=selected_budget,
             knowledge_source=lambda: _workspace_program(source),
             compaction_llm=compaction_llm,

--- a/tests/evolution/swarm/test_evolver.py
+++ b/tests/evolution/swarm/test_evolver.py
@@ -9,6 +9,7 @@ import threading
 import time
 from datetime import UTC, datetime
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import yaml
@@ -20,10 +21,19 @@ from aec_bench.contracts.evolution import (
 )
 from aec_bench.contracts.experiment_manifest import AgentConfig, ComputeConfig, TaskSelector
 from aec_bench.contracts.trial_record import CostRecord
+from aec_bench.evolution import variation_operator
 from aec_bench.evolution.cancellation import AVOCancellationSignal
 from aec_bench.evolution.core import DevelopmentAttempt, SelectionPlan, VariationResult, VariationStatus
 from aec_bench.evolution.evaluation import CandidateEvaluationBatch, bind_evaluated_candidate
 from aec_bench.evolution.memory import AVOMemoryEntry
+from aec_bench.evolution.supervision import (
+    AVORemainingBudget,
+    AVOSupervisionAdvice,
+    AVOSupervisionRequest,
+    AVOSupervisionResult,
+    AVOSupervisionTrigger,
+)
+from aec_bench.evolution.swarm import evolver as swarm_evolver_module
 from aec_bench.evolution.swarm.core import AgentBudget, SwarmAgentResult, SwarmAssignment
 from aec_bench.evolution.swarm.evolver import (
     SwarmAgentEvolver,
@@ -377,6 +387,179 @@ def test_factory_creates_independent_workspaces(tmp_path: Path) -> None:
     # Each agent should have a different workspace path
     assert e1._workspace._root != e2._workspace._root
     factory.cleanup()
+
+
+def test_factory_isolates_supervisor_state_and_checkpoint_paths_per_agent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = _setup_workspace(tmp_path)
+    task_dir = _setup_task(tmp_path)
+    inputs_root = tmp_path / "inputs"
+    inputs_root.mkdir()
+    _inputs_workspace, batch = _setup_evolution_inputs(inputs_root)
+    models: list[object] = []
+    supervisor_runners = []
+    captures = []
+
+    def build_model(_model_name: str) -> object:
+        model = object()
+        models.append(model)
+        return model
+
+    monkeypatch.setattr(swarm_evolver_module, "build_pydantic_model", build_model)
+
+    def batch_planner(**_kwargs):
+        return lambda _size, _cycle: batch
+
+    def candidate_evaluator(**_kwargs):
+        def evaluate(snapshot, current_batch):
+            return tuple(
+                make_trial_record(
+                    trial_id=trial.trial_id,
+                    task_id=trial.task_id,
+                    evaluation={
+                        "reward": 0.5,
+                        "validity": {
+                            "output_parseable": True,
+                            "schema_valid": True,
+                            "verifier_completed": True,
+                        },
+                    },
+                )
+                for trial in current_batch.trials
+            )
+
+        return evaluate
+
+    monkeypatch.setattr(swarm_evolver_module, "make_local_candidate_batch_planner", batch_planner)
+    monkeypatch.setattr(swarm_evolver_module, "make_local_candidate_evaluator", candidate_evaluator)
+
+    class RecordingSupervisor:
+        def __init__(self, label: str, model: object) -> None:
+            self.label = label
+            self.model = model
+            self.requests: list[AVOSupervisionRequest] = []
+
+        def __call__(self, request: AVOSupervisionRequest) -> AVOSupervisionResult:
+            self.requests.append(request)
+            return AVOSupervisionResult(
+                output=AVOSupervisionAdvice(
+                    directions=(f"Private direction for {self.label}.",),
+                    reasoning="Advice must stay inside this agent's call.",
+                ),
+                usage=VariationUsage(model_requests=1, supervisor_interventions=1),
+            )
+
+    def build_supervisor(model: object, *, model_identity: str) -> SimpleNamespace:
+        runner = RecordingSupervisor(f"agent-{len(supervisor_runners)}", model)
+        supervisor_runners.append(runner)
+        return SimpleNamespace(runner=runner)
+
+    monkeypatch.setattr(variation_operator, "build_supervision_composition", build_supervisor)
+
+    def capture_run(
+        request,
+        _source,
+        child_candidate_id,
+        *,
+        agent_runner,
+        supervisor_runner,
+        checkpoint_path,
+        cancellation_signal,
+        **_kwargs,
+    ) -> VariationResult:
+        supervision_request = AVOSupervisionRequest(
+            goal=request.selection.goal,
+            selected_parent_id=request.selection.parent_candidate_id,
+            strategy=request.selection.strategy,
+            attempt_summaries=(),
+            remaining_budget=AVORemainingBudget(
+                remaining_model_requests=1,
+                remaining_tool_calls=1,
+                remaining_development_evaluations=1,
+                remaining_elapsed_seconds=1.0,
+                remaining_supervisor_interventions=1,
+                cost_limit_usd=None,
+                remaining_cost_usd=None,
+            ),
+            trigger_reason=AVOSupervisionTrigger.EXHAUSTED_DIRECTION_REQUEST,
+        )
+        advice = supervisor_runner(supervision_request).output
+        captures.append(
+            {
+                "agent_runner": agent_runner,
+                "supervisor_runner": supervisor_runner,
+                "cancellation_signal": cancellation_signal,
+                "checkpoint_path": checkpoint_path,
+                "advice": advice,
+                "child_candidate_id": child_candidate_id,
+            }
+        )
+        return VariationResult(
+            status=VariationStatus.ABSTAINED,
+            child=None,
+            mutation=None,
+            reasoning=advice.directions[0],
+            usage=VariationUsage(),
+        )
+
+    monkeypatch.setattr(variation_operator, "run_agentic_variation", capture_run)
+    factory = SwarmEvolverFactory(
+        workspace_source=source,
+        task_dirs=[task_dir],
+        classifier_llm=StubClassifierLLM(),
+        model="test-model",
+    )
+
+    first = factory.create("agent-0")
+    second = factory.create("agent-1")
+    parent = Workspace(source).export_snapshot("parent")
+    selection = SelectionPlan("parent", (), "conservative", "Improve checks", "Use the host direction.")
+    first_assignment = SwarmAssignment(
+        run_id="run-test",
+        assignment_id="assignment-1",
+        agent_id="agent-0",
+        selection=selection,
+        parent=parent,
+        inspirations=(),
+        budget=AgentBudget(2.0),
+        issued_at=datetime.now(UTC),
+    )
+    second_assignment = SwarmAssignment(
+        run_id="run-test",
+        assignment_id="assignment-2",
+        agent_id="agent-1",
+        selection=selection,
+        parent=parent,
+        inspirations=(),
+        budget=AgentBudget(2.0),
+        issued_at=datetime.now(UTC),
+    )
+    first._sync_step(first_assignment)
+    second._sync_step(second_assignment)
+    factory.cleanup()
+
+    assert len(models) == 2
+    assert models[0] is not models[1]
+    assert len(supervisor_runners) == 2
+    assert supervisor_runners[0].model is models[0]
+    assert supervisor_runners[1].model is models[1]
+    assert supervisor_runners[0] is not supervisor_runners[1]
+    assert first._variation_operator is not second._variation_operator
+    assert first.cancellation_signal is not second.cancellation_signal
+    assert len(captures) == 2
+    assert captures[0]["agent_runner"] is not captures[1]["agent_runner"]
+    assert captures[0]["supervisor_runner"] is supervisor_runners[0]
+    assert captures[1]["supervisor_runner"] is supervisor_runners[1]
+    assert captures[0]["cancellation_signal"] is first.cancellation_signal
+    assert captures[1]["cancellation_signal"] is second.cancellation_signal
+    assert captures[0]["checkpoint_path"] != captures[1]["checkpoint_path"]
+    assert captures[0]["checkpoint_path"].parent.parent == source / "_avo_checkpoints"
+    assert captures[1]["checkpoint_path"].parent.parent == source / "_avo_checkpoints"
+    assert captures[0]["advice"].directions != captures[1]["advice"].directions
+    assert len(supervisor_runners[0].requests) == 1
+    assert len(supervisor_runners[1].requests) == 1
+    assert supervisor_runners[0].requests[0] is not supervisor_runners[1].requests[0]
 
 
 def test_evolver_returns_submitted_child_without_mutating_canonical_workspace(tmp_path: Path) -> None:

--- a/tests/evolution/test_agent_loop.py
+++ b/tests/evolution/test_agent_loop.py
@@ -29,8 +29,9 @@ from aec_bench.evolution.agent_loop import (
     PydanticAIStructuredRunner,
     run_agentic_variation,
 )
-from aec_bench.evolution.agent_protocol import AgentResponse
+from aec_bench.evolution.agent_protocol import AgentResponse, _render_agent_prompt
 from aec_bench.evolution.analysis import BehavioralPattern, EvolutionAnalysis, GraduatedScope
+from aec_bench.evolution.cancellation import AVOCancellationError, AVOCancellationSignal
 from aec_bench.evolution.checkpoint import AVOConfigurationIdentity, AVOIncompleteExternalEffectError, read_checkpoint
 from aec_bench.evolution.core import (
     AVOBudget,
@@ -43,7 +44,14 @@ from aec_bench.evolution.development import DevelopmentEvaluationBoundary
 from aec_bench.evolution.evaluation import CandidateEvaluationBatch
 from aec_bench.evolution.memory import AVOMemoryEntry
 from aec_bench.evolution.resume import AVOResumeMismatchError, checkpoint_path
-from aec_bench.evolution.supervision import AVOSupervisionAdvice, AVOSupervisionResult
+from aec_bench.evolution.supervision import (
+    AVOSupervisionAdvice,
+    AVOSupervisionFailure,
+    AVOSupervisionFailureCode,
+    AVOSupervisionRequest,
+    AVOSupervisionResult,
+    AVOSupervisionTrigger,
+)
 from aec_bench.evolution.workspace import Workspace
 from tests.evolution.test_development import _batch, _record
 from tests.support.trial_record_factories import make_trial_record
@@ -162,6 +170,38 @@ def _boundary(
     )
 
 
+def _outcome_boundary(
+    tmp_path: Path, child_invalid: tuple[bool, ...]
+) -> tuple[DevelopmentEvaluationBoundary, list[int]]:
+    selected_batch = _batch(tmp_path / "batch")
+    evaluation_count = [0]
+
+    def evaluate(_snapshot: object, _batch_value: object):
+        evaluation_count[0] += 1
+        invalid = evaluation_count[0] > 1 and child_invalid[evaluation_count[0] - 2]
+        validity = ValidityCheck(
+            output_parseable=not invalid,
+            schema_valid=True,
+            verifier_completed=True,
+            errors=("invalid fixture",) if invalid else (),
+        )
+        reward = 0.0 if invalid else 0.4
+        return (
+            _record(
+                trial_id=f"outcome-development-trial-{evaluation_count[0]}",
+            ).model_copy(update={"evaluation": EvaluationResult(reward=reward, validity=validity)}),
+        )
+
+    boundary = DevelopmentEvaluationBoundary(
+        planner=lambda _size, _cycle: selected_batch,
+        evaluator=evaluate,
+        batch_size=1,
+        experiment_id="development-experiment",
+        host_experiment_id="host-experiment",
+    )
+    return boundary, evaluation_count
+
+
 def _checkpoint_identity() -> AVOConfigurationIdentity:
     return AVOConfigurationIdentity(
         model_identity="test-model",
@@ -275,6 +315,7 @@ def test_explicit_supervision_request_persists_advice_for_next_main_context(tmp_
     main_runner = _SequenceRunner(
         [
             _command(AgentToolName.REQUEST_SUPERVISION),
+            _command(AgentToolName.REQUEST_SUPERVISION),
             _command(AgentToolName.ABSTAIN, reasoning="The advised direction is not safe to submit."),
         ]
     )
@@ -304,15 +345,283 @@ def test_explicit_supervision_request_persists_advice_for_next_main_context(tmp_
 
     assert result.status is VariationStatus.ABSTAINED
     assert len(supervisor_calls) == 1
-    assert len(main_runner.contexts) == 2
+    assert len(main_runner.contexts) == 3
     next_context = main_runner.contexts[1]
     assert next_context.latest_supervision_advice is not None
     assert next_context.latest_supervision_advice.directions == ("Try a bounded verification-focused direction.",)
     assert "request_supervision" not in next_context.tools
+    prompt = _render_agent_prompt(next_context)
+    assert "optional advisory guidance only" in prompt
+    assert "does not itself perform or authorize workspace edits" in prompt
+    assert "SupervisorRunner" not in prompt
+    assert "credentials" not in prompt
+    assert "hidden verifier" not in prompt
     assert result.usage.supervisor_interventions == 1
     saved = read_checkpoint(path)
     assert len(saved.supervision_records) == 1
     assert saved.supervision_records[0].advice == next_context.latest_supervision_advice
+    assert saved.exhausted_direction_requested is False
+    assert not saved.incomplete_external_effects
+
+
+def test_three_stagnant_child_evaluations_trigger_once_and_open_a_new_direction_window(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path / "workspace")
+    request = _request(workspace)
+    boundary, evaluation_count = _outcome_boundary(tmp_path / "boundary", (False, False, False, False))
+    commands: list[AgentCommand] = []
+    for index in range(4):
+        commands.extend(
+            (
+                _command(
+                    AgentToolName.APPLY_MUTATION,
+                    mutation={"type": "modify_prompt", "content": f"Direction {index}"},
+                ),
+                _command(AgentToolName.EVALUATE_CURRENT_REVISION, hypothesis=f"Try direction {index}."),
+            )
+        )
+    commands.append(_command(AgentToolName.ABSTAIN, reasoning="The bounded direction window is complete."))
+    main_runner = _SequenceRunner(commands)
+    supervisor_requests: list[AVOSupervisionRequest] = []
+
+    def supervisor(supervision_request: AVOSupervisionRequest) -> AVOSupervisionResult:
+        supervisor_requests.append(supervision_request)
+        return AVOSupervisionResult(
+            output=AVOSupervisionAdvice(directions=("Try a different bounded direction.",), reasoning="No progress."),
+            usage=VariationUsage(model_requests=1, supervisor_interventions=1),
+        )
+
+    result = run_agentic_variation(
+        request,
+        workspace,
+        "child",
+        development_boundary=boundary,
+        agent_runner=main_runner,
+        supervisor_runner=supervisor,
+        budget=AVOBudget(max_supervisor_interventions=1),
+    )
+
+    assert result.status is VariationStatus.ABSTAINED
+    assert evaluation_count[0] == 5  # parent baseline plus four child evaluations
+    assert len(supervisor_requests) == 1
+    assert supervisor_requests[0].trigger_reason is AVOSupervisionTrigger.VALID_DEVELOPMENT_STAGNATION
+    assert len(supervisor_requests[0].attempt_summaries) == 3
+    assert main_runner.contexts[6].state.consecutive_without_progress == 0
+    assert main_runner.contexts[6].latest_supervision_advice is not None
+
+
+def test_two_invalid_child_assessments_trigger_one_supervisor_without_counting_raw_errors(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path / "workspace")
+    request = _request(workspace)
+    boundary, evaluation_count = _outcome_boundary(tmp_path / "boundary", (True, True))
+    main_runner = _SequenceRunner(
+        [
+            _command(AgentToolName.APPLY_MUTATION, mutation={"type": "modify_prompt", "content": "Invalid one"}),
+            _command(AgentToolName.EVALUATE_CURRENT_REVISION, hypothesis="First invalid result."),
+            _command(AgentToolName.APPLY_MUTATION, mutation={"type": "modify_prompt", "content": "Invalid two"}),
+            _command(AgentToolName.EVALUATE_CURRENT_REVISION, hypothesis="Second invalid result."),
+            _command(AgentToolName.ABSTAIN, reasoning="Invalid evidence cannot be submitted."),
+        ]
+    )
+    supervisor_requests: list[AVOSupervisionRequest] = []
+
+    def supervisor(supervision_request: AVOSupervisionRequest) -> AVOSupervisionResult:
+        supervisor_requests.append(supervision_request)
+        return AVOSupervisionResult(
+            output=AVOSupervisionAdvice(directions=("Try a bounded alternative.",), reasoning="Two invalid results."),
+            usage=VariationUsage(model_requests=1, supervisor_interventions=1),
+        )
+
+    result = run_agentic_variation(
+        request,
+        workspace,
+        "child",
+        development_boundary=boundary,
+        agent_runner=main_runner,
+        supervisor_runner=supervisor,
+        budget=AVOBudget(max_supervisor_interventions=1),
+    )
+
+    assert result.status is VariationStatus.ABSTAINED
+    assert evaluation_count[0] == 3  # parent plus two returned invalid assessments
+    assert len(supervisor_requests) == 1
+    assert supervisor_requests[0].trigger_reason is AVOSupervisionTrigger.CONSECUTIVE_INVALID_OR_FAILED_EVALUATIONS
+
+
+def test_confirmed_supervision_failure_is_visible_once_and_does_not_retry(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path / "workspace")
+    request = _request(workspace)
+    path = checkpoint_path(tmp_path / "state", run_id=request.run_id, variation_id="run-test:variation-1:child-child")
+    main_runner = _SequenceRunner(
+        [
+            _command(AgentToolName.REQUEST_SUPERVISION),
+            _command(AgentToolName.ABSTAIN, reasoning="Continue without supervisor advice."),
+        ]
+    )
+    supervisor_calls = 0
+
+    def supervisor(_supervision_request: AVOSupervisionRequest) -> AVOSupervisionResult:
+        nonlocal supervisor_calls
+        supervisor_calls += 1
+        return AVOSupervisionResult(
+            output=AVOSupervisionFailure(
+                code=AVOSupervisionFailureCode.OUTPUT_VALIDATION_REJECTED,
+                detail="The supervisor response was not usable.",
+            ),
+            usage=VariationUsage(model_requests=1, supervisor_interventions=1),
+        )
+
+    result = run_agentic_variation(
+        request,
+        workspace,
+        "child",
+        development_boundary=_boundary(tmp_path / "boundary"),
+        agent_runner=main_runner,
+        supervisor_runner=supervisor,
+        budget=AVOBudget(max_supervisor_interventions=1),
+        checkpoint_path=path,
+        configuration_identity=_checkpoint_identity(),
+    )
+
+    assert result.status is VariationStatus.ABSTAINED
+    assert supervisor_calls == 1
+    assert main_runner.contexts[1].latest_supervision_failure is not None
+    assert main_runner.contexts[1].latest_supervision_failure.detail == "The supervisor response was not usable."
+    saved = read_checkpoint(path)
+    assert saved.supervision_records[0].failure == main_runner.contexts[1].latest_supervision_failure
+    assert not saved.incomplete_external_effects
+
+
+def test_successful_supervision_reconciles_before_cancellation_and_resume_is_idempotent(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path / "workspace")
+    request = _request(workspace)
+    path = checkpoint_path(tmp_path / "state", run_id=request.run_id, variation_id="run-test:variation-1:child-child")
+    first_boundary = _boundary(tmp_path / "boundary")
+    resume_boundary = _boundary(tmp_path / "resume-boundary", batch=first_boundary.batch)
+    signal = AVOCancellationSignal()
+    current_time = [0.0]
+    main_calls = 0
+    supervisor_calls = 0
+
+    def main_runner(_context: AgentContext) -> AgentResponse:
+        nonlocal main_calls
+        main_calls += 1
+        return AgentResponse(
+            command=_command(AgentToolName.REQUEST_SUPERVISION),
+            model_cost_usd=0.4,
+            input_tokens=10,
+            output_tokens=5,
+        )
+
+    def supervisor(_supervision_request: AVOSupervisionRequest) -> AVOSupervisionResult:
+        nonlocal supervisor_calls
+        supervisor_calls += 1
+        signal.cancel("cancel during supervisor call")
+        current_time[0] = 2.0
+        return AVOSupervisionResult(
+            output=AVOSupervisionAdvice(directions=("Use a bounded alternative.",), reasoning="Try once."),
+            usage=VariationUsage(
+                model_requests=1,
+                supervisor_interventions=1,
+                input_tokens=7,
+                output_tokens=3,
+                model_cost_usd=0.2,
+                elapsed_seconds=2.0,
+            ),
+        )
+
+    with pytest.raises(AVOCancellationError):
+        run_agentic_variation(
+            request,
+            workspace,
+            "child",
+            development_boundary=first_boundary,
+            agent_runner=main_runner,
+            supervisor_runner=supervisor,
+            budget=AVOBudget(max_supervisor_interventions=1),
+            checkpoint_path=path,
+            configuration_identity=_checkpoint_identity(),
+            cancellation_signal=signal,
+            clock=lambda: current_time[0],
+        )
+    saved = read_checkpoint(path)
+    assert saved.terminal_result is not None
+    assert saved.terminal_result.status is VariationStatus.CANCELLED
+    assert saved.usage.model_requests == 2
+    assert saved.usage.supervisor_interventions == 1
+    assert saved.usage.input_tokens == 17
+    assert saved.usage.output_tokens == 8
+    assert saved.usage.model_cost_usd == pytest.approx(0.6)
+    assert saved.usage.elapsed_seconds == pytest.approx(2.0)
+    assert saved.supervision_records[0].advice is not None
+    assert not saved.incomplete_external_effects
+
+    with pytest.raises(AVOCancellationError):
+        run_agentic_variation(
+            request,
+            workspace,
+            "child",
+            development_boundary=resume_boundary,
+            agent_runner=lambda _context: (_ for _ in ()).throw(AssertionError("main must not retry")),
+            supervisor_runner=lambda _request: (_ for _ in ()).throw(AssertionError("supervisor must not retry")),
+            budget=AVOBudget(max_supervisor_interventions=1),
+            checkpoint_path=path,
+            configuration_identity=_checkpoint_identity(),
+        )
+    assert main_calls == 1
+    assert supervisor_calls == 1
+
+
+def test_supervision_usage_plane_overrun_is_checkpointed_before_budget_stop(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path / "workspace")
+    request = _request(workspace)
+    path = checkpoint_path(tmp_path / "state", run_id=request.run_id, variation_id="run-test:variation-1:child-child")
+    main_calls = 0
+    supervisor_calls = 0
+
+    def main_runner(_context: AgentContext) -> AgentResponse:
+        nonlocal main_calls
+        main_calls += 1
+        return AgentResponse(
+            command=_command(AgentToolName.REQUEST_SUPERVISION),
+            model_cost_usd=0.4,
+            input_tokens=10,
+            output_tokens=5,
+        )
+
+    def supervisor(_request: AVOSupervisionRequest) -> AVOSupervisionResult:
+        nonlocal supervisor_calls
+        supervisor_calls += 1
+        return AVOSupervisionResult(
+            output=AVOSupervisionAdvice(directions=("Use one bounded alternative.",), reasoning="Try once."),
+            usage=VariationUsage(
+                model_requests=1,
+                supervisor_interventions=1,
+                input_tokens=7,
+                output_tokens=3,
+                model_cost_usd=0.2,
+                elapsed_seconds=0.5,
+            ),
+        )
+
+    result = run_agentic_variation(
+        request,
+        workspace,
+        "child",
+        development_boundary=_boundary(tmp_path / "boundary"),
+        agent_runner=main_runner,
+        supervisor_runner=supervisor,
+        budget=AVOBudget(max_supervisor_interventions=1, max_input_tokens=15),
+        checkpoint_path=path,
+        configuration_identity=_checkpoint_identity(),
+    )
+
+    assert result.status is VariationStatus.BUDGET_EXHAUSTED
+    assert "max_input_tokens" in result.reasoning
+    assert main_calls == 1
+    assert supervisor_calls == 1
+    saved = read_checkpoint(path)
+    assert saved.usage.input_tokens == 17
+    assert saved.supervision_records[0].advice is not None
     assert not saved.incomplete_external_effects
 
 

--- a/tests/evolution/test_agent_loop.py
+++ b/tests/evolution/test_agent_loop.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 import yaml
 
+import aec_bench.evolution.agent_loop as agent_loop_module
 import aec_bench.evolution.checkpoint as checkpoint_module
 from aec_bench.contracts.evaluation_result import EvaluationResult, ValidityCheck
 from aec_bench.contracts.evolution import (
@@ -172,9 +173,12 @@ def _boundary(
 
 
 def _outcome_boundary(
-    tmp_path: Path, child_invalid: tuple[bool, ...]
+    tmp_path: Path,
+    child_invalid: tuple[bool, ...],
+    *,
+    batch: CandidateEvaluationBatch | None = None,
 ) -> tuple[DevelopmentEvaluationBoundary, list[int]]:
-    selected_batch = _batch(tmp_path / "batch")
+    selected_batch = batch or _batch(tmp_path / "batch")
     evaluation_count = [0]
 
     def evaluate(_snapshot: object, _batch_value: object):
@@ -365,6 +369,97 @@ def test_explicit_supervision_request_persists_advice_for_next_main_context(tmp_
     assert not saved.incomplete_external_effects
 
 
+def test_cancellation_before_supervision_clears_pending_request_before_terminal_checkpoint(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path / "workspace")
+    request = _request(workspace)
+    path = checkpoint_path(tmp_path / "state", run_id=request.run_id, variation_id="run-test:variation-1:child-child")
+    signal = AVOCancellationSignal()
+
+    def request_then_cancel(context: AgentContext) -> AgentCommand:
+        context.tools["request_supervision"]()
+        signal.cancel("cancel before supervisor call")
+        return _command(AgentToolName.ABSTAIN, reasoning="Cancellation wins before dispatch.")
+
+    with pytest.raises(AVOCancellationError):
+        run_agentic_variation(
+            request,
+            workspace,
+            "child",
+            development_boundary=_boundary(tmp_path / "boundary"),
+            agent_runner=request_then_cancel,
+            supervisor_runner=lambda _request: pytest.fail("supervisor must not be called"),
+            budget=AVOBudget(max_supervisor_interventions=1),
+            checkpoint_path=path,
+            configuration_identity=_checkpoint_identity(),
+            cancellation_signal=signal,
+        )
+
+    saved = read_checkpoint(path)
+    assert saved.terminal_result is not None
+    assert saved.terminal_result.status is VariationStatus.CANCELLED
+    assert saved.exhausted_direction_requested is False
+    assert saved.usage.supervisor_interventions == 0
+    assert not saved.incomplete_external_effects
+
+
+@pytest.mark.parametrize(
+    ("supervisor_cost", "expected_cost"),
+    ((0.2, pytest.approx(0.7)), (None, None)),
+)
+def test_supervision_reconciles_private_cost_tracker_for_later_main_responses(
+    supervisor_cost: float | None,
+    expected_cost: float | None,
+    tmp_path: Path,
+) -> None:
+    workspace = _workspace(tmp_path / f"workspace-{supervisor_cost}")
+    request = _request(workspace)
+    main_responses = [
+        AgentResponse(
+            command=_command(AgentToolName.REQUEST_SUPERVISION),
+            model_cost_usd=0.4,
+            input_tokens=10,
+            output_tokens=5,
+        ),
+        AgentResponse(
+            command=_command(AgentToolName.ABSTAIN, reasoning="Continue with the bounded main loop."),
+            model_cost_usd=0.1,
+            input_tokens=2,
+            output_tokens=1,
+        ),
+    ]
+
+    def main_runner(_context: AgentContext) -> AgentResponse:
+        return main_responses.pop(0)
+
+    def supervisor(_request: AVOSupervisionRequest) -> AVOSupervisionResult:
+        return AVOSupervisionResult(
+            output=AVOSupervisionAdvice(directions=("Try one bounded alternative.",), reasoning="The path repeats."),
+            usage=VariationUsage(
+                model_requests=1,
+                supervisor_interventions=1,
+                input_tokens=7,
+                output_tokens=3,
+                model_cost_usd=supervisor_cost,
+            ),
+        )
+
+    result = run_agentic_variation(
+        request,
+        workspace,
+        "child",
+        development_boundary=_boundary(tmp_path / f"boundary-{supervisor_cost}"),
+        agent_runner=main_runner,
+        supervisor_runner=supervisor,
+        budget=AVOBudget(max_supervisor_interventions=1),
+    )
+
+    assert result.status is VariationStatus.ABSTAINED
+    if expected_cost is None:
+        assert result.usage.model_cost_usd is None
+    else:
+        assert result.usage.model_cost_usd == expected_cost
+
+
 def test_supervision_advice_is_private_to_one_call_and_cannot_change_outer_inputs(tmp_path: Path) -> None:
     workspace = _workspace(tmp_path / "workspace")
     request = _request(workspace)
@@ -487,6 +582,91 @@ def test_three_stagnant_child_evaluations_trigger_once_and_open_a_new_direction_
     assert len(supervisor_requests[0].attempt_summaries) == 3
     assert main_runner.contexts[6].state.consecutive_without_progress == 0
     assert main_runner.contexts[6].latest_supervision_advice is not None
+
+
+def test_resume_resolves_persisted_trigger_before_next_main_request(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    workspace = _workspace(tmp_path / "workspace")
+    request = _request(workspace)
+    first_boundary, _ = _outcome_boundary(tmp_path / "first-boundary", (False, False, False))
+    resume_boundary = _outcome_boundary(
+        tmp_path / "resume-boundary",
+        (False, False, False),
+        batch=first_boundary.batch,
+    )[0]
+    path = checkpoint_path(tmp_path / "state", run_id=request.run_id, variation_id="run-test:variation-1:child-child")
+    first_runner = _SequenceRunner(
+        [
+            _command(AgentToolName.APPLY_MUTATION, mutation={"type": "modify_prompt", "content": "Direction 1"}),
+            _command(AgentToolName.EVALUATE_CURRENT_REVISION, hypothesis="Try direction 1."),
+            _command(AgentToolName.APPLY_MUTATION, mutation={"type": "modify_prompt", "content": "Direction 2"}),
+            _command(AgentToolName.EVALUATE_CURRENT_REVISION, hypothesis="Try direction 2."),
+            _command(AgentToolName.APPLY_MUTATION, mutation={"type": "modify_prompt", "content": "Direction 3"}),
+            _command(AgentToolName.EVALUATE_CURRENT_REVISION, hypothesis="Try direction 3."),
+        ]
+    )
+    original_maybe_run_supervision = agent_loop_module._LoopController._maybe_run_supervision
+
+    def crash_before_supervision(controller: object) -> None:
+        assert isinstance(controller, agent_loop_module._LoopController)
+        if controller.state.consecutive_without_progress >= 3:
+            raise RuntimeError("simulated crash before persisted trigger was resolved")
+        original_maybe_run_supervision(controller)
+
+    monkeypatch.setattr(agent_loop_module._LoopController, "_maybe_run_supervision", crash_before_supervision)
+    with pytest.raises(RuntimeError, match="simulated crash before persisted trigger"):
+        run_agentic_variation(
+            request,
+            workspace,
+            "child",
+            development_boundary=first_boundary,
+            agent_runner=first_runner,
+            supervisor_runner=lambda _request: pytest.fail("first run must not call supervision"),
+            budget=AVOBudget(max_supervisor_interventions=1),
+            checkpoint_path=path,
+            configuration_identity=_checkpoint_identity(),
+        )
+
+    saved_before_resume = read_checkpoint(path)
+    assert saved_before_resume.consecutive_without_progress == 3
+    assert saved_before_resume.usage.supervisor_interventions == 0
+    assert not saved_before_resume.incomplete_external_effects
+
+    monkeypatch.setattr(agent_loop_module._LoopController, "_maybe_run_supervision", original_maybe_run_supervision)
+    supervisor_calls: list[AVOSupervisionRequest] = []
+
+    def supervisor(supervision_request: AVOSupervisionRequest) -> AVOSupervisionResult:
+        supervisor_calls.append(supervision_request)
+        return AVOSupervisionResult(
+            output=AVOSupervisionAdvice(
+                directions=("Try a new bounded direction.",), reasoning="Three attempts stalled."
+            ),
+            usage=VariationUsage(model_requests=1, supervisor_interventions=1),
+        )
+
+    resumed_runner = _SequenceRunner(
+        [_command(AgentToolName.ABSTAIN, reasoning="Stop after the resumed supervision context.")]
+    )
+    resumed = run_agentic_variation(
+        request,
+        workspace,
+        "child",
+        development_boundary=resume_boundary,
+        agent_runner=resumed_runner,
+        supervisor_runner=supervisor,
+        budget=AVOBudget(max_supervisor_interventions=1),
+        checkpoint_path=path,
+        configuration_identity=_checkpoint_identity(),
+    )
+
+    assert resumed.status is VariationStatus.ABSTAINED
+    assert len(supervisor_calls) == 1
+    assert supervisor_calls[0].trigger_reason is AVOSupervisionTrigger.VALID_DEVELOPMENT_STAGNATION
+    assert len(resumed_runner.contexts) == 1
+    assert resumed_runner.contexts[0].latest_supervision_advice is not None
+    assert resumed_runner.contexts[0].state.consecutive_without_progress == 0
 
 
 def test_two_invalid_child_assessments_trigger_one_supervisor_without_counting_raw_errors(tmp_path: Path) -> None:

--- a/tests/evolution/test_agent_loop.py
+++ b/tests/evolution/test_agent_loop.py
@@ -28,6 +28,7 @@ from aec_bench.evolution.agent_loop import (
     PydanticAIStructuredRunner,
     run_agentic_variation,
 )
+from aec_bench.evolution.agent_protocol import AgentResponse
 from aec_bench.evolution.analysis import BehavioralPattern, EvolutionAnalysis, GraduatedScope
 from aec_bench.evolution.checkpoint import AVOConfigurationIdentity, AVOIncompleteExternalEffectError, read_checkpoint
 from aec_bench.evolution.core import (
@@ -162,6 +163,7 @@ def _boundary(
 def _checkpoint_identity() -> AVOConfigurationIdentity:
     return AVOConfigurationIdentity(
         model_identity="test-model",
+        supervisor_model_identity="test-supervisor-model",
         tool_identity="avo-tools:1",
         development_evaluator_identity="development-evaluator:test",
         configuration_identity="test-config:1",
@@ -710,6 +712,31 @@ def test_hard_limit_exhausts_without_silent_submission(tmp_path: Path) -> None:
     assert result.usage.development_evaluations == 1
 
 
+def test_token_limit_blocks_model_selected_tool_effect(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path / "workspace")
+    request = _request(workspace)
+
+    result = run_agentic_variation(
+        request,
+        workspace,
+        "child",
+        development_boundary=_boundary(tmp_path),
+        agent_runner=lambda _context: AgentResponse(
+            command=_command(
+                AgentToolName.APPLY_MUTATION,
+                mutation={"type": "modify_prompt", "content": "Must not be applied."},
+            ),
+            input_tokens=11,
+            output_tokens=1,
+        ),
+        budget=AVOBudget(max_input_tokens=10),
+    )
+
+    assert result.status is VariationStatus.BUDGET_EXHAUSTED
+    assert workspace.export_snapshot("parent").system_prompt == request.parent.snapshot.system_prompt
+    assert result.usage.input_tokens == 11
+
+
 def test_invalid_development_evidence_cannot_become_best_attempt(tmp_path: Path) -> None:
     workspace = _workspace(tmp_path / "workspace")
     request = _request(workspace)
@@ -752,6 +779,15 @@ def test_provider_failure_propagates(tmp_path: Path) -> None:
 def test_typed_mutation_rejects_unknown_action() -> None:
     with pytest.raises(ValueError):
         MutationInput.model_validate({"type": "shell", "command": "rm -rf /"})
+
+
+@pytest.mark.parametrize("field_name", ["input_tokens", "output_tokens"])
+def test_agent_response_rejects_negative_token_usage(field_name: str) -> None:
+    with pytest.raises(ValueError, match="non-negative integers"):
+        AgentResponse(
+            command=AgentCommand(tool=AgentToolName.ABSTAIN, arguments={"reasoning": "No change."}),
+            **{field_name: -1},
+        )
 
 
 def test_pydantic_ai_runner_is_a_provider_boundary() -> None:

--- a/tests/evolution/test_agent_loop.py
+++ b/tests/evolution/test_agent_loop.py
@@ -18,6 +18,7 @@ from aec_bench.contracts.evolution import (
     FieldScore,
     MutationStrategy,
     ObservationEnrichment,
+    VariationUsage,
     WorkspaceSnapshot,
 )
 from aec_bench.evolution.agent_loop import (
@@ -42,6 +43,7 @@ from aec_bench.evolution.development import DevelopmentEvaluationBoundary
 from aec_bench.evolution.evaluation import CandidateEvaluationBatch
 from aec_bench.evolution.memory import AVOMemoryEntry
 from aec_bench.evolution.resume import AVOResumeMismatchError, checkpoint_path
+from aec_bench.evolution.supervision import AVOSupervisionAdvice, AVOSupervisionResult
 from aec_bench.evolution.workspace import Workspace
 from tests.evolution.test_development import _batch, _record
 from tests.support.trial_record_factories import make_trial_record
@@ -261,6 +263,95 @@ def test_loop_fails_closed_on_incomplete_model_request(tmp_path: Path) -> None:
             "child",
             development_boundary=_boundary(tmp_path / "second-boundary", batch=first_boundary.batch),
             agent_runner=lambda _context: (_ for _ in ()).throw(AssertionError("model must not retry")),
+            checkpoint_path=path,
+            configuration_identity=_checkpoint_identity(),
+        )
+
+
+def test_explicit_supervision_request_persists_advice_for_next_main_context(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path / "workspace")
+    request = _request(workspace)
+    path = checkpoint_path(tmp_path / "state", run_id=request.run_id, variation_id="run-test:variation-1:child-child")
+    main_runner = _SequenceRunner(
+        [
+            _command(AgentToolName.REQUEST_SUPERVISION),
+            _command(AgentToolName.ABSTAIN, reasoning="The advised direction is not safe to submit."),
+        ]
+    )
+    supervisor_calls = []
+
+    def supervisor(supervision_request):
+        supervisor_calls.append(supervision_request)
+        return AVOSupervisionResult(
+            output=AVOSupervisionAdvice(
+                directions=("Try a bounded verification-focused direction.",),
+                reasoning="The current direction has repeated without progress.",
+            ),
+            usage=VariationUsage(model_requests=1, supervisor_interventions=1, elapsed_seconds=0.25),
+        )
+
+    result = run_agentic_variation(
+        request,
+        workspace,
+        "child",
+        development_boundary=_boundary(tmp_path / "boundary"),
+        agent_runner=main_runner,
+        supervisor_runner=supervisor,
+        budget=AVOBudget(max_supervisor_interventions=1),
+        checkpoint_path=path,
+        configuration_identity=_checkpoint_identity(),
+    )
+
+    assert result.status is VariationStatus.ABSTAINED
+    assert len(supervisor_calls) == 1
+    assert len(main_runner.contexts) == 2
+    next_context = main_runner.contexts[1]
+    assert next_context.latest_supervision_advice is not None
+    assert next_context.latest_supervision_advice.directions == ("Try a bounded verification-focused direction.",)
+    assert "request_supervision" not in next_context.tools
+    assert result.usage.supervisor_interventions == 1
+    saved = read_checkpoint(path)
+    assert len(saved.supervision_records) == 1
+    assert saved.supervision_records[0].advice == next_context.latest_supervision_advice
+    assert not saved.incomplete_external_effects
+
+
+def test_supervision_provider_exception_leaves_marker_and_resume_does_not_retry(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path / "workspace")
+    request = _request(workspace)
+    boundary = _boundary(tmp_path / "boundary")
+    path = checkpoint_path(tmp_path / "state", run_id=request.run_id, variation_id="run-test:variation-1:child-child")
+    budget = AVOBudget(max_supervisor_interventions=1)
+
+    def failing_supervisor(_request):
+        raise RuntimeError("ambiguous supervisor provider")
+
+    with pytest.raises(AVOIncompleteExternalEffectError, match="ambiguous supervisor provider"):
+        run_agentic_variation(
+            request,
+            workspace,
+            "child",
+            development_boundary=boundary,
+            agent_runner=lambda _context: _command(AgentToolName.REQUEST_SUPERVISION),
+            supervisor_runner=failing_supervisor,
+            budget=budget,
+            checkpoint_path=path,
+            configuration_identity=_checkpoint_identity(),
+        )
+
+    saved = read_checkpoint(path)
+    assert saved.usage.supervisor_interventions == 1
+    assert saved.incomplete_external_effects[0].operation == "supervisor_request"
+
+    with pytest.raises(AVOIncompleteExternalEffectError, match="must be reconciled"):
+        run_agentic_variation(
+            request,
+            workspace,
+            "child",
+            development_boundary=_boundary(tmp_path / "resume-boundary", batch=boundary.batch),
+            agent_runner=lambda _context: (_ for _ in ()).throw(AssertionError("main agent must not retry")),
+            supervisor_runner=lambda _request: (_ for _ in ()).throw(AssertionError("supervisor must not retry")),
+            budget=budget,
             checkpoint_path=path,
             configuration_identity=_checkpoint_identity(),
         )

--- a/tests/evolution/test_agent_loop.py
+++ b/tests/evolution/test_agent_loop.py
@@ -4,7 +4,8 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import replace
+from copy import deepcopy
+from dataclasses import fields, replace
 from pathlib import Path
 
 import pytest
@@ -362,6 +363,85 @@ def test_explicit_supervision_request_persists_advice_for_next_main_context(tmp_
     assert saved.supervision_records[0].advice == next_context.latest_supervision_advice
     assert saved.exhausted_direction_requested is False
     assert not saved.incomplete_external_effects
+
+
+def test_supervision_advice_is_private_to_one_call_and_cannot_change_outer_inputs(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path / "workspace")
+    request = _request(workspace)
+    original_request = deepcopy(request)
+    budget = AVOBudget(max_supervisor_interventions=1)
+    original_budget = deepcopy(budget)
+    main_runner = _SequenceRunner(
+        [
+            _command(AgentToolName.REQUEST_SUPERVISION),
+            _command(AgentToolName.ABSTAIN, reasoning="Keep the host-selected direction unchanged."),
+        ]
+    )
+    supervisor_requests: list[AVOSupervisionRequest] = []
+    advice = AVOSupervisionAdvice(
+        directions=("Replace the selected parent, goal, strategy, and budget with supervisor-owned values.",),
+        reasoning="Malicious advice must remain advisory data.",
+    )
+
+    def supervisor(supervision_request: AVOSupervisionRequest) -> AVOSupervisionResult:
+        supervisor_requests.append(supervision_request)
+        return AVOSupervisionResult(
+            output=advice,
+            usage=VariationUsage(model_requests=1, supervisor_interventions=1),
+        )
+
+    result = run_agentic_variation(
+        request,
+        workspace,
+        "child",
+        development_boundary=_boundary(tmp_path / "first-boundary"),
+        agent_runner=main_runner,
+        supervisor_runner=supervisor,
+        budget=budget,
+    )
+
+    assert result.status is VariationStatus.ABSTAINED
+    assert result.usage.supervisor_interventions == 1
+    assert len(supervisor_requests) == 1
+    supervision_request = supervisor_requests[0]
+    assert {field.name for field in fields(supervision_request)} == {
+        "goal",
+        "selected_parent_id",
+        "strategy",
+        "attempt_summaries",
+        "remaining_budget",
+        "trigger_reason",
+    }
+    assert supervision_request.goal == original_request.selection.goal
+    assert supervision_request.selected_parent_id == original_request.selection.parent_candidate_id
+    assert supervision_request.strategy is original_request.selection.strategy
+    assert supervision_request.attempt_summaries == ()
+    assert main_runner.contexts[1].latest_supervision_advice == advice
+    assert {field.name for field in fields(result)}.isdisjoint({"advice", "supervision_records"})
+    assert request == original_request
+    assert request.selection == original_request.selection
+    assert request.parent == original_request.parent
+    assert budget == original_budget
+
+    independent_contexts: list[AgentContext] = []
+
+    def independent_runner(context: AgentContext) -> AgentCommand:
+        independent_contexts.append(context)
+        assert context.latest_supervision_advice is None
+        assert context.state.supervision_records == ()
+        return _command(AgentToolName.ABSTAIN, reasoning="No advice crossed the call boundary.")
+
+    independent_result = run_agentic_variation(
+        request,
+        workspace,
+        "second-child",
+        development_boundary=_boundary(tmp_path / "second-boundary"),
+        agent_runner=independent_runner,
+    )
+
+    assert independent_result.status is VariationStatus.ABSTAINED
+    assert independent_result.usage.supervisor_interventions == 0
+    assert len(independent_contexts) == 1
 
 
 def test_three_stagnant_child_evaluations_trigger_once_and_open_a_new_direction_window(tmp_path: Path) -> None:

--- a/tests/evolution/test_application_config.py
+++ b/tests/evolution/test_application_config.py
@@ -86,10 +86,12 @@ class TestRunEvolutionFromConfig:
 
         assert result is expected
         assert builder["agent_model"] == "sonnet"
+        assert builder["supervisor_model"] == builder["agent_model"]
+        assert builder["supervisor_model_identity"] == "sonnet"
         assert builder["development_batch_size"] == config.batch_size
         assert callable(builder["development_batch_planner"])
         assert callable(builder["development_evaluator"])
-        assert builder["budget"].max_model_requests == 12
+        assert "budget" not in builder
         assert builder["checkpoint_root"] == ws_root
         identity = builder["configuration_identity"]
         assert identity.model_identity == "sonnet"

--- a/tests/evolution/test_application_functional.py
+++ b/tests/evolution/test_application_functional.py
@@ -7,6 +7,7 @@ import json
 from datetime import UTC, datetime
 from pathlib import Path
 
+import pytest
 import yaml
 
 from aec_bench.contracts.evolution import (
@@ -17,6 +18,7 @@ from aec_bench.contracts.evolution import (
 from aec_bench.contracts.experiment_manifest import AgentConfig, ComputeConfig, TaskSelector
 from aec_bench.evolution import variation_operator
 from aec_bench.evolution.application import run_evolution
+from aec_bench.evolution.checkpoint import AVOConfigurationIdentity
 from aec_bench.evolution.core import (
     DevelopmentAttempt,
     EvaluatedCandidate,
@@ -393,6 +395,7 @@ def test_agentic_operator_creates_one_development_boundary_per_variation_call(tm
     workspace, batch = _setup(tmp_path)
     planned_cycles: list[int] = []
     boundaries = []
+    budgets = []
 
     def development_plan(_size: int, cycle: int) -> CandidateEvaluationBatch:
         planned_cycles.append(cycle)
@@ -419,6 +422,7 @@ def test_agentic_operator_creates_one_development_boundary_per_variation_call(tm
 
     def capture(*args, **kwargs):
         boundaries.append(kwargs["development_boundary"])
+        budgets.append(kwargs["budget"])
         return original_run(*args, **kwargs)
 
     monkeypatch.setattr(variation_operator, "run_agentic_variation", capture)
@@ -449,6 +453,7 @@ def test_agentic_operator_creates_one_development_boundary_per_variation_call(tm
     assert result.cycles_completed == 2
     assert planned_cycles == [0, 1]
     assert len(boundaries) == 2
+    assert all(budget.max_supervisor_interventions == 1 for budget in budgets)
     assert boundaries[0] is not boundaries[1]
     assert all(boundary.role.value == "development" for boundary in boundaries)
     assert all(boundary.host_experiment_id == "experiment-001" for boundary in boundaries)
@@ -508,3 +513,36 @@ def test_agentic_operator_names_development_evidence_by_run(tmp_path: Path, monk
 
     assert len(boundaries) == 2
     assert boundaries[0].experiment_id != boundaries[1].experiment_id
+
+
+def test_agentic_operator_requires_explicit_matching_supervisor_identity(tmp_path: Path) -> None:
+    identity = AVOConfigurationIdentity(
+        model_identity="test-model",
+        supervisor_model_identity="test-supervisor",
+        tool_identity="avo-tools:1",
+        development_evaluator_identity="development-evaluator:test",
+        configuration_identity="test-config:1",
+    )
+    common = {
+        "development_batch_planner": lambda _size, _cycle: None,
+        "development_evaluator": lambda _snapshot, _batch: (),
+        "development_batch_size": 1,
+        "configuration_identity": identity,
+    }
+
+    with pytest.raises(ValueError, match="supervisor_model_identity must match"):
+        build_agentic_variation_operator(
+            agent_model=object(),
+            supervisor_model=object(),
+            supervisor_model_identity="wrong-supervisor",
+            **common,
+        )
+
+    model = object()
+    operator = build_agentic_variation_operator(
+        agent_model=model,
+        supervisor_model=model,
+        supervisor_model_identity="test-supervisor",
+        **common,
+    )
+    assert callable(operator)

--- a/tests/evolution/test_application_functional.py
+++ b/tests/evolution/test_application_functional.py
@@ -424,6 +424,8 @@ def test_agentic_operator_creates_one_development_boundary_per_variation_call(tm
     monkeypatch.setattr(variation_operator, "run_agentic_variation", capture)
     operator = build_agentic_variation_operator(
         agent_model=TestModel(custom_output_args={"tool": "abstain", "arguments": {"reasoning": "No safe change."}}),
+        supervisor_model=TestModel(),
+        supervisor_model_identity="test-supervisor",
         development_batch_planner=development_plan,
         development_evaluator=development_evaluate,
         development_batch_size=1,
@@ -478,6 +480,8 @@ def test_agentic_operator_names_development_evidence_by_run(tmp_path: Path, monk
     monkeypatch.setattr(variation_operator, "run_agentic_variation", capture)
     operator = build_agentic_variation_operator(
         agent_model=object(),
+        supervisor_model=object(),
+        supervisor_model_identity="test-supervisor",
         development_batch_planner=lambda _size, _cycle: batch_one,
         development_evaluator=lambda _snapshot, _batch: (),
         development_batch_size=1,

--- a/tests/evolution/test_application_qd.py
+++ b/tests/evolution/test_application_qd.py
@@ -415,6 +415,8 @@ def test_qd_uses_the_shared_variation_seam_and_hosts_only_the_final_child(
     monkeypatch.setattr(agent_loop.PydanticAIStructuredRunner, "__call__", next_command)
     operator = build_agentic_variation_operator(
         agent_model=TestModel(),
+        supervisor_model=TestModel(),
+        supervisor_model_identity="test-supervisor",
         development_batch_planner=lambda _size, _cycle: batch,
         development_evaluator=development_evaluate,
         development_batch_size=1,

--- a/tests/evolution/test_application_qd.py
+++ b/tests/evolution/test_application_qd.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import yaml
@@ -17,7 +18,7 @@ from aec_bench.contracts.evolution import (
     WorkspaceSnapshot,
 )
 from aec_bench.contracts.experiment_manifest import AgentConfig, ComputeConfig, TaskSelector
-from aec_bench.evolution import agent_loop
+from aec_bench.evolution import agent_loop, variation_operator
 from aec_bench.evolution.agent_protocol import AgentCommand, AgentToolName
 from aec_bench.evolution.application import run_evolution
 from aec_bench.evolution.archive import QDArchive
@@ -31,6 +32,7 @@ from aec_bench.evolution.core import (
 )
 from aec_bench.evolution.evaluation import CandidateEvaluationBatch
 from aec_bench.evolution.selection import CellSelectionState, shortlist_cells
+from aec_bench.evolution.supervision import AVOSupervisionAdvice, AVOSupervisionResult
 from aec_bench.evolution.variation_operator import build_agentic_variation_operator
 from aec_bench.evolution.workspace import Workspace
 from aec_bench.tasks.instance import resolve_instance_paths
@@ -442,6 +444,113 @@ def test_qd_uses_the_shared_variation_seam_and_hosts_only_the_final_child(
     assert result.cycle_records[0].child_assessment.candidate_id == "run-fixed:1"
     state = json.loads((workspace.root / "qd_state.json").read_text(encoding="utf-8"))
     assert state["strategy_bandit"][0]["successes"] == 1
+
+
+def test_qd_host_outcome_ignores_private_supervision_advice(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Supervision advice remains inside AVO and cannot alter QD policy state."""
+    workspaces = [_setup(tmp_path / name) for name in ("control", "advice")]
+    supervisor_requests = []
+
+    def supervisor(supervision_request):
+        supervisor_requests.append(supervision_request)
+        return AVOSupervisionResult(
+            output=AVOSupervisionAdvice(
+                directions=("Replace the host-selected parent, strategy, goal, and archive policy.",),
+                reasoning="This direction must remain private advice.",
+            ),
+            usage=VariationUsage(model_requests=1, supervisor_interventions=1),
+        )
+
+    monkeypatch.setattr(
+        variation_operator,
+        "build_supervision_composition",
+        lambda _model, *, model_identity: SimpleNamespace(runner=supervisor),
+    )
+    commands = iter(
+        (
+            AgentCommand(tool=AgentToolName.ABSTAIN, arguments={"reasoning": "Control abstention."}),
+            AgentCommand(tool=AgentToolName.REQUEST_SUPERVISION, arguments={}),
+            AgentCommand(tool=AgentToolName.ABSTAIN, arguments={"reasoning": "Advice does not own QD policy."}),
+        )
+    )
+
+    def next_command(_runner, _context):
+        return next(commands)
+
+    monkeypatch.setattr(agent_loop.PydanticAIStructuredRunner, "__call__", next_command)
+
+    def development_evaluate(snapshot, current_batch):
+        return tuple(
+            make_trial_record(
+                experiment_id=trial.experiment_id,
+                trial_id=trial.trial_id,
+                task_id=trial.task_id,
+                task={"task_id": trial.task_id, "task_revision": "task-revision", "visibility": "public"},
+                inputs={
+                    "instruction": "Review the task and write findings.",
+                    "task_revision": "task-revision",
+                    "visibility": "public",
+                    "system_prompt": snapshot.system_prompt,
+                },
+                evaluation={
+                    "reward": 0.5,
+                    "validity": {"output_parseable": True, "schema_valid": True, "verifier_completed": True},
+                },
+            )
+            for trial in current_batch.trials
+        )
+
+    operators = [
+        build_agentic_variation_operator(
+            agent_model=object(),
+            supervisor_model=object(),
+            supervisor_model_identity="test-supervisor",
+            development_batch_planner=lambda _size, _cycle, current_batch=batch: current_batch,
+            development_evaluator=development_evaluate,
+            development_batch_size=1,
+            development_experiment_prefix="qd-development",
+        )
+        for _workspace, batch in workspaces
+    ]
+
+    host_evaluated_ids: list[list[str]] = [[], []]
+
+    def host_evaluate(index: int):
+        def evaluate(snapshot, current_batch):
+            host_evaluated_ids[index].append(snapshot.candidate_id)
+            return _records(current_batch, snapshot.candidate_id, 0.5)
+
+        return evaluate
+
+    results = [
+        _run(
+            workspace,
+            batch,
+            _config(workspace.root),
+            evaluate=host_evaluate(index),
+            variation=operator,
+            calls=[],
+        )
+        for index, ((workspace, batch), operator) in enumerate(zip(workspaces, operators, strict=True))
+    ]
+
+    control, advised = results
+    control_record = control.cycle_records[0].model_dump(exclude={"evolver_usage"})
+    advised_record = advised.cycle_records[0].model_dump(exclude={"evolver_usage"})
+    assert advised_record == control_record
+    assert advised.cycle_records[0].evolver_usage.supervisor_interventions == 1
+    assert control.cycle_records[0].evolver_usage.supervisor_interventions == 0
+    assert host_evaluated_ids == [["baseline"], ["baseline"]]
+    assert len(supervisor_requests) == 1
+    assert supervisor_requests[0].goal == "test selection"
+    assert supervisor_requests[0].selected_parent_id == "baseline"
+    assert supervisor_requests[0].strategy == control.cycle_records[0].selection.strategy
+    assert json.loads((workspaces[0][0].root / "archive.json").read_text(encoding="utf-8")) == json.loads(
+        (workspaces[1][0].root / "archive.json").read_text(encoding="utf-8")
+    )
+    assert json.loads((workspaces[0][0].root / "qd_state.json").read_text(encoding="utf-8")) == json.loads(
+        (workspaces[1][0].root / "qd_state.json").read_text(encoding="utf-8")
+    )
 
 
 def test_fixed_seed_selection_and_resume_numbering_are_reproducible(tmp_path: Path) -> None:

--- a/tests/evolution/test_checkpoint.py
+++ b/tests/evolution/test_checkpoint.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -33,6 +34,13 @@ from aec_bench.evolution.checkpoint import (
 )
 from aec_bench.evolution.core import AVOState, DevelopmentAttempt, EvaluatedCandidate, VariationStatus
 from aec_bench.evolution.development import DevelopmentEvaluationProvenance
+from aec_bench.evolution.supervision import (
+    AVOSupervisionAdvice,
+    AVOSupervisionFailure,
+    AVOSupervisionFailureCode,
+    AVOSupervisionRecord,
+    AVOSupervisionTrigger,
+)
 from tests.support.trial_record_factories import make_trial_record
 
 
@@ -115,6 +123,9 @@ def _checkpoint(
     with_artifact: bool = False,
     terminal_status: VariationStatus | None = None,
     terminal_result: AVOCheckpointTerminalResult | None = None,
+    supervision_records: tuple[AVOSupervisionRecord, ...] = (),
+    exhausted_direction_requested: bool = False,
+    max_supervisor_interventions: int = 1,
 ) -> AVOCheckpoint:
     attempt = DevelopmentAttempt(
         attempt_id="attempt-1",
@@ -139,9 +150,14 @@ def _checkpoint(
         current_revision=current_revision,
         attempts=(attempt,),
         best_attempt_id="attempt-1",
-        usage=VariationUsage(development_evaluations=1),
+        usage=VariationUsage(
+            development_evaluations=1,
+            supervisor_interventions=len(supervision_records),
+        ),
         terminal_status=terminal_status,
         parent_snapshot=parent,
+        supervision_records=supervision_records,
+        exhausted_direction_requested=exhausted_direction_requested,
     )
     return AVOCheckpoint.from_state(
         run_id="run-1",
@@ -161,7 +177,7 @@ def _checkpoint(
             development_evaluator_identity="evaluator:1",
             configuration_identity="config:1",
         ),
-        budget=AVOBudgetSnapshot().to_budget(),
+        budget=AVOBudgetSnapshot(max_supervisor_interventions=max_supervisor_interventions).to_budget(),
         current_snapshot=current_snapshot or WorkspaceSnapshot(system_prompt="Child prompt", candidate_id="child"),
         terminal_result=terminal_result,
     )
@@ -197,6 +213,118 @@ def test_checkpoint_snapshots_round_trip_supervisor_identity_tokens_and_limits()
     assert AVOUsageSnapshot.from_usage(usage).to_usage() == usage
     assert AVOBudgetSnapshot.from_budget(budget).to_budget() == budget
     assert identity.model_dump(mode="json")["supervisor_model_identity"] == "provider:supervisor"
+
+
+@pytest.mark.parametrize(
+    "record",
+    [
+        AVOSupervisionRecord(
+            trigger_reason=AVOSupervisionTrigger.VALID_DEVELOPMENT_STAGNATION,
+            advice=AVOSupervisionAdvice(
+                directions=("Use a narrower verification path.",),
+                reasoning="The latest valid attempts repeat the same direction.",
+            ),
+        ),
+        AVOSupervisionRecord(
+            trigger_reason=AVOSupervisionTrigger.CONSECUTIVE_INVALID_OR_FAILED_EVALUATIONS,
+            failure=AVOSupervisionFailure(
+                code=AVOSupervisionFailureCode.OUTPUT_VALIDATION_REJECTED,
+                detail="The supervisor output was not valid advice.",
+            ),
+        ),
+    ],
+)
+def test_checkpoint_round_trips_ordered_supervision_outcome_and_pending_request(
+    record: AVOSupervisionRecord,
+    tmp_path: Path,
+) -> None:
+    checkpoint = _checkpoint(supervision_records=(record,))
+    path = write_checkpoint(tmp_path / "avo.json", checkpoint)
+    restored = read_checkpoint(path)
+
+    assert restored.supervision_records == (record,)
+    assert restored.to_state().supervision_records == (record,)
+    assert restored.model_dump(mode="json") == read_checkpoint(path).model_dump(mode="json")
+
+    pending = _checkpoint(exhausted_direction_requested=True)
+    assert pending.exhausted_direction_requested is True
+    assert pending.to_state().exhausted_direction_requested is True
+
+
+def test_checkpoint_preserves_ordered_supervision_history_within_explicit_budget() -> None:
+    first = AVOSupervisionRecord(
+        trigger_reason=AVOSupervisionTrigger.VALID_DEVELOPMENT_STAGNATION,
+        advice=AVOSupervisionAdvice(directions=("Try direction one.",), reasoning="First intervention."),
+    )
+    second = AVOSupervisionRecord(
+        trigger_reason=AVOSupervisionTrigger.EXHAUSTED_DIRECTION_REQUEST,
+        advice=AVOSupervisionAdvice(directions=("Try direction two.",), reasoning="Second intervention."),
+    )
+    checkpoint = _checkpoint(
+        supervision_records=(first, second),
+        max_supervisor_interventions=2,
+    )
+
+    assert checkpoint.supervision_records == (first, second)
+    assert checkpoint.to_state().supervision_records == (first, second)
+
+
+def test_checkpoint_rejects_supervision_history_over_budget() -> None:
+    first = AVOSupervisionRecord(
+        trigger_reason=AVOSupervisionTrigger.VALID_DEVELOPMENT_STAGNATION,
+        advice=AVOSupervisionAdvice(directions=("Try direction one.",), reasoning="First intervention."),
+    )
+    second = AVOSupervisionRecord(
+        trigger_reason=AVOSupervisionTrigger.EXHAUSTED_DIRECTION_REQUEST,
+        advice=AVOSupervisionAdvice(directions=("Try direction two.",), reasoning="Second intervention."),
+    )
+
+    with pytest.raises(ValidationError, match="exceed the configured supervisor intervention budget"):
+        _checkpoint(supervision_records=(first, second))
+
+
+def test_checkpoint_rejects_supervision_usage_without_outcome_or_incomplete_request() -> None:
+    checkpoint = _checkpoint()
+    with pytest.raises(ValidationError, match="supervision_records and incomplete requests"):
+        _validated_update(
+            checkpoint,
+            usage=AVOUsageSnapshot.from_usage(VariationUsage(model_requests=1, supervisor_interventions=1)),
+        )
+
+
+def test_checkpoint_accepts_one_incomplete_supervisor_request_before_outcome() -> None:
+    checkpoint = _checkpoint(exhausted_direction_requested=True)
+    pending_effect = AVOIncompleteExternalEffect(
+        effect_id="variation-1:supervisor-1",
+        operation="supervisor_request",
+        reason="Supervisor request started; completion is not yet confirmed.",
+    )
+    resumed_shape = _validated_update(
+        checkpoint,
+        usage=AVOUsageSnapshot.from_usage(VariationUsage(model_requests=1, supervisor_interventions=1)),
+        incomplete_external_effects=(pending_effect,),
+    )
+
+    assert resumed_shape.incomplete_external_effects == (pending_effect,)
+
+
+def test_avo_state_rejects_untyped_or_overcounted_supervision_records() -> None:
+    base = _checkpoint().to_state()
+    with pytest.raises(TypeError, match="AVOSupervisionRecord"):
+        replace(base, supervision_records=(object(),))
+    with pytest.raises(ValueError, match="cannot exceed supervisor_interventions"):
+        replace(
+            base,
+            supervision_records=(
+                AVOSupervisionRecord(
+                    trigger_reason=AVOSupervisionTrigger.EXHAUSTED_DIRECTION_REQUEST,
+                    advice=AVOSupervisionAdvice(
+                        directions=("Try a different direction.",),
+                        reasoning="The current path is exhausted.",
+                    ),
+                ),
+            ),
+        )
 
 
 @pytest.mark.parametrize("field_name", ["max_input_tokens", "max_output_tokens"])

--- a/tests/evolution/test_checkpoint.py
+++ b/tests/evolution/test_checkpoint.py
@@ -156,6 +156,7 @@ def _checkpoint(
         development_case_ids=("case-1",),
         configuration_identity=AVOConfigurationIdentity(
             model_identity="provider:model",
+            supervisor_model_identity="provider:supervisor-model",
             tool_identity="avo-tools:1",
             development_evaluator_identity="evaluator:1",
             configuration_identity="config:1",
@@ -170,6 +171,38 @@ def _validated_update(checkpoint: AVOCheckpoint, **updates: object) -> AVOCheckp
     payload = checkpoint.model_dump(mode="python")
     payload.update(updates)
     return AVOCheckpoint.model_validate(payload)
+
+
+def test_checkpoint_snapshots_round_trip_supervisor_identity_tokens_and_limits() -> None:
+    usage = VariationUsage(
+        model_requests=2,
+        supervisor_interventions=1,
+        input_tokens=120,
+        output_tokens=30,
+        model_cost_usd=0.6,
+    )
+    budget = AVOBudgetSnapshot(
+        max_input_tokens=200,
+        max_output_tokens=60,
+        max_supervisor_interventions=1,
+    ).to_budget()
+    identity = AVOConfigurationIdentity(
+        model_identity="provider:main",
+        supervisor_model_identity="provider:supervisor",
+        tool_identity="avo-tools:1",
+        development_evaluator_identity="evaluator:1",
+        configuration_identity="config:1",
+    )
+
+    assert AVOUsageSnapshot.from_usage(usage).to_usage() == usage
+    assert AVOBudgetSnapshot.from_budget(budget).to_budget() == budget
+    assert identity.model_dump(mode="json")["supervisor_model_identity"] == "provider:supervisor"
+
+
+@pytest.mark.parametrize("field_name", ["max_input_tokens", "max_output_tokens"])
+def test_checkpoint_rejects_non_positive_token_limits(field_name: str) -> None:
+    with pytest.raises(ValidationError, match="positive integers"):
+        AVOBudgetSnapshot(**{field_name: 0})
 
 
 def test_checkpoint_round_trips_exact_attempt_evidence_and_trace_enrichment(tmp_path: Path) -> None:

--- a/tests/evolution/test_checkpoint.py
+++ b/tests/evolution/test_checkpoint.py
@@ -308,6 +308,22 @@ def test_checkpoint_accepts_one_incomplete_supervisor_request_before_outcome() -
     assert resumed_shape.incomplete_external_effects == (pending_effect,)
 
 
+def test_checkpoint_rejects_pending_direction_after_supervisor_budget_is_consumed() -> None:
+    record = AVOSupervisionRecord(
+        trigger_reason=AVOSupervisionTrigger.EXHAUSTED_DIRECTION_REQUEST,
+        advice=AVOSupervisionAdvice(
+            directions=("Try a bounded alternative.",), reasoning="The first direction stalled."
+        ),
+    )
+
+    with pytest.raises(ValidationError, match="cannot remain after supervisor budget is consumed"):
+        _checkpoint(
+            supervision_records=(record,),
+            exhausted_direction_requested=True,
+            max_supervisor_interventions=1,
+        )
+
+
 def test_avo_state_rejects_untyped_or_overcounted_supervision_records() -> None:
     base = _checkpoint().to_state()
     with pytest.raises(TypeError, match="AVOSupervisionRecord"):
@@ -377,7 +393,7 @@ def test_checkpoint_writer_uses_durable_replacement(monkeypatch: pytest.MonkeyPa
     assert json.loads(calls[0][2]) == checkpoint.model_dump(mode="json")
 
 
-@pytest.mark.parametrize("schema_version", [None, 0, 2, "1"])
+@pytest.mark.parametrize("schema_version", [None, 0, 1, "2"])
 def test_checkpoint_reader_rejects_missing_or_unsupported_schema(schema_version: object, tmp_path: Path) -> None:
     payload = _checkpoint().model_dump(mode="json")
     if schema_version is None:

--- a/tests/evolution/test_core.py
+++ b/tests/evolution/test_core.py
@@ -191,7 +191,7 @@ class TestAVOContracts:
         assert budget.max_tool_calls == 40
         assert budget.max_development_evaluations == 7
         assert budget.max_elapsed_seconds == 1800.0
-        assert budget.max_supervisor_interventions == 0
+        assert budget.max_supervisor_interventions == 1
 
     @pytest.mark.parametrize(
         "field_name",
@@ -211,6 +211,11 @@ class TestAVOContracts:
 
     def test_supervisor_limit_zero_disables_supervision(self) -> None:
         assert AVOBudget(max_supervisor_interventions=0).max_supervisor_interventions == 0
+
+    @pytest.mark.parametrize("field_name", ["max_input_tokens", "max_output_tokens"])
+    def test_budget_rejects_non_positive_token_limits(self, field_name: str) -> None:
+        with pytest.raises(ValueError, match="positive integer"):
+            AVOBudget(**{field_name: 0})
 
     @pytest.mark.parametrize("field_name", ["max_elapsed_seconds", "max_cost_usd"])
     def test_budget_rejects_non_finite_limits(self, field_name: str) -> None:

--- a/tests/evolution/test_core.py
+++ b/tests/evolution/test_core.py
@@ -191,7 +191,7 @@ class TestAVOContracts:
         assert budget.max_tool_calls == 40
         assert budget.max_development_evaluations == 7
         assert budget.max_elapsed_seconds == 1800.0
-        assert budget.max_supervisor_interventions == 1
+        assert budget.max_supervisor_interventions == 0
 
     @pytest.mark.parametrize(
         "field_name",
@@ -211,6 +211,18 @@ class TestAVOContracts:
 
     def test_supervisor_limit_zero_disables_supervision(self) -> None:
         assert AVOBudget(max_supervisor_interventions=0).max_supervisor_interventions == 0
+
+    def test_supervisor_limit_does_not_end_the_main_variation_loop(self) -> None:
+        budget = AVOBudget(max_supervisor_interventions=1)
+        state = AVOState(
+            variation_id="variation",
+            parent_candidate_id="parent",
+            child_candidate_id="child",
+            current_revision=0,
+            usage=VariationUsage(supervisor_interventions=1),
+        )
+
+        assert budget_exhaustion_reason(budget, state) is None
 
     @pytest.mark.parametrize("field_name", ["max_input_tokens", "max_output_tokens"])
     def test_budget_rejects_non_positive_token_limits(self, field_name: str) -> None:

--- a/tests/evolution/test_supervision.py
+++ b/tests/evolution/test_supervision.py
@@ -4,6 +4,7 @@
 from dataclasses import FrozenInstanceError, replace
 
 import pytest
+from pydantic_ai.models.test import TestModel
 
 from aec_bench.contracts.evolution import (
     CandidateAssessment,
@@ -20,9 +21,15 @@ from aec_bench.evolution.memory import AVOMemoryEntry, AVOMemoryOutcome
 from aec_bench.evolution.supervision import (
     AVORemainingBudget,
     AVOSupervisionAdvice,
+    AVOSupervisionFailure,
+    AVOSupervisionFailureCode,
     AVOSupervisionRequest,
+    AVOSupervisionResult,
     AVOSupervisionTrigger,
+    PydanticAISupervisionRunner,
     project_remaining_budget,
+    reconcile_supervision_usage,
+    reserve_supervision_usage,
     should_trigger_supervision,
     supervision_trigger_reason,
 )
@@ -179,6 +186,27 @@ def test_unknown_or_unconfigured_cost_remains_unknown() -> None:
     assert unconfigured_projection.remaining_cost_usd is None
 
 
+def test_token_projection_preserves_bounded_unknown_and_unbounded_states() -> None:
+    bounded = AVOBudget(max_input_tokens=100, max_output_tokens=20)
+    empty = project_remaining_budget(bounded, _state())
+    unknown = project_remaining_budget(
+        bounded,
+        replace(_state(), usage=VariationUsage(model_requests=1, input_tokens=40)),
+    )
+    unbounded = project_remaining_budget(AVOBudget(), _state())
+
+    assert empty.input_token_limit == 100
+    assert empty.remaining_input_tokens == 100
+    assert empty.output_token_limit == 20
+    assert empty.remaining_output_tokens == 20
+    assert unknown.input_token_limit == 100
+    assert unknown.remaining_input_tokens == 60
+    assert unknown.output_token_limit == 20
+    assert unknown.remaining_output_tokens is None
+    assert unbounded.input_token_limit is None
+    assert unbounded.remaining_input_tokens is None
+
+
 def test_supervision_request_and_advice_validate_and_canonicalise_values() -> None:
     summary = AVOMemoryEntry(
         source_variation_id="variation-1",
@@ -202,6 +230,132 @@ def test_supervision_request_and_advice_validate_and_canonicalise_values() -> No
     assert request.attempt_summaries == (summary,)
     assert request.trigger_reason is AVOSupervisionTrigger.EXHAUSTED_DIRECTION_REQUEST
     assert advice.directions == ("Try a different tool order.",)
+
+
+def _request() -> AVOSupervisionRequest:
+    return AVOSupervisionRequest(
+        goal="Improve the candidate.",
+        selected_parent_id="parent",
+        strategy=MutationStrategy.EXPLORATORY,
+        attempt_summaries=(),
+        remaining_budget=AVORemainingBudget(
+            remaining_model_requests=5,
+            remaining_tool_calls=5,
+            remaining_development_evaluations=5,
+            remaining_elapsed_seconds=30.0,
+            remaining_supervisor_interventions=1,
+            cost_limit_usd=None,
+            remaining_cost_usd=None,
+        ),
+        trigger_reason=AVOSupervisionTrigger.EXHAUSTED_DIRECTION_REQUEST,
+    )
+
+
+def test_pydantic_supervisor_returns_one_validated_result_without_tools_or_retry() -> None:
+    model = TestModel(custom_output_args={"directions": ["Try a narrower prompt."], "reasoning": "The path repeats."})
+    result = PydanticAISupervisionRunner(model, model_identity="test-supervisor:model")(_request())
+
+    assert isinstance(result, AVOSupervisionResult)
+    assert isinstance(result.output, AVOSupervisionAdvice)
+    assert result.output.directions == ("Try a narrower prompt.",)
+    assert result.usage.model_requests == 1
+    assert result.usage.supervisor_interventions == 1
+    assert result.usage.input_tokens is not None
+    assert result.usage.output_tokens is not None
+    assert result.usage.elapsed_seconds >= 0
+    assert model.last_model_request_parameters is not None
+    assert model.last_model_request_parameters.function_tools == []
+    assert model.last_model_request_parameters.builtin_tools == []
+
+
+def test_supervision_failure_and_result_are_immutable_typed_contracts() -> None:
+    failure = AVOSupervisionFailure(
+        code=AVOSupervisionFailureCode.OUTPUT_VALIDATION_REJECTED,
+        detail="The injected supervisor output was rejected.",
+    )
+    result = AVOSupervisionResult(
+        output=failure,
+        usage=VariationUsage(model_requests=1, supervisor_interventions=1),
+    )
+
+    assert isinstance(result.output, AVOSupervisionFailure)
+    assert result.output.code is AVOSupervisionFailureCode.OUTPUT_VALIDATION_REJECTED
+    with pytest.raises(FrozenInstanceError):
+        result.output = failure  # type: ignore[misc]
+
+
+def test_supervision_usage_reservation_and_reconciliation_share_avo_budget() -> None:
+    before = VariationUsage(model_requests=1, input_tokens=10, output_tokens=4, model_cost_usd=0.4)
+    budget = AVOBudget(max_model_requests=3, max_supervisor_interventions=1, max_input_tokens=30, max_output_tokens=20)
+
+    reserved = reserve_supervision_usage(before, budget)
+    reconciled = reconcile_supervision_usage(
+        before,
+        budget,
+        VariationUsage(
+            model_requests=1,
+            supervisor_interventions=1,
+            input_tokens=7,
+            output_tokens=3,
+            model_cost_usd=0.2,
+            elapsed_seconds=1.5,
+        ),
+    )
+
+    assert reserved.model_requests == 2
+    assert reserved.supervisor_interventions == 1
+    assert reconciled.model_requests == 2
+    assert reconciled.supervisor_interventions == 1
+    assert reconciled.input_tokens == 17
+    assert reconciled.output_tokens == 7
+    assert reconciled.model_cost_usd == pytest.approx(0.6)
+    assert reconciled.elapsed_seconds == pytest.approx(1.5)
+
+
+def test_supervision_usage_rejects_unknown_tokens_when_a_bound_cannot_be_proved() -> None:
+    with pytest.raises(ValueError, match="max_input_tokens_unknown"):
+        reconcile_supervision_usage(
+            VariationUsage(model_requests=1),
+            AVOBudget(max_input_tokens=100, max_supervisor_interventions=1),
+            VariationUsage(model_requests=1, supervisor_interventions=1, input_tokens=None, output_tokens=2),
+        )
+
+
+def test_supervision_reservation_allows_first_unknown_cost_then_rejects_unknown_reconciliation() -> None:
+    budget = AVOBudget(max_cost_usd=2, max_supervisor_interventions=1)
+
+    reserved = reserve_supervision_usage(VariationUsage(), budget)
+
+    assert reserved.model_requests == 1
+    with pytest.raises(ValueError, match="max_cost_usd_unknown"):
+        reconcile_supervision_usage(
+            VariationUsage(),
+            budget,
+            VariationUsage(model_requests=1, supervisor_interventions=1),
+        )
+
+
+def test_supervision_reservation_allows_first_model_cost_after_known_evaluation_cost() -> None:
+    usage = VariationUsage(
+        development_evaluations=1,
+        development_evaluation_cost_usd=0.25,
+    )
+
+    reserved = reserve_supervision_usage(
+        usage,
+        AVOBudget(max_cost_usd=2, max_supervisor_interventions=1),
+    )
+
+    assert reserved.model_requests == 1
+    assert reserved.development_evaluation_cost_usd == 0.25
+
+
+def test_supervision_reservation_rejects_elapsed_budget_at_limit() -> None:
+    with pytest.raises(ValueError, match="max_elapsed_seconds"):
+        reserve_supervision_usage(
+            VariationUsage(elapsed_seconds=5.0),
+            AVOBudget(max_elapsed_seconds=5.0, max_supervisor_interventions=1),
+        )
 
 
 @pytest.mark.parametrize("directions", [(), ("",), ("A", "A"), ("A", "B", "C", "D")])

--- a/tests/evolution/test_supervision.py
+++ b/tests/evolution/test_supervision.py
@@ -1,0 +1,210 @@
+# ABOUTME: Tests deterministic AVO supervision triggers and bounded contracts.
+# ABOUTME: Proves supervisor inputs, advice, and budget projections stay read-only and validated.
+
+from dataclasses import FrozenInstanceError, replace
+
+import pytest
+
+from aec_bench.contracts.evolution import (
+    CandidateAssessment,
+    EvolutionObservation,
+    MutationStrategy,
+    MutationSummary,
+    ObservationEnrichment,
+    VariationUsage,
+    WorkspaceSnapshot,
+)
+from aec_bench.evolution.core import AVOBudget, AVOState, DevelopmentAttempt
+from aec_bench.evolution.evaluation import bind_evaluated_candidate
+from aec_bench.evolution.memory import AVOMemoryEntry, AVOMemoryOutcome
+from aec_bench.evolution.supervision import (
+    AVORemainingBudget,
+    AVOSupervisionAdvice,
+    AVOSupervisionRequest,
+    AVOSupervisionTrigger,
+    project_remaining_budget,
+    should_trigger_supervision,
+    supervision_trigger_reason,
+)
+from tests.support.trial_record_factories import make_trial_record
+
+
+def _attempt(revision: int, *, valid: bool = True) -> DevelopmentAttempt:
+    candidate_id = f"candidate-{revision}"
+    trial_id = f"trial-{revision}"
+    assessment = CandidateAssessment(
+        candidate_id=candidate_id,
+        batch_score=0.5,
+        structural_score=0.5,
+        discipline_scores={"structural": 0.5},
+        trial_ids=(trial_id,),
+        evaluation_case_ids=(f"case-{revision}",),
+        valid=valid,
+        invalid_reasons=(() if valid else ("development evaluation failed",)),
+    )
+    evaluated = bind_evaluated_candidate(
+        WorkspaceSnapshot(system_prompt=f"Prompt {revision}.", candidate_id=candidate_id),
+        (
+            EvolutionObservation(
+                trial=make_trial_record(trial_id=trial_id),
+                enrichment=ObservationEnrichment(),
+                candidate_id=candidate_id,
+                discipline="structural",
+            ),
+        ),
+        assessment,
+    )
+    return DevelopmentAttempt(
+        attempt_id=f"attempt-{revision}",
+        revision=revision,
+        evaluated=evaluated,
+        mutation=MutationSummary(prompt_modified=True),
+        hypothesis=f"Hypothesis {revision}.",
+        usage_after=VariationUsage(development_evaluations=revision),
+    )
+
+
+def _state(
+    *,
+    attempts: tuple[DevelopmentAttempt, ...] = (),
+    stagnant: int = 0,
+    errors: int = 0,
+    interventions: int = 0,
+) -> AVOState:
+    return AVOState(
+        variation_id="variation-1",
+        parent_candidate_id="parent",
+        child_candidate_id="child",
+        current_revision=len(attempts),
+        attempts=attempts,
+        consecutive_without_progress=stagnant,
+        consecutive_evaluation_errors=errors,
+        usage=VariationUsage(
+            development_evaluations=len(attempts),
+            supervisor_interventions=interventions,
+        ),
+    )
+
+
+def _budget(*, interventions: int = 1) -> AVOBudget:
+    return AVOBudget(max_supervisor_interventions=interventions)
+
+
+def test_three_latest_valid_non_progress_attempts_trigger_supervision() -> None:
+    state = _state(attempts=tuple(_attempt(revision) for revision in range(1, 4)), stagnant=3)
+
+    assert supervision_trigger_reason(state, _budget()) is AVOSupervisionTrigger.VALID_DEVELOPMENT_STAGNATION
+    assert should_trigger_supervision(state, _budget()) is True
+
+
+def test_parent_baseline_does_not_count_toward_valid_stagnation() -> None:
+    state = _state(attempts=(_attempt(1), _attempt(2)), stagnant=3)
+
+    assert supervision_trigger_reason(state, _budget()) is None
+
+
+def test_invalid_or_failed_evaluations_trigger_supervision() -> None:
+    invalid_state = _state(attempts=(_attempt(1, valid=False), _attempt(2, valid=False)))
+    mixed_state = _state(attempts=(_attempt(1, valid=False),), errors=1)
+    failed_state = _state(errors=2)
+
+    assert (
+        supervision_trigger_reason(invalid_state, _budget())
+        is AVOSupervisionTrigger.CONSECUTIVE_INVALID_OR_FAILED_EVALUATIONS
+    )
+    assert (
+        supervision_trigger_reason(failed_state, _budget())
+        is AVOSupervisionTrigger.CONSECUTIVE_INVALID_OR_FAILED_EVALUATIONS
+    )
+    assert (
+        supervision_trigger_reason(mixed_state, _budget())
+        is AVOSupervisionTrigger.CONSECUTIVE_INVALID_OR_FAILED_EVALUATIONS
+    )
+
+
+def test_explicit_exhausted_direction_request_is_bounded_by_intervention_limit() -> None:
+    state = _state()
+
+    assert (
+        supervision_trigger_reason(state, _budget(), exhausted_direction_requested=True)
+        is AVOSupervisionTrigger.EXHAUSTED_DIRECTION_REQUEST
+    )
+    assert supervision_trigger_reason(_state(interventions=1), _budget(), exhausted_direction_requested=True) is None
+    assert supervision_trigger_reason(state, _budget(interventions=0), exhausted_direction_requested=True) is None
+
+
+def test_remaining_budget_projects_only_unspent_non_negative_allowances() -> None:
+    state = AVOState(
+        variation_id="variation-1",
+        parent_candidate_id="parent",
+        child_candidate_id="child",
+        current_revision=0,
+        usage=VariationUsage(
+            model_requests=3,
+            tool_calls=7,
+            development_evaluations=2,
+            supervisor_interventions=1,
+            model_cost_usd=0.4,
+            development_evaluation_cost_usd=0.2,
+            elapsed_seconds=12.5,
+        ),
+    )
+    budget = AVOBudget(
+        max_model_requests=5,
+        max_tool_calls=10,
+        max_development_evaluations=4,
+        max_elapsed_seconds=20,
+        max_supervisor_interventions=2,
+        max_cost_usd=2,
+    )
+
+    remaining = project_remaining_budget(budget, state)
+
+    assert remaining == AVORemainingBudget(2, 3, 2, 7.5, 1, 2, 1.4)
+    assert remaining.remaining_model_requests == 2
+    with pytest.raises(FrozenInstanceError):
+        remaining.remaining_model_requests = 0  # type: ignore[misc]
+
+
+def test_unknown_or_unconfigured_cost_remains_unknown() -> None:
+    unknown = replace(_state(), usage=VariationUsage(model_requests=1))
+    unknown_budget = AVOBudget(max_cost_usd=2)
+    unconfigured_budget = AVOBudget()
+
+    unknown_projection = project_remaining_budget(unknown_budget, unknown)
+    unconfigured_projection = project_remaining_budget(unconfigured_budget, unknown)
+    assert unknown_projection.cost_limit_usd == 2
+    assert unknown_projection.remaining_cost_usd is None
+    assert unconfigured_projection.cost_limit_usd is None
+    assert unconfigured_projection.remaining_cost_usd is None
+
+
+def test_supervision_request_and_advice_validate_and_canonicalise_values() -> None:
+    summary = AVOMemoryEntry(
+        source_variation_id="variation-1",
+        source_attempt_id="attempt-1",
+        hypothesis="Try a narrower prompt.",
+        change_summary="system prompt modified",
+        evidence_summary="valid=False",
+        outcome=AVOMemoryOutcome.INVALID,
+    )
+    request = AVOSupervisionRequest(
+        goal="Improve the candidate.",
+        selected_parent_id="parent",
+        strategy=MutationStrategy.EXPLORATORY,
+        attempt_summaries=[summary],  # type: ignore[arg-type]
+        remaining_budget=AVORemainingBudget(1, 2, 3, 4.0, 1, None, None),
+        trigger_reason=AVOSupervisionTrigger.EXHAUSTED_DIRECTION_REQUEST,
+    )
+    advice = AVOSupervisionAdvice(directions=("  Try a different tool order. ",), reasoning="The prior path repeats.")
+
+    assert request.strategy is MutationStrategy.EXPLORATORY
+    assert request.attempt_summaries == (summary,)
+    assert request.trigger_reason is AVOSupervisionTrigger.EXHAUSTED_DIRECTION_REQUEST
+    assert advice.directions == ("Try a different tool order.",)
+
+
+@pytest.mark.parametrize("directions", [(), ("",), ("A", "A"), ("A", "B", "C", "D")])
+def test_supervision_advice_requires_one_to_three_unique_non_blank_directions(directions: tuple[str, ...]) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        AVOSupervisionAdvice(directions=directions, reasoning="Reason.")

--- a/tests/evolution/test_supervision.py
+++ b/tests/evolution/test_supervision.py
@@ -15,7 +15,7 @@ from aec_bench.contracts.evolution import (
     VariationUsage,
     WorkspaceSnapshot,
 )
-from aec_bench.evolution.core import AVOBudget, AVOState, DevelopmentAttempt
+from aec_bench.evolution.core import AVOBudget, AVOState, DevelopmentAttempt, budget_exhaustion_reason
 from aec_bench.evolution.evaluation import bind_evaluated_candidate
 from aec_bench.evolution.memory import AVOMemoryEntry, AVOMemoryOutcome
 from aec_bench.evolution.supervision import (
@@ -23,6 +23,7 @@ from aec_bench.evolution.supervision import (
     AVOSupervisionAdvice,
     AVOSupervisionFailure,
     AVOSupervisionFailureCode,
+    AVOSupervisionRecord,
     AVOSupervisionRequest,
     AVOSupervisionResult,
     AVOSupervisionTrigger,
@@ -284,6 +285,28 @@ def test_supervision_failure_and_result_are_immutable_typed_contracts() -> None:
         result.output = failure  # type: ignore[misc]
 
 
+def test_supervision_record_requires_exactly_one_confirmed_outcome() -> None:
+    advice = AVOSupervisionAdvice(directions=("Try a new direction.",), reasoning="The current direction repeats.")
+    failure = AVOSupervisionFailure(
+        code=AVOSupervisionFailureCode.OUTPUT_VALIDATION_REJECTED,
+        detail="The supervisor output was rejected.",
+    )
+    valid = AVOSupervisionRecord(
+        trigger_reason=AVOSupervisionTrigger.EXHAUSTED_DIRECTION_REQUEST,
+        advice=advice,
+    )
+
+    assert valid.advice == advice
+    with pytest.raises(ValueError, match="advice or confirmed failure"):
+        AVOSupervisionRecord(trigger_reason=AVOSupervisionTrigger.EXHAUSTED_DIRECTION_REQUEST)
+    with pytest.raises(ValueError, match="advice or confirmed failure"):
+        AVOSupervisionRecord(
+            trigger_reason=AVOSupervisionTrigger.EXHAUSTED_DIRECTION_REQUEST,
+            advice=advice,
+            failure=failure,
+        )
+
+
 def test_supervision_usage_reservation_and_reconciliation_share_avo_budget() -> None:
     before = VariationUsage(model_requests=1, input_tokens=10, output_tokens=4, model_cost_usd=0.4)
     budget = AVOBudget(max_model_requests=3, max_supervisor_interventions=1, max_input_tokens=30, max_output_tokens=20)
@@ -321,18 +344,32 @@ def test_supervision_usage_rejects_unknown_tokens_when_a_bound_cannot_be_proved(
         )
 
 
-def test_supervision_reservation_allows_first_unknown_cost_then_rejects_unknown_reconciliation() -> None:
-    budget = AVOBudget(max_cost_usd=2, max_supervisor_interventions=1)
+def test_supervision_reconciliation_preserves_unknown_cost_for_budget_exhaustion() -> None:
+    budget = AVOBudget(max_cost_usd=2, max_supervisor_interventions=2)
 
     reserved = reserve_supervision_usage(VariationUsage(), budget)
 
     assert reserved.model_requests == 1
-    with pytest.raises(ValueError, match="max_cost_usd_unknown"):
-        reconcile_supervision_usage(
-            VariationUsage(),
+    reconciled = reconcile_supervision_usage(
+        VariationUsage(),
+        budget,
+        VariationUsage(model_requests=1, supervisor_interventions=1),
+    )
+
+    assert reconciled.model_cost_usd is None
+    assert (
+        budget_exhaustion_reason(
             budget,
-            VariationUsage(model_requests=1, supervisor_interventions=1),
+            AVOState(
+                variation_id="variation",
+                parent_candidate_id="parent",
+                child_candidate_id="child",
+                current_revision=0,
+                usage=reconciled,
+            ),
         )
+        == "max_cost_usd_unknown"
+    )
 
 
 def test_supervision_reservation_allows_first_model_cost_after_known_evaluation_cost() -> None:

--- a/tests/evolution/test_supervision.py
+++ b/tests/evolution/test_supervision.py
@@ -285,6 +285,20 @@ def test_supervision_failure_and_result_are_immutable_typed_contracts() -> None:
         result.output = failure  # type: ignore[misc]
 
 
+def test_supervision_result_rejects_development_evaluation_cost() -> None:
+    advice = AVOSupervisionAdvice(directions=("Try one bounded alternative.",), reasoning="The direction stalled.")
+
+    with pytest.raises(ValueError, match="must not include development evaluation cost"):
+        AVOSupervisionResult(
+            output=advice,
+            usage=VariationUsage(
+                model_requests=1,
+                supervisor_interventions=1,
+                development_evaluation_cost_usd=0.0,
+            ),
+        )
+
+
 def test_supervision_record_requires_exactly_one_confirmed_outcome() -> None:
     advice = AVOSupervisionAdvice(directions=("Try a new direction.",), reasoning="The current direction repeats.")
     failure = AVOSupervisionFailure(


### PR DESCRIPTION
## Summary

- add deterministic supervision triggers and validated advice contracts
- run one isolated, read-only supervisor within the shared AVO budget
- persist supervision outcomes, failures, usage, and incomplete effects for safe resume
- keep advice private to each variation call and preserve direct, QD, and swarm authority
- move the internal checkpoint format to schema version 2

## Focused verification

- 164 focused evolution tests passed
- Ruff check and format check passed for changed files
- mypy passed for all 9 changed production files
- provenance check passed with 0 violations
- offline source and wheel build passed

The full test suite was not run because this change uses the agreed focused-test boundary. The optional application configuration test cannot collect in this worktree because the existing harbor extra is not installed; the changed module compiles and its static checks pass.