### PR TITLE
Enforce task lifecycle and visibility selection

### DIFF
--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -69,6 +69,13 @@ During the repository migration, files without `[identity]` use the named
 current legacy defaults and does not allocate a UUID; those defaults do not
 apply to the explicit metadata contract.
 
+`TaskSelector.lifecycle_filter` defaults to `active` and is passed unchanged to
+task selection. `deprecated` requires explicit inclusion. Proposed and retired
+tasks are rejected at selection and again before a new trial plan is created.
+`TaskSelector.visibility_filter` defaults to `public`; private and holdout tasks
+require explicit visibility context, and a public selection does not include
+holdout tasks.
+
 Maintained task packages now record the canonical key from their repository
 path. The key uses the identity rules, so legacy path components such as
 `L2` are represented as lowercase `l2`; the filesystem path remains unchanged.
@@ -867,7 +874,7 @@ and discovery only. There is no current response field named generic `version`,
 
 ## Visibility classification
 
-`Visibility.PUBLIC` and `Visibility.HOLDOUT` are independent of lifecycle,
+`Visibility.PUBLIC`, `Visibility.PRIVATE`, and `Visibility.HOLDOUT` are independent of lifecycle,
 difficulty, task name, and storage path. Importers and evaluators preserve the
 explicit value. Historical records that omit visibility remain unknown and are
 ineligible for operations that require a public or holdout classification.

--- a/src/aec_bench/cli/commands/run.py
+++ b/src/aec_bench/cli/commands/run.py
@@ -331,6 +331,7 @@ def _execute_manifest(
         agents=manifest.agents,
         compute=manifest.compute,
         repetitions=manifest.repetitions,
+        permitted_visibility=manifest.tasks.visibility_filter,
     )
 
     from aec_bench.contracts.task_definition import TaskDefinition

--- a/src/aec_bench/contracts/experiment_manifest.py
+++ b/src/aec_bench/contracts/experiment_manifest.py
@@ -6,7 +6,7 @@ from typing import Any
 from pydantic import Field, PositiveInt, field_validator, model_validator
 
 from aec_bench.contracts.dataset import DatasetRef
-from aec_bench.contracts.task_definition import Difficulty, Lifecycle
+from aec_bench.contracts.task_definition import Difficulty, Lifecycle, Visibility
 from aec_bench.contracts.validators import (
     NonEmptyStr,
     StrictModel,
@@ -22,6 +22,7 @@ class TaskSelector(StrictModel):
     domains: list[str] = Field(default_factory=list)
     difficulties: list[Difficulty] = Field(default_factory=list)
     lifecycle_filter: list[Lifecycle] = Field(default_factory=lambda: [Lifecycle.ACTIVE])
+    visibility_filter: list[Visibility] = Field(default_factory=lambda: [Visibility.PUBLIC])
 
     @field_validator("lifecycle_filter")
     @classmethod

--- a/src/aec_bench/experimentation/qualification/run_bundle_scored_attempt.py
+++ b/src/aec_bench/experimentation/qualification/run_bundle_scored_attempt.py
@@ -749,6 +749,7 @@ def _reconcile_dispatch(
                     agents=lowered.manifest.agents,
                     compute=lowered.manifest.compute,
                     repetitions=lowered.manifest.repetitions,
+                    permitted_visibility=lowered.manifest.tasks.visibility_filter,
                 )
             ),
             exit_code=0,

--- a/src/aec_bench/harness/experiment_runner.py
+++ b/src/aec_bench/harness/experiment_runner.py
@@ -58,6 +58,7 @@ class HarborImportExperimentRunner:
             agents=manifest.agents,
             compute=manifest.compute,
             repetitions=manifest.repetitions,
+            permitted_visibility=manifest.tasks.visibility_filter,
         )
         tracker = ImportProgressTracker(
             experiment_id=manifest.experiment_id,

--- a/src/aec_bench/harness/harbor_dispatch.py
+++ b/src/aec_bench/harness/harbor_dispatch.py
@@ -17,6 +17,7 @@ from aec_bench.contracts.execution_environment import HarborEnvironmentBinding
 from aec_bench.contracts.experiment_manifest import AgentConfig, ExperimentManifest
 from aec_bench.contracts.task_definition import TaskDefinition
 from aec_bench.harness.execution_payload import ExecutionBundle, build_entrypoint_execution_bundle
+from aec_bench.tasks.selector import validate_execution_tasks
 from aec_bench.trials import plan_trials
 
 HARBOR_NATIVE_BACKENDS = ("modal", "e2b", "daytona", "docker")
@@ -122,6 +123,7 @@ class HarborExperimentDispatcher:
     ) -> HarborDispatchResult:
         if not tasks:
             raise HarborDispatchError("manifest did not select any tasks for Harbor dispatch")
