### PR TITLE
PRD2: reconcile local artifact results with persisted plans

### DIFF
--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -87,6 +87,20 @@ rejects duplicate task or condition identities. Direct model loading applies
 the same task identity and secret value checks; secret-bearing values may use
 named environment references such as `api_key_env` or `env:VARIABLE`.
 
+The canonical local artifact entrypoint, `run_persisted_artifact_plan`, reads
+one persisted ready plan from `EvidenceRunStore`. It validates each selected
+artifact task against its exact task snapshot reference before calling
+`start_run`; no adapter effect occurs before the run is started. It executes
+only artifact-family planned trial UUIDs, uses each planned UUID as the
+`TrialRecord.trial_id`, and returns records in plan ordinal order. Each record
+may carry a `PlannedTrialBinding` with the run, trial, task release, agent
+condition, repetition, execution family, evaluation profile, and expected
+authority identities, including its plan ordinal. Adapter and resolved-model
+values must match the planned agent condition. The TrialRecord attempt count
+remains `1`; repetition is the planned repetition in the binding. Legacy
+`run_experiment` remains available to current callers
+until the later execution migration.
+
 ## Task specification
 
 `TaskDefinition` is the validated runnable description of an artifact or

--- a/provenance-registry.toml
+++ b/provenance-registry.toml
@@ -2036,6 +2036,27 @@ duplication = "unique"
 format = "lowercase 40-character Git commit"
 
 [[field]]
+symbol = "aec_bench.contracts.trial_record.PlannedTrialBinding.schema_version"
+surface = "pydantic_model"
+wire_name = "schema_version"
+category = "compatibility"
+domain_owner = "trial_record"
+authority = "canonical_local_artifact_execution"
+authoritative = true
+exposure = "persisted"
+status = "current"
+payload_contract = "optional binding from one TrialRecord to one canonical planned artifact trial"
+canonicalization = "fixed integer literal 1"
+consumer = "trial reconstruction and run comparison consumers"
+validation_behavior = "PlannedTrialBinding accepts only schema_version 1 and validates its run, trial, task release, repetition, execution family, evaluation profile, and expected authorities"
+mismatch_behavior = "reject the trial record binding"
+retention = "trial_record_lifetime"
+rationale = "Local artifact execution must retain the canonical plan binding while keeping TrialRecord readable for legacy callers."
+duplication = "unique"
+compatibility_behavior = "read the optional schema-1 binding or treat its absence as a legacy unbound record"
+compatibility_kind = "external_schema"
+
+[[field]]
 symbol = "aec_bench.contracts.trial_record.RunManifest.schema_version"
 surface = "pydantic_model"
 wire_name = "schema_version"

--- a/src/aec_bench/contracts/trial_record.py
+++ b/src/aec_bench/contracts/trial_record.py
@@ -17,7 +17,9 @@ from aec_bench.contracts.authority_evidence import AuthorityEvidenceKind, Author
 from aec_bench.contracts.dataset import DatasetRef, dataset_reference_key
 from aec_bench.contracts.evaluation_refs import EvaluationRegimeRef
 from aec_bench.contracts.evaluation_result import EvaluationResult
+from aec_bench.contracts.identity import EntityIdentity
 from aec_bench.contracts.task_definition import Visibility
