### PR TITLE
Migrate repository task metadata

### DIFF
--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -69,6 +69,10 @@ During the repository migration, files without `[identity]` use the named
 current legacy defaults and does not allocate a UUID; those defaults do not
 apply to the explicit metadata contract.
 
+Maintained task packages now record the canonical key from their repository
+path. The key uses the identity rules, so legacy path components such as
+`L2` are represented as lowercase `l2`; the filesystem path remains unchanged.
+
 Executable interactive worlds use their registered world definition and
 profile instead of pretending to be a static `TaskDefinition`. Both families
 can still enter the same experiment, trial, evaluation, and reporting layers.

--- a/src/aec_bench/tasks/loader.py
+++ b/src/aec_bench/tasks/loader.py
@@ -41,10 +41,23 @@ KNOWN_DOMAINS = {
     "plumbing",
 }
 WORKSPACE_OUTPUT_PATH_RE: Final[str] = r"/workspace/[A-Za-z0-9._/-]+"
+_TASK_KEY_COMPONENT_RE: Final[re.Pattern[str]] = re.compile(r"[^a-z0-9_-]+")
 
 
 def derive_task_id(instance_dir: Path, tasks_root: Path) -> str:
     return instance_dir.relative_to(tasks_root).as_posix()
+
+
+def canonical_task_key(relative_path: str) -> EntityKey:
+    """Map an existing task path to the lowercase identity-key form."""
+
+    components: list[str] = []
+    for component in relative_path.split("/"):
+        normalised = _TASK_KEY_COMPONENT_RE.sub("-", component.lower()).strip("-_")
+        if not normalised or not normalised[0].isalnum() or not normalised[0].isascii():
+            normalised = f"task-{normalised}" if normalised else "task"
+        components.append(normalised)
+    return EntityKey("/".join(components))
 
 
 def load_task_definition(instance_dir: Path, tasks_root: Path) -> TaskDefinition:
