### PR TITLE
PRD 1: add identity and portable path foundations

### DIFF
--- a/provenance-registry.toml
+++ b/provenance-registry.toml
@@ -1320,6 +1320,27 @@ compatibility_behavior = "the migration command accepts schema 1 only"
 compatibility_kind = "external_schema"
 
 [[field]]
+symbol = "aec_bench.contracts.identity.EntityIdentity.version"
+surface = "pydantic_model"
+wire_name = "version"
+category = "compatibility"
+domain_owner = "contracts_foundation"
+authority = "entity_author"
+authoritative = true
+exposure = "public"
+status = "current"
+payload_contract = "one durable entity identity"
+canonicalization = "positive base-10 integer"
+consumer = "task, run, trial, attempt, artifact, world, lifecycle, study, and catalogue identity consumers"
+validation_behavior = "Pydantic rejects zero, negative, boolean, fractional, and non-integer version values"
+mismatch_behavior = "reject_entity_identity"
+retention = "entity_identity_lifetime"
+rationale = "A durable entity revision changes through an explicit positive version instead of a content-derived ID."
+duplication = "unique"
+compatibility_behavior = "resolve the exact entity version and reject unavailable or mismatched revisions"
+compatibility_kind = "entity_revision"
+
+[[field]]
 symbol = "aec_bench.contracts.learning_study.RunExperienceStep.commit_post_state"
 surface = "pydantic_model"
 wire_name = "commit_post_state"

--- a/scripts/check_provenance_fields.py
+++ b/scripts/check_provenance_fields.py
@@ -125,7 +125,13 @@ _CONTRACT_KEY_PRIORITY = (
     "semantics_version",
 )
 _IGNORED_PATH_PARTS = {"__pycache__", ".mypy_cache", ".pytest_cache", ".ruff_cache", "node_modules"}
