### PR TITLE
PRD 2: add UUID-backed run planning

### DIFF
--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -37,6 +37,7 @@ readable.
 | Experiment manifest | Experiment orchestration | User configuration becomes an executable plan | Internal, except documented CLI/config behavior | [`ExperimentManifest`](../src/aec_bench/contracts/experiment_manifest.py) | Persisted configuration |
 | Agent condition | Experiment orchestration | One requested adapter/model condition retains a stable UUID-backed identity and explicit runtime inputs | Internal foundation; callers supply stable conditions when resolving a run | [`AgentCondition`](../src/aec_bench/contracts/experiment_manifest.py) and [`EntityIdentity`](../src/aec_bench/contracts/identity.py) | In-process resolved condition |
 | Resolved run specification | Experiment orchestration | One experiment manifest, exact task releases, and stable agent conditions become one explicit requested run condition | Internal schema 1; no persistence or execution ownership yet | [`ResolvedRunSpec`](../src/aec_bench/contracts/resolved_run.py) and [`resolve_run_spec`](../src/aec_bench/contracts/resolved_run.py) | In-process requested run condition |
+| Canonical run plan and planned trial | Experiment orchestration and harness | One resolved run becomes UUID-backed, ordered, complete work with typed execution details | Internal schema; pure in-process planning only in this increment | [`RunPlan`, `PlannedTrial`, and `plan_run`](../src/aec_bench/contracts/run_plan.py) | In-process requested work plan |
 | Learning Study design and evidence | Experimentation | An authored protocol composes exact task members and family relations, then compiles to existing trials; committed state and explicit comparison-validity evidence stay outside `TrialRecord` | Internal Release A persisted contracts | [`LearningStudyProtocolSpec`, `LearningStudySpec`](../src/aec_bench/contracts/learning_study.py), [`LearningFamilySpec`](../src/aec_bench/contracts/learning_family.py), [`learning_study_evidence.py`](../src/aec_bench/contracts/learning_study_evidence.py), [`learning_study_assessment.py`](../src/aec_bench/contracts/learning_study_assessment.py), and the [Gate A decision](adr/learning-studies-gate-a.md) | Maintained or caller-selected protocol directory, compiled plan, append-only receipts and sequenced events, ordinary trial ledger, and pair-level paired-difference assessment |
 | Evolution workspace candidate lineage | Experimentation and feedback | Mutable workspace files become exact Git source and explicit candidate lineage | Workspace manifest schema 1; legacy labels require an explicit migration plan | [`WorkspaceCandidateVersion`, `WorkspaceManifest`, and `WorkspaceMigrationPlan`](../src/aec_bench/contracts/evolution.py) plus [`Workspace`](../src/aec_bench/evolution/workspace.py) | Persisted workspace Git metadata and manifest |
 | Evolution functional search and swarm coordination | Evolution application and swarm manager | Exact candidate material is paired with its own evaluation evidence before policy or shared effects use it | Internal pre-1.0 values; no new public schema promise | [`EvaluatedCandidate`, `CandidateEvaluationBatch`, `CandidateProposal`, `SwarmAssignment`, `SwarmAgentResult`, and `SwarmState`](../src/aec_bench/evolution/core.py), [`evaluation.py`](../src/aec_bench/evolution/evaluation.py), and [`swarm/core.py`](../src/aec_bench/evolution/swarm/core.py) | In-process functional values, AVO checkpoints, and swarm state outputs |
@@ -302,6 +303,20 @@ The current restriction against mixing conditional evidence and operations is
 host implementation policy for this subtype, not finite-lifecycle meaning.
 
 ## Run plans and published run packages
+
+The canonical `RunPlan` in [`run_plan.py`](../src/aec_bench/contracts/run_plan.py)
+is the pure planning contract for a `ResolvedRunSpec`. It assigns a new UUIDv7
+to each `PlannedTrial`, preserves task-release and agent-condition references,
+orders trials with contiguous ordinals, and records an explicit execution
+family, task metadata, attempt recipe, evaluation reference, seed, and
+supported pre-execution typed extensions. Callers provide exact task planning
+profiles and one combination validator, so mixed artifact, world, and lifecycle
+plans fail before readiness when a task is unavailable, disallowed by the
+visibility policy, or incompatible with an agent or route. Its summary gives
+task, condition, repetition, total, family, backend, visibility, and deprecated
+task counts without requiring callers to inspect every trial. Planning does not
+persist data or start execution. The existing compiled `RunPlan` below remains
+the specialised run-package contract until a later migration.
 
 `RunPlan` is the plain internal execution value. It contains one `RunManifest`,
 the ordered exact task references, the compiled Harness, the compiled execution