+        validate_execution_tasks(tasks, permitted_visibility=manifest.tasks.visibility_filter)
         overrides = dict(task_path_overrides or {})
         feedback_tasks = tuple(
             task.task_id
@@ -148,6 +150,7 @@ class HarborExperimentDispatcher:
             agents=manifest.agents,
             compute=manifest.compute,
             repetitions=manifest.repetitions,
+            permitted_visibility=manifest.tasks.visibility_filter,
         )
         return dispatch_harbor_config(
             config=job_config,

--- a/src/aec_bench/harness/harbor_runtime.py
+++ b/src/aec_bench/harness/harbor_runtime.py
@@ -50,6 +50,7 @@ class HarborExperimentRuntime:
             agents=effective_manifest.agents,
             compute=effective_manifest.compute,
             repetitions=effective_manifest.repetitions,
+            permitted_visibility=effective_manifest.tasks.visibility_filter,
         )
         if list(trials) != expected_trials:
             raise ValueError("planned trials do not match the Harbor experiment manifest")

--- a/src/aec_bench/harness/harbor_workflow.py
+++ b/src/aec_bench/harness/harbor_workflow.py
@@ -127,6 +127,7 @@ class SynchronousHarborWorkflow:
                     agents=manifest.agents,
                     compute=manifest.compute,
                     repetitions=manifest.repetitions,
+                    permitted_visibility=manifest.tasks.visibility_filter,
                 )
             ),
         )
@@ -192,6 +193,7 @@ class SynchronousHarborWorkflow:
             agents=manifest.agents,
             compute=manifest.compute,
             repetitions=manifest.repetitions,