-_COMPATIBILITY_KINDS = {"external_schema", "package_distribution", "protocol", "qualification_matrix"}
+_COMPATIBILITY_KINDS = {
+    "entity_revision",
+    "external_schema",
+    "package_distribution",
+    "protocol",
+    "qualification_matrix",
+}
 _FIELD_STATUSES = {"current", "temporary_exception"}
 _ACTOR_REQUEST_FINGERPRINT_KEYS = {
     "action_name",

--- a/src/aec_bench/contracts/identity.py
+++ b/src/aec_bench/contracts/identity.py
@@ -1,0 +1,221 @@
+# ABOUTME: Defines shared UUIDv7, human-readable identity, and portable path values.
+# ABOUTME: Keeps durable identity and filesystem containment rules in one contract boundary.
+
+from __future__ import annotations
+
+import re
+import secrets
+import time
+from enum import StrEnum
+from pathlib import Path, PureWindowsPath
+from uuid import RFC_4122, UUID
+
+from pydantic import PositiveInt, field_validator, model_validator
+from pydantic_core import core_schema
+
+from aec_bench.contracts.validators import FrozenStrictModel
+
+
+class EntityKind(StrEnum):
+    """Durable entity categories that use the shared identity factory."""
+
+    TASK = "task"
+    EXPERIMENT = "experiment"
+    RUN = "run"
+    PLAN = "plan"
+    TRIAL = "trial"
+    ATTEMPT = "attempt"
+    ARTIFACT = "artifact"
+    WORLD = "world"
+    WORLD_PROFILE = "world_profile"
+    LIFECYCLE = "lifecycle"
+    VARIANT = "variant"
+    STUDY = "study"
+    RECEIPT = "receipt"
+    CATALOGUE_RELEASE = "catalogue_release"
+
+
+def _parse_uuid(value: UUID | str) -> UUID:
+    if isinstance(value, UUID):
+        return value
+    if not isinstance(value, str):
+        raise TypeError("entity ID must be a UUID or UUID string")
+    try:
+        return UUID(value)
+    except (ValueError, AttributeError) as error:
+        raise ValueError("entity ID must be a valid UUID") from error
+
+
+def validate_uuidv7(value: UUID | str) -> UUID:
+    """Validate and return an RFC 9562 UUID version 7."""
+
+    parsed = _parse_uuid(value)
+    if parsed.version != 7 or parsed.variant != RFC_4122:
+        raise ValueError("entity ID must be an RFC 9562 UUIDv7")
+    return parsed
+
+
+def new_entity_id(kind: EntityKind | str) -> UUID:
+    """Create one random UUIDv7 for *kind*.
+
+    The kind is validated at the call boundary to make accidental use of a
+    free-form label visible. It is not encoded in the UUID.
+    """
+
+    try:
+        EntityKind(kind)
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"unsupported entity kind: {kind!r}") from error
+
+    timestamp_ms = time.time_ns() // 1_000_000
+    # UUIDv7: 48-bit Unix timestamp, version 7, 12 random bits, RFC 4122
+    # variant, and 62 random bits. The random fields prevent same-millisecond
+    # entity creation from colliding.
+    random_a = secrets.randbits(12)
+    random_b = secrets.randbits(62)
+    return _build_uuidv7(timestamp_ms, random_a, random_b)
+
+
+def _build_uuidv7(timestamp_ms: int, random_a: int, random_b: int) -> UUID:
+    if not 0 <= timestamp_ms < 1 << 48:
+        raise ValueError("UUIDv7 timestamp must fit in 48 bits")
+    if not 0 <= random_a < 1 << 12:
+        raise ValueError("UUIDv7 rand_a must fit in 12 bits")
+    if not 0 <= random_b < 1 << 62:
+        raise ValueError("UUIDv7 rand_b must fit in 62 bits")
+    value = (timestamp_ms << 80) | (7 << 76) | (random_a << 64) | (0b10 << 62) | random_b
+    return UUID(int=value)
+
+
+_KEY_PATTERN = re.compile(r"[a-z0-9][a-z0-9_-]*(?:/[a-z0-9][a-z0-9_-]*)*")
+
+
+def validate_entity_key(value: str) -> str:
+    """Validate one stable, human-readable entity key."""
+
+    if not isinstance(value, str):
+        raise TypeError("entity key must be a string")
+    if _KEY_PATTERN.fullmatch(value) is None:
+        raise ValueError(
+            "entity key must use lowercase ASCII letters, numbers, hyphens, underscores, "
+            "and non-empty slash-separated components"
+        )
+    return value
+
+
+class EntityKey(str):
+    """A validated human-readable key used to name a durable entity."""
+
+    def __new__(cls, value: str) -> EntityKey:
+        return str.__new__(cls, validate_entity_key(value))
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source_type: object, handler: object) -> core_schema.CoreSchema:
+        del source_type, handler
+        return core_schema.no_info_after_validator_function(cls, core_schema.str_schema(strict=True))
+
+
+class EntityIdentity(FrozenStrictModel):
+    """Stable identity, readable key, and positive semantic version."""
+
+    id: UUID
+    key: EntityKey
+    version: PositiveInt
+    aliases: tuple[EntityKey, ...] = ()
+
+    @field_validator("id", mode="before")
+    @classmethod
+    def validate_id(cls, value: UUID | str) -> UUID:
+        return validate_uuidv7(value)
+
+    @model_validator(mode="after")
+    def validate_aliases(self) -> EntityIdentity:
+        if self.key in self.aliases:
+            raise ValueError("entity aliases must not include the canonical key")
+        if len(self.aliases) != len(set(self.aliases)):
+            raise ValueError("entity aliases must be unique")
+        return self
+
+
+_WINDOWS_RESERVED_NAMES = (
+    frozenset({"CON", "PRN", "AUX", "NUL"})
+    | {f"COM{number}" for number in range(1, 10)}
+    | {f"LPT{number}" for number in range(1, 10)}
+)
+_WINDOWS_FORBIDDEN_CHARS = frozenset('<>:"|?*')
+_MAX_COMPONENT_BYTES = 255
+
+
+def validate_portable_relative_path(value: str) -> str:
+    """Validate one portable, slash-separated relative path."""
+
+    if not isinstance(value, str):
+        raise TypeError("portable relative path must be a string")
+    if not value or any(ord(character) < 0x20 for character in value) or "\\" in value:
+        raise ValueError(
+            "portable relative path must be non-empty and must not contain control characters or backslashes"
+        )
+    if value.startswith("/"):
+        raise ValueError("portable relative path must not be absolute")
+
+    components = value.split("/")
+    if any(component in {"", ".", ".."} for component in components):
+        raise ValueError("portable relative path must contain only non-empty ordinary components")
+    for component in components:
+        if len(component.encode("utf-8")) > _MAX_COMPONENT_BYTES:
+            raise ValueError("portable relative path component exceeds 255 UTF-8 bytes")
+        if component[-1] in {".", " "} or any(character in _WINDOWS_FORBIDDEN_CHARS for character in component):
+            raise ValueError("portable relative path contains a Windows-incompatible component")
+        windows_name = component.split(".", 1)[0].upper()
+        if windows_name in _WINDOWS_RESERVED_NAMES:
+            raise ValueError("portable relative path contains a Windows-reserved component")
+    if PureWindowsPath(value).drive:
+        raise ValueError("portable relative path must not be drive-qualified")
+    return value
+
+
+class PortableRelativePath(str):
+    """A validated slash-separated path that can be used on supported platforms."""
+
+    def __new__(cls, value: str) -> PortableRelativePath:
+        return str.__new__(cls, validate_portable_relative_path(value))
+
+    @property
+    def parts(self) -> tuple[str, ...]:
+        return tuple(self.split("/"))
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source_type: object, handler: object) -> core_schema.CoreSchema:
+        del source_type, handler
+        return core_schema.no_info_after_validator_function(cls, core_schema.str_schema(strict=True))
+
+
+def resolve_below(root: Path, relative: PortableRelativePath | str) -> Path:
+    """Resolve *relative* below *root*, including symlink containment."""
+
+    validated = relative if isinstance(relative, PortableRelativePath) else PortableRelativePath(relative)
+    resolved_root = root.resolve()
+    candidate = resolved_root.joinpath(*validated.parts).resolve()
+    if not candidate.is_relative_to(resolved_root):
+        raise ValueError(f"path escapes its trusted root: {relative}")
+    return candidate
+
+
+def format_display_ref(key: EntityKey | str, entity_id: UUID | str) -> str:
+    """Format a readable key and the display-only short UUID suffix."""
+
+    return f"{EntityKey(key)} · {validate_uuidv7(entity_id).hex[-8:]}"
+
+
+__all__ = (
+    "EntityIdentity",
+    "EntityKey",
+    "EntityKind",
+    "PortableRelativePath",
+    "format_display_ref",
+    "new_entity_id",
+    "resolve_below",
+    "validate_entity_key",
+    "validate_portable_relative_path",
+    "validate_uuidv7",
+)