+from aec_bench.contracts.task_snapshot import TaskSnapshotRef
 from aec_bench.contracts.trial_extensions import (
     AdaptationProvenance,
     ArtifactReference,
@@ -198,6 +200,32 @@ class TrialInput(FrozenStrictModel):
 InputRecord = TrialInput
 
 
+class PlannedTrialBinding(FrozenStrictModel):
+    """Optional exact binding from one result to its canonical planned trial."""
+
+    schema_version: Literal[1] = 1
+    run_identity: EntityIdentity
+    trial_identity: EntityIdentity
+    task_release: TaskSnapshotRef
+    agent_condition_identity: EntityIdentity
+    ordinal: PositiveInt
+    repetition: PositiveInt
+    execution_family: TrialTaskKind
+    evaluation_profile: EvaluationRegimeRef | None = None
+    expected_authorities: tuple[AuthorityExpectation, ...] = ()
+
+    @field_validator("expected_authorities")
+    @classmethod
+    def validate_expected_authorities(
+        cls,
+        value: tuple[AuthorityExpectation, ...],
+    ) -> tuple[AuthorityExpectation, ...]:
+        keys = [(item.authority_kind, item.protocol) for item in value]
+        if len(keys) != len(set(keys)):
+            raise ValueError("planned trial authority identities must be unique")
+        return value
+
+
 class TrialArtifactRef(FrozenStrictModel):
     role: NonEmptyStr
     artifact: ArtifactRef
@@ -329,6 +357,7 @@ class TrialRecord(StrictModel):
     trial_id: NonEmptyStr
     run_id: NonEmptyStr
     task_id: NonEmptyStr
+    planned_trial_binding: PlannedTrialBinding | None = None
     attempt: PositiveInt = 1
     execution_status: ExecutionStatus
     evaluation_status: EvaluationStatus
@@ -379,6 +408,16 @@ class TrialRecord(StrictModel):
 
     @model_validator(mode="after")
     def validate_statuses(self) -> Self:
+        binding = self.planned_trial_binding
+        if binding is not None:
+            if str(binding.trial_identity.id) != self.trial_id:
+                raise ValueError("planned trial binding trial identity does not match trial_id")
+            if str(binding.run_identity.id) != self.run_id:
+                raise ValueError("planned trial binding run identity does not match run_id")
+            if binding.task_release.task_id != self.task_id:
+                raise ValueError("planned trial binding task release does not match task_id")
+            if binding.execution_family != self.input.task_kind:
+                raise ValueError("planned trial binding execution family does not match task kind")
         terminal = self.execution_status in {
             ExecutionStatus.COMPLETED,
             ExecutionStatus.FAILED,
@@ -409,6 +448,12 @@ class TrialRecord(StrictModel):
             raise ValueError("trial run_id does not match the run manifest")
         self._run_manifest = manifest
         self._validate_evidence_against_manifest()
+        binding = self.planned_trial_binding
+        if binding is not None:
+            if binding.expected_authorities != manifest.expected_authorities:
+                raise ValueError("planned trial binding authority policy does not match the run manifest")
+            if binding.evaluation_profile != manifest.evaluation_regime:
+                raise ValueError("planned trial binding evaluation profile does not match the run manifest")
         return self
 
     def bind_artifact_root(self, root: Path) -> Self:
@@ -652,6 +697,7 @@ __all__ = (
     "LifecycleTrialProvenance",
     "MetaHarnessTrialProvenance",
     "OutputRecord",
+    "PlannedTrialBinding",
     "ProviderRoute",
     "ProposalSessionTrialProvenance",
     "PublicationEligibility",

--- a/src/aec_bench/harness/artifact_tasks.py
+++ b/src/aec_bench/harness/artifact_tasks.py
@@ -11,6 +11,7 @@ import tempfile
 import time
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, replace
+from datetime import datetime
 from pathlib import Path
 from typing import Annotated, Any, Literal, Protocol
 
@@ -20,16 +21,23 @@ from aec_bench.adapters.base import Adapter, AdapterRequest, AdapterResult
 from aec_bench.contracts.agent_output import AgentOutputStatus
 from aec_bench.contracts.canonical_refs import CanonicalRefSet, parse_canonical_refs
 from aec_bench.contracts.evaluation_result import EvaluationResult, ValidityCheck
+from aec_bench.contracts.identity import EntityIdentity
+from aec_bench.contracts.resolved_run import ResolvedRunSpec
+from aec_bench.contracts.run_plan import BestOfAttemptRecipe
+from aec_bench.contracts.run_plan import PlannedTrial as CanonicalPlannedTrial
+from aec_bench.contracts.run_plan import SingleAttemptRecipe as CanonicalSingleAttemptRecipe
 from aec_bench.contracts.task_definition import ToolSpec
 from aec_bench.contracts.trial_extensions import ArtifactReference, VerifierExecutionReceipt
 from aec_bench.contracts.trial_record import (
     EvaluationStatus,
     ExecutionStatus,
+    PlannedTrialBinding,
     TrialRecord,
 )
 from aec_bench.contracts.validators import StrictModel
 from aec_bench.evaluation.normalisation import NormalisationResult, normalise_output
 from aec_bench.evaluation.verifier_outcome import map_verifier_execution
+from aec_bench.harness.compilation.task_snapshot import TaskSnapshotError, assert_task_snapshot_matches_directory
 from aec_bench.harness.local_runtime import (
     patch_workspace_paths,
     read_instruction,
@@ -43,6 +51,7 @@ from aec_bench.harness.verifier_execution import (
     execute_verifier,
     localise_staged_verifier_paths,
 )
+from aec_bench.ledger.evidence_run_store import EvidenceRunStore
 from aec_bench.ledger.writer import materialize_trial_record
 from aec_bench.tasks.instance import ResolvedTaskInstance
 from aec_bench.tasks.snapshot import build_task_snapshot_archive
@@ -632,6 +641,9 @@ def run_trial(
     verify: bool = True,
     keep_workspaces: bool = False,
     selected_workspace_export: Path | None = None,
+    planned_trial_binding: PlannedTrialBinding | None = None,
+    planned_run_spec: ResolvedRunSpec | None = None,
+    result_validator: Callable[[AdapterResult], None] | None = None,
 ) -> TrialRecord:
     """Run one tracked recipe, verify its selection, and return durable trial evidence."""
 
@@ -661,6 +673,8 @@ def run_trial(
             parent=parent,
             instruction=instruction,
         )
+        if result_validator is not None:
+            result_validator(attempt.result)
         attempts.append(attempt)
         return attempt
 
@@ -677,6 +691,8 @@ def run_trial(
                 attempts=attempts,
                 selection=selection,
                 started=started,
+                planned_trial_binding=planned_trial_binding,
+                planned_run_spec=planned_run_spec,
             )
         if all(selected is not item for item in attempts):
             raise ValueError("attempt recipe selected an untracked attempt")
@@ -714,6 +730,8 @@ def run_trial(
             selection_evidence=selection.evidence,
             verifier_receipt=verifier_receipt,
             evaluation_status=evaluation_status,
+            planned_trial_binding=planned_trial_binding,
+            planned_run_spec=planned_run_spec,
         )
     finally:
         if snapshot_dir is not None:
@@ -775,13 +793,13 @@ def run_experiment(
 
     records: list[TrialRecord] = []
     for trial in trials:
-        task = tasks_by_id.get(trial.task_id)
-        if task is None:
+        selected_task = tasks_by_id.get(trial.task_id)
+        if selected_task is None:
             raise ValueError(f"planned trial references an unresolved task: {trial.task_id}")
         records.append(
             run_trial(
                 runtime=runtime,
-                task=task,
+                task=selected_task,
                 trial=trial,
                 recipe=selected_recipe,
                 reviewer=reviewer,
@@ -790,6 +808,133 @@ def run_experiment(
             )
         )
     return records
+
+
+def run_persisted_artifact_plan(
+    *,
+    store: EvidenceRunStore,
+    run_identity: EntityIdentity,
+    runtime: LocalTaskRuntime,
+    tasks: Sequence[ResolvedTaskInstance],
+    started_at: datetime,
+    reviewer: ReviewerRunConfig | None = None,
+    verify: bool = True,
+    keep_workspaces: bool = False,
+) -> list[TrialRecord]:
+    """Execute the artifact subset of one persisted ready plan in ordinal order."""
+
+    stored = store.read_run(run_identity)
+    plan = stored.plan
+    if plan is None or stored.state.state != "ready":
+        raise ValueError("a persisted ready plan is required for local artifact execution")
+
+    tasks_by_id: dict[str, ResolvedTaskInstance] = {}
+    for task in tasks:
+        if task.task.task_id in tasks_by_id:
+            raise ValueError(f"resolved tasks must have unique task ids: {task.task.task_id}")
+        tasks_by_id[task.task.task_id] = task
+
+    artifact_trials = tuple(trial for trial in plan.trials if trial.execution_family == "artifact")
+    if not artifact_trials:
+        raise ValueError("persisted plan contains no artifact-family trials")
+    for trial in artifact_trials:
+        selected_task = tasks_by_id.get(trial.task_release.task_id)
+        if selected_task is None:
+            raise ValueError(f"planned artifact trial references an unresolved task: {trial.task_release.task_id}")
+        _validate_canonical_task_release(trial, selected_task)
+
+    store.start_run(run_identity, started_at=started_at)
+    records: list[TrialRecord] = []
+    for trial in artifact_trials:
+        task = tasks_by_id[trial.task_release.task_id]
+        _validate_canonical_task_release(trial, task)
+        legacy_trial = _legacy_trial_for_canonical(trial, stored.spec)
+        records.append(
+            run_trial(
+                runtime=runtime,
+                task=task,
+                trial=legacy_trial,
+                recipe=_legacy_recipe_for_canonical(trial),
+                reviewer=reviewer,
+                verify=verify,
+                keep_workspaces=keep_workspaces,
+                planned_trial_binding=_planned_trial_binding(trial, stored.spec),
+                planned_run_spec=stored.spec,
+                result_validator=_result_validator(trial),
+            )
+        )
+    return sorted(records, key=lambda record: _trial_ordinal(record, artifact_trials))
+
+
+def _validate_canonical_task_release(trial: CanonicalPlannedTrial, task: ResolvedTaskInstance) -> None:
+    reference = trial.task_release
+    if reference.task_identity is None or task.task.identity != reference.task_identity:
+        raise ValueError(f"task identity does not match planned release: {reference.task_id}")
+    try:
+        assert_task_snapshot_matches_directory(reference=reference, task_dir=task.instance_dir)
+    except TaskSnapshotError as error:
+        raise ValueError(f"task release does not match planned snapshot: {reference.task_id}") from error
+
+
+def _legacy_trial_for_canonical(trial: CanonicalPlannedTrial, spec: ResolvedRunSpec) -> PlannedTrial:
+    from aec_bench.contracts.experiment_manifest import AgentConfig
+
+    condition = trial.agent_condition
+    return PlannedTrial(
+        trial_id=str(trial.trial_identity.id),
+        experiment_id=str(spec.experiment_identity.id),
+        task_id=trial.task_release.task_id,
+        agent=AgentConfig(
+            name=str(condition.identity.key),
+            adapter=condition.adapter,
+            model=condition.model,
+            client=condition.client,
+            parameters=condition.parameters,
+            system_prompt=condition.system_prompt,
+        ),
+        compute=trial.compute,
+        repetition=trial.repetition,
+        extensions={str(extension.extension_kind): extension.value for extension in trial.extensions},
+    )
+
+
+def _legacy_recipe_for_canonical(trial: CanonicalPlannedTrial) -> AttemptRecipe:
+    if isinstance(trial.attempt_recipe, CanonicalSingleAttemptRecipe):
+        return single_attempt()
+    if isinstance(trial.attempt_recipe, BestOfAttemptRecipe):
+        return best_of(k=trial.attempt_recipe.candidates, selector=self_select())
+    raise TypeError(f"unsupported canonical attempt recipe: {type(trial.attempt_recipe).__name__}")
+
+
+def _planned_trial_binding(trial: CanonicalPlannedTrial, spec: ResolvedRunSpec) -> PlannedTrialBinding:
+    return PlannedTrialBinding(
+        run_identity=spec.run_identity,
+        trial_identity=trial.trial_identity,
+        task_release=trial.task_release,
+        agent_condition_identity=trial.agent_condition.identity,
+        ordinal=trial.ordinal,
+        repetition=trial.repetition,
+        execution_family=trial.execution_family,
+        evaluation_profile=trial.evaluation_profile,
+        expected_authorities=spec.expected_authorities,
+    )
+
+
+def _result_validator(trial: CanonicalPlannedTrial) -> Callable[[AdapterResult], None]:
+    def validate(result: AdapterResult) -> None:
+        if result.adapter_name != trial.agent_condition.adapter:
+            raise ValueError("adapter result does not match the planned agent condition")
+        if result.resolved_model != trial.agent_condition.model:
+            raise ValueError("resolved model does not match the planned agent condition")
+
+    return validate
+
+
+def _trial_ordinal(record: TrialRecord, trials: Sequence[CanonicalPlannedTrial]) -> int:
+    for trial in trials:
+        if str(trial.trial_identity.id) == record.trial_id:
+            return trial.ordinal
+    raise ValueError(f"record does not match a planned artifact trial: {record.trial_id}")
 
 
 def run_trial_with_verifier_feedback(
@@ -929,11 +1074,15 @@ def _build_materialized_record(
     selection_evidence: AttemptSelectionEvidence | None = None,
     verifier_receipt: VerifierExecutionReceipt | None = None,
     evaluation_status: EvaluationStatus | None = None,
+    planned_trial_binding: PlannedTrialBinding | None = None,
+    planned_run_spec: ResolvedRunSpec | None = None,
 ) -> TrialRecord:
     output_path = resolve_workspace_path(actor_snapshot, task.task.verifier.expected_output_path)
     record = build_trial_record(
         trial_id=trial.trial_id,
-        experiment_id=trial.experiment_id,
+        experiment_id=(
+            trial.experiment_id if planned_run_spec is None else str(planned_run_spec.experiment_identity.id)
+        ),
         task=task.task,
         task_revision=runtime.task_revision(task),
         request=selected.request,
@@ -951,9 +1100,14 @@ def _build_materialized_record(
         raw_output_path=str(output_path) if output_path.is_file() else None,
         conversation_path=_existing_path(actor_snapshot / "conversation.jsonl"),
         trajectory_path=_existing_path(actor_snapshot / "trajectory.jsonl"),
-        attempt=trial.repetition,
+        attempt=1 if planned_trial_binding is not None else trial.repetition,
         extensions=_trial_extensions(trial, selection_evidence, verifier_receipt),
         evaluation_status=evaluation_status,
+        planned_trial_binding=planned_trial_binding,
+        run_id=None if planned_run_spec is None else str(planned_run_spec.run_identity.id),
+        dataset=None if planned_run_spec is None else planned_run_spec.dataset,
+        expected_authorities=() if planned_run_spec is None else planned_run_spec.expected_authorities,
+        evaluation_regime=None if planned_run_spec is None else planned_run_spec.evaluation_regime,
     )
     _attach_workspace_files(record=record, workspace=actor_snapshot)
     _attach_post_execution_files(record=record, workspace=evidence_workspace)
@@ -968,11 +1122,15 @@ def _build_failed_materialized_record(
     attempts: list[TaskAttempt],
     selection: AttemptSelection,
     started: float,
+    planned_trial_binding: PlannedTrialBinding | None = None,
+    planned_run_spec: ResolvedRunSpec | None = None,
 ) -> TrialRecord:
     representative = attempts[0]
     record = build_trial_record(
         trial_id=trial.trial_id,
-        experiment_id=trial.experiment_id,
+        experiment_id=(
+            trial.experiment_id if planned_run_spec is None else str(planned_run_spec.experiment_identity.id)
+        ),
         task=task.task,
         task_revision=runtime.task_revision(task),
         request=representative.request,
@@ -987,10 +1145,15 @@ def _build_failed_materialized_record(
         verification_seconds=None,
         runtime_image="local",
         compute_backend=trial.compute.backend,
-        attempt=trial.repetition,
+        attempt=1 if planned_trial_binding is not None else trial.repetition,
         extensions=_trial_extensions(trial, selection.evidence),
         execution_status_override=ExecutionStatus.FAILED,
         include_output=False,
+        planned_trial_binding=planned_trial_binding,
+        run_id=None if planned_run_spec is None else str(planned_run_spec.run_identity.id),
+        dataset=None if planned_run_spec is None else planned_run_spec.dataset,
+        expected_authorities=() if planned_run_spec is None else planned_run_spec.expected_authorities,
+        evaluation_regime=None if planned_run_spec is None else planned_run_spec.evaluation_regime,
     )
     return materialize_trial_record(artifact_root=runtime.artifact_root, record=record)
 
@@ -1280,6 +1443,7 @@ __all__ = (
     "best_of",
     "build_attempt_recipe",
     "run_experiment",
+    "run_persisted_artifact_plan",
     "run_trial",
     "run_trial_with_verifier_feedback",
     "self_select",

--- a/src/aec_bench/harness/trial_record_builder.py
+++ b/src/aec_bench/harness/trial_record_builder.py
@@ -12,6 +12,7 @@ from aec_bench.contracts.agent_output import AgentOutputStatus
 from aec_bench.contracts.artifacts import ArtifactRef
 from aec_bench.contracts.authority_evidence import AuthorityEvidenceRef
 from aec_bench.contracts.dataset import DatasetRef
+from aec_bench.contracts.evaluation_refs import EvaluationRegimeRef
 from aec_bench.contracts.evaluation_result import EvaluationResult
 from aec_bench.contracts.task_definition import TaskDefinition
 from aec_bench.contracts.trial_record import (
@@ -23,6 +24,7 @@ from aec_bench.contracts.trial_record import (
     ExecutionEnvironmentRef,
     ExecutionStatus,
     FileReference,
+    PlannedTrialBinding,
     ProviderRoute,
     QualificationRequirement,
     RunManifest,
@@ -107,6 +109,8 @@ def build_trial_record(
     evaluation_status: EvaluationStatus | None = None,
     execution_status_override: ExecutionStatus | None = None,
     include_output: bool = True,
+    planned_trial_binding: PlannedTrialBinding | None = None,
+    evaluation_regime: EvaluationRegimeRef | None = None,
 ) -> TrialRecord:
     stop_reason = result.stop_reason or result.failure_kind
     final_reason = result.completion_reason or stop_reason
@@ -136,11 +140,13 @@ def build_trial_record(
         provider_route=provider_route or _provider_route(result),
         expected_authorities=expected_authorities,
         qualification=qualification,
+        evaluation_regime=evaluation_regime,
     )
     record = TrialRecord(
         trial_id=trial_id,
         run_id=selected_run_id,
         task_id=task.task_id,
+        planned_trial_binding=planned_trial_binding,
         attempt=attempt,
         execution_status=execution_status,
         evaluation_status=(

--- a/tests/harness/test_persisted_artifact_plan.py
+++ b/tests/harness/test_persisted_artifact_plan.py
@@ -1,0 +1,319 @@
+# ABOUTME: Tests canonical local execution from a persisted resolved run plan.
+# ABOUTME: Proves start ordering, exact task binding, planned trial selection, and result integrity.
+
+import hashlib
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from aec_bench.adapters.base import AdapterRequest, AdapterResult
+from aec_bench.contracts.agent_output import AgentOutput, AgentOutputStatus
+from aec_bench.contracts.artifacts import ArtifactRef
+from aec_bench.contracts.experiment_manifest import (
+    AgentCondition,
+    AgentConfig,
+    ComputeConfig,
+    ExperimentManifest,
+    TaskSelector,
+)
+from aec_bench.contracts.identity import EntityIdentity, EntityKind, new_entity_id
+from aec_bench.contracts.resolved_run import ResolvedRunSpec, resolve_run_spec
+from aec_bench.contracts.run_plan import RunPlan, TaskPlanningProfile, plan_run
+from aec_bench.contracts.task_definition import Lifecycle, TaskMetadata, Visibility
+from aec_bench.contracts.task_snapshot import ArtifactTaskSnapshotRef
+from aec_bench.harness.artifact_tasks import LocalTaskRuntime, run_persisted_artifact_plan
+from aec_bench.ledger.evidence_run_store import EvidenceRunStore
+from aec_bench.tasks.instance import ResolvedTaskInstance, resolve_instance_paths
+from aec_bench.tasks.snapshot import TASK_SNAPSHOT_MEDIA_TYPE, build_task_snapshot_archive
+from tests.support.task_factories import make_task_definition
+
+_CREATED_AT = datetime(2026, 8, 30, 12, 0, tzinfo=UTC)
+
+
+def _identity(kind: EntityKind, key: str, version: int = 1) -> EntityIdentity:
+    return EntityIdentity(id=new_entity_id(kind), key=key, version=version)
+
+
+def _task(tmp_path: Path, *, name: str = "one") -> ResolvedTaskInstance:
+    task_dir = tmp_path / name
+    task_dir.mkdir()
+    (task_dir / "instruction.md").write_text("Write /workspace/deliverables/result.md\n", encoding="utf-8")
+    (task_dir / "remove-me.txt").write_text("stale\n", encoding="utf-8")
+    environment = task_dir / "environment"
+    environment.mkdir()
+    (environment / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+    tests = task_dir / "tests"
+    tests.mkdir()
+    (tests / "verify.py").write_text("# private\n", encoding="utf-8")
+    definition = make_task_definition(
+        task_id=f"test/artifact/{name}",
+        identity=_identity(EntityKind.TASK, f"test/artifact/{name}", version=2),
+        environment={"dockerfile": "environment/Dockerfile"},
+        verifier={
+            "script": "tests/verify.py",
+            "expected_output_path": "/workspace/deliverables/result.md",
+            "reward_path": "logs/verifier/reward.json",
+            "details_path": "logs/verifier/details.json",
+        },
+    )
+    return resolve_instance_paths(definition, task_dir)
+
+
+def _release(task: ResolvedTaskInstance) -> ArtifactTaskSnapshotRef:
+    identity = task.task.identity
+    assert identity is not None
+    archive = build_task_snapshot_archive(task.instance_dir)
+    digest = hashlib.sha256(archive).hexdigest()
+    return ArtifactTaskSnapshotRef(
+        task_id=task.task.task_id,
+        task_identity=identity,
+        artifact=ArtifactRef(
+            artifact_id=f"task-snapshots/{digest}.tar.zst",
+            sha256=digest,
+            size_bytes=len(archive),
+            media_type=TASK_SNAPSHOT_MEDIA_TYPE,
+        ),
+    )
+
+
+def _spec(task: ResolvedTaskInstance, *, condition_count: int = 1) -> ResolvedRunSpec:
+    agents = tuple(
+        AgentConfig(name=f"agent-{index}", adapter="direct", model=f"model-{index}") for index in range(condition_count)
+    )
+    manifest = ExperimentManifest(
+        experiment_id="artifact-plan-test",
+        name="Artifact plan test",
+        tasks=TaskSelector(visibility_filter=[Visibility.PUBLIC]),
+        agents=list(agents),
+        compute=ComputeConfig(backend="local", resource_limits={"memory_mb": 512}),
+    )
+    conditions = tuple(
+        AgentCondition(
+            identity=_identity(EntityKind.AGENT_CONDITION, agent.name),
+            adapter=agent.adapter,
+            model=agent.model,
+            client=agent.client,
+            system_prompt=agent.system_prompt,
+            parameters=agent.parameters,
+        )
+        for agent in agents
+    )
+    return resolve_run_spec(
+        manifest,
+        task_releases=[_release(task)],
+        agent_conditions=conditions,
+        experiment_identity=_identity(EntityKind.EXPERIMENT, manifest.experiment_id),
+        run_identity=_identity(EntityKind.RUN, "artifact-plan-run"),
+        created_at=_CREATED_AT,
+        created_by="test",
+    )
+
+
+def _ready_store(tmp_path: Path, spec: ResolvedRunSpec) -> tuple[EvidenceRunStore, RunPlan]:
+    plan = plan_run(
+        spec,
+        plan_identity=_identity(EntityKind.PLAN, "artifact-plan"),
+        created_at=datetime(2026, 8, 30, 12, 1, tzinfo=UTC),
+        task_profiles={
+            spec.task_releases[0].task_identity.id: TaskPlanningProfile(
+                metadata=TaskMetadata(
+                    identity=spec.task_releases[0].task_identity,
+                    lifecycle=Lifecycle.ACTIVE,
+                    visibility=Visibility.PUBLIC,
+                ),
+                execution_family="artifact",
+            )
+        },
+        validate_combination=lambda task_release, condition, execution_family: None,
+    )
+    store = EvidenceRunStore(tmp_path / "runs")
+    store.create_run(spec)
+    store.write_draft_plan(spec.run_identity, plan.model_copy(update={"state": "draft"}))
+    store.promote_ready_plan(spec.run_identity, plan)
+    return store, plan
+
+
+class _Adapter:
+    def __init__(
+        self,
+        model: str,
+        workspace: Path,
+        calls: list[str],
+        state: EvidenceRunStore,
+        run_identity: EntityIdentity,
+        adapter_name: str = "direct",
+    ) -> None:
+        self.model = model
+        self.adapter_name = adapter_name
+        self.workspace = workspace
+        self.calls = calls
+        self.state = state
+        self.run_identity = run_identity
+
+    def execute(self, request: AdapterRequest) -> AdapterResult:
+        assert self.state.read_run(self.run_identity).state.state == "started"
+        self.calls.append(self.model)
+        output = self.workspace / "deliverables" / "result.md"
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text("Complete\n", encoding="utf-8")
+        return AdapterResult(
+            adapter_name=self.adapter_name,
+            resolved_model=self.model,
+            configuration_record={},
+            agent_output=AgentOutput(
+                status=AgentOutputStatus.COMPLETED,
+                output_path=request.output_path,
+                output_format=request.output_format,
+            ),
+            transcript=[],
+        )
+
+
+def _runtime(
+    store: EvidenceRunStore,
+    spec: ResolvedRunSpec,
+    calls: list[str],
+    *,
+    drift: bool = False,
+    adapter_drift: bool = False,
+) -> LocalTaskRuntime:
+    def build(**kwargs: Any) -> _Adapter:
+        model = "wrong-model" if drift else kwargs["model_name"]
+        adapter_name = "wrong-adapter" if adapter_drift else "direct"
+        return _Adapter(model, Path(kwargs["workspace"]), calls, store, spec.run_identity, adapter_name)
+
+    return LocalTaskRuntime(
+        work_root=store.root / "work",
+        adapter_builder=build,
+        normalise=False,
+    )
+
+
+def test_persisted_artifact_plan_starts_before_effect_and_binds_record(tmp_path: Path) -> None:
+    task = _task(tmp_path)
+    spec = _spec(task)
+    store, plan = _ready_store(tmp_path, spec)
+    calls: list[str] = []
+
+    records = run_persisted_artifact_plan(
+        store=store,
+        run_identity=spec.run_identity,
+        runtime=_runtime(store, spec, calls),
+        tasks=[task],
+        started_at=datetime(2026, 8, 30, 12, 2, tzinfo=UTC),
+        verify=False,
+    )
+
+    assert calls == ["model-0"]
+    assert [record.trial_id for record in records] == [str(plan.trials[0].trial_identity.id)]
+    binding = records[0].planned_trial_binding
+    assert binding is not None
+    assert binding.run_identity == spec.run_identity
+    assert binding.trial_identity == plan.trials[0].trial_identity
+    assert binding.task_release == plan.trials[0].task_release
+    assert binding.ordinal == plan.trials[0].ordinal
+    assert binding.repetition == plan.trials[0].repetition
+    assert records[0].attempt == 1
+
+
+def test_persisted_artifact_plan_rejects_missing_or_unstarted_plan(tmp_path: Path) -> None:
+    task = _task(tmp_path)
+    spec = _spec(task)
+    store = EvidenceRunStore(tmp_path / "runs")
+    store.create_run(spec)
+    with pytest.raises(ValueError, match="persisted ready plan"):
+        run_persisted_artifact_plan(
+            store=store,
+            run_identity=spec.run_identity,
+            runtime=_runtime(store, spec, []),
+            tasks=[task],
+            started_at=datetime(2026, 8, 30, 12, 2, tzinfo=UTC),
+            verify=False,
+        )
+
+
+def test_persisted_artifact_plan_rejects_release_drift_and_does_not_start(tmp_path: Path) -> None:
+    task = _task(tmp_path)
+    spec = _spec(task)
+    store, _ = _ready_store(tmp_path, spec)
+    (task.instance_dir / "instruction.md").write_text("changed\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="planned snapshot"):
+        run_persisted_artifact_plan(
+            store=store,
+            run_identity=spec.run_identity,
+            runtime=_runtime(store, spec, []),
+            tasks=[task],
+            started_at=datetime(2026, 8, 30, 12, 2, tzinfo=UTC),
+            verify=False,
+        )
+    assert store.read_run(spec.run_identity).state.state == "ready"
+
+
+def test_persisted_artifact_plan_ignores_unplanned_tasks(tmp_path: Path) -> None:
+    task = _task(tmp_path)
+    extra = _task(tmp_path, name="extra")
+    spec = _spec(task)
+    store, _ = _ready_store(tmp_path, spec)
+    calls: list[str] = []
+
+    records = run_persisted_artifact_plan(
+        store=store,
+        run_identity=spec.run_identity,
+        runtime=_runtime(store, spec, calls),
+        tasks=[extra, task],
+        started_at=datetime(2026, 8, 30, 12, 2, tzinfo=UTC),
+        verify=False,
+    )
+
+    assert len(records) == 1
+    assert calls == ["model-0"]
+
+
+def test_persisted_artifact_plan_rejects_result_identity_drift(tmp_path: Path) -> None:
+    task = _task(tmp_path)
+    spec = _spec(task)
+    store, _ = _ready_store(tmp_path, spec)
+    with pytest.raises(ValueError, match="resolved model"):
+        run_persisted_artifact_plan(
+            store=store,
+            run_identity=spec.run_identity,
+            runtime=_runtime(store, spec, [], drift=True),
+            tasks=[task],
+            started_at=datetime(2026, 8, 30, 12, 2, tzinfo=UTC),
+            verify=False,
+        )
+
+
+def test_persisted_artifact_plan_rejects_adapter_identity_drift(tmp_path: Path) -> None:
+    task = _task(tmp_path)
+    spec = _spec(task)
+    store, _ = _ready_store(tmp_path, spec)
+    with pytest.raises(ValueError, match="adapter result"):
+        run_persisted_artifact_plan(
+            store=store,
+            run_identity=spec.run_identity,
+            runtime=_runtime(store, spec, [], adapter_drift=True),
+            tasks=[task],
+            started_at=datetime(2026, 8, 30, 12, 2, tzinfo=UTC),
+            verify=False,
+        )
+
+
+def test_persisted_artifact_plan_returns_plan_order_for_multiple_conditions(tmp_path: Path) -> None:
+    task = _task(tmp_path)
+    spec = _spec(task, condition_count=2)
+    store, plan = _ready_store(tmp_path, spec)
+    calls: list[str] = []
+    records = run_persisted_artifact_plan(
+        store=store,
+        run_identity=spec.run_identity,
+        runtime=_runtime(store, spec, calls),
+        tasks=[task],
+        started_at=datetime(2026, 8, 30, 12, 2, tzinfo=UTC),
+        verify=False,
+    )
+
+    assert [record.trial_id for record in records] == [str(trial.trial_identity.id) for trial in plan.trials]
+    assert calls == ["model-0", "model-1"]


### PR DESCRIPTION
## Summary

- execute local artifact trials only from a persisted ready RunPlan
- validate exact task release identity and snapshot bytes before adapter effects
- bind each TrialRecord to its planned UUID, ordinal, repetition, evaluation profile, and authority policy
- reject adapter or resolved-model drift and preserve plan order

## Review order

1. PlannedTrialBinding in trial_record.py
2. run_persisted_artifact_plan in artifact_tasks.py
3. focused persisted-plan tests
4. contract and provenance updates

## Validation

- focused affected suite: 63 passed
- wider contracts, ledger, and artifact suite: 912 passed; 4 unrelated compatibility-boundary failures reproduced on the parent branch
- Ruff check: passed
- Ruff format check: passed
- provenance audit: PASS, 0 violations
- git diff --check: passed

## Scope

This is PRD2 pull request 6. It is stacked on the plan persistence PR. Harbor, world, lifecycle, provider-resolution, and run-status changes remain in later pull requests.