+            permitted_visibility=manifest.tasks.visibility_filter,
         )
         progress_tracker = WorkflowProgressTracker(
             experiment_id=manifest.experiment_id,

--- a/src/aec_bench/harness/scheduler.py
+++ b/src/aec_bench/harness/scheduler.py
@@ -5,8 +5,8 @@ from collections.abc import Sequence
 from pathlib import Path
 
 from aec_bench.contracts.experiment_manifest import ExperimentManifest
-from aec_bench.contracts.task_definition import Lifecycle, TaskDefinition
-from aec_bench.tasks.selector import select_tasks
+from aec_bench.contracts.task_definition import TaskDefinition
+from aec_bench.tasks.selector import select_tasks, validate_execution_tasks
 from aec_bench.trials import PlannedTrial
 from aec_bench.worlds.tasks import WorldTask
 
@@ -74,19 +74,17 @@ def select_manifest_task_values(
             tasks_root=tasks_root or resolved_project / "tasks",
         )
 
-    return select_tasks(
+    selected = select_tasks(
         tasks,
         domains=manifest.tasks.domains or None,
         difficulties=manifest.tasks.difficulties or None,
         include_patterns=manifest.tasks.include_patterns or None,
         exclude_patterns=manifest.tasks.exclude_patterns or None,
-        lifecycle=[
-            Lifecycle.PROPOSED,
-            Lifecycle.ACTIVE,
-            Lifecycle.DEPRECATED,
-            Lifecycle.RETIRED,
-        ],
+        lifecycle=manifest.tasks.lifecycle_filter,
+        visibility=manifest.tasks.visibility_filter,
     )
+    validate_execution_tasks(selected, permitted_visibility=manifest.tasks.visibility_filter)
+    return selected
 
 
 def batch_planned_trials(

--- a/src/aec_bench/init/skill_data/configure-experiment/SKILL.md
+++ b/src/aec_bench/init/skill_data/configure-experiment/SKILL.md
@@ -174,7 +174,11 @@ Write to `experiment.yaml` in the project root (or a user-chosen filename).
 
 Show the file contents with YAML syntax highlighting.
 
-Important: do NOT include `lifecycle_filter` in the YAML — it's in the contract but not consumed by the scheduler.
+The generated YAML may include `lifecycle_filter` and `visibility_filter` under
+`tasks`. `lifecycle_filter` defaults to `[active]`; add `deprecated` only when
+you explicitly want deprecated tasks. Proposed and retired tasks are rejected
+before a new run. `visibility_filter` defaults to `[public]`; private and
+holdout tasks require an explicit permitted visibility context.
 
 ### Step 6 — Dry Run
 

--- a/src/aec_bench/init/skill_data/configure-experiment/references/manifest-schema.md
+++ b/src/aec_bench/init/skill_data/configure-experiment/references/manifest-schema.md
@@ -24,7 +24,8 @@ Controls which tasks are included in the experiment.
 | `domains` | list[string] | No | [] | Discipline filter. Values come from the task directory structure (e.g., `civil`, `electrical`, `ground`, `maritime`, `mechanical`, `structural`). Empty means all domains. |
 | `difficulties` | list[string] | No | [] | Difficulty filter: `easy`, `medium`, `hard`. Empty means all difficulties. |
 
-**Note:** The contract also has a `lifecycle_filter` field, but it is not currently consumed by the scheduler. Do not include it in generated YAML.
+| `lifecycle_filter` | list[string] | No | [`active`] | Lifecycle filter passed to task selection. `deprecated` requires explicit opt-in; `proposed` and `retired` are rejected for new runs. |
+| `visibility_filter` | list[string] | No | [`public`] | Visibility context passed to task selection. Private and holdout tasks require explicit inclusion; public runs do not include holdout tasks. |
 
 ## agents (list of AgentConfig)
 

--- a/src/aec_bench/tasks/selector.py
+++ b/src/aec_bench/tasks/selector.py
@@ -31,6 +31,24 @@ class SelectableTask(Protocol):
 SelectableTaskT = TypeVar("SelectableTaskT", bound=SelectableTask)
 
 
+def validate_execution_tasks(
+    tasks: Sequence[SelectableTask],
+    *,
+    permitted_visibility: Sequence[Visibility] = (Visibility.PUBLIC,),
+) -> None:
+    """Reject task values that cannot enter a new execution plan."""
+
+    allowed_visibility = frozenset(permitted_visibility)
+    for task in tasks:
+        if task.lifecycle in {Lifecycle.PROPOSED, Lifecycle.RETIRED}:
+            raise ValueError(f"task {task.task_id!r} has lifecycle {task.lifecycle.value!r} and cannot start a new run")
+        if task.visibility not in allowed_visibility:
+            raise ValueError(
+                f"task {task.task_id!r} has visibility {task.visibility.value!r}; "
+                "an explicit permitted visibility context is required"
+            )
+
+
 def select_tasks(
     tasks: list[SelectableTaskT],
     *,

--- a/src/aec_bench/trials.py
+++ b/src/aec_bench/trials.py
@@ -10,6 +10,8 @@ from typing import Any, Protocol
 from pydantic import BaseModel
 
 from aec_bench.contracts.experiment_manifest import AgentConfig, ComputeConfig
+from aec_bench.contracts.task_definition import Visibility
+from aec_bench.tasks.selector import SelectableTask, validate_execution_tasks
 
 
 @dataclass(frozen=True)
@@ -36,11 +38,8 @@ def build_trial_id(
     return f"{experiment_id}--{normalized_task_id}--{agent_name}--rep{repetition:02d}"
 
 
-class PlannableTask(Protocol):
-    """The task identity needed by deterministic trial planning."""
-
-    @property
-    def task_id(self) -> str: ...
+class PlannableTask(SelectableTask, Protocol):
+    """The task identity and execution policy needed by trial planning."""
 
 
 def plan_trials(
@@ -50,6 +49,7 @@ def plan_trials(
     agents: Sequence[AgentConfig],
     compute: ComputeConfig | None = None,
     repetitions: int = 1,
+    permitted_visibility: Sequence[Visibility] = (Visibility.PUBLIC,),
 ) -> list[PlannedTrial]:
     """Expand tasks, agents, and repetitions into stable planned trials."""
 
@@ -59,6 +59,7 @@ def plan_trials(
         raise ValueError("trial planning requires at least one agent")
     if repetitions < 1:
         raise ValueError("repetitions must be positive")
+    validate_execution_tasks(tasks, permitted_visibility=permitted_visibility)
     selected_compute = compute or ComputeConfig(backend="local")
     plan: list[PlannedTrial] = []
     for task in sorted(tasks, key=lambda item: item.task_id):

--- a/tests/contracts/test_experiment_manifest.py
+++ b/tests/contracts/test_experiment_manifest.py
@@ -1,6 +1,8 @@
 # ABOUTME: Tests for ExperimentManifest and related selection/configuration contracts.
 # ABOUTME: These tests define the validated experiment-planning boundary for the harness.
 
+from typing import Any, cast
+
 import pytest
 from pydantic import ValidationError
 
@@ -13,11 +15,11 @@ from aec_bench.contracts.experiment_manifest import (
     ExperimentManifest,
     TaskSelector,
 )
-from aec_bench.contracts.task_definition import Difficulty, Lifecycle
+from aec_bench.contracts.task_definition import Difficulty, Lifecycle, Visibility
 
 
 def _build_manifest(**overrides: object) -> ExperimentManifest:
-    payload: dict = {
+    payload: dict[str, object] = {
         "experiment_id": "experiment-001",
         "name": "Modal smoke run",
         "description": "Validate trustworthy-trial path.",
@@ -55,6 +57,7 @@ def test_experiment_manifest_accepts_valid_payload() -> None:
 
     assert manifest.repetitions == 1
     assert manifest.tasks.lifecycle_filter == [Lifecycle.ACTIVE]
+    assert manifest.tasks.visibility_filter == [Visibility.PUBLIC]
 
 
 def test_agent_config_accepts_explicit_client_config() -> None:
@@ -113,6 +116,12 @@ def test_task_selector_accepts_deprecated_in_lifecycle_filter() -> None:
     selector = TaskSelector(lifecycle_filter=[Lifecycle.DEPRECATED])
 
     assert Lifecycle.DEPRECATED in selector.lifecycle_filter
+
+
+def test_task_selector_accepts_explicit_non_public_visibility_context() -> None:
+    selector = TaskSelector(visibility_filter=[Visibility.PRIVATE, Visibility.HOLDOUT])
+
+    assert selector.visibility_filter == [Visibility.PRIVATE, Visibility.HOLDOUT]
 
 
 def test_agent_config_accepts_harness_as_adapter_synonym() -> None:
@@ -179,7 +188,7 @@ def test_task_selector_accepts_exact_dataset_reference() -> None:
 
 def test_task_selector_rejects_mutable_dataset_selector() -> None:
     with pytest.raises(ValidationError):
-        TaskSelector(dataset="my-suite")
+        TaskSelector(dataset=cast(Any, "my-suite"))
 
 
 def test_task_selector_defaults_dataset_to_none() -> None:

--- a/tests/harness/test_experiment_runner.py
+++ b/tests/harness/test_experiment_runner.py
@@ -15,6 +15,7 @@ from aec_bench.contracts.experiment_manifest import (
     ExperimentManifest,
     TaskSelector,
 )
+from aec_bench.contracts.task_definition import Lifecycle, Visibility
 from aec_bench.contracts.trial_record import (
     AgentReference,
     EnvironmentSnapshot,
@@ -70,7 +71,9 @@ def test_runner_transforms_records_before_validation_and_persistence(tmp_path: P
     monkeypatch.setattr(
         HarborImportExperimentRunner,
         "_selected_tasks",
-        lambda _self, _manifest: [SimpleNamespace(task_id=task_id)],
+        lambda _self, _manifest: [
+            SimpleNamespace(task_id=task_id, lifecycle=Lifecycle.ACTIVE, visibility=Visibility.PUBLIC)
+        ],
     )
     transformed_trial_ids: list[str] = []
 
@@ -165,7 +168,9 @@ def test_runner_returns_replayable_paths_for_identical_duplicate_records(
     monkeypatch.setattr(
         HarborImportExperimentRunner,
         "_selected_tasks",
-        lambda _self, _manifest: [SimpleNamespace(task_id=task_id)],
+        lambda _self, _manifest: [
+            SimpleNamespace(task_id=task_id, lifecycle=Lifecycle.ACTIVE, visibility=Visibility.PUBLIC)
+        ],
     )
     runner = HarborImportExperimentRunner(
         repo_root=tmp_path,

--- a/tests/harness/test_scheduler.py
+++ b/tests/harness/test_scheduler.py
@@ -3,6 +3,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from aec_bench.contracts.dataset import (
     DatasetManifest,
     DatasetTaskEntry,
@@ -13,7 +15,8 @@ from aec_bench.contracts.experiment_manifest import (
     ExperimentManifest,
     TaskSelector,
 )
-from aec_bench.contracts.task_definition import Difficulty
+from aec_bench.contracts.identity import new_entity_id
+from aec_bench.contracts.task_definition import Difficulty, Lifecycle, Visibility
 from aec_bench.dataset.publication import publish_dataset
 from aec_bench.dataset.storage import save_dataset
 from aec_bench.harness.scheduler import (
@@ -40,7 +43,7 @@ def _make_dataset_manifest(
     return DatasetManifest(
         dataset_id=name,
         description="Test dataset",
-        tasks=tasks,
+        tasks=tuple(tasks),
     )
 
 
@@ -146,7 +149,14 @@ def test_select_manifest_tasks_filters_by_dataset_when_set(tmp_path: Path) -> No
     project_root = tmp_path / "project"
     task_directory = project_root / "tasks/electrical/voltage-drop/alpha"
     task_directory.mkdir(parents=True)
-    (task_directory / "task.toml").write_text("[metadata]\n", encoding="utf-8")
+    (task_directory / "task.toml").write_text(
+        "[identity]\n"
+        f'id = "{new_entity_id("task")}"\n'
+        'key = "electrical/voltage-drop/alpha"\n'
+        "version = 1\n\n"
+        '[metadata]\nlifecycle = "active"\nvisibility = "public"\n',
+        encoding="utf-8",
+    )
     (task_directory / "instruction.md").write_text("Complete the task.\n", encoding="utf-8")
     (task_directory / "tests").mkdir()
     (task_directory / "tests/test.sh").write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
@@ -185,7 +195,14 @@ def test_select_manifest_tasks_loads_dataset_task_from_declared_path(tmp_path: P
     project_root = tmp_path / "project"
     task_directory = project_root / "tasks/electrical/voltage-drop/missing"
     task_directory.mkdir(parents=True)
-    (task_directory / "task.toml").write_text("[metadata]\n", encoding="utf-8")
+    (task_directory / "task.toml").write_text(
+        "[identity]\n"
+        f'id = "{new_entity_id("task")}"\n'
+        'key = "electrical/voltage-drop/missing"\n'
+        "version = 1\n\n"
+        '[metadata]\nlifecycle = "active"\nvisibility = "public"\n',
+        encoding="utf-8",
+    )
     (task_directory / "instruction.md").write_text("Complete the task.\n", encoding="utf-8")
     (task_directory / "tests").mkdir()
     (task_directory / "tests/test.sh").write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
@@ -230,3 +247,101 @@ def test_select_manifest_tasks_without_dataset_field_is_unchanged() -> None:
     selected = select_manifest_tasks(tasks, manifest)
 
     assert [task.task_id for task in selected] == ["electrical/voltage-drop/alpha"]
+
+
+def test_manifest_selection_defaults_to_active_public_tasks() -> None:
+    tasks = [
+        make_task_definition(task_id="electrical/active", lifecycle=Lifecycle.ACTIVE),
+        make_task_definition(task_id="electrical/deprecated", lifecycle=Lifecycle.DEPRECATED),
+        make_task_definition(task_id="electrical/private", visibility=Visibility.PRIVATE),
+        make_task_definition(task_id="electrical/holdout", visibility=Visibility.HOLDOUT),
+    ]
+    manifest = ExperimentManifest(
+        experiment_id="experiment-001",
+        name="Default policy",
+        tasks=TaskSelector(),
+        agents=[AgentConfig(name="agent-a", adapter="tool_loop", model="gpt-5.4")],
+        compute=ComputeConfig(backend="modal"),
+    )
+
+    selected = select_manifest_tasks(tasks, manifest)
+
+    assert [task.task_id for task in selected] == ["electrical/active"]
+
+
+def test_manifest_selection_requires_explicit_deprecated_opt_in() -> None:
+    task = make_task_definition(task_id="electrical/deprecated", lifecycle=Lifecycle.DEPRECATED)
+    manifest = ExperimentManifest(
+        experiment_id="experiment-001",
+        name="Deprecated policy",
+        tasks=TaskSelector(lifecycle_filter=[Lifecycle.DEPRECATED]),
+        agents=[AgentConfig(name="agent-a", adapter="tool_loop", model="gpt-5.4")],
+        compute=ComputeConfig(backend="modal"),
+    )
+
+    assert select_manifest_tasks([task], manifest) == [task]
+
+
+@pytest.mark.parametrize("lifecycle", [Lifecycle.PROPOSED, Lifecycle.RETIRED])
+def test_manifest_selection_rejects_proposed_and_retired_tasks(lifecycle: Lifecycle) -> None:
+    task = make_task_definition(task_id=f"electrical/{lifecycle.value}", lifecycle=lifecycle)
+    manifest = ExperimentManifest.model_construct(
+        experiment_id="experiment-001",
+        name="Forbidden lifecycle policy",
+        tasks=TaskSelector.model_construct(
+            dataset=None,
+            include_patterns=[],
+            exclude_patterns=[],
+            domains=[],
+            difficulties=[],
+            lifecycle_filter=[lifecycle],
+            visibility_filter=[Visibility.PUBLIC],
+        ),
+        agents=[AgentConfig(name="agent-a", adapter="tool_loop", model="gpt-5.4")],
+        compute=ComputeConfig(backend="modal"),
+        repetitions=1,
+        disable_verification=False,
+        description=None,
+        reviewer=None,
+    )
+
+    with pytest.raises(ValueError, match=f"{lifecycle.value}.*cannot start"):
+        select_manifest_tasks([task], manifest)
+
+
+def test_manifest_selection_allows_non_public_tasks_only_with_explicit_context() -> None:
+    task = make_task_definition(task_id="electrical/holdout", visibility=Visibility.HOLDOUT)
+    manifest = ExperimentManifest(
+        experiment_id="experiment-001",
+        name="Holdout policy",
+        tasks=TaskSelector(visibility_filter=[Visibility.HOLDOUT]),
+        agents=[AgentConfig(name="agent-a", adapter="tool_loop", model="gpt-5.4")],
+        compute=ComputeConfig(backend="modal"),
+    )
+
+    assert select_manifest_tasks([task], manifest) == [task]
+
+
+def test_plan_trials_rejects_forbidden_lifecycle_and_visibility_without_context() -> None:
+    agent = AgentConfig(name="agent-a", adapter="direct", model="test-model")
+
+    with pytest.raises(ValueError, match="proposed.*cannot start"):
+        plan_trials("forbidden", tasks=[make_task_definition(lifecycle=Lifecycle.PROPOSED)], agents=[agent])
+    with pytest.raises(ValueError, match="retired.*cannot start"):
+        plan_trials("forbidden", tasks=[make_task_definition(lifecycle=Lifecycle.RETIRED)], agents=[agent])
+    with pytest.raises(ValueError, match="holdout.*explicit permitted"):
+        plan_trials("forbidden", tasks=[make_task_definition(visibility=Visibility.HOLDOUT)], agents=[agent])
+
+
+def test_plan_trials_accepts_explicit_holdout_context() -> None:
+    agent = AgentConfig(name="agent-a", adapter="direct", model="test-model")
+    task = make_task_definition(visibility=Visibility.HOLDOUT)
+
+    plan = plan_trials(
+        "permitted",
+        tasks=[task],
+        agents=[agent],
+        permitted_visibility=[Visibility.HOLDOUT],
+    )
+
+    assert len(plan) == 1


### PR DESCRIPTION
## Summary

- pass manifest lifecycle filters unchanged to task selection
- default new runs to active and public tasks
- require explicit opt-in for deprecated, private, and holdout tasks
- reject proposed and retired tasks during selection and again before planning or Harbor dispatch
- update experiment-authoring guidance to describe the enforced filters

## Review guide

This is PR 4 of the PRD 1 stack. Start with the scheduler, selector policy, and plan_trials guard. The remaining call-site edits forward the manifest visibility context to the shared planning boundary.

## Evidence

- focused tests: 62 passed, 3 skipped
- broader task and contract checks: 156 passed
- Ruff check and format check passed
- relevant mypy checks passed
- git diff --check passed
- optional Harbor integration tests are delegated to CI because the local environment lacks Harbor packages

## Assumption

visibility_filter = [public] is the default public execution context. Private and holdout tasks require explicit inclusion.