--- a/src/aec_bench/contracts/identity.py
+++ b/src/aec_bench/contracts/identity.py
@@ -8,9 +8,10 @@ import secrets
 import time
 from enum import StrEnum
 from pathlib import Path, PureWindowsPath
+from typing import Annotated
 from uuid import RFC_4122, UUID
 
-from pydantic import PositiveInt, field_validator, model_validator
+from pydantic import Field, field_validator, model_validator
 from pydantic_core import core_schema
 
 from aec_bench.contracts.validators import FrozenStrictModel
@@ -120,7 +121,7 @@ class EntityIdentity(FrozenStrictModel):
 
     id: UUID
     key: EntityKey
-    version: PositiveInt
+    version: Annotated[int, Field(strict=True, gt=0)]
     aliases: tuple[EntityKey, ...] = ()
 
     @field_validator("id", mode="before")

--- a/tests/contracts/test_identity.py
+++ b/tests/contracts/test_identity.py
@@ -69,9 +69,15 @@ def test_entity_identity_validates_key_and_positive_version() -> None:
     assert isinstance(identity.key, EntityKey)
     assert format_display_ref(identity.key, identity.id) == "civil/drainage/pipe-sizing · " + identity.id.hex[-8:]
 
-    for invalid_version in (0, -1):
+    for invalid_version in (0, -1, True, 1.0, "1"):
         with pytest.raises(ValidationError):