@@ -83,7 +96,7 @@ def _load_task_definition_with_metadata(
 
     relative_path = derive_task_id(instance_dir, tasks_root)
     try:
-        path_key = EntityKey(relative_path)
+        path_key = canonical_task_key(relative_path)
     except (TypeError, ValueError) as error:
         raise LoadError(f"task path is not a valid entity key: {relative_path}") from error
     if task_metadata.identity.key != path_key and path_key not in task_metadata.identity.aliases:

--- a/src/aec_bench/tasks/metadata_migration.py
+++ b/src/aec_bench/tasks/metadata_migration.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import tempfile
 import tomllib
 from dataclasses import asdict, dataclass
@@ -13,12 +12,11 @@ from pathlib import Path
 from typing import Any
 from uuid import UUID
 
-from aec_bench.contracts.identity import EntityIdentity, EntityKey, EntityKind, new_entity_id, validate_uuidv7
+from aec_bench.contracts.identity import EntityIdentity, EntityKind, new_entity_id, validate_uuidv7
 from aec_bench.contracts.task_definition import Lifecycle, Visibility
-from aec_bench.tasks.loader import iter_task_instance_dirs
+from aec_bench.tasks.loader import canonical_task_key, iter_task_instance_dirs
 
 REPORT_SCHEMA_VERSION = 1
-_KEY_COMPONENT_RE = re.compile(r"[^a-z0-9_-]+")
 
 
 class MigrationReportError(ValueError):
@@ -132,7 +130,7 @@ def _build_entry(
     metadata = raw_toml.get("metadata")
     metadata_mapping = metadata if isinstance(metadata, dict) else {}
     identity = _read_identity(raw_toml)
-    proposed_key = _proposed_key(current_path)
+    proposed_key = str(canonical_task_key(current_path))
 
     if identity is not None:
         generated_uuid = identity.id
@@ -210,16 +208,6 @@ def _read_identity(raw_toml: dict[str, Any]) -> EntityIdentity | None:
         return EntityIdentity.model_validate(identity)
     except (TypeError, ValueError):
         return None
-
-
-def _proposed_key(current_path: str) -> str:
-    components: list[str] = []
-    for component in current_path.split("/"):
-        normalised = _KEY_COMPONENT_RE.sub("-", component.lower()).strip("-_")
-        if not normalised or not normalised[0].isalnum() or not normalised[0].isascii():
-            normalised = f"task-{normalised}" if normalised else "task"
-        components.append(normalised)
-    return str(EntityKey("/".join(components)))
 
 
 def _inferred_lifecycle(metadata: dict[str, Any]) -> str:

--- a/tasks/civil/drainage-review/drainage-model-run-provenance-issue-review-package/brownfield-drainage-upgrade-industrial-precinct-catchment-02/task.toml
+++ b/tasks/civil/drainage-review/drainage-model-run-provenance-issue-review-package/brownfield-drainage-upgrade-industrial-precinct-catchment-02/task.toml
@@ -1,4 +1,10 @@
+[identity]
+id = "01a04c6c-4b1d-7fb8-8532-e6ba5813eda7"
+key = "civil/drainage-review/drainage-model-run-provenance-issue-review-package/brownfield-drainage-upgrade-industrial-precinct-catchment-02"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
 domain = "civil"
 category = "drainage-review"
 difficulty = "hard"

--- a/tasks/civil/drainage-review/drainage-model-run-provenance-issue-review-package/industrial-precinct-catchment-industrial-precinct-catchment-00/task.toml
+++ b/tasks/civil/drainage-review/drainage-model-run-provenance-issue-review-package/industrial-precinct-catchment-industrial-precinct-catchment-00/task.toml
@@ -1,4 +1,10 @@
+[identity]
+id = "01a04c6c-4b1d-78b8-a546-0ce83aaefd4c"
+key = "civil/drainage-review/drainage-model-run-provenance-issue-review-package/industrial-precinct-catchment-industrial-precinct-catchment-00"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
 domain = "civil"
 category = "drainage-review"
 difficulty = "hard"

--- a/tasks/civil/pipe-hydraulics/hazen-williams-headloss/sydney-greenfield-new-pvc-00/task.toml
+++ b/tasks/civil/pipe-hydraulics/hazen-williams-headloss/sydney-greenfield-new-pvc-00/task.toml
@@ -1,4 +1,10 @@
+[identity]
+id = "01a04c6c-4b1d-7398-8c57-e397028279e8"
+key = "civil/pipe-hydraulics/hazen-williams-headloss/sydney-greenfield-new-pvc-00"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
 domain = "civil"
 category = "pipe-hydraulics"
 difficulty = "easy"

--- a/tasks/electrical/catenary-sag/task.toml
+++ b/tasks/electrical/catenary-sag/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b1e-7d81-9793-19e78bb54375"
+key = "electrical/catenary-sag"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "easy"
 category = "reasoning"
 tags = ["electrical", "transmission-lines", "deterministic", "IEC-60826"]

--- a/tasks/electrical/conduit-fill/task.toml
+++ b/tasks/electrical/conduit-fill/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b1e-7a69-b331-3e21fd8fd65e"
+key = "electrical/conduit-fill"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "easy"
 category = "reasoning"
 tags = ["electrical", "ict-comms", "deterministic", "ANSI-TIA-569"]

--- a/tasks/electrical/fault-current/task.toml
+++ b/tasks/electrical/fault-current/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b1e-7c7f-b974-6b72ee8cce4d"
+key = "electrical/fault-current"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["electrical", "substations", "deterministic", "IEC-60909"]

--- a/tasks/electrical/pf-droop/task.toml
+++ b/tasks/electrical/pf-droop/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b1e-7dd5-816d-ad357eb69537"
+key = "electrical/pf-droop"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "power-systems"
 tags = ["electrical", "grid-control", "multimodal", "droop-curve"]

--- a/tasks/electrical/qv-droop/task.toml
+++ b/tasks/electrical/qv-droop/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b1e-76a2-9588-01509a6051ea"
+key = "electrical/qv-droop"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "power-systems"
 tags = ["electrical", "grid-control", "multimodal", "qv-droop"]

--- a/tasks/electrical/rlm-test/task.toml
+++ b/tasks/electrical/rlm-test/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b1f-7eb7-8084-6e6ef0f9a22b"
+key = "electrical/rlm-test"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "easy"
 category = "reasoning"
 tags = ["rlm-test", "electrical", "deterministic"]

--- a/tasks/electrical/voltage-drop/task.toml
+++ b/tasks/electrical/voltage-drop/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b1f-7345-bf57-112fd35c60a2"
+key = "electrical/voltage-drop"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "easy"
 category = "reasoning"
 tags = ["electrical", "buildings-electrical", "deterministic", "AS-NZS-3008"]

--- a/tasks/maritime/block-coefficient/capesize-bulk-carrier/task.toml
+++ b/tasks/maritime/block-coefficient/capesize-bulk-carrier/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b1f-70b0-95f9-f34297ef3cc6"
+key = "maritime/block-coefficient/capesize-bulk-carrier"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "easy"
 category = "reasoning"
 tags = ["maritime", "csr-h", "iacs", "block-coefficient", "principal-particulars", "deterministic"]

--- a/tasks/maritime/freeboard-length/general-cargo-waterline-governs/task.toml
+++ b/tasks/maritime/freeboard-length/general-cargo-waterline-governs/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b1f-7987-aeb1-c22601b37541"
+key = "maritime/freeboard-length/general-cargo-waterline-governs"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["maritime", "csr-h", "iacs", "freeboard-length", "principal-particulars", "deterministic"]

--- a/tasks/maritime/rule-length/bulk-carrier-lower-bound/task.toml
+++ b/tasks/maritime/rule-length/bulk-carrier-lower-bound/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b1f-71b5-aa13-ee07e8b9ea7e"
+key = "maritime/rule-length/bulk-carrier-lower-bound"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["maritime", "csr-h", "iacs", "rule-length", "principal-particulars", "deterministic"]

--- a/tasks/mechanical/heat-load/audit-mixed-use/adelaide-15rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-mixed-use/adelaide-15rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b1f-7955-92bd-c1fe4338cf2f"
+key = "mechanical/heat-load/audit-mixed-use/adelaide-15rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "hard"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "with-tool"]

--- a/tasks/mechanical/heat-load/audit-mixed-use/brisbane-15rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-mixed-use/brisbane-15rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b20-7f14-85f8-0cde399b1cba"
+key = "mechanical/heat-load/audit-mixed-use/brisbane-15rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "hard"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "with-tool"]

--- a/tasks/mechanical/heat-load/audit-mixed-use/cairns-15rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-mixed-use/cairns-15rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b20-7059-9051-fdb71d436a78"
+key = "mechanical/heat-load/audit-mixed-use/cairns-15rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "hard"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "with-tool"]

--- a/tasks/mechanical/heat-load/audit-mixed-use/canberra-15rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-mixed-use/canberra-15rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b20-7bb4-9946-d55f58daeb40"
+key = "mechanical/heat-load/audit-mixed-use/canberra-15rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "hard"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "with-tool"]

--- a/tasks/mechanical/heat-load/audit-mixed-use/darwin-15rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-mixed-use/darwin-15rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b20-710c-99ef-6a2ad119930c"
+key = "mechanical/heat-load/audit-mixed-use/darwin-15rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "hard"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "with-tool"]

--- a/tasks/mechanical/heat-load/audit-mixed-use/hobart-15rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-mixed-use/hobart-15rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b21-7628-85e7-b46036fba269"
+key = "mechanical/heat-load/audit-mixed-use/hobart-15rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "hard"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "with-tool"]

--- a/tasks/mechanical/heat-load/audit-mixed-use/melbourne-15rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-mixed-use/melbourne-15rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b21-7677-a16d-7e912ca928d4"
+key = "mechanical/heat-load/audit-mixed-use/melbourne-15rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "hard"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "with-tool"]

--- a/tasks/mechanical/heat-load/audit-mixed-use/perth-15rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-mixed-use/perth-15rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b21-7908-86bb-bcaf06afd78a"
+key = "mechanical/heat-load/audit-mixed-use/perth-15rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "hard"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "with-tool"]

--- a/tasks/mechanical/heat-load/audit-mixed-use/sydney-15rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-mixed-use/sydney-15rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b21-772c-a854-5720178d2346"
+key = "mechanical/heat-load/audit-mixed-use/sydney-15rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "hard"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "with-tool"]

--- a/tasks/mechanical/heat-load/audit-mixed-use/townsville-15rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-mixed-use/townsville-15rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b22-7cea-ba9c-915074a9eb94"
+key = "mechanical/heat-load/audit-mixed-use/townsville-15rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "hard"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "with-tool"]

--- a/tasks/mechanical/heat-load/audit-office-building-L0/adelaide-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L0/adelaide-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b24-7b1f-a0d6-9698b8f225a3"
+key = "mechanical/heat-load/audit-office-building-l0/adelaide-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "hard"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L0"]

--- a/tasks/mechanical/heat-load/audit-office-building-L0/brisbane-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L0/brisbane-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b24-742c-bce3-d0d1cf6394df"
+key = "mechanical/heat-load/audit-office-building-l0/brisbane-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "hard"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L0"]

--- a/tasks/mechanical/heat-load/audit-office-building-L0/cairns-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L0/cairns-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b24-78de-a88f-69573756634e"
+key = "mechanical/heat-load/audit-office-building-l0/cairns-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "hard"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L0"]

--- a/tasks/mechanical/heat-load/audit-office-building-L0/canberra-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L0/canberra-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b24-71e2-b341-e176f1070b1f"
+key = "mechanical/heat-load/audit-office-building-l0/canberra-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "hard"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L0"]