--- a/provenance-registry.toml
+++ b/provenance-registry.toml
@@ -1782,6 +1782,26 @@ compatibility_behavior = "accept schema 1 and reject every other value"
 compatibility_kind = "external_schema"
 
 [[field]]
+symbol = "aec_bench.contracts.run_plan.RunPlan.created_at"
+surface = "pydantic_model"
+wire_name = "created_at"
+category = "event_time"
+domain_owner = "experiment_orchestration"
+authority = "run_plan_planner"
+authoritative = true
+exposure = "application_memory"
+status = "current"
+payload_contract = "creation time for one UUID-backed requested run plan"
+canonicalization = "timezone-aware datetime serialized in Pydantic JSON mode"
+consumer = "plan review and later run persistence"
+validation_behavior = "RunPlan rejects naive or timezone-less creation times"
+mismatch_behavior = "reject_run_plan"
+retention = "run_plan_lifetime"
+rationale = "Plan review requires an unambiguous creation event time."
+duplication = "unique"
+event = "run plan created"
+
+[[field]]
 symbol = "aec_bench.contracts.task_snapshot.RepositoryTaskSnapshotRef.source_revision"
 surface = "pydantic_model"
 wire_name = "source_revision"

--- a/src/aec_bench/contracts/run_plan.py
+++ b/src/aec_bench/contracts/run_plan.py
@@ -1,0 +1,369 @@
+# ABOUTME: Defines the UUID-backed ordered plan and trial contracts for one resolved run.
+# ABOUTME: Expands requested state into pure, validated work without persistence or execution.
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Callable, Mapping, Sequence
+from datetime import datetime
+from typing import Annotated, Literal, Self
+from uuid import UUID
+
+from pydantic import BaseModel, Field, NonNegativeInt, PositiveInt, field_serializer, field_validator, model_validator
+
+from aec_bench.contracts.evaluation_refs import EvaluationRegimeRef
+from aec_bench.contracts.experiment_manifest import AgentCondition, ComputeConfig
+from aec_bench.contracts.identity import EntityIdentity, EntityKey, EntityKind, new_entity_id
+from aec_bench.contracts.resolved_run import ResolvedRunSpec
+from aec_bench.contracts.task_definition import Lifecycle, TaskMetadata, Visibility
+from aec_bench.contracts.task_snapshot import TaskSnapshotRef
+from aec_bench.contracts.trial_extensions import (
+    AdaptationProvenance,
+)
+from aec_bench.contracts.trial_record import TrialTaskKind
+from aec_bench.contracts.validators import FrozenStrictModel, NonEmptyStr
+
+
+class SingleAttemptRecipe(FrozenStrictModel):
+    """Run one attempt for a planned trial."""
+
+    kind: Literal["single_attempt"] = "single_attempt"
+
+
+class BestOfAttemptRecipe(FrozenStrictModel):
+    """Run a fixed number of attempts with one declared selector."""
+
+    kind: Literal["best_of"] = "best_of"
+    candidates: PositiveInt
+    selector: Literal["self"] = "self"
+
+
+type AttemptRecipe = Annotated[SingleAttemptRecipe | BestOfAttemptRecipe, Field(discriminator="kind")]
+
+
+_EXTENSION_TYPES: Mapping[str, type[BaseModel]] = {
+    "adaptation": AdaptationProvenance,
+}
+
+
+class PlannedTrialExtension(FrozenStrictModel):
+    """One supported typed extension retained with a planned trial."""
+
+    extension_kind: EntityKey
+    value: BaseModel
+
+    @model_validator(mode="before")
+    @classmethod
+    def parse_typed_value(cls, value: object) -> object:
+        if not isinstance(value, Mapping):
+            return value
+        expected = _EXTENSION_TYPES.get(str(value.get("extension_kind")))
+        raw_extension = value.get("value")
+        if expected is not None and isinstance(raw_extension, Mapping):
+            parsed = dict(value)
+            parsed["value"] = expected.model_validate(raw_extension)
+            return parsed
+        return value
+
+    @field_serializer("value")
+    def serialize_typed_value(self, value: BaseModel) -> object:
+        return value.model_dump(mode="json")
+
+    @model_validator(mode="after")
+    def validate_supported_type(self) -> Self:
+        expected = _EXTENSION_TYPES.get(str(self.extension_kind))
+        if expected is None:
+            raise ValueError(f"unsupported planned trial extension: {self.extension_kind}")
+        if not isinstance(self.value, expected):
+            raise ValueError(
+                f"planned trial extension {self.extension_kind} requires {expected.__name__}, "
+                f"got {type(self.value).__name__}"
+            )
+        return self
+
+
+class PlannedTrial(FrozenStrictModel):
+    """One exact ordered unit of work in a run plan."""
+
+    trial_identity: EntityIdentity
+    ordinal: PositiveInt
+    run_identity: EntityIdentity
+    task_release: TaskSnapshotRef
+    task_metadata: TaskMetadata
+    agent_condition: AgentCondition
+    compute: ComputeConfig
+    repetition: PositiveInt
+    seed: Annotated[int, Field(strict=True, ge=0)] | None = None
+    execution_family: TrialTaskKind
+    attempt_recipe: AttemptRecipe
+    evaluation_profile: EvaluationRegimeRef | None = None
+    extensions: tuple[PlannedTrialExtension, ...] = ()
+
+    @property
+    def trial_id(self) -> UUID:
+        """Return the UUID-backed trial identity."""
+
+        return self.trial_identity.id
+
+    @property
+    def trial_key(self) -> EntityKey:
+        """Return the readable key from the authoritative trial identity."""
+
+        return self.trial_identity.key
+
+    @model_validator(mode="after")
+    def validate_references(self) -> Self:
+        if self.task_release.task_identity is None:
+            raise ValueError("planned trial task release must include task identity")
+        if self.task_metadata.identity != self.task_release.task_identity:
+            raise ValueError("planned trial task metadata must match the task release")
+        if self.task_metadata.lifecycle not in {Lifecycle.ACTIVE, Lifecycle.DEPRECATED}:
+            raise ValueError("planned trial requires an active or deprecated task release")
+        if self.trial_identity.version < 1:
+            raise ValueError("planned trial identity version must be positive")
+        if self.run_identity.version < 1:
+            raise ValueError("planned trial run identity version must be positive")
+        extension_kinds = [str(extension.extension_kind) for extension in self.extensions]
+        if len(extension_kinds) != len(set(extension_kinds)):
+            raise ValueError("planned trial extension kinds must be unique")
+        return self
+
+
+class RunPlanSummary(FrozenStrictModel):
+    """Counts that describe a plan without enumerating its trials."""
+
+    selected_task_count: PositiveInt
+    agent_condition_count: PositiveInt
+    repetitions: PositiveInt
+    total_trials: PositiveInt
+    trials_by_execution_family: dict[TrialTaskKind, PositiveInt]
+    trials_by_backend: dict[NonEmptyStr, PositiveInt]
+    visibility_policy: tuple[Visibility, ...]
+    tasks_by_visibility: dict[Visibility, PositiveInt]
+    deprecated_task_count: NonNegativeInt
+
+    @field_validator("visibility_policy")
+    @classmethod
+    def validate_visibility_policy(cls, value: tuple[Visibility, ...]) -> tuple[Visibility, ...]:
+        if not value:
+            raise ValueError("run plan visibility policy must not be empty")
+        if len(value) != len(set(value)):
+            raise ValueError("run plan visibility policy must be unique")
+        return value
+
+
+class RunPlan(FrozenStrictModel):
+    """One UUID-backed, ordered plan for a resolved run."""
+
+    plan_identity: EntityIdentity
+    run_identity: EntityIdentity
+    created_at: datetime
+    state: Literal["draft", "ready", "started", "closed"] = "draft"
+    trials: tuple[PlannedTrial, ...]
+    summary: RunPlanSummary
+
+    @property
+    def plan_id(self) -> UUID:
+        """Return the UUID-backed plan identity."""
+
+        return self.plan_identity.id
+
+    @property
+    def plan_key(self) -> EntityKey:
+        """Return the readable key from the authoritative plan identity."""
+
+        return self.plan_identity.key
+
+    @property
+    def plan_version(self) -> int:
+        """Return the version from the authoritative plan identity."""
+
+        return self.plan_identity.version
+
+    @property
+    def run_id(self) -> UUID:
+        """Return the UUID-backed run identity."""
+
+        return self.run_identity.id
+
+    @field_validator("created_at")
+    @classmethod
+    def validate_created_at_timezone(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("run plan created_at must include a timezone")
+        return value
+
+    @model_validator(mode="after")
+    def validate_plan(self) -> Self:
+        if self.plan_identity.id == self.run_identity.id:
+            raise ValueError("run plan and run identities must be distinct")
+        if not self.trials:
+            raise ValueError("run plan must include at least one planned trial")
+        if self.state == "ready":
+            self._validate_ready_trials()
+        return self
+
+    def _validate_ready_trials(self) -> None:
+        if tuple(trial.ordinal for trial in self.trials) != tuple(range(1, len(self.trials) + 1)):
+            raise ValueError("ready run plan trial ordinals must be contiguous from 1")
+        trial_ids = [trial.trial_identity.id for trial in self.trials]
+        if len(trial_ids) != len(set(trial_ids)):
+            raise ValueError("ready run plan trial identities must be unique")
+        trial_keys = [str(trial.trial_key) for trial in self.trials]
+        if len(trial_keys) != len(set(trial_keys)):
+            raise ValueError("ready run plan trial keys must be unique")
+        if any(trial.run_identity != self.run_identity for trial in self.trials):
+            raise ValueError("ready run plan trials must reference the plan run identity")
+        task_ids = {trial.task_release.task_id for trial in self.trials}
+        agent_ids = {trial.agent_condition.identity.id for trial in self.trials}
+        if self.summary.selected_task_count != len(task_ids):
+            raise ValueError("run plan summary task count does not match trials")
+        if self.summary.agent_condition_count != len(agent_ids):
+            raise ValueError("run plan summary agent count does not match trials")
+        if self.summary.total_trials != len(self.trials):
+            raise ValueError("run plan summary total does not match trials")
+        if self.summary.repetitions != max(trial.repetition for trial in self.trials):
+            raise ValueError("run plan summary repetitions do not match trials")
+        family_counts = {
+            family: sum(trial.execution_family == family for trial in self.trials)
+            for family in {trial.execution_family for trial in self.trials}
+        }
+        if self.summary.trials_by_execution_family != family_counts:
+            raise ValueError("run plan summary execution-family counts do not match trials")
+        backend_counts = {
+            backend: sum(trial.compute.backend == backend for trial in self.trials)
+            for backend in {trial.compute.backend for trial in self.trials}
+        }
+        if self.summary.trials_by_backend != backend_counts:
+            raise ValueError("run plan summary backend counts do not match trials")
+        task_metadata: dict[UUID, TaskMetadata] = {}
+        for trial in self.trials:
+            task_identity = trial.task_metadata.identity.id
+            existing = task_metadata.setdefault(task_identity, trial.task_metadata)
+            if existing != trial.task_metadata:
+                raise ValueError("ready run plan task metadata must be consistent")
+        visibility_counts = Counter(metadata.visibility for metadata in task_metadata.values())
+        if self.summary.tasks_by_visibility != dict(visibility_counts):
+            raise ValueError("run plan summary visibility counts do not match trials")
+        deprecated_count = sum(metadata.lifecycle is Lifecycle.DEPRECATED for metadata in task_metadata.values())
+        if self.summary.deprecated_task_count != deprecated_count:
+            raise ValueError("run plan summary deprecated task count does not match trials")
+        if any(metadata.visibility not in self.summary.visibility_policy for metadata in task_metadata.values()):
+            raise ValueError("ready run plan task visibility is outside the plan policy")
+
+
+class TaskPlanningProfile(FrozenStrictModel):
+    """Validated task metadata needed to make one release ready for planning."""
+
+    metadata: TaskMetadata
+    execution_family: TrialTaskKind
+
+    @model_validator(mode="after")
+    def validate_runnable_lifecycle(self) -> Self:
+        if self.metadata.lifecycle not in {Lifecycle.ACTIVE, Lifecycle.DEPRECATED}:
+            raise ValueError("run planning requires an active or deprecated task release")
+        return self
+
+
+TrialIdentityFactory = Callable[[str], EntityIdentity]
+CombinationValidator = Callable[[TaskSnapshotRef, AgentCondition, TrialTaskKind], None]
+
+
+def plan_run(
+    spec: ResolvedRunSpec,
+    *,
+    plan_identity: EntityIdentity,
+    created_at: datetime,
+    task_profiles: Mapping[UUID, TaskPlanningProfile],
+    validate_combination: CombinationValidator,
+    attempt_recipe: AttemptRecipe | None = None,
+    trial_identity_factory: TrialIdentityFactory | None = None,
+    extensions: Sequence[PlannedTrialExtension] = (),
+) -> RunPlan:
+    """Expand one resolved run into an ordered, ready plan without external effects."""
+
+    if created_at.tzinfo is None or created_at.utcoffset() is None:
+        raise ValueError("run plan created_at must include a timezone")
+    if created_at < spec.created_at:
+        raise ValueError("run plan created_at must not precede the resolved run specification")
+    release_ids = {release.task_identity.id for release in spec.task_releases if release.task_identity is not None}
+    if set(task_profiles) != release_ids:
+        raise ValueError("task planning profiles must exactly match the resolved task releases")
+    make_trial_identity = trial_identity_factory or _new_trial_identity
+    selected_attempt_recipe = attempt_recipe or SingleAttemptRecipe()
+    trials: list[PlannedTrial] = []
+    ordinal = 1
+    for task_release in spec.task_releases:
+        assert task_release.task_identity is not None
+        profile = task_profiles[task_release.task_identity.id]
+        if profile.metadata.identity != task_release.task_identity:
+            raise ValueError("task planning profile identity must match the task release")
+        if profile.metadata.visibility not in spec.visibility:
+            raise ValueError("task planning profile visibility is outside the resolved run policy")
+        for condition in spec.agent_conditions:
+            validate_combination(task_release, condition, profile.execution_family)
+            for repetition in range(1, spec.repetitions + 1):
+                trial_key = EntityKey(f"{task_release.task_id}__{condition.identity.key}__rep-{repetition:02d}")
+                trial_identity = make_trial_identity(str(trial_key))
+                if trial_identity.key != trial_key:
+                    raise ValueError("trial identity factory must preserve the requested trial key")
+                trials.append(
+                    PlannedTrial(
+                        trial_identity=trial_identity,
+                        ordinal=ordinal,
+                        run_identity=spec.run_identity,
+                        task_release=task_release,
+                        task_metadata=profile.metadata,
+                        agent_condition=condition,
+                        compute=spec.compute,
+                        repetition=repetition,
+                        seed=spec.randomization_seed,
+                        execution_family=profile.execution_family,
+                        attempt_recipe=selected_attempt_recipe,
+                        evaluation_profile=spec.evaluation_regime,
+                        extensions=tuple(extensions),
+                    )
+                )
+                ordinal += 1
+    family_counts = Counter(trial.execution_family for trial in trials)
+    visibility_counts = Counter(profile.metadata.visibility for profile in task_profiles.values())
+    summary = RunPlanSummary(
+        selected_task_count=len(spec.task_releases),
+        agent_condition_count=len(spec.agent_conditions),
+        repetitions=spec.repetitions,
+        total_trials=len(trials),
+        trials_by_execution_family=dict(family_counts),
+        trials_by_backend={spec.compute.backend: len(trials)},
+        visibility_policy=spec.visibility,
+        tasks_by_visibility=dict(visibility_counts),
+        deprecated_task_count=sum(
+            profile.metadata.lifecycle is Lifecycle.DEPRECATED for profile in task_profiles.values()
+        ),
+    )
+    return RunPlan(
+        plan_identity=plan_identity,
+        run_identity=spec.run_identity,
+        created_at=created_at,
+        state="ready",
+        trials=tuple(trials),
+        summary=summary,
+    )
+
+
+def _new_trial_identity(key: str) -> EntityIdentity:
+    return EntityIdentity(id=new_entity_id(EntityKind.TRIAL), key=EntityKey(key), version=1)
+
+
+__all__ = (
+    "AttemptRecipe",
+    "BestOfAttemptRecipe",
+    "CombinationValidator",
+    "PlannedTrial",
+    "PlannedTrialExtension",
+    "RunPlan",
+    "RunPlanSummary",
+    "SingleAttemptRecipe",
+    "TaskPlanningProfile",
+    "TrialIdentityFactory",
+    "plan_run",
+)

--- a/tests/contracts/test_run_plan.py
+++ b/tests/contracts/test_run_plan.py
@@ -1,0 +1,285 @@
+# ABOUTME: Tests pure expansion of a resolved run into UUID-backed ordered work.
+# ABOUTME: Covers plan summaries, identity factories, readiness validation, and typed extensions.
+
+from datetime import UTC, datetime
+from uuid import UUID
+
+import pytest
+from pydantic import ValidationError
+
+from aec_bench.contracts.artifacts import ArtifactRef
+from aec_bench.contracts.experiment_manifest import (
+    AgentCondition,
+    AgentConfig,
+    ComputeConfig,
+    ExperimentManifest,
+    TaskSelector,
+)
+from aec_bench.contracts.identity import EntityIdentity, EntityKind, new_entity_id
+from aec_bench.contracts.resolved_run import ResolvedRunSpec, resolve_run_spec
+from aec_bench.contracts.run_plan import (
+    PlannedTrialExtension,
+    RunPlan,
+    SingleAttemptRecipe,
+    TaskPlanningProfile,
+    plan_run,
+)
+from aec_bench.contracts.task_definition import Lifecycle, TaskMetadata, Visibility
+from aec_bench.contracts.task_snapshot import ArtifactTaskSnapshotRef, TaskSnapshotRef
+from aec_bench.contracts.trial_extensions import AdaptationProvenance
+from aec_bench.contracts.trial_record import TrialTaskKind
+
+_PLAN_CREATED_AT = datetime(2026, 8, 30, 12, 1, tzinfo=UTC)
+
+
+def _identity(kind: EntityKind, key: str, version: int = 1) -> EntityIdentity:
+    return EntityIdentity(id=new_entity_id(kind), key=key, version=version)
+
+
+def _snapshot(task_id: str, version: int = 1) -> ArtifactTaskSnapshotRef:
+    digest = "a" * 64
+    return ArtifactTaskSnapshotRef(
+        task_id=task_id,
+        task_identity=_identity(EntityKind.TASK, task_id, version),
+        artifact=ArtifactRef(
+            artifact_id=f"artifacts/sha256/{digest}",
+            sha256=digest,
+            size_bytes=1,
+            media_type="application/vnd.aec-bench.task-snapshot+tar+zstd",
+        ),
+    )
+
+
+def _resolved_run(*, repetitions: int = 2) -> ResolvedRunSpec:
+    manifest = ExperimentManifest(
+        experiment_id="pump-study",
+        name="Pump study",
+        tasks=TaskSelector(visibility_filter=[Visibility.PUBLIC]),
+        agents=[
+            AgentConfig(name="baseline", adapter="direct", model="model-a"),
+            AgentConfig(name="candidate", adapter="direct", model="model-b"),
+        ],
+        compute=ComputeConfig(backend="local", resource_limits={"cpu": 2}),
+        repetitions=repetitions,
+    )
+    conditions = tuple(
+        AgentCondition(
+            identity=_identity(EntityKind.AGENT_CONDITION, agent.name),
+            adapter=agent.adapter,
+            model=agent.model,
+            client=agent.client,
+            system_prompt=agent.system_prompt,
+            parameters=agent.parameters,
+        )
+        for agent in manifest.agents
+    )
+    return resolve_run_spec(
+        manifest,
+        task_releases=[_snapshot("civil/pump-sizing", 2), _snapshot("civil/pipe-loss", 3)],
+        agent_conditions=conditions,
+        experiment_identity=_identity(EntityKind.EXPERIMENT, "pump-study", 2),
+        run_identity=_identity(EntityKind.RUN, "pump-study-run"),
+        created_at=datetime(2026, 8, 30, 12, 0, tzinfo=UTC),
+        created_by="theo",
+        randomization_seed=42,
+    )
+
+
+def _task_profiles(
+    spec: ResolvedRunSpec,
+    *,
+    second_family: TrialTaskKind = "world",
+) -> dict[UUID, TaskPlanningProfile]:
+    profiles: dict[UUID, TaskPlanningProfile] = {}
+    for index, release in enumerate(spec.task_releases):
+        assert release.task_identity is not None
+        profiles[release.task_identity.id] = TaskPlanningProfile(
+            metadata=TaskMetadata(
+                identity=release.task_identity,
+                lifecycle=Lifecycle.ACTIVE if index == 0 else Lifecycle.DEPRECATED,
+                visibility=Visibility.PUBLIC,
+            ),
+            execution_family="artifact" if index == 0 else second_family,
+        )
+    return profiles
+
+
+def _accept_combination(
+    task_release: TaskSnapshotRef,
+    condition: AgentCondition,
+    execution_family: TrialTaskKind,
+) -> None:
+    del task_release, condition, execution_family
+
+
+def test_plan_run_expands_exact_order_and_summary() -> None:
+    spec = _resolved_run()
+    plan = plan_run(
+        spec,
+        plan_identity=_identity(EntityKind.PLAN, "pump-study-plan"),
+        created_at=_PLAN_CREATED_AT,
+        task_profiles=_task_profiles(spec),
+        validate_combination=_accept_combination,
+        attempt_recipe=SingleAttemptRecipe(),
+    )
+
+    assert plan.state == "ready"
+    assert plan.summary.selected_task_count == 2
+    assert plan.summary.agent_condition_count == 2
+    assert plan.summary.repetitions == 2
+    assert plan.summary.total_trials == 8
+    assert plan.summary.trials_by_execution_family == {"artifact": 4, "world": 4}
+    assert plan.summary.trials_by_backend == {"local": 8}
+    assert plan.summary.tasks_by_visibility == {Visibility.PUBLIC: 2}
+    assert plan.summary.deprecated_task_count == 1
+    assert [trial.ordinal for trial in plan.trials] == list(range(1, 9))
+    assert [trial.repetition for trial in plan.trials[:4]] == [1, 2, 1, 2]
+    assert all(trial.task_release.task_identity is not None for trial in plan.trials)
+    assert all(trial.seed == 42 for trial in plan.trials)
+    assert RunPlan.model_validate_json(plan.model_dump_json()) == plan
+
+
+def test_repeated_planning_creates_fresh_trial_uuids() -> None:
+    spec = _resolved_run(repetitions=1)
+    first = plan_run(
+        spec,
+        plan_identity=_identity(EntityKind.PLAN, "pump-study-plan-a"),
+        created_at=_PLAN_CREATED_AT,
+        task_profiles=_task_profiles(spec),
+        validate_combination=_accept_combination,
+    )
+    second = plan_run(
+        spec,
+        plan_identity=_identity(EntityKind.PLAN, "pump-study-plan-b"),
+        created_at=_PLAN_CREATED_AT,
+        task_profiles=_task_profiles(spec),
+        validate_combination=_accept_combination,
+    )
+
+    assert {trial.trial_id for trial in first.trials}.isdisjoint({trial.trial_id for trial in second.trials})
+
+
+def test_plan_run_accepts_supported_typed_extensions() -> None:
+    extension = PlannedTrialExtension(
+        extension_kind="adaptation",
+        value=AdaptationProvenance(
+            family_id="family-1",
+            seed_task_id="civil/pump-sizing",
+            variation_key="variant-1",
+            variation={"axis": "value"},
+        ),
+    )
+    spec = _resolved_run(repetitions=1)
+    plan = plan_run(
+        spec,
+        plan_identity=_identity(EntityKind.PLAN, "pump-study-plan"),
+        created_at=_PLAN_CREATED_AT,
+        task_profiles=_task_profiles(spec),
+        validate_combination=_accept_combination,
+        extensions=[extension],
+    )
+
+    assert all(trial.extensions == (extension,) for trial in plan.trials)
+    assert RunPlan.model_validate_json(plan.model_dump_json()) == plan
+
+
+def test_plan_run_rejects_duplicate_trial_id_from_factory() -> None:
+    identity = _identity(EntityKind.TRIAL, "placeholder")
+
+    def duplicate_identity(key: str) -> EntityIdentity:
+        return identity.model_copy(update={"key": key})
+
+    with pytest.raises(ValidationError, match="trial identities must be unique"):
+        spec = _resolved_run(repetitions=1)
+        plan_run(
+            spec,
+            plan_identity=_identity(EntityKind.PLAN, "pump-study-plan"),
+            created_at=_PLAN_CREATED_AT,
+            task_profiles=_task_profiles(spec),
+            validate_combination=_accept_combination,
+            trial_identity_factory=duplicate_identity,
+        )
+
+
+def test_ready_plan_rejects_non_contiguous_ordinals() -> None:
+    spec = _resolved_run(repetitions=1)
+    plan = plan_run(
+        spec,
+        plan_identity=_identity(EntityKind.PLAN, "pump-study-plan"),
+        created_at=_PLAN_CREATED_AT,
+        task_profiles=_task_profiles(spec),
+        validate_combination=_accept_combination,
+    )
+    changed_trial = plan.trials[1].model_copy(update={"ordinal": 99})
+    with pytest.raises(ValidationError, match="ordinals must be contiguous"):
+        RunPlan(
+            plan_identity=plan.plan_identity,
+            run_identity=plan.run_identity,
+            created_at=plan.created_at,
+            state=plan.state,
+            trials=(plan.trials[0], changed_trial, *plan.trials[2:]),
+            summary=plan.summary,
+        )
+
+
+def test_plan_run_requires_exact_runnable_task_profiles() -> None:
+    spec = _resolved_run(repetitions=1)
+    profiles = _task_profiles(spec)
+    profiles.pop(next(iter(profiles)))
+    with pytest.raises(ValueError, match="exactly match"):
+        plan_run(
+            spec,
+            plan_identity=_identity(EntityKind.PLAN, "pump-study-plan"),
+            created_at=_PLAN_CREATED_AT,
+            task_profiles=profiles,
+            validate_combination=_accept_combination,
+        )
+
+    profiles = _task_profiles(spec)
+    task_id = next(iter(profiles))
+    profiles[task_id] = profiles[task_id].model_copy(
+        update={"metadata": profiles[task_id].metadata.model_copy(update={"visibility": Visibility.HOLDOUT})}
+    )
+    with pytest.raises(ValueError, match="outside the resolved run policy"):
+        plan_run(
+            spec,
+            plan_identity=_identity(EntityKind.PLAN, "pump-study-plan"),
+            created_at=_PLAN_CREATED_AT,
+            task_profiles=profiles,
+            validate_combination=_accept_combination,
+        )
+
+
+def test_ready_plan_rejects_inaccurate_visibility_summary() -> None:
+    spec = _resolved_run(repetitions=1)
+    plan = plan_run(
+        spec,
+        plan_identity=_identity(EntityKind.PLAN, "pump-study-plan"),
+        created_at=_PLAN_CREATED_AT,
+        task_profiles=_task_profiles(spec),
+        validate_combination=_accept_combination,
+    )
+    changed_summary = plan.summary.model_copy(update={"tasks_by_visibility": {Visibility.PRIVATE: 2}})
+    with pytest.raises(ValidationError, match="visibility counts"):
+        RunPlan(
+            plan_identity=plan.plan_identity,
+            run_identity=plan.run_identity,
+            created_at=plan.created_at,
+            state=plan.state,
+            trials=plan.trials,
+            summary=changed_summary,
+        )
+
+
+def test_plan_run_rejects_invalid_creation_time() -> None:
+    spec = _resolved_run(repetitions=1)
+    inputs = {
+        "spec": spec,
+        "plan_identity": _identity(EntityKind.PLAN, "pump-study-plan"),
+        "task_profiles": _task_profiles(spec),
+        "validate_combination": _accept_combination,
+    }
+    with pytest.raises(ValueError, match="timezone"):
+        plan_run(created_at=datetime(2026, 8, 30, 12, 1), **inputs)
+    with pytest.raises(ValueError, match="must not precede"):
+        plan_run(created_at=datetime(2026, 8, 30, 11, 59, tzinfo=UTC), **inputs)


### PR DESCRIPTION
## Summary

- add the canonical UUID-backed `RunPlan` and ordered `PlannedTrial` contracts
- expand one `ResolvedRunSpec` through a pure planner with no persistence or execution effects
- validate exact task metadata, lifecycle, visibility, task-agent compatibility, UUID and key uniqueness, and contiguous ordinals
- support mixed artifact, world, and lifecycle plans with accurate family, backend, visibility, and deprecation summaries
- keep task, agent, compute, repetition, seed, attempt-recipe, evaluation, and supported pre-execution extension inputs explicit

## Scope

This PR adds the canonical plan contract only. It does not change the current legacy execution callers or persist plans. Those changes are later PRD 2 increments. The existing specialised run-package `RunPlan` remains temporarily distinct and is documented as such.

This PR is stacked on #182.

## Validation

- focused identity, resolved-run, and run-plan suite — 64 passed
- broader PRD1/PRD2 contract and run-bundle boundary suite — 117 passed
- provenance audit — PASS, zero violations
- Ruff check and format check — passed
- scoped mypy — passed
- `git diff --check` — passed