-            EntityIdentity(id=identity.id, key=EntityKey("civil/drainage/pipe-sizing"), version=invalid_version)
+            EntityIdentity.model_validate(
+                {
+                    "id": identity.id,
+                    "key": "civil/drainage/pipe-sizing",
+                    "version": invalid_version,
+                }
+            )
 
 
 @pytest.mark.parametrize(

--- a/tests/contracts/test_identity.py
+++ b/tests/contracts/test_identity.py
@@ -1,0 +1,230 @@
+# ABOUTME: Tests shared UUIDv7 identity and portable path value contracts.
+# ABOUTME: Covers malformed values, display references, and symlink containment.
+
+from pathlib import Path
+from uuid import RFC_4122, UUID
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+from pydantic import ValidationError
+
+from aec_bench.contracts.identity import (
+    EntityIdentity,
+    EntityKey,
+    EntityKind,
+    PortableRelativePath,
+    _build_uuidv7,
+    format_display_ref,
+    new_entity_id,
+    resolve_below,
+    validate_portable_relative_path,
+    validate_uuidv7,
+)
+
+
+def test_new_entity_id_creates_uuidv7() -> None:
+    entity_id = new_entity_id(EntityKind.TASK)
+
+    assert isinstance(entity_id, UUID)
+    assert validate_uuidv7(entity_id) == entity_id
+    assert entity_id.version == 7
+    assert entity_id.variant == RFC_4122
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "not-a-uuid",
+        "550e8400-e29b-41d4-a716-446655440000",
+    ],
+)
+def test_validate_uuidv7_rejects_invalid_versions(value: str) -> None:
+    with pytest.raises(ValueError, match="entity ID"):
+        validate_uuidv7(value)
+
+
+def test_uuidv7_layout_encodes_epoch_milliseconds_and_random_fields() -> None:
+    timestamp_ms = 1_706_000_123_456
+    random_a = 0xABC
+    random_b = 0x1234_5678_9ABC_DEF
+
+    entity_id = _build_uuidv7(timestamp_ms, random_a, random_b)
+
+    expected_int = (timestamp_ms << 80) | (7 << 76) | (random_a << 64) | (0b10 << 62) | random_b
+    assert entity_id == UUID(int=expected_int)
+    assert entity_id.int >> 80 == timestamp_ms
+
+
+def test_new_entity_id_accepts_string_kind_and_rejects_unknown_kind() -> None:
+    assert new_entity_id("run").version == 7
+
+    with pytest.raises(ValueError, match="unsupported entity kind"):
+        new_entity_id("unknown")
+
+
+def test_entity_identity_validates_key_and_positive_version() -> None:
+    identity = EntityIdentity(id=new_entity_id("task"), key=EntityKey("civil/drainage/pipe-sizing"), version=3)
+
+    assert isinstance(identity.key, EntityKey)
+    assert format_display_ref(identity.key, identity.id) == "civil/drainage/pipe-sizing · " + identity.id.hex[-8:]
+
+    for invalid_version in (0, -1):
+        with pytest.raises(ValidationError):
+            EntityIdentity(id=identity.id, key=EntityKey("civil/drainage/pipe-sizing"), version=invalid_version)
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "",
+        " ",
+        "/leading",
+        "trailing/",
+        "repeated//separator",
+        ".",
+        "a/.",
+        "a/..",
+        "a\\b",
+        "a\x00b",
+        "Éngineering/task",
+        "UPPER/task",
+        "a b/task",
+    ],
+)
+def test_entity_key_rejects_unsafe_values(key: str) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        EntityKey(key)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "",
+        "/absolute/path",
+        "C:/Windows/path",
+        "C:relative-drive-path",
+        "//server/share",
+        "a\\b",
+        "a\x00b",
+        "a/../outside",
+        "a/./inside",
+        "a//b",
+        "a/",
+        "CON/file.txt",
+        "report:name.txt",
+    ],
+)
+def test_portable_relative_path_rejects_unsafe_values(path: str) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        PortableRelativePath(path)
+
+
+def test_portable_relative_path_allows_unicode_and_exposes_components() -> None:
+    path = PortableRelativePath("données/rapport-01.txt")
+
+    assert path.parts == ("données", "rapport-01.txt")
+    assert validate_portable_relative_path(path) == path
+
+
+@given(
+    st.text(
+        alphabet=st.characters(whitelist_categories=("L", "M", "N")),
+        min_size=1,
+        max_size=40,
+    )
+)
+def test_portable_relative_path_accepts_unicode_components(component: str) -> None:
+    path = PortableRelativePath(f"engineering-{component}/report")
+
+    assert path.parts == (f"engineering-{component}", "report")
+
+
+@given(st.lists(st.sampled_from((".", "..")), min_size=1, max_size=4))
+def test_portable_relative_path_rejects_traversal_components(components: list[str]) -> None:
+    with pytest.raises(ValueError):
+        PortableRelativePath("/".join(("workspace", *components, "output")))
+
+
+@given(st.integers(min_value=2, max_value=512))
+def test_portable_relative_path_rejects_repeated_separators(component_count: int) -> None:
+    path = "segment" + ("/segment" * component_count) + "//output"
+
+    with pytest.raises(ValueError):
+        PortableRelativePath(path)
+
+
+@given(
+    st.sampled_from(("C:", "D:", "Z:")),
+    st.text(alphabet=st.characters(whitelist_categories=("Ll", "Nd")), min_size=1, max_size=24),
+)
+def test_portable_relative_path_rejects_windows_drive_forms(drive: str, component: str) -> None:
+    with pytest.raises(ValueError):
+        PortableRelativePath(f"{drive}/{component}")
+
+
+@given(st.text(alphabet=st.characters(whitelist_categories=("Ll", "Nd")), min_size=1, max_size=24))
+def test_portable_relative_path_rejects_backslash_forms(component: str) -> None:
+    with pytest.raises(ValueError):
+        PortableRelativePath(f"workspace\\{component}")
+
+
+@given(st.text(alphabet=st.characters(whitelist_categories=("Ll", "Nd")), max_size=24))
+def test_portable_relative_path_rejects_null_bytes(component: str) -> None:
+    with pytest.raises(ValueError):
+        PortableRelativePath(f"workspace/{component}\x00/output")
+
+
+@given(st.integers(min_value=1, max_value=255))
+def test_portable_relative_path_allows_components_up_to_255_utf8_bytes(component_length: int) -> None:
+    component = "x" * component_length
+
+    assert PortableRelativePath(component).parts == (component,)
+
+
+@given(st.integers(min_value=256, max_value=2_048))
+def test_portable_relative_path_rejects_ascii_components_over_255_bytes(component_length: int) -> None:
+    with pytest.raises(ValueError, match="255 UTF-8 bytes"):
+        PortableRelativePath("x" * component_length)
+
+
+@given(st.integers(min_value=128, max_value=1_024))
+def test_portable_relative_path_rejects_multibyte_components_over_255_bytes(component_length: int) -> None:
+    with pytest.raises(ValueError, match="255 UTF-8 bytes"):
+        PortableRelativePath("é" * component_length)
+
+
+def test_resolve_below_returns_descendant(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+
+    assert resolve_below(root, PortableRelativePath("aec-bench/output.json")) == root / "aec-bench/output.json"
+
+
+def test_resolve_below_keeps_encoded_traversal_literal(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    relative = PortableRelativePath("workspace/%2e%2e/out.json")
+
+    assert resolve_below(root, relative) == root / "workspace/%2e%2e/out.json"
+
+
+def test_resolve_below_rejects_symlink_escape(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    outside = tmp_path / "outside"
+    root.mkdir()
+    outside.mkdir()
+    (root / "linked").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="escapes"):
+        resolve_below(root, PortableRelativePath("linked/secret.txt"))
+
+
+def test_resolve_below_accepts_symlink_that_stays_inside(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    target = root / "real"
+    target.mkdir()
+    (root / "linked").symlink_to(target, target_is_directory=True)
+
+    assert resolve_below(root, PortableRelativePath("linked/file.txt")) == target / "file.txt"

--- a/tests/test_provenance_manifest_discovery.py
+++ b/tests/test_provenance_manifest_discovery.py
@@ -111,6 +111,7 @@ def _compatibility_registration(
     wire_name: str,
     surface: str = "pydantic_model",
     aliases: list[str] | None = None,
+    compatibility_kind: str = "external_schema",
 ) -> str:
     aliases_line = ""
     if aliases:
@@ -137,7 +138,7 @@ def _compatibility_registration(
     rationale = "The fixture exercises compatibility metadata."
     duplication = "unique"
     compatibility_behavior = "reject unsupported schema"
-    compatibility_kind = "external_schema"
+    compatibility_kind = "{compatibility_kind}"
     '''
 
 
@@ -608,6 +609,22 @@ def test_version_token_registry_field_requires_compatibility_or_qualification_sc
 
     with pytest.raises(provenance.ProvenanceInputError, match="version-shaped"):
         provenance.load_registry(registry)
+
+
+def test_version_token_registry_field_accepts_entity_revision_compatibility_scope(tmp_path: Path) -> None:
+    symbol = "aec_bench.contracts.identity.EntityIdentity.version"
+    registry = _write_registry(
+        tmp_path,
+        _compatibility_registration(
+            symbol,
+            wire_name="version",
+            compatibility_kind="entity_revision",
+        ),
+    )
+
+    loaded = provenance.load_registry(registry)
+
+    assert loaded.by_locator[symbol].metadata["compatibility_kind"] == "entity_revision"
 
 
 def test_registry_wire_name_drift_follows_serialization_alias(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add one UUIDv7 generation and validation API for durable entity IDs
- add validated human-readable entity keys and positive-version identities
- add portable relative path validation and symlink-aware root containment
- add example-based and property-based contract tests

## Scope

This is PRD 1, PR 1 only. It does not migrate task metadata, change selection, add verifier receipts, or change current execution paths.

## Checks

- 79 focused tests passed
- Ruff check passed
- Ruff format check passed
- Mypy passed for both changed files
- git diff --check passed