--- a/tasks/mechanical/heat-load/audit-office-building-L0/darwin-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L0/darwin-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b25-7b63-8015-6894e48b9390"
+key = "mechanical/heat-load/audit-office-building-l0/darwin-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "hard"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L0"]

--- a/tasks/mechanical/heat-load/audit-office-building-L0/hobart-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L0/hobart-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b25-7071-b10d-8ff34cfb9e99"
+key = "mechanical/heat-load/audit-office-building-l0/hobart-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "hard"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L0"]

--- a/tasks/mechanical/heat-load/audit-office-building-L0/melbourne-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L0/melbourne-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b25-727f-a154-2c098ec0be7a"
+key = "mechanical/heat-load/audit-office-building-l0/melbourne-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "hard"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L0"]

--- a/tasks/mechanical/heat-load/audit-office-building-L0/perth-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L0/perth-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b25-73e3-83df-37d196ff81e3"
+key = "mechanical/heat-load/audit-office-building-l0/perth-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "hard"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L0"]

--- a/tasks/mechanical/heat-load/audit-office-building-L0/sydney-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L0/sydney-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b26-786a-8fe4-2b30f8adab4f"
+key = "mechanical/heat-load/audit-office-building-l0/sydney-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "hard"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L0"]

--- a/tasks/mechanical/heat-load/audit-office-building-L0/townsville-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L0/townsville-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b26-7b2c-9b79-ed7c5f1f21f3"
+key = "mechanical/heat-load/audit-office-building-l0/townsville-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "hard"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L0"]

--- a/tasks/mechanical/heat-load/audit-office-building-L1/adelaide-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L1/adelaide-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b26-7c3a-bbf9-904c50100d9a"
+key = "mechanical/heat-load/audit-office-building-l1/adelaide-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L1"]

--- a/tasks/mechanical/heat-load/audit-office-building-L1/brisbane-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L1/brisbane-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b26-723b-bcfe-deee7d064660"
+key = "mechanical/heat-load/audit-office-building-l1/brisbane-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L1"]

--- a/tasks/mechanical/heat-load/audit-office-building-L1/cairns-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L1/cairns-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b26-7060-9633-978aed44eddb"
+key = "mechanical/heat-load/audit-office-building-l1/cairns-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L1"]

--- a/tasks/mechanical/heat-load/audit-office-building-L1/canberra-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L1/canberra-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b27-72d2-a5d0-1e0dd52de6b3"
+key = "mechanical/heat-load/audit-office-building-l1/canberra-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L1"]

--- a/tasks/mechanical/heat-load/audit-office-building-L1/darwin-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L1/darwin-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b27-772c-a5c3-5ac805a29205"
+key = "mechanical/heat-load/audit-office-building-l1/darwin-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L1"]

--- a/tasks/mechanical/heat-load/audit-office-building-L1/hobart-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L1/hobart-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b27-7652-9455-68d931fb38b4"
+key = "mechanical/heat-load/audit-office-building-l1/hobart-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L1"]

--- a/tasks/mechanical/heat-load/audit-office-building-L1/melbourne-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L1/melbourne-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b27-7c95-852f-0a1e3eda28f1"
+key = "mechanical/heat-load/audit-office-building-l1/melbourne-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L1"]

--- a/tasks/mechanical/heat-load/audit-office-building-L1/perth-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L1/perth-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b27-750f-b670-f490660f7218"
+key = "mechanical/heat-load/audit-office-building-l1/perth-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L1"]

--- a/tasks/mechanical/heat-load/audit-office-building-L1/sydney-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L1/sydney-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b27-70f5-9b7a-e09673e63bfd"
+key = "mechanical/heat-load/audit-office-building-l1/sydney-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L1"]

--- a/tasks/mechanical/heat-load/audit-office-building-L1/townsville-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L1/townsville-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b28-75de-9a45-5a50c64efd49"
+key = "mechanical/heat-load/audit-office-building-l1/townsville-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L1"]

--- a/tasks/mechanical/heat-load/audit-office-building-L2/adelaide-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L2/adelaide-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b28-747e-86f6-2a4786707acf"
+key = "mechanical/heat-load/audit-office-building-l2/adelaide-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L2"]

--- a/tasks/mechanical/heat-load/audit-office-building-L2/brisbane-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L2/brisbane-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b28-78c7-8658-1d6dcd9adb4c"
+key = "mechanical/heat-load/audit-office-building-l2/brisbane-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L2"]

--- a/tasks/mechanical/heat-load/audit-office-building-L2/cairns-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L2/cairns-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b28-7767-9305-b0a73adab46a"
+key = "mechanical/heat-load/audit-office-building-l2/cairns-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L2"]

--- a/tasks/mechanical/heat-load/audit-office-building-L2/canberra-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L2/canberra-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b28-7122-b6e3-d1b04d841f54"
+key = "mechanical/heat-load/audit-office-building-l2/canberra-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L2"]

--- a/tasks/mechanical/heat-load/audit-office-building-L2/darwin-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L2/darwin-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b28-7fd7-bbc5-7030475751b3"
+key = "mechanical/heat-load/audit-office-building-l2/darwin-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L2"]

--- a/tasks/mechanical/heat-load/audit-office-building-L2/hobart-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L2/hobart-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b29-7931-91c6-6711b73e4ef7"
+key = "mechanical/heat-load/audit-office-building-l2/hobart-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L2"]

--- a/tasks/mechanical/heat-load/audit-office-building-L2/melbourne-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L2/melbourne-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b29-7105-9cb1-520e3aeef43d"
+key = "mechanical/heat-load/audit-office-building-l2/melbourne-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L2"]

--- a/tasks/mechanical/heat-load/audit-office-building-L2/perth-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L2/perth-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b29-7b71-8d1a-cbdac31f3b3f"
+key = "mechanical/heat-load/audit-office-building-l2/perth-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L2"]

--- a/tasks/mechanical/heat-load/audit-office-building-L2/sydney-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L2/sydney-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b29-7385-9aec-2403bae0cbcb"
+key = "mechanical/heat-load/audit-office-building-l2/sydney-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L2"]

--- a/tasks/mechanical/heat-load/audit-office-building-L2/townsville-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L2/townsville-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b2a-7d79-99a4-3880a9fec021"
+key = "mechanical/heat-load/audit-office-building-l2/townsville-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L2"]

--- a/tasks/mechanical/heat-load/audit-office-building-L3/adelaide-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L3/adelaide-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b2a-72a5-b95f-9b7c51dad2b8"
+key = "mechanical/heat-load/audit-office-building-l3/adelaide-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L3"]

--- a/tasks/mechanical/heat-load/audit-office-building-L3/brisbane-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L3/brisbane-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b2a-7006-bca1-5f71abfa9538"
+key = "mechanical/heat-load/audit-office-building-l3/brisbane-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L3"]

--- a/tasks/mechanical/heat-load/audit-office-building-L3/cairns-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L3/cairns-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b2a-7538-87d5-b276a0c902f9"
+key = "mechanical/heat-load/audit-office-building-l3/cairns-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L3"]

