### PR TITLE
Add task authoring diagnostics

### DIFF
--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -81,6 +81,16 @@ Maintained task packages now record the canonical key from their repository
 path. The key uses the identity rules, so legacy path components such as
 `L2` are represented as lowercase `l2`; the filesystem path remains unchanged.
 
+The task authoring commands expose this contract for review. `aec-bench task
+validate <task-path>` reports the display identity, task version, lifecycle,
+visibility, runnable state, verifier entrypoint and verifier protocol version,
+plus classified errors and warnings. `aec-bench task explain <task-key-or-id>`
+resolves the canonical key, aliases, UUID, version, policy, output contract,
+and verifier. `aec-bench task migrate-metadata --check` writes and displays a
+stable migration report, including unresolved reviewer decisions, without
+changing task files. `--write` changes identity only when lifecycle and
+visibility are already explicit and supported; it refuses to invent policy.
+
 Executable interactive worlds use their registered world definition and
 profile instead of pretending to be a static `TaskDefinition`. Both families
 can still enter the same experiment, trial, evaluation, and reporting layers.

--- a/provenance-registry.toml
+++ b/provenance-registry.toml
@@ -805,6 +805,50 @@ compatibility_behavior = "reject unsupported protocol versions"
 compatibility_kind = "protocol"
 
 [[field]]
+symbol = "aec_bench.cli.commands.task._task_authoring_details.verifier_version"
+aliases = ["mapping:aec_bench.cli.commands.task._task_authoring_details.verifier_version", "mapping:aec_bench.cli.commands.task.explain_command.verifier.version"]
+surface = "mapping"
+wire_name = "verifier_version"
+category = "compatibility"
+domain_owner = "task_authoring"
+authority = "verifier_protocol"
+authoritative = true
+exposure = "public"
+status = "current"
+payload_contract = "task authoring diagnostics and task explanation output"
+canonicalization = "positive base-10 integer for the verifier protocol"
+consumer = "task authors and migration reviewers"
+validation_behavior = "The authoring commands report the configured verifier protocol version without deriving it from task identity."
+mismatch_behavior = "report_task_diagnostic"
+retention = "task_authoring_output_lifetime"
+rationale = "Authoring diagnostics must identify the verifier protocol separately from the task revision."
+duplication = "projection"
+compatibility_behavior = "Consumers read the reported verifier protocol version as an explicit compatibility value."
+compatibility_kind = "protocol"
+
+[[field]]
+symbol = "aec_bench.cli.commands.task._task_authoring_details.version"
+aliases = ["mapping:aec_bench.cli.commands.task._task_authoring_details.version", "mapping:aec_bench.cli.commands.task.explain_command.version"]
+surface = "mapping"
+wire_name = "version"
+category = "compatibility"
+domain_owner = "task_authoring"
+authority = "task_identity"
+authoritative = true
+exposure = "public"
+status = "current"
+payload_contract = "task authoring diagnostics and task explanation output"
+canonicalization = "positive base-10 integer from the task identity"
+consumer = "task authors and migration reviewers"
+validation_behavior = "The authoring commands report the explicit task identity version and do not infer a replacement revision."
+mismatch_behavior = "report_task_diagnostic"
+retention = "task_authoring_output_lifetime"
+rationale = "Task authoring output must expose the semantic task revision as distinct from verifier protocol identity."
+duplication = "projection"
+compatibility_behavior = "Consumers resolve the task identity version before applying metadata changes."
+compatibility_kind = "entity_revision"
+
+[[field]]
 symbol = "aec_bench.contracts.artifacts.ArtifactRef.sha256"
 aliases = ["aec_bench.web.schemas.ArtifactIntegrityResponse.sha256"]
 surface = "pydantic_model"

--- a/src/aec_bench/cli/commands/task.py
+++ b/src/aec_bench/cli/commands/task.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import typer
 import yaml
 
+from aec_bench.cli.commands.config import resolve_path
 from aec_bench.cli.commands.lifecycle import app as lifecycle_app
 from aec_bench.cli.commands.world import app as world_app
 from aec_bench.cli.output import console, emit
@@ -45,34 +46,231 @@ def validate_command(
     from aec_bench.tasks.validator import validate_task
 
     report = validate_task(task_dir, tasks_root=root)
+    details = _task_authoring_details(task_dir, root, report)
 
-    # Human-readable output
-    console.print(f"\n[bold]{report.task_id}[/bold]\n")
+    data = report.to_dict()
+    data["identity"] = details
 
-    if not report.findings:
-        console.print("  [green]✓ All checks passed[/green]\n")
-    else:
-        for finding in report.findings:
-            icon = _SEVERITY_ICONS.get(finding.severity.value, "?")
-            console.print(f"  {icon} [bold]{finding.check}[/bold] — {finding.file}")
-            console.print(f"    {finding.message}")
-            if finding.fix_hint:
-                console.print(f"    [dim]Fix: {finding.fix_hint}[/dim]")
-
-    # Summary line
-    if report.passed:
-        console.print(f"[green bold]Passed[/green bold] — {report.warning_count} warning(s)\n")
-    else:
+    def render(_value: dict[str, object]) -> None:
+        console.print(f"\n[bold]Task: {details['display_ref'] or report.task_id}[/bold]")
+        console.print(f"Version: {details['version'] or 'unknown'}")
+        console.print(f"Lifecycle: {details['lifecycle'] or 'unknown'}")
+        console.print(f"Visibility: {details['visibility'] or 'unknown'}")
+        runnable = details["runnable"]
+        console.print(f"Runnable: {'yes' if runnable is True else 'no' if runnable is False else 'unknown'}")
         console.print(
-            f"[red bold]{report.error_count} error(s)[/red bold], "
-            f"{report.warning_count} warning(s) — not ready for promotion\n"
+            f"Verifier: {details['verifier_entrypoint'] or 'unknown'}, "
+            f"version {details['verifier_version'] or 'unknown'}\n"
         )
 
-    # Structured JSON output for agents
-    emit("task validate", report.to_dict(), start_time=start)
+        if not report.findings:
+            console.print("  [green]✓ All checks passed[/green]\n")
+        else:
+            for finding in report.findings:
+                icon = _SEVERITY_ICONS.get(finding.severity.value, "?")
+                console.print(f"  {icon} [bold]{finding.check}[/bold] — {finding.file}")
+                console.print(f"    {finding.message}")
+                if finding.fix_hint:
+                    console.print(f"    [dim]Fix: {finding.fix_hint}[/dim]")
+
+        console.print(f"Errors: {'none' if report.error_count == 0 else report.error_count}")
+        console.print(f"Warnings: {'none' if report.warning_count == 0 else report.warning_count}")
+        if report.passed:
+            console.print(f"[green bold]Passed[/green bold] — {report.warning_count} warning(s)\n")
+        else:
+            console.print(
+                f"[red bold]{report.error_count} error(s)[/red bold], "
+                f"{report.warning_count} warning(s) — not ready for promotion\n"
+            )
+
+    emit("task validate", data, start_time=start, human_renderer=render)
 
     if not report.passed:
         raise typer.Exit(1)
+
+
+@app.command("explain")
+def explain_command(
+    task_ref: str = typer.Argument(help="Canonical task key, alias, UUID, or legacy task path"),
+    tasks_root: str | None = typer.Option(None, "--tasks-root", "-t", help="Root directory containing tasks"),
+) -> None:
+    """Explain one task identity, policy, output contract, and verifier."""
+
+    start = time.monotonic()
+    root = resolve_path("tasks_root", cli_override=tasks_root)
+    from aec_bench.tasks.registry import TaskRegistry
+
+    registry = TaskRegistry(root)
+    registry.reload()
+    task = next((candidate for candidate in registry.all() if _task_matches(candidate, task_ref)), None)
+    if task is None:
+        emit("task explain", data=None, errors=[f"task not found: {task_ref}"], start_time=start)
+        raise typer.Exit(1)
+
+    identity = task.identity
+    data = {
+        "canonical_key": task.task_id,
+        "aliases": [] if identity is None else [str(alias) for alias in identity.aliases],
+        "id": None if identity is None else str(identity.id),
+        "version": None if identity is None else identity.version,
+        "lifecycle": task.lifecycle.value,
+        "visibility": task.visibility.value,
+        "runnable": task.runnable,
+        "output_contract": {
+            "expected_output_path": task.verifier.expected_output_path,
+            "reward_path": task.verifier.reward_path,
+            "details_path": task.verifier.details_path,
+        },
+        "verifier": {"entrypoint": task.verifier.script, "version": _verifier_protocol_version()},
+    }
+
+    def render(value: dict[str, object]) -> None:
+        console.print(f"Task: {value['canonical_key']}")
+        aliases = value["aliases"]
+        alias_text = ", ".join(aliases) if isinstance(aliases, list) else "none"
+        console.print(f"Aliases: {alias_text or 'none'}")
+        console.print(f"UUID: {value['id'] or 'legacy task without UUID'}")
+        console.print(f"Version: {value['version'] or 'legacy task without version'}")
+        console.print(f"Lifecycle: {value['lifecycle']}")
+        console.print(f"Visibility: {value['visibility']}")
+        console.print(f"Runnable: {'yes' if value['runnable'] else 'no'}")
+        console.print(f"Output contract: {value['output_contract']}")
+        console.print(f"Verifier: {value['verifier']}")
+
+    emit("task explain", data=data, start_time=start, human_renderer=render)
+
+
+@app.command("migrate-metadata")
+def migrate_metadata_command(
+    check: bool = typer.Option(False, "--check", help="Report reviewed metadata changes without writing task files"),
+    write: bool = typer.Option(False, "--write", help="Apply reviewed metadata values to task files"),
+    tasks_root: str | None = typer.Option(None, "--tasks-root", "-t", help="Root directory containing tasks"),
+    report_path: Path | None = typer.Option(None, "--report-path", help="Stable migration report path"),
+) -> None:
+    """Check or apply the reviewed task metadata migration report."""
+
+    start = time.monotonic()
+    if check == write:
+        raise typer.BadParameter("choose exactly one of --check or --write")
+    root = resolve_path("tasks_root", cli_override=tasks_root)
+    output_path = (
+        report_path.resolve() if report_path is not None else root.parent / "artefacts" / "task-metadata-report.json"
+    )
+    from aec_bench.tasks.metadata_migration import (
+        MigrationReportError,
+        apply_task_metadata_migration,
+        generate_task_metadata_migration_report,
+        planned_task_metadata_changes,
+    )
+
+    try:
+        report = generate_task_metadata_migration_report(root, output_path)
+        changes = planned_task_metadata_changes(root, report)
+        if write:
+            changes = apply_task_metadata_migration(root, report)
+    except (MigrationReportError, OSError, UnicodeError, ValueError) as error:
+        emit("task migrate-metadata", data=None, errors=[str(error)], start_time=start)
+        raise typer.Exit(1) from error
+
+    action = "would update" if check else "updated"
+    data = {
+        "report_path": str(output_path),
+        "task_count": len(report.tasks),
+        "changed_paths": list(changes),
+        "mode": "check" if check else "write",
+    }
+
+    def render(_value: dict[str, object]) -> None:
+        console.print(f"Task metadata migration {action} {len(changes)} task(s).")
+        console.print(f"Report: {output_path}")
+        for path in changes:
+            console.print(f"  - {path}")
+        for entry in report.tasks:
+            decisions = "; ".join(entry.required_reviewer_decisions)
+            console.print(
+                f"  {entry.current_path}: {entry.proposed_key} · {str(entry.generated_uuid)[-8:]} "
+                f"lifecycle={entry.current_inferred_lifecycle} visibility={entry.current_inferred_visibility}; "
+                f"review: {decisions}"
+            )
+
+    emit("task migrate-metadata", data, start_time=start, human_renderer=render)
+
+
+def _verifier_protocol_version() -> int:
+    from aec_bench.harness.verifier_execution import VERIFIER_PROTOCOL_VERSION
+
+    return VERIFIER_PROTOCOL_VERSION
+
+
+def _task_matches(task: object, reference: str) -> bool:
+    from aec_bench.contracts.task_definition import TaskDefinition
+
+    if not isinstance(task, TaskDefinition):
+        return False
+    if task.task_id == reference:
+        return True
+    if task.identity is None:
+        return False
+    return reference == str(task.identity.id) or reference in {str(alias) for alias in task.identity.aliases}
+
+
+def _task_authoring_details(task_dir: Path, tasks_root: Path, report: object) -> dict[str, object]:
+    from aec_bench.tasks.loader import LoadError, load_task_definition
+    from aec_bench.tasks.validator import Severity, ValidationFinding, ValidationReport
+
+    details: dict[str, object] = {
+        "display_ref": None,
+        "id": None,
+        "key": None,
+        "version": None,
+        "lifecycle": None,
+        "visibility": None,
+        "runnable": None,
+        "verifier_entrypoint": None,
+        "verifier_version": None,
+    }
+    if not isinstance(report, ValidationReport) or not (task_dir / "task.toml").is_file():
+        return details
+    try:
+        task = load_task_definition(task_dir, tasks_root)
+    except (LoadError, KeyError, TypeError, ValueError) as error:
+        report.findings.append(
+            ValidationFinding(
+                severity=Severity.ERROR,
+                check="metadata",
+                file="task.toml",
+                message=str(error),
+                fix_hint="Run `aec-bench task migrate-metadata --check` and repair the reported metadata.",
+            )
+        )
+        return details
+    details.update(
+        lifecycle=task.lifecycle.value,
+        visibility=task.visibility.value,
+        runnable=task.runnable,
+        verifier_entrypoint=task.verifier.script,
+        verifier_version=_verifier_protocol_version(),
+    )
+    if task.identity is None:
+        report.findings.append(
+            ValidationFinding(
+                severity=Severity.WARNING,
+                check="metadata",
+                file="task.toml",
+                message="task identity metadata is missing; the task uses bounded legacy compatibility loading",
+                fix_hint="Run `aec-bench task migrate-metadata --check` before publishing this task.",
+            )
+        )
+    else:
+        from aec_bench.contracts.identity import format_display_ref
+
+        details.update(
+            display_ref=format_display_ref(task.identity.key, task.identity.id),
+            id=str(task.identity.id),
+            key=str(task.identity.key),
+            version=task.identity.version,
+        )
+    return details
 
 
 @app.command("genome")

--- a/src/aec_bench/tasks/metadata_migration.py
+++ b/src/aec_bench/tasks/metadata_migration.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import tempfile
 import tomllib
 from dataclasses import asdict, dataclass
@@ -75,6 +76,153 @@ def generate_task_metadata_migration_report(
     output_path.parent.mkdir(parents=True, exist_ok=True)
     _write_report_atomically(output_path, report.to_json())
     return report
+
+
+def apply_task_metadata_migration(tasks_root: Path, report: TaskMetadataMigrationReport) -> tuple[str, ...]:
+    """Write reviewed identity and policy values to the listed task packages."""
+
+    changes = _task_metadata_changes(tasks_root, report, require_policy=True)
+    for entry, after in changes:
+        task_toml = tasks_root / entry.current_path / "task.toml"
+        task_toml.write_text(after, encoding="utf-8")
+    return tuple(entry.current_path for entry, _after in changes)
+
+
+def planned_task_metadata_changes(tasks_root: Path, report: TaskMetadataMigrationReport) -> tuple[str, ...]:
+    """Return task paths that would change when the reviewed report is applied."""
+
+    return tuple(
+        entry.current_path for entry, _after in _task_metadata_changes(tasks_root, report, require_policy=False)
+    )
+
+
+def _task_metadata_changes(
+    tasks_root: Path,
+    report: TaskMetadataMigrationReport,
+    *,
+    require_policy: bool,
+) -> list[tuple[TaskMetadataMigrationEntry, str]]:
+    changes: list[tuple[TaskMetadataMigrationEntry, str]] = []
+    for entry in report.tasks:
+        task_path = tasks_root / entry.current_path
+        task_toml = task_path / "task.toml"
+        if not task_toml.is_file():
+            raise MigrationReportError(f"cannot write {entry.current_path}: task.toml is missing")
+        before = task_toml.read_text(encoding="utf-8")
+        try:
+            raw_toml = tomllib.loads(before)
+        except tomllib.TOMLDecodeError as error:
+            raise MigrationReportError(
+                f"cannot write {entry.current_path}: task.toml is not valid TOML: {error}"
+            ) from error
+        metadata = raw_toml.get("metadata")
+        if not isinstance(metadata, dict):
+            if not require_policy:
+                continue
+            raise MigrationReportError(
+                f"cannot write {entry.current_path}: reviewer must author [metadata].lifecycle and visibility"
+            )
+        authored_lifecycle = metadata.get("lifecycle")
+        authored_visibility = metadata.get("visibility")
+        if not require_policy and (
+            not isinstance(authored_lifecycle, str)
+            or authored_lifecycle not in {item.value for item in Lifecycle}
+            or not isinstance(authored_visibility, str)
+            or authored_visibility not in {item.value for item in Visibility}
+        ):
+            continue
+        if entry.current_inferred_visibility not in {item.value for item in Visibility}:
+            raise MigrationReportError(
+                f"cannot write {entry.current_path}: visibility is not classified as public, private, or holdout"
+            )
+        if entry.current_inferred_lifecycle not in {item.value for item in Lifecycle}:
+            raise MigrationReportError(f"cannot write {entry.current_path}: lifecycle is not supported")
+        if not isinstance(authored_lifecycle, str) or authored_lifecycle not in {item.value for item in Lifecycle}:
+            raise MigrationReportError(
+                f"cannot write {entry.current_path}: reviewer must author a supported [metadata].lifecycle"
+            )
+        if not isinstance(authored_visibility, str) or authored_visibility not in {item.value for item in Visibility}:
+            raise MigrationReportError(
+                f"cannot write {entry.current_path}: reviewer must author public, private, or holdout visibility"
+            )
+        if (
+            authored_lifecycle != entry.current_inferred_lifecycle
+            or authored_visibility != entry.current_inferred_visibility
+        ):
+            raise MigrationReportError(
+                f"cannot write {entry.current_path}: reviewed report policy does not match authored metadata"
+            )
+        after = _with_explicit_metadata(
+            before,
+            identity={
+                "id": str(entry.generated_uuid),
+                "key": entry.proposed_key,
+                "version": entry.proposed_version,
+            },
+            lifecycle=authored_lifecycle,
+            visibility=authored_visibility,
+        )
+        if after != before:
+            changes.append((entry, after))
+    return changes
+
+
+def _with_explicit_metadata(
+    text: str,
+    *,
+    identity: dict[str, str | int],
+    lifecycle: str,
+    visibility: str,
+) -> str:
+    """Add or replace the small explicit metadata sections without reformatting other TOML."""
+
+    lines = text.splitlines()
+    first_section = next((index for index, line in enumerate(lines) if line.lstrip().startswith("[")), len(lines))
+    identity_block = [
+        "[identity]",
+        f'id = "{identity["id"]}"',
+        f'key = "{identity["key"]}"',
+        f"version = {identity['version']}",
+        "",
+    ]
+    if first_section == len(lines):
+        lines.extend(identity_block)
+    else:
+        identity_start = next((index for index, line in enumerate(lines) if line.strip() == "[identity]"), None)
+        if identity_start is None:
+            lines[first_section:first_section] = identity_block
+        else:
+            identity_end = next(
+                (index for index in range(identity_start + 1, len(lines)) if lines[index].lstrip().startswith("[")),
+                len(lines),
+            )
+            lines[identity_start:identity_end] = identity_block
+
+    metadata_start = next((index for index, line in enumerate(lines) if line.strip() == "[metadata]"), None)
+    if metadata_start is None:
+        if lines and lines[-1] != "":
+            lines.append("")
+        lines.extend(["[metadata]", f'lifecycle = "{lifecycle}"', f'visibility = "{visibility}"'])
+    else:
+        metadata_end = next(
+            (index for index in range(metadata_start + 1, len(lines)) if lines[index].lstrip().startswith("[")),
+            len(lines),
+        )
+        section = lines[metadata_start + 1 : metadata_end]
+        section = _replace_toml_string(section, "lifecycle", lifecycle)
+        section = _replace_toml_string(section, "visibility", visibility)
+        lines[metadata_start + 1 : metadata_end] = section
+    return "\n".join(lines) + "\n"
+
+
+def _replace_toml_string(lines: list[str], key: str, value: str) -> list[str]:
+    pattern = re.compile(rf"^\s*{re.escape(key)}\s*=")
+    for index, line in enumerate(lines):
+        if pattern.match(line):
+            lines[index] = f'{key} = "{value}"'
+            return lines
+    lines.insert(0, f'{key} = "{value}"')
+    return lines
 
 
 def _validate_report_entries(entries: tuple[TaskMetadataMigrationEntry, ...]) -> None:
@@ -269,5 +417,7 @@ __all__ = (
     "REPORT_SCHEMA_VERSION",
     "TaskMetadataMigrationEntry",
     "TaskMetadataMigrationReport",
+    "apply_task_metadata_migration",
     "generate_task_metadata_migration_report",
+    "planned_task_metadata_changes",
 )

--- a/src/aec_bench/tasks/registry.py
+++ b/src/aec_bench/tasks/registry.py
@@ -2,13 +2,59 @@
 # ABOUTME: Loads real task instances once and supports lookup plus experiment filters.
 
 import logging
+from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path
 
 from aec_bench.contracts.task_definition import Difficulty, Lifecycle, TaskDefinition, Visibility
-from aec_bench.tasks.loader import LoadError, iter_task_instance_dirs, load_task_definition
+from aec_bench.tasks.loader import LoadError, load_task_definition
 from aec_bench.tasks.selector import select_tasks
 
 logger = logging.getLogger(__name__)
+
+
+class TaskDiagnosticKind(StrEnum):
+    """Classification for one task that could not load."""
+
+    MISSING_FILE = "missing_file"
+    TOML_PARSE = "toml_parse"
+    DECODE = "decode"
+    CONTRACT = "contract_validation"
+    INVALID_ID = "invalid_id"
+    INVALID_KEY = "invalid_key"
+    UNSAFE_PATH = "unsafe_path"
+    UNSUPPORTED_VALUE = "unsupported_value"
+    LOAD = "load_error"
+
+
+@dataclass(frozen=True)
+class TaskDiagnostic:
+    """Actionable information about one invalid task package."""
+
+    path: Path
+    kind: TaskDiagnosticKind
+    message: str
+
+    @property
+    def code(self) -> str:
+        """Return the stable diagnostic classification."""
+
+        return self.kind.value
+
+    def to_dict(self) -> dict[str, str]:
+        return {"path": str(self.path), "kind": self.kind.value, "message": self.message}
+
+
+@dataclass(frozen=True)
+class TaskRegistrySummary:
+    """Counts from one registry reload."""
+
+    discovered: int
+    valid: int
+    invalid: int
+
+    def to_dict(self) -> dict[str, int]:
+        return {"discovered": self.discovered, "valid": self.valid, "invalid": self.invalid}
 
 
 class TaskRegistry:
@@ -16,23 +62,58 @@ class TaskRegistry:
         self.tasks_root = tasks_root
         self._tasks: dict[str, TaskDefinition] = {}
         self._load_errors: list[tuple[Path, str]] = []
+        self._diagnostics: list[TaskDiagnostic] = []
+        self._summary = TaskRegistrySummary(discovered=0, valid=0, invalid=0)
 
-    def reload(self) -> None:
+    def reload(self) -> TaskRegistrySummary:
         tasks: dict[str, TaskDefinition] = {}
-        errors: list[tuple[Path, str]] = []
-        for instance_dir in iter_task_instance_dirs(self.tasks_root):
+        diagnostics: list[TaskDiagnostic] = []
+        instance_dirs = _candidate_task_dirs(self.tasks_root)
+        for instance_dir in instance_dirs:
             try:
                 task = load_task_definition(instance_dir, self.tasks_root)
+                if task.task_id in tasks:
+                    raise LoadError(f"duplicate task identity key: {task.task_id}")
                 tasks[task.task_id] = task
-            except LoadError as exc:
+            except (LoadError, KeyError, TypeError, ValueError) as exc:
                 logger.warning("failed to load task at %s: %s", instance_dir, exc)
-                errors.append((instance_dir, str(exc)))
+                diagnostics.append(_diagnostic(instance_dir, str(exc)))
         self._tasks = tasks
-        self._load_errors = errors
+        self._diagnostics = diagnostics
+        self._load_errors = [(item.path, item.message) for item in diagnostics]
+        self._summary = TaskRegistrySummary(
+            discovered=len(instance_dirs),
+            valid=len(tasks),
+            invalid=len(diagnostics),
+        )
+        return self._summary
 
     @property
     def load_errors(self) -> list[tuple[Path, str]]:
         return list(self._load_errors)
+
+    @property
+    def valid_tasks(self) -> list[TaskDefinition]:
+        """Return tasks that loaded successfully."""
+
+        return self.all()
+
+    @property
+    def invalid_diagnostics(self) -> list[TaskDiagnostic]:
+        """Return classified diagnostics from the latest reload."""
+
+        return list(self._diagnostics)
+
+    @property
+    def summary(self) -> TaskRegistrySummary:
+        return self._summary
+
+    def require_valid(self) -> None:
+        """Fail when the latest catalogue contains an invalid task."""
+
+        if self._diagnostics:
+            details = "; ".join(f"{item.path}: {item.message}" for item in self._diagnostics)
+            raise ValueError(f"task catalogue contains invalid tasks: {details}")
 
     def get(self, task_id: str) -> TaskDefinition | None:
         return self._tasks.get(task_id)
@@ -61,3 +142,40 @@ class TaskRegistry:
             include_patterns=include_patterns,
             exclude_patterns=exclude_patterns,
         )
+
+
+def _candidate_task_dirs(tasks_root: Path) -> list[Path]:
+    if not tasks_root.is_dir():
+        return []
+    candidates = {path.parent for path in tasks_root.rglob("task.toml")}
+    candidates.update(path.parent for path in tasks_root.rglob("instruction.md"))
+    return sorted(candidates)
+
+
+def _diagnostic(instance_dir: Path, message: str) -> TaskDiagnostic:
+    lowered = message.lower()
+    if "missing " in lowered or "missing task.toml" in lowered:
+        kind = TaskDiagnosticKind.MISSING_FILE
+    elif "invalid task.toml" in lowered:
+        kind = TaskDiagnosticKind.DECODE if "decode" in lowered or "utf" in lowered else TaskDiagnosticKind.TOML_PARSE
+    elif "entity id" in lowered or "uuid" in lowered:
+        kind = TaskDiagnosticKind.INVALID_ID
+    elif "entity key" in lowered or "identity key" in lowered or "task path is not" in lowered:
+        kind = TaskDiagnosticKind.INVALID_KEY
+    elif "unsafe" in lowered or "escape" in lowered or "portable" in lowered or "path must be relative" in lowered:
+        kind = TaskDiagnosticKind.UNSAFE_PATH
+    elif "unsupported" in lowered or "lifecycle" in lowered or "visibility" in lowered or "difficulty" in lowered:
+        kind = TaskDiagnosticKind.UNSUPPORTED_VALUE
+    elif "invalid task definition" in lowered or "invalid task metadata" in lowered or "validation error" in lowered:
+        kind = TaskDiagnosticKind.CONTRACT
+    else:
+        kind = TaskDiagnosticKind.LOAD
+    return TaskDiagnostic(path=instance_dir, kind=kind, message=message)
+
+
+__all__ = (
+    "TaskDiagnostic",
+    "TaskDiagnosticKind",
+    "TaskRegistry",
+    "TaskRegistrySummary",
+)

--- a/tests/cli/test_task.py
+++ b/tests/cli/test_task.py
@@ -3,12 +3,14 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import yaml
 from typer.testing import CliRunner
 
 from aec_bench.cli.main import app
+from aec_bench.contracts.identity import EntityKind, new_entity_id
 
 runner = CliRunner()
 
@@ -61,6 +63,18 @@ def _make_valid_named_task(root: Path, *segments: str) -> Path:
     return task_dir
 
 
+def _add_explicit_identity(task_dir: Path, *, lifecycle: str = "active", visibility: str = "public") -> str:
+    task_id = new_entity_id(EntityKind.TASK)
+    task_toml = (task_dir / "task.toml").read_text(encoding="utf-8")
+    task_toml = task_toml.replace(
+        "[metadata]\n",
+        f'[identity]\nid = "{task_id}"\nkey = "electrical/test-task"\nversion = 2\n\n'
+        f'[metadata]\nlifecycle = "{lifecycle}"\nvisibility = "{visibility}"\n',
+    )
+    (task_dir / "task.toml").write_text(task_toml, encoding="utf-8")
+    return str(task_id)
+
+
 class TestTaskValidate:
     def test_valid_task_exits_zero(self, tmp_path: Path) -> None:
         task_dir = _make_valid_task(tmp_path)
@@ -79,10 +93,18 @@ class TestTaskValidate:
         assert "test-task" in result.output
 
     def test_json_output_has_findings(self, tmp_path: Path) -> None:
-        task_dir = tmp_path / "electrical" / "bad-task"
-        task_dir.mkdir(parents=True)
+        task_dir = _make_valid_task(tmp_path)
+        task_id = _add_explicit_identity(task_dir)
         result = runner.invoke(app, ["--json", "task", "validate", str(task_dir)])
-        assert "findings" in result.output
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["status"] == "success"
+        assert payload["data"]["findings"] == []
+        assert payload["data"]["identity"]["id"] == task_id
+        assert payload["data"]["identity"]["version"] == 2
+        assert payload["data"]["identity"]["lifecycle"] == "active"
+        assert payload["data"]["identity"]["visibility"] == "public"
 
     def test_tasks_root_option(self, tmp_path: Path) -> None:
         task_dir = _make_valid_task(tmp_path)
@@ -92,6 +114,151 @@ class TestTaskValidate:
         )
         assert result.exit_code == 0
         assert "electrical/test-task" in result.output
+
+    def test_output_includes_explicit_identity_and_policy(self, tmp_path: Path) -> None:
+        task_dir = _make_valid_task(tmp_path)
+        _add_explicit_identity(task_dir)
+
+        result = runner.invoke(app, ["--text", "task", "validate", str(task_dir)])
+
+        assert result.exit_code == 0
+        assert "Task: electrical/test-task ·" in result.output
+        assert "Version: 2" in result.output
+        assert "Lifecycle: active" in result.output
+        assert "Visibility: public" in result.output
+        assert "Runnable: yes" in result.output
+        assert "Verifier: tests/test.sh, version 1" in result.output
+        assert "Errors: none" in result.output
+        assert "Warnings: none" in result.output
+
+
+class TestTaskExplain:
+    def test_explain_resolves_key_and_uuid(self, tmp_path: Path) -> None:
+        task_dir = _make_valid_task(tmp_path)
+        task_id = _add_explicit_identity(task_dir)
+
+        result = runner.invoke(app, ["--text", "task", "explain", task_id, "--tasks-root", str(tmp_path)])
+
+        assert result.exit_code == 0
+        assert "Canonical_key" not in result.output
+        assert "Task: electrical/test-task" in result.output
+        assert task_id in result.output
+        assert "Version: 2" in result.output
+        assert "Output contract" in result.output
+        assert "tests/test.sh" in result.output
+
+    def test_explain_unknown_task_fails(self, tmp_path: Path) -> None:
+        result = runner.invoke(app, ["--text", "task", "explain", "electrical/missing", "--tasks-root", str(tmp_path)])
+
+        assert result.exit_code == 1
+        assert "task not found" in result.output
+
+
+class TestTaskMetadataMigration:
+    def test_check_write_and_second_check_are_idempotent(self, tmp_path: Path) -> None:
+        task_dir = _make_valid_task(tmp_path)
+        report_path = tmp_path / "migration-report.json"
+        task_toml = (
+            (task_dir / "task.toml")
+            .read_text(encoding="utf-8")
+            .replace("[metadata]\n", '[metadata]\nlifecycle = "active"\nvisibility = "public"\n')
+        )
+        (task_dir / "task.toml").write_text(task_toml, encoding="utf-8")
+
+        check = runner.invoke(
+            app,
+            [
+                "--text",
+                "task",
+                "migrate-metadata",
+                "--check",
+                "--tasks-root",
+                str(tmp_path),
+                "--report-path",
+                str(report_path),
+            ],
+        )
+        write = runner.invoke(
+            app,
+            [
+                "--text",
+                "task",
+                "migrate-metadata",
+                "--write",
+                "--tasks-root",
+                str(tmp_path),
+                "--report-path",
+                str(report_path),
+            ],
+        )
+        second_check = runner.invoke(
+            app,
+            [
+                "--text",
+                "task",
+                "migrate-metadata",
+                "--check",
+                "--tasks-root",
+                str(tmp_path),
+                "--report-path",
+                str(report_path),
+            ],
+        )
+
+        assert check.exit_code == 0
+        assert "would update 1" in check.output
+        assert write.exit_code == 0
+        assert "updated 1" in write.output
+        assert second_check.exit_code == 0
+        assert "would update 0" in second_check.output
+
+    def test_write_refuses_missing_policy_instead_of_inventing_it(self, tmp_path: Path) -> None:
+        task_dir = _make_valid_task(tmp_path)
+        task_toml = (
+            (task_dir / "task.toml")
+            .read_text(encoding="utf-8")
+            .replace("[metadata]\n", '[metadata]\nvisibility = "public"\n')
+        )
+        (task_dir / "task.toml").write_text(task_toml, encoding="utf-8")
+
+        check = runner.invoke(
+            app,
+            ["--text", "task", "migrate-metadata", "--check", "--tasks-root", str(tmp_path)],
+        )
+        result = runner.invoke(
+            app,
+            ["--text", "task", "migrate-metadata", "--write", "--tasks-root", str(tmp_path)],
+        )
+
+        assert check.exit_code == 0
+        assert "review:" in check.output
+        assert result.exit_code == 1
+        assert "reviewer must author" in result.output
+
+    def test_json_output_is_single_envelope(self, tmp_path: Path) -> None:
+        task_dir = _make_valid_task(tmp_path)
+        _add_explicit_identity(task_dir)
+        report_path = tmp_path / "migration-report.json"
+
+        result = runner.invoke(
+            app,
+            [
+                "--json",
+                "task",
+                "migrate-metadata",
+                "--check",
+                "--tasks-root",
+                str(tmp_path),
+                "--report-path",
+                str(report_path),
+            ],
+        )
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["status"] == "success"
+        assert payload["data"]["mode"] == "check"
+        assert payload["data"]["task_count"] == 1
 
 
 class TestTaskGenome:

--- a/tests/tasks/test_metadata_migration.py
+++ b/tests/tasks/test_metadata_migration.py
@@ -20,7 +20,7 @@ from aec_bench.tasks.loader import (
     load_task_definition,
     parse_task_metadata,
 )
-from aec_bench.tasks.metadata_migration import generate_task_metadata_migration_report
+from aec_bench.tasks.metadata_migration import apply_task_metadata_migration, generate_task_metadata_migration_report
 
 TASKS_ROOT = Path(__file__).resolve().parents[2] / "tasks"
 
@@ -226,6 +226,15 @@ def test_migration_report_rejects_new_duplicate_generated_uuids(tmp_path: Path) 
     with patch.object(metadata_migration, "new_entity_id", return_value=task_id):
         with pytest.raises(ValueError, match="duplicate generated UUID.*electrical/first.*electrical/second"):
             generate_task_metadata_migration_report(tasks_root, tmp_path / "report.json")
+
+
+def test_metadata_migration_write_refuses_inferred_lifecycle(tmp_path: Path) -> None:
+    tasks_root = tmp_path / "tasks"
+    _write_task(tasks_root, "electrical", "voltage-drop", lifecycle=None, visibility="public")
+    report = generate_task_metadata_migration_report(tasks_root, tmp_path / "report.json")
+
+    with pytest.raises(ValueError, match="reviewer must author.*lifecycle"):
+        apply_task_metadata_migration(tasks_root, report)
 
 
 def test_migration_report_keeps_existing_bytes_when_replacement_fails(tmp_path: Path) -> None:

--- a/tests/tasks/test_registry.py
+++ b/tests/tasks/test_registry.py
@@ -3,8 +3,10 @@
 
 from pathlib import Path
 
+import pytest
+
 from aec_bench.contracts.task_definition import Lifecycle
-from aec_bench.tasks.registry import TaskRegistry
+from aec_bench.tasks.registry import TaskDiagnosticKind, TaskRegistry
 
 TASKS_ROOT = Path(__file__).resolve().parents[2] / "tasks"
 
@@ -71,6 +73,29 @@ def test_registry_survives_malformed_task(tmp_path: Path) -> None:
     assert registry.all()[0].task_id == "mechanical/heat-load/good"
     assert len(registry.load_errors) == 1
     assert "bad" in str(registry.load_errors[0][0])
+    assert registry.summary.discovered == 2
+    assert registry.summary.valid == 1
+    assert registry.summary.invalid == 1
+    assert registry.invalid_diagnostics[0].kind is TaskDiagnosticKind.MISSING_FILE
+    with pytest.raises(ValueError, match="invalid tasks"):
+        registry.require_valid()
+
+
+def test_registry_classifies_unsupported_legacy_metadata(tmp_path: Path) -> None:
+    task_dir = tmp_path / "mechanical" / "heat-load" / "bad-value"
+    (task_dir / "tests").mkdir(parents=True)
+    (task_dir / "instruction.md").write_text("Write findings to /workspace/output.jsonl.\n", encoding="utf-8")
+    (task_dir / "tests" / "test.sh").write_text("#!/bin/bash\n", encoding="utf-8")
+    (task_dir / "task.toml").write_text(
+        '[metadata]\nvisibility = "not-a-supported-visibility"\n',
+        encoding="utf-8",
+    )
+
+    registry = TaskRegistry(tasks_root=tmp_path)
+    registry.reload()
+
+    assert registry.summary.to_dict() == {"discovered": 1, "valid": 0, "invalid": 1}
+    assert registry.invalid_diagnostics[0].kind is TaskDiagnosticKind.UNSUPPORTED_VALUE
 
 
 def test_registry_returns_empty_for_nonexistent_root(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- extend `task validate` with readable identity, version, lifecycle, visibility, runnable state, verifier identity, and explicit error and warning counts
- add `task explain` resolution by canonical key, alias, or UUID
- add safe `task migrate-metadata --check` and `--write` flows with stable UUID allocation and idempotent writes
- refuse metadata writes unless lifecycle and visibility are already explicit and supported
- let `TaskRegistry.reload()` retain valid tasks while returning classified invalid-task diagnostics and a catalogue summary
- keep text rendering and JSON output separate so agent-facing stdout remains one parseable envelope

## Review order

1. `src/aec_bench/tasks/registry.py`
2. `src/aec_bench/tasks/metadata_migration.py`
3. `src/aec_bench/cli/commands/task.py`
4. focused tests, contract documentation, and provenance entries

## Evidence

- task and CLI tests: 138 passed
- Ruff check: passed
- changed-file Ruff format check: passed
- mypy for all six changed Python files: passed
- provenance audit: 0 violations
- `git diff --check`: passed

## Current limits

- the migration writer adds identity only when task policy is already explicit; it does not invent or approve lifecycle or visibility
- compatibility loading remains until PR9 removes unsafe defaults
- the required CI gate remains PR8

Stacked on #177.