--- a/tasks/mechanical/heat-load/audit-office-building-L3/canberra-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L3/canberra-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b2a-79e8-9449-37efdc9e412c"
+key = "mechanical/heat-load/audit-office-building-l3/canberra-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L3"]

--- a/tasks/mechanical/heat-load/audit-office-building-L3/darwin-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L3/darwin-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b2b-7462-868d-ae466c47a6d4"
+key = "mechanical/heat-load/audit-office-building-l3/darwin-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L3"]

--- a/tasks/mechanical/heat-load/audit-office-building-L3/hobart-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L3/hobart-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b2b-71dd-8443-c1828f33923c"
+key = "mechanical/heat-load/audit-office-building-l3/hobart-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L3"]

--- a/tasks/mechanical/heat-load/audit-office-building-L3/melbourne-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L3/melbourne-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b2b-7173-853f-953e6316bab8"
+key = "mechanical/heat-load/audit-office-building-l3/melbourne-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L3"]

--- a/tasks/mechanical/heat-load/audit-office-building-L3/perth-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L3/perth-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b2b-758f-acc1-b7ee9fb6c76b"
+key = "mechanical/heat-load/audit-office-building-l3/perth-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L3"]

--- a/tasks/mechanical/heat-load/audit-office-building-L3/sydney-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L3/sydney-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b2b-71da-9230-9df3dbc0caf6"
+key = "mechanical/heat-load/audit-office-building-l3/sydney-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L3"]

--- a/tasks/mechanical/heat-load/audit-office-building-L3/townsville-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-L3/townsville-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b2b-70ef-a4d9-d9c9928d85f0"
+key = "mechanical/heat-load/audit-office-building-l3/townsville-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool", "ablation-L3"]

--- a/tasks/mechanical/heat-load/audit-office-building-no-tool/adelaide-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-no-tool/adelaide-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b2c-73ad-a3d2-c71914d72779"
+key = "mechanical/heat-load/audit-office-building-no-tool/adelaide-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool"]

--- a/tasks/mechanical/heat-load/audit-office-building-no-tool/brisbane-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-no-tool/brisbane-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b2c-7c6a-b8e3-0f625b0caa97"
+key = "mechanical/heat-load/audit-office-building-no-tool/brisbane-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool"]

--- a/tasks/mechanical/heat-load/audit-office-building-no-tool/cairns-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-no-tool/cairns-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b2c-7bb1-acc2-afed5c81b602"
+key = "mechanical/heat-load/audit-office-building-no-tool/cairns-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool"]

--- a/tasks/mechanical/heat-load/audit-office-building-no-tool/canberra-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-no-tool/canberra-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b2c-7aef-82b1-3b369153b927"
+key = "mechanical/heat-load/audit-office-building-no-tool/canberra-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool"]

--- a/tasks/mechanical/heat-load/audit-office-building-no-tool/darwin-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-no-tool/darwin-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b2c-7dfe-b0aa-e10315cbe425"
+key = "mechanical/heat-load/audit-office-building-no-tool/darwin-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool"]

--- a/tasks/mechanical/heat-load/audit-office-building-no-tool/hobart-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-no-tool/hobart-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b2d-734d-a579-b242c43b90c1"
+key = "mechanical/heat-load/audit-office-building-no-tool/hobart-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool"]

--- a/tasks/mechanical/heat-load/audit-office-building-no-tool/melbourne-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-no-tool/melbourne-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b2d-7e4f-bc3a-095e2ce75d07"
+key = "mechanical/heat-load/audit-office-building-no-tool/melbourne-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool"]

--- a/tasks/mechanical/heat-load/audit-office-building-no-tool/perth-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-no-tool/perth-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b2d-721f-8d9a-ad8d0a206380"
+key = "mechanical/heat-load/audit-office-building-no-tool/perth-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool"]

--- a/tasks/mechanical/heat-load/audit-office-building-no-tool/sydney-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-no-tool/sydney-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b2d-7320-9217-49c24ed83f44"
+key = "mechanical/heat-load/audit-office-building-no-tool/sydney-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool"]

--- a/tasks/mechanical/heat-load/audit-office-building-no-tool/townsville-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building-no-tool/townsville-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b2d-7123-bae7-291771f27935"
+key = "mechanical/heat-load/audit-office-building-no-tool/townsville-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "no-tool"]

--- a/tasks/mechanical/heat-load/audit-office-building/adelaide-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building/adelaide-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b22-7202-a2d0-d177a3de4df5"
+key = "mechanical/heat-load/audit-office-building/adelaide-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "with-tool"]

--- a/tasks/mechanical/heat-load/audit-office-building/brisbane-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building/brisbane-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b22-7520-a9c9-5480ba78dfbe"
+key = "mechanical/heat-load/audit-office-building/brisbane-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "with-tool"]

--- a/tasks/mechanical/heat-load/audit-office-building/cairns-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building/cairns-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b22-71f5-8f38-87d0ce4657bd"
+key = "mechanical/heat-load/audit-office-building/cairns-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "with-tool"]

--- a/tasks/mechanical/heat-load/audit-office-building/canberra-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building/canberra-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b23-74b2-8d53-9950b4e0c7ab"
+key = "mechanical/heat-load/audit-office-building/canberra-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "with-tool"]

--- a/tasks/mechanical/heat-load/audit-office-building/darwin-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building/darwin-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b23-7bcf-9126-99ade85c87a3"
+key = "mechanical/heat-load/audit-office-building/darwin-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "with-tool"]

--- a/tasks/mechanical/heat-load/audit-office-building/hobart-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building/hobart-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b23-70e9-8bf9-55132f4e8c45"
+key = "mechanical/heat-load/audit-office-building/hobart-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "with-tool"]

--- a/tasks/mechanical/heat-load/audit-office-building/melbourne-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building/melbourne-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b23-7204-ad03-cac69b365f34"
+key = "mechanical/heat-load/audit-office-building/melbourne-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "with-tool"]

--- a/tasks/mechanical/heat-load/audit-office-building/perth-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building/perth-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b23-78c8-872c-aa71dfeed6a6"
+key = "mechanical/heat-load/audit-office-building/perth-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "with-tool"]

--- a/tasks/mechanical/heat-load/audit-office-building/sydney-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building/sydney-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b24-7f5d-a33f-607687bcd9d2"
+key = "mechanical/heat-load/audit-office-building/sydney-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "with-tool"]

--- a/tasks/mechanical/heat-load/audit-office-building/townsville-8rm/task.toml
+++ b/tasks/mechanical/heat-load/audit-office-building/townsville-8rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b24-79e2-8a64-00950f3c33de"
+key = "mechanical/heat-load/audit-office-building/townsville-8rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "audit", "AS-1668-2", "with-tool"]

--- a/tasks/mechanical/heat-load/multi-room-mixed/adelaide-3rm/task.toml
+++ b/tasks/mechanical/heat-load/multi-room-mixed/adelaide-3rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b2d-7c8c-acca-09843f72fc36"
+key = "mechanical/heat-load/multi-room-mixed/adelaide-3rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "multi-room", "with-tool", "AS-1668-2"]

--- a/tasks/mechanical/heat-load/multi-room-mixed/brisbane-4rm/task.toml
+++ b/tasks/mechanical/heat-load/multi-room-mixed/brisbane-4rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b2e-7d17-b28c-a40c0eecf091"
+key = "mechanical/heat-load/multi-room-mixed/brisbane-4rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "multi-room", "with-tool", "AS-1668-2"]

--- a/tasks/mechanical/heat-load/multi-room-mixed/cairns-4rm/task.toml
+++ b/tasks/mechanical/heat-load/multi-room-mixed/cairns-4rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b2e-70da-ad63-47898693828b"
+key = "mechanical/heat-load/multi-room-mixed/cairns-4rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "multi-room", "with-tool", "AS-1668-2"]

--- a/tasks/mechanical/heat-load/multi-room-mixed/canberra-5rm/task.toml
+++ b/tasks/mechanical/heat-load/multi-room-mixed/canberra-5rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b2e-739d-ae45-4e83e6b97aa2"
+key = "mechanical/heat-load/multi-room-mixed/canberra-5rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "multi-room", "with-tool", "AS-1668-2"]

--- a/tasks/mechanical/heat-load/multi-room-mixed/darwin-4rm/task.toml
+++ b/tasks/mechanical/heat-load/multi-room-mixed/darwin-4rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b2e-73a5-8fd2-cc941c6a8616"
+key = "mechanical/heat-load/multi-room-mixed/darwin-4rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "multi-room", "with-tool", "AS-1668-2"]

--- a/tasks/mechanical/heat-load/multi-room-mixed/hobart-5rm/task.toml
+++ b/tasks/mechanical/heat-load/multi-room-mixed/hobart-5rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b2e-7ef6-ba74-ff26c3f6935b"
+key = "mechanical/heat-load/multi-room-mixed/hobart-5rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "multi-room", "with-tool", "AS-1668-2"]

--- a/tasks/mechanical/heat-load/multi-room-mixed/melbourne-6rm/task.toml
+++ b/tasks/mechanical/heat-load/multi-room-mixed/melbourne-6rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b2f-79b5-b607-3c727890a0b7"
+key = "mechanical/heat-load/multi-room-mixed/melbourne-6rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "multi-room", "with-tool", "AS-1668-2"]

--- a/tasks/mechanical/heat-load/multi-room-mixed/perth-7rm/task.toml
+++ b/tasks/mechanical/heat-load/multi-room-mixed/perth-7rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b2f-7a9e-a8fe-c77316fefb78"
+key = "mechanical/heat-load/multi-room-mixed/perth-7rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "multi-room", "with-tool", "AS-1668-2"]

--- a/tasks/mechanical/heat-load/multi-room-mixed/sydney-5rm/task.toml
+++ b/tasks/mechanical/heat-load/multi-room-mixed/sydney-5rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b2f-7920-91ea-5cb6dae929ff"
+key = "mechanical/heat-load/multi-room-mixed/sydney-5rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "multi-room", "with-tool", "AS-1668-2"]

--- a/tasks/mechanical/heat-load/multi-room-mixed/townsville-6rm/task.toml
+++ b/tasks/mechanical/heat-load/multi-room-mixed/townsville-6rm/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b2f-7ddc-8f24-4f019a838a33"
+key = "mechanical/heat-load/multi-room-mixed/townsville-6rm"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "multi-room", "with-tool", "AS-1668-2"]

--- a/tasks/mechanical/heat-load/single-room-office-L0/adelaide-library-150m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L0/adelaide-library-150m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b31-7dd8-9536-f5db5b494c7b"
+key = "mechanical/heat-load/single-room-office-l0/adelaide-library-150m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "hard"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L0"]

--- a/tasks/mechanical/heat-load/single-room-office-L0/brisbane-office-85m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L0/brisbane-office-85m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b31-7dd9-ae1f-69e751abe2ae"
+key = "mechanical/heat-load/single-room-office-l0/brisbane-office-85m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "hard"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L0"]

--- a/tasks/mechanical/heat-load/single-room-office-L0/cairns-server-60m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L0/cairns-server-60m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b32-7194-816d-fe821f809464"
+key = "mechanical/heat-load/single-room-office-l0/cairns-server-60m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "hard"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L0"]

--- a/tasks/mechanical/heat-load/single-room-office-L0/canberra-hotel-40m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L0/canberra-hotel-40m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b32-78a4-882d-dfb9f56ca45d"
+key = "mechanical/heat-load/single-room-office-l0/canberra-hotel-40m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "hard"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L0"]

--- a/tasks/mechanical/heat-load/single-room-office-L0/darwin-gym-300m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L0/darwin-gym-300m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b32-70be-a441-c54124a83b19"
+key = "mechanical/heat-load/single-room-office-l0/darwin-gym-300m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "hard"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L0"]

--- a/tasks/mechanical/heat-load/single-room-office-L0/hobart-retail-100m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L0/hobart-retail-100m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b32-7a06-92c6-462a3ba14eae"
+key = "mechanical/heat-load/single-room-office-l0/hobart-retail-100m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "hard"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L0"]

--- a/tasks/mechanical/heat-load/single-room-office-L0/melbourne-conference-50m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L0/melbourne-conference-50m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b32-7f6b-b6e5-7f2633f9531f"
+key = "mechanical/heat-load/single-room-office-l0/melbourne-conference-50m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "hard"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L0"]

--- a/tasks/mechanical/heat-load/single-room-office-L0/perth-restaurant-200m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L0/perth-restaurant-200m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b33-7d39-a5db-57d7f2f7dfb8"
+key = "mechanical/heat-load/single-room-office-l0/perth-restaurant-200m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "hard"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L0"]

--- a/tasks/mechanical/heat-load/single-room-office-L0/sydney-classroom-120m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L0/sydney-classroom-120m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b33-7ba1-b351-34a22d39ff39"
+key = "mechanical/heat-load/single-room-office-l0/sydney-classroom-120m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "hard"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L0"]

--- a/tasks/mechanical/heat-load/single-room-office-L0/townsville-cafeteria-80m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L0/townsville-cafeteria-80m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b33-7a0d-8e6d-8dbd857a7582"
+key = "mechanical/heat-load/single-room-office-l0/townsville-cafeteria-80m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "hard"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L0"]

--- a/tasks/mechanical/heat-load/single-room-office-L1/adelaide-library-150m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L1/adelaide-library-150m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b33-769b-9b84-9bdc0953e76c"
+key = "mechanical/heat-load/single-room-office-l1/adelaide-library-150m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L1"]

--- a/tasks/mechanical/heat-load/single-room-office-L1/brisbane-office-85m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L1/brisbane-office-85m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b33-7d95-9288-9eeb33a9811c"
+key = "mechanical/heat-load/single-room-office-l1/brisbane-office-85m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L1"]

--- a/tasks/mechanical/heat-load/single-room-office-L1/cairns-server-60m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L1/cairns-server-60m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b34-74a7-b8b8-73cc7a44480a"
+key = "mechanical/heat-load/single-room-office-l1/cairns-server-60m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L1"]

--- a/tasks/mechanical/heat-load/single-room-office-L1/canberra-hotel-40m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L1/canberra-hotel-40m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b34-7dda-9dbe-6c6703c46f9e"
+key = "mechanical/heat-load/single-room-office-l1/canberra-hotel-40m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L1"]

--- a/tasks/mechanical/heat-load/single-room-office-L1/darwin-gym-300m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L1/darwin-gym-300m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b34-7127-99d6-45f3c581b834"
+key = "mechanical/heat-load/single-room-office-l1/darwin-gym-300m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L1"]

--- a/tasks/mechanical/heat-load/single-room-office-L1/hobart-retail-100m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L1/hobart-retail-100m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b34-7032-b0a9-ac24863943d7"
+key = "mechanical/heat-load/single-room-office-l1/hobart-retail-100m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L1"]

--- a/tasks/mechanical/heat-load/single-room-office-L1/melbourne-conference-50m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L1/melbourne-conference-50m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b34-7fd3-b311-6a2df4e40ee0"
+key = "mechanical/heat-load/single-room-office-l1/melbourne-conference-50m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L1"]

--- a/tasks/mechanical/heat-load/single-room-office-L1/perth-restaurant-200m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L1/perth-restaurant-200m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b35-7111-a422-0f7ae6d834ae"
+key = "mechanical/heat-load/single-room-office-l1/perth-restaurant-200m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L1"]

--- a/tasks/mechanical/heat-load/single-room-office-L1/sydney-classroom-120m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L1/sydney-classroom-120m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b35-7954-ae12-42cbf9e8c311"
+key = "mechanical/heat-load/single-room-office-l1/sydney-classroom-120m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L1"]

--- a/tasks/mechanical/heat-load/single-room-office-L1/townsville-cafeteria-80m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L1/townsville-cafeteria-80m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b35-777c-8d33-9574bd12fae2"
+key = "mechanical/heat-load/single-room-office-l1/townsville-cafeteria-80m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L1"]

--- a/tasks/mechanical/heat-load/single-room-office-L2/adelaide-library-150m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L2/adelaide-library-150m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b35-7eac-979b-5833e1941999"
+key = "mechanical/heat-load/single-room-office-l2/adelaide-library-150m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L2"]

--- a/tasks/mechanical/heat-load/single-room-office-L2/brisbane-office-85m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L2/brisbane-office-85m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b35-71bd-9d86-b3a6ace95066"
+key = "mechanical/heat-load/single-room-office-l2/brisbane-office-85m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L2"]

--- a/tasks/mechanical/heat-load/single-room-office-L2/cairns-server-60m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L2/cairns-server-60m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b35-75f5-93c4-f8cd7210bd1d"
+key = "mechanical/heat-load/single-room-office-l2/cairns-server-60m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L2"]

--- a/tasks/mechanical/heat-load/single-room-office-L2/canberra-hotel-40m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L2/canberra-hotel-40m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b36-783e-92ec-7de129268975"
+key = "mechanical/heat-load/single-room-office-l2/canberra-hotel-40m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L2"]

--- a/tasks/mechanical/heat-load/single-room-office-L2/darwin-gym-300m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L2/darwin-gym-300m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b36-7461-97f1-d5be4d211c9f"
+key = "mechanical/heat-load/single-room-office-l2/darwin-gym-300m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L2"]

--- a/tasks/mechanical/heat-load/single-room-office-L2/hobart-retail-100m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L2/hobart-retail-100m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b36-7680-aeb9-ee30e660447f"
+key = "mechanical/heat-load/single-room-office-l2/hobart-retail-100m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L2"]

--- a/tasks/mechanical/heat-load/single-room-office-L2/melbourne-conference-50m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L2/melbourne-conference-50m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b36-758b-a4e0-7a61427c55e8"
+key = "mechanical/heat-load/single-room-office-l2/melbourne-conference-50m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L2"]

--- a/tasks/mechanical/heat-load/single-room-office-L2/perth-restaurant-200m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L2/perth-restaurant-200m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b36-702b-a087-6c7481a3cffe"
+key = "mechanical/heat-load/single-room-office-l2/perth-restaurant-200m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L2"]

--- a/tasks/mechanical/heat-load/single-room-office-L2/sydney-classroom-120m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L2/sydney-classroom-120m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b37-7c57-b42f-cbfd5ff3e6ed"
+key = "mechanical/heat-load/single-room-office-l2/sydney-classroom-120m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L2"]

--- a/tasks/mechanical/heat-load/single-room-office-L2/townsville-cafeteria-80m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L2/townsville-cafeteria-80m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b37-7052-9193-9c6f59df2d16"
+key = "mechanical/heat-load/single-room-office-l2/townsville-cafeteria-80m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L2"]

--- a/tasks/mechanical/heat-load/single-room-office-L3/adelaide-library-150m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L3/adelaide-library-150m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b37-73c4-be31-46ca6e066bc7"
+key = "mechanical/heat-load/single-room-office-l3/adelaide-library-150m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L3"]

--- a/tasks/mechanical/heat-load/single-room-office-L3/brisbane-office-85m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L3/brisbane-office-85m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b37-7550-8dc4-48d4322eb8a3"
+key = "mechanical/heat-load/single-room-office-l3/brisbane-office-85m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L3"]

--- a/tasks/mechanical/heat-load/single-room-office-L3/cairns-server-60m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L3/cairns-server-60m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b37-7b14-a676-89b7b029d351"
+key = "mechanical/heat-load/single-room-office-l3/cairns-server-60m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L3"]

--- a/tasks/mechanical/heat-load/single-room-office-L3/canberra-hotel-40m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L3/canberra-hotel-40m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b37-72fe-a3c0-8f61ddd11c98"
+key = "mechanical/heat-load/single-room-office-l3/canberra-hotel-40m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L3"]

--- a/tasks/mechanical/heat-load/single-room-office-L3/darwin-gym-300m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L3/darwin-gym-300m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b38-7d68-bcdf-deabbf853e78"
+key = "mechanical/heat-load/single-room-office-l3/darwin-gym-300m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L3"]

--- a/tasks/mechanical/heat-load/single-room-office-L3/hobart-retail-100m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L3/hobart-retail-100m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b38-7f09-8869-00259c0f2484"
+key = "mechanical/heat-load/single-room-office-l3/hobart-retail-100m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L3"]

--- a/tasks/mechanical/heat-load/single-room-office-L3/melbourne-conference-50m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L3/melbourne-conference-50m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b38-7209-918d-b8dc58b32f12"
+key = "mechanical/heat-load/single-room-office-l3/melbourne-conference-50m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L3"]

--- a/tasks/mechanical/heat-load/single-room-office-L3/perth-restaurant-200m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L3/perth-restaurant-200m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b38-7403-b384-2cd319a00896"
+key = "mechanical/heat-load/single-room-office-l3/perth-restaurant-200m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L3"]

--- a/tasks/mechanical/heat-load/single-room-office-L3/sydney-classroom-120m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L3/sydney-classroom-120m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b39-7a21-8a1a-84c1c6669bea"
+key = "mechanical/heat-load/single-room-office-l3/sydney-classroom-120m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L3"]

--- a/tasks/mechanical/heat-load/single-room-office-L3/townsville-cafeteria-80m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-L3/townsville-cafeteria-80m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b39-7c95-be09-4108ef7832a6"
+key = "mechanical/heat-load/single-room-office-l3/townsville-cafeteria-80m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "medium"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool", "ablation-L3"]

--- a/tasks/mechanical/heat-load/single-room-office-no-tool/adelaide-library-150m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-no-tool/adelaide-library-150m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b39-7ce7-943a-58c21858eeac"
+key = "mechanical/heat-load/single-room-office-no-tool/adelaide-library-150m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "easy"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool"]

--- a/tasks/mechanical/heat-load/single-room-office-no-tool/brisbane-office-85m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-no-tool/brisbane-office-85m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b39-70f9-9a4d-88169fc5baad"
+key = "mechanical/heat-load/single-room-office-no-tool/brisbane-office-85m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "easy"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool"]

--- a/tasks/mechanical/heat-load/single-room-office-no-tool/cairns-server-60m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-no-tool/cairns-server-60m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b3a-72bf-8681-c6a6685726ba"
+key = "mechanical/heat-load/single-room-office-no-tool/cairns-server-60m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "easy"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool"]

--- a/tasks/mechanical/heat-load/single-room-office-no-tool/canberra-hotel-40m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-no-tool/canberra-hotel-40m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b3a-7252-9039-eda9c5b322e5"
+key = "mechanical/heat-load/single-room-office-no-tool/canberra-hotel-40m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "easy"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool"]

--- a/tasks/mechanical/heat-load/single-room-office-no-tool/darwin-gym-300m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-no-tool/darwin-gym-300m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b3a-763c-8502-b584df33bb7e"
+key = "mechanical/heat-load/single-room-office-no-tool/darwin-gym-300m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "easy"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool"]

--- a/tasks/mechanical/heat-load/single-room-office-no-tool/hobart-retail-100m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-no-tool/hobart-retail-100m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b3a-7b99-bfcf-4827c952f23a"
+key = "mechanical/heat-load/single-room-office-no-tool/hobart-retail-100m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "easy"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool"]

--- a/tasks/mechanical/heat-load/single-room-office-no-tool/melbourne-conference-50m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-no-tool/melbourne-conference-50m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b3a-7a30-aa72-b18195d675cc"
+key = "mechanical/heat-load/single-room-office-no-tool/melbourne-conference-50m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "easy"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool"]

--- a/tasks/mechanical/heat-load/single-room-office-no-tool/perth-restaurant-200m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-no-tool/perth-restaurant-200m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b3b-75f7-95ae-fde8d694f8d1"
+key = "mechanical/heat-load/single-room-office-no-tool/perth-restaurant-200m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "easy"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool"]

--- a/tasks/mechanical/heat-load/single-room-office-no-tool/sydney-classroom-120m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-no-tool/sydney-classroom-120m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b3b-750f-8447-8f408c64ff30"
+key = "mechanical/heat-load/single-room-office-no-tool/sydney-classroom-120m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "easy"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool"]

--- a/tasks/mechanical/heat-load/single-room-office-no-tool/townsville-cafeteria-80m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office-no-tool/townsville-cafeteria-80m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b3b-773b-a89b-027c8a791f90"
+key = "mechanical/heat-load/single-room-office-no-tool/townsville-cafeteria-80m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "easy"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "no-tool"]

--- a/tasks/mechanical/heat-load/single-room-office/adelaide-library-150m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office/adelaide-library-150m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b2f-746d-bd7a-d6a1e5e18bc2"
+key = "mechanical/heat-load/single-room-office/adelaide-library-150m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "easy"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "with-tool"]

--- a/tasks/mechanical/heat-load/single-room-office/brisbane-office-85m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office/brisbane-office-85m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b30-7878-9834-b429d0c3975a"
+key = "mechanical/heat-load/single-room-office/brisbane-office-85m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "easy"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "with-tool"]

--- a/tasks/mechanical/heat-load/single-room-office/cairns-server-60m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office/cairns-server-60m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b30-79c2-b565-e1ccacff6bc4"
+key = "mechanical/heat-load/single-room-office/cairns-server-60m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "easy"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "with-tool"]

--- a/tasks/mechanical/heat-load/single-room-office/canberra-hotel-40m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office/canberra-hotel-40m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b30-7cad-8abc-a2b40c9bb89c"
+key = "mechanical/heat-load/single-room-office/canberra-hotel-40m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "easy"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "with-tool"]

--- a/tasks/mechanical/heat-load/single-room-office/darwin-gym-300m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office/darwin-gym-300m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b30-7d0b-8ae1-0e07a38a56a1"
+key = "mechanical/heat-load/single-room-office/darwin-gym-300m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "easy"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "with-tool"]

--- a/tasks/mechanical/heat-load/single-room-office/hobart-retail-100m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office/hobart-retail-100m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b30-7afe-a1bc-1c241e25adff"
+key = "mechanical/heat-load/single-room-office/hobart-retail-100m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "easy"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "with-tool"]

--- a/tasks/mechanical/heat-load/single-room-office/melbourne-conference-50m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office/melbourne-conference-50m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b30-7a7b-b9c0-c6087dd0f3a8"
+key = "mechanical/heat-load/single-room-office/melbourne-conference-50m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "easy"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "with-tool"]

--- a/tasks/mechanical/heat-load/single-room-office/perth-restaurant-200m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office/perth-restaurant-200m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b31-7688-b54d-ccb29eef91c0"
+key = "mechanical/heat-load/single-room-office/perth-restaurant-200m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "easy"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "with-tool"]

--- a/tasks/mechanical/heat-load/single-room-office/sydney-classroom-120m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office/sydney-classroom-120m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b31-745c-b20a-f8020103e549"
+key = "mechanical/heat-load/single-room-office/sydney-classroom-120m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "easy"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "with-tool"]

--- a/tasks/mechanical/heat-load/single-room-office/townsville-cafeteria-80m2/task.toml
+++ b/tasks/mechanical/heat-load/single-room-office/townsville-cafeteria-80m2/task.toml
@@ -1,6 +1,13 @@
 version = "1.0"
 
+[identity]
+id = "01a04c6c-4b31-7684-afbe-d663faa1b616"
+key = "mechanical/heat-load/single-room-office/townsville-cafeteria-80m2"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
+visibility = "public"
 difficulty = "easy"
 category = "reasoning"
 tags = ["mechanical", "hvac", "heat-load", "deterministic", "AS-1668-2", "with-tool"]

--- a/tasks/mechanical/pump-sizing/pump-power-calculation/water-pump-station-water-pump-00/task.toml
+++ b/tasks/mechanical/pump-sizing/pump-power-calculation/water-pump-station-water-pump-00/task.toml
@@ -1,4 +1,10 @@
+[identity]
+id = "01a04c6c-4b3b-71b7-a488-8e5e46c576f6"
+key = "mechanical/pump-sizing/pump-power-calculation/water-pump-station-water-pump-00"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
 domain = "mechanical"
 category = "pump-sizing"
 difficulty = "easy"

--- a/tasks/mechanical/stormwater-pump-control/stormwater-pump-station-control-backup-energy-package/stormwater-pump-station-stormwater-pump-control-energy-case-00/task.toml
+++ b/tasks/mechanical/stormwater-pump-control/stormwater-pump-station-control-backup-energy-package/stormwater-pump-station-stormwater-pump-control-energy-case-00/task.toml
@@ -1,4 +1,10 @@
+[identity]
+id = "01a04c6c-4b3c-73d0-ade9-ad8299c3fd08"
+key = "mechanical/stormwater-pump-control/stormwater-pump-station-control-backup-energy-package/stormwater-pump-station-stormwater-pump-control-energy-case-00"
+version = 1
+
 [metadata]
+lifecycle = "proposed"
 domain = "mechanical"
 category = "stormwater-pump-control"
 difficulty = "easy"

--- a/tests/tasks/test_loader.py
+++ b/tests/tasks/test_loader.py
@@ -15,7 +15,7 @@ def test_loader_reads_real_mechanical_instance() -> None:
 
     task = load_task_definition(instance_dir, TASKS_ROOT)
 
-    assert task.task_id == "mechanical/heat-load/single-room-office-L2/adelaide-library-150m2"
+    assert task.task_id == "mechanical/heat-load/single-room-office-l2/adelaide-library-150m2"
     assert task.task_type == "heat-load"
     assert task.domain == "mechanical"
     assert task.category == "reasoning"

--- a/tests/tasks/test_metadata_migration.py
+++ b/tests/tasks/test_metadata_migration.py
@@ -2,6 +2,7 @@
 # ABOUTME: Verifies bounded legacy compatibility, missing-policy errors, and stable report output.
 
 import os
+import tomllib
 from pathlib import Path
 from unittest.mock import patch
 from uuid import UUID
@@ -10,8 +11,18 @@ import pytest
 
 from aec_bench.contracts.identity import EntityKind, new_entity_id, validate_uuidv7
 from aec_bench.tasks import metadata_migration
-from aec_bench.tasks.loader import LoadError, load_legacy_task_definition, load_task_definition, parse_task_metadata
+from aec_bench.tasks.loader import (
+    LoadError,
+    derive_task_id,
+    iter_task_instance_dirs,
+    load_legacy_task_definition,
+    load_task_catalog,
+    load_task_definition,
+    parse_task_metadata,
+)
 from aec_bench.tasks.metadata_migration import generate_task_metadata_migration_report
+
+TASKS_ROOT = Path(__file__).resolve().parents[2] / "tasks"
 
 
 def _write_task(
@@ -230,3 +241,42 @@ def test_migration_report_keeps_existing_bytes_when_replacement_fails(tmp_path: 
 
     assert report_path.read_bytes() == original_bytes
     assert list(report_path.parent.glob(f".{report_path.name}.*.tmp")) == []
+
+
+def test_repository_tasks_have_complete_explicit_metadata_and_strict_loader_success(tmp_path: Path) -> None:
+    report_path = tmp_path / "task-metadata-report.json"
+
+    first_report = generate_task_metadata_migration_report(TASKS_ROOT, report_path)
+    first_bytes = report_path.read_bytes()
+    second_report = generate_task_metadata_migration_report(TASKS_ROOT, report_path)
+    catalogue = load_task_catalog(TASKS_ROOT)
+
+    assert first_report == second_report
+    assert report_path.read_bytes() == first_bytes
+    assert len(first_report.tasks) == len(iter_task_instance_dirs(TASKS_ROOT))
+    assert len(catalogue) == len(first_report.tasks)
+    assert len({entry.generated_uuid for entry in first_report.tasks}) == len(first_report.tasks)
+    assert len({entry.proposed_key for entry in first_report.tasks}) == len(first_report.tasks)
+
+    entries_by_path = {entry.current_path: entry for entry in first_report.tasks}
+    for task_dir in iter_task_instance_dirs(TASKS_ROOT):
+        current_path = derive_task_id(task_dir, TASKS_ROOT)
+        entry = entries_by_path[current_path]
+        task = catalogue[entry.proposed_key]
+        assert task.identity is not None
+        assert str(task.identity.id) == str(entry.generated_uuid)
+        assert str(task.identity.key) == entry.proposed_key
+        assert task.task_id == entry.proposed_key
+        assert task.identity.version == 1
+        assert task.lifecycle.value == "proposed"
+        assert task.visibility.value == "public"
+
+        raw_toml = tomllib.loads((task_dir / "task.toml").read_text(encoding="utf-8"))
+        assert raw_toml.get("version") in {None, "1.0"}
+        assert raw_toml["identity"] == {
+            "id": str(entry.generated_uuid),
+            "key": entry.proposed_key,
+            "version": 1,
+        }
+        assert raw_toml["metadata"]["lifecycle"] == "proposed"
+        assert raw_toml["metadata"]["visibility"] == "public"


### PR DESCRIPTION
## Summary

- add stable UUIDv7 identity, canonical key, and version 1 to all 155 maintained task packages
- record the reviewed lifecycle and visibility policy explicitly: proposed and public
- use one canonical path-to-key rule for legacy uppercase task directory components
- add repository-wide regression coverage for complete metadata, uniqueness, strict loading, and stable reports

## Review guide

This is PR 3 of the PRD 1 stack. Review the loader and regression test first. The 155 task-file edits are mechanical additions from the approved migration report. No existing task metadata was removed.

## Evidence

- 155 task files match the approved report
- 155 unique UUIDv7 values and 155 unique canonical keys
- tests/tasks/: 117 passed
- focused loader and migration tests: 37 passed
- Ruff check and format check passed
- mypy passed for all changed Python files
- git diff --check passed

## Policy decision

Theo approved lifecycle = proposed and visibility = public for all maintained repository tasks.