### PR TITLE
PRD2: reconcile Harbor trials with persisted plans

### DIFF
--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -101,6 +101,44 @@ remains `1`; repetition is the planned repetition in the binding. Legacy
 `run_experiment` remains available to current callers
 until the later execution migration.
 
+Canonical Harbor dispatch validates the persisted ready plan and writes all
+one-trial job configurations and transport sidecars before the first Harbor
+effect. Each job contains one task, one agent, and one attempt.
+`HarborTrialTransport` carries a transport-safe Harbor job name with the exact
+planned trial UUID. Import does not treat a
+Harbor job ID or generated trial name as an AEC-Bench trial identity. The
+`HarborImportReconciliation` report lists expected, observed, missing,
+duplicate, and accepted planned trial IDs. It also lists observed, unexpected,
+and duplicate Harbor trial names. Import rejects any membership mismatch
+before it binds records, then validates each record against its exact
+planned task release, agent condition, compute backend, execution family, and
+attempt. Accepted records retain Harbor job and trial names only as observed
+backend metadata and return in plan ordinal order.
+
+The transport and reconciliation values have this JSON shape (UUIDs are
+illustrative):
+
+```json
+{
+  "schema_version": 1,
+  "transport": {
+    "harbor_job_name": "aec-planned-0190abcd12347abc8def0123456789ab",
+    "planned_trial_id": "0190abcd-1234-7abc-8def-0123456789ab",
+    "harbor_trial_name": null
+  },
+  "reconciliation": {
+    "expected_trial_ids": ["0190abcd-1234-7abc-8def-0123456789ab"],
+    "observed_trial_ids": ["0190abcd-1234-7abc-8def-0123456789ab"],
+    "observed_trial_names": ["task-name__backend-generated-id"],
+    "missing_trial_ids": [],
+    "unexpected_trial_names": [],
+    "duplicate_trial_ids": [],
+    "duplicate_trial_names": [],
+    "accepted_trial_ids": ["0190abcd-1234-7abc-8def-0123456789ab"]
+  }
+}
+```
+
 ## Task specification
 
 `TaskDefinition` is the validated runnable description of an artifact or

--- a/provenance-registry.toml
+++ b/provenance-registry.toml
@@ -2890,6 +2890,48 @@ compatibility_behavior = "read v1 and v2 explicitly; reject unsupported runtime-
 compatibility_kind = "external_schema"
 
 [[field]]
+symbol = "aec_bench.harness.harbor_reconciliation.HarborImportReconciliation.schema_version"
+surface = "pydantic_model"
+wire_name = "schema_version"
+category = "compatibility"
+domain_owner = "harbor_execution"
+authority = "harbor_import_reconciliation"
+authoritative = true
+exposure = "persisted"
+status = "current"
+payload_contract = "exact Harbor import membership reconciliation report schema 1"
+canonicalization = "fixed integer literal 1"
+consumer = "canonical Harbor import boundary"
+validation_behavior = "HarborImportReconciliation accepts schema version 1 and requires unique expected and accepted planned trial UUIDs"
+mismatch_behavior = "reject unsupported Harbor import reconciliation report"
+retention = "harbor_import_lifetime"
+rationale = "Exact imports need a stable reader contract for expected, observed, missing, unexpected, duplicate, and accepted trial membership."
+duplication = "unique"
+compatibility_behavior = "the canonical Harbor importer accepts schema 1 only"
+compatibility_kind = "external_schema"
+
+[[field]]
+symbol = "aec_bench.harness.harbor_reconciliation.HarborTrialTransport.schema_version"
+surface = "pydantic_model"
+wire_name = "schema_version"
+category = "compatibility"
+domain_owner = "harbor_execution"
+authority = "harbor_trial_transport"
+authoritative = true
+exposure = "persisted"
+status = "current"
+payload_contract = "safe Harbor job-name to planned trial UUID transport mapping schema 1"
+canonicalization = "fixed integer literal 1"
+consumer = "canonical Harbor dispatch and import boundaries"
+validation_behavior = "HarborTrialTransport accepts schema version 1 and binds one non-empty Harbor job name to one planned trial UUID"
+mismatch_behavior = "reject an unsupported or unbound Harbor trial transport mapping"
+retention = "harbor_job_lifetime"
+rationale = "Harbor-generated identifiers are backend observations; the transport mapping preserves the exact AEC-Bench planned trial identity."
+duplication = "unique"
+compatibility_behavior = "the canonical Harbor importer accepts schema 1 only"
+compatibility_kind = "external_schema"
+
+[[field]]
 symbol = "aec_bench.harness.world_actor.authority.AuthorityCloseReport.closed_at"
 aliases = ["manifest:aec-bench/actor-invocation-evidence/1[close].closed_at"]
 surface = "dataclass"

--- a/src/aec_bench/harness/experiment_runner.py
+++ b/src/aec_bench/harness/experiment_runner.py
@@ -6,9 +6,16 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from aec_bench.contracts.experiment_manifest import AgentConfig, ExperimentManifest
+from aec_bench.contracts.resolved_run import ResolvedRunSpec
+from aec_bench.contracts.run_plan import RunPlan
 from aec_bench.contracts.task_definition import TaskDefinition
 from aec_bench.contracts.trial_record import TrialRecord
-from aec_bench.harness.harbor_importing.core import import_harbor_job
+from aec_bench.harness.harbor_importing.core import import_harbor_job, import_harbor_trial, iter_harbor_trial_dirs
+from aec_bench.harness.harbor_reconciliation import (
+    HarborImportReconciliation,
+    read_harbor_trial_transport,
+    reconcile_harbor_trial_records,
+)
 from aec_bench.harness.progress_tracker import ImportProgressTracker
 from aec_bench.harness.scheduler import select_manifest_tasks
 from aec_bench.ledger.writer import DuplicateTrialRecordError, write_trial_record
@@ -37,10 +44,64 @@ class ExperimentImportResult:
 
 
 @dataclass(frozen=True)
+class HarborPlanImportResult:
+    records: list[TrialRecord]
+    reconciliation: HarborImportReconciliation
+    ledger_paths: list[Path]
+
+
+@dataclass(frozen=True)
 class HarborImportExperimentRunner:
     repo_root: Path
     tasks_root: Path
     ledger_root: Path
+
+    def import_harbor_plan(
+        self,
+        *,
+        job_dir: Path,
+        run_spec: ResolvedRunSpec,
+        run_plan: RunPlan,
+        transport_path: Path,
+    ) -> HarborPlanImportResult:
+        """Import and persist one exact planned Harbor job result."""
+
+        transport = read_harbor_trial_transport(transport_path)
+        if len(transport) != 1:
+            raise ExperimentImportMismatchError("canonical Harbor job transport must contain exactly one planned trial")
+        if Path(job_dir).name != transport[0].harbor_job_name:
+            raise ExperimentImportMismatchError("Harbor job directory does not match its planned transport name")
+        imported_records = [
+            import_harbor_trial(
+                trial_dir=trial_dir,
+                repo_root=self.repo_root,
+                experiment_id=str(run_spec.experiment_identity.id),
+                dataset=run_spec.dataset,
+            )
+            for trial_dir in iter_harbor_trial_dirs(job_dir=job_dir)
+        ]
+        records, reconciliation = reconcile_harbor_trial_records(
+            records=imported_records,
+            run_spec=run_spec,
+            run_plan=run_plan,
+            transport=transport,
+        )
+        ledger_paths: list[Path] = []
+        for record in records:
+            try:
+                path = write_trial_record(ledger_root=self.ledger_root, record=record)
+            except DuplicateTrialRecordError as error:
+                path = self.ledger_root / record.experiment_id / f"{record.trial_id}.json"
+                if not path.is_file() or path.read_bytes() != record.model_dump_json(indent=2).encode("utf-8"):
+                    raise ExperimentImportMismatchError(
+                        "duplicate canonical TrialRecord identity resolves to different ledger content"
+                    ) from error
+            ledger_paths.append(path)
+        return HarborPlanImportResult(
+            records=records,
+            reconciliation=reconciliation,
+            ledger_paths=ledger_paths,
+        )
 
     def import_harbor_job(
         self,

--- a/src/aec_bench/harness/harbor_dispatch.py
+++ b/src/aec_bench/harness/harbor_dispatch.py
@@ -3,20 +3,30 @@
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
-from collections.abc import Mapping
-from dataclasses import dataclass
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, replace
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Protocol
+from uuid import UUID
 
 import yaml
 from harbor.models.job.config import JobConfig  # type: ignore[import-untyped]
 
 from aec_bench.contracts.execution_environment import HarborEnvironmentBinding
 from aec_bench.contracts.experiment_manifest import AgentConfig, ExperimentManifest
+from aec_bench.contracts.identity import EntityIdentity
+from aec_bench.contracts.resolved_run import ResolvedRunSpec
+from aec_bench.contracts.run_plan import PlannedTrial, RunPlan
 from aec_bench.contracts.task_definition import TaskDefinition
+from aec_bench.harness.compilation.task_snapshot import TaskSnapshotError, assert_task_snapshot_matches_directory
 from aec_bench.harness.execution_payload import ExecutionBundle, build_entrypoint_execution_bundle
+from aec_bench.harness.harbor_reconciliation import HarborTrialTransport, build_harbor_trial_transport
+from aec_bench.ledger.evidence_run_store import EvidenceRunStore
+from aec_bench.tasks.instance import ResolvedTaskInstance
 from aec_bench.tasks.selector import validate_execution_tasks
 from aec_bench.trials import plan_trials
 
@@ -41,6 +51,17 @@ class HarborDispatchResult:
     selected_task_count: int
     planned_trial_count: int
     exit_code: int | None = None
+    planned_trial_ids: tuple[UUID, ...] = ()
+    trial_transport: tuple[HarborTrialTransport, ...] = ()
+    trial_transport_path: Path | None = None
+
+
+@dataclass(frozen=True)
+class HarborPlannedDispatchResult:
+    """All one-trial Harbor jobs prepared for one persisted plan subset."""
+
+    run_identity: EntityIdentity
+    dispatches: tuple[HarborDispatchResult, ...]
 
 
 class HarborCommandExecutor(Protocol):
@@ -84,12 +105,22 @@ def dispatch_harbor_config(
     planned_trial_count: int,
     executor: HarborCommandExecutor | None = None,
     execute: bool = True,
+    planned_trial_ids: Sequence[UUID] = (),
+    trial_transport: Sequence[HarborTrialTransport] = (),
 ) -> HarborDispatchResult:
     """Write and optionally execute one validated Harbor configuration."""
 
     destination = Path(config_path)
     destination.parent.mkdir(parents=True, exist_ok=True)
     destination.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+    transport_items = tuple(trial_transport)
+    transport_path = None
+    if transport_items:
+        transport_path = destination.with_suffix(destination.suffix + ".trial-transport.json")
+        transport_path.write_text(
+            json.dumps([item.model_dump(mode="json") for item in transport_items], indent=2) + "\n",
+            encoding="utf-8",
+        )
     command, exit_code = execute_harbor_config(
         config_path=destination,
         project_root=project_root,
@@ -102,6 +133,9 @@ def dispatch_harbor_config(
         selected_task_count=selected_task_count,
         planned_trial_count=planned_trial_count,
         exit_code=exit_code,
+        planned_trial_ids=tuple(planned_trial_ids),
+        trial_transport=transport_items,
+        trial_transport_path=transport_path,
     )
 
 
@@ -120,6 +154,9 @@ class HarborExperimentDispatcher:
         environment_binding: HarborEnvironmentBinding | None = None,
         executor: HarborCommandExecutor | None = None,
         execute: bool = True,
+        planned_trials: Sequence[PlannedTrial] | None = None,
+        trial_transport: Sequence[HarborTrialTransport] = (),
+        job_name: str | None = None,
     ) -> HarborDispatchResult:
         if not tasks:
             raise HarborDispatchError("manifest did not select any tasks for Harbor dispatch")
@@ -143,8 +180,9 @@ class HarborExperimentDispatcher:
             jobs_dir=self.jobs_dir,
             task_path_overrides=task_path_overrides,
             environment_binding=environment_binding,
+            job_name=job_name,
         )
-        planned_trials = plan_trials(
+        legacy_planned_trials = plan_trials(
             manifest.experiment_id,
             tasks=tasks,
             agents=manifest.agents,
@@ -152,14 +190,169 @@ class HarborExperimentDispatcher:
             repetitions=manifest.repetitions,
             permitted_visibility=manifest.tasks.visibility_filter,
         )
+        canonical_trials = tuple(planned_trials) if planned_trials is not None else ()
+        planned_trial_ids = tuple(trial.trial_identity.id for trial in canonical_trials)
+        if len(set(planned_trial_ids)) != len(planned_trial_ids):
+            raise HarborDispatchError("canonical Harbor planned trial IDs must be unique")
+        selected_task_ids = {task.task_id for task in tasks}
+        if any(trial.task_release.task_id not in selected_task_ids for trial in canonical_trials):
+            raise HarborDispatchError("canonical Harbor planned trials must use selected tasks")
+        selected_transport = tuple(trial_transport)
+        if canonical_trials and not selected_transport:
+            raise HarborDispatchError("canonical Harbor dispatch requires an explicit trial transport mapping")
+        if selected_transport and {item.planned_trial_id for item in selected_transport} != set(planned_trial_ids):
+            raise HarborDispatchError("Harbor transport must cover the exact canonical planned trial subset")
+        if len({item.harbor_job_name for item in selected_transport}) != len(selected_transport):
+            raise HarborDispatchError("Harbor transport job names must be unique")
         return dispatch_harbor_config(
             config=job_config,
             config_path=config_path,
             project_root=self.project_root,
             selected_task_count=len(tasks),
-            planned_trial_count=len(planned_trials),
+            planned_trial_count=len(legacy_planned_trials),
             executor=executor,
             execute=execute,
+            planned_trial_ids=planned_trial_ids,
+            trial_transport=selected_transport,
+        )
+
+    def dispatch_persisted_plan(
+        self,
+        *,
+        store: EvidenceRunStore,
+        run_identity: EntityIdentity,
+        manifest: ExperimentManifest,
+        tasks: Sequence[ResolvedTaskInstance],
+        config_dir: Path,
+        started_at: datetime,
+        planned_trial_ids: Sequence[UUID] | None = None,
+        environment_binding: HarborEnvironmentBinding | None = None,
+        executor: HarborCommandExecutor | None = None,
+        execute: bool = True,
+    ) -> HarborPlannedDispatchResult:
+        """Prepare every exact one-trial job before starting a persisted run."""
+
+        stored = store.read_run(run_identity)
+        run_plan = stored.plan
+        if run_plan is None or stored.state.state != "ready":
+            raise HarborDispatchError("canonical Harbor dispatch requires a persisted ready run plan")
+        requested_ids = None if planned_trial_ids is None else tuple(planned_trial_ids)
+        if requested_ids is not None and len(requested_ids) != len(set(requested_ids)):
+            raise HarborDispatchError("canonical Harbor planned trial IDs must be unique")
+        artifact_trials = tuple(trial for trial in run_plan.trials if trial.execution_family == "artifact")
+        selected_ids = {trial.trial_identity.id for trial in artifact_trials}
+        if requested_ids is not None:
+            unknown_ids = set(requested_ids) - selected_ids
+            if unknown_ids:
+                raise HarborDispatchError("canonical Harbor trial subset is outside the artifact run plan")
+            requested_set = set(requested_ids)
+            artifact_trials = tuple(trial for trial in artifact_trials if trial.trial_identity.id in requested_set)
+        if not artifact_trials:
+            raise HarborDispatchError("persisted run plan contains no selected artifact trials for Harbor")
+
+        tasks_by_id = {item.task.task_id: item for item in tasks}
+        if len(tasks_by_id) != len(tasks):
+            raise HarborDispatchError("canonical Harbor tasks must have unique task IDs")
+        missing_tasks = sorted({trial.task_release.task_id for trial in artifact_trials} - set(tasks_by_id))
+        if missing_tasks:
+            raise HarborDispatchError("canonical Harbor planned tasks are not supplied: " + ", ".join(missing_tasks))
+
+        destination = Path(config_dir)
+        destination.mkdir(parents=True, exist_ok=True)
+        prepared: list[HarborDispatchResult] = []
+        for trial in artifact_trials:
+            prepared.append(
+                self.dispatch_planned_trial(
+                    run_spec=stored.spec,
+                    run_plan=run_plan,
+                    planned_trial=trial,
+                    manifest=manifest,
+                    task=tasks_by_id[trial.task_release.task_id],
+                    config_path=destination / f"aec-planned-{trial.trial_identity.id.hex}.yaml",
+                    environment_binding=environment_binding,
+                    execute=False,
+                )
+            )
+
+        if not execute:
+            return HarborPlannedDispatchResult(run_identity=run_identity, dispatches=tuple(prepared))
+        store.start_run(run_identity, started_at=started_at)
+        completed: list[HarborDispatchResult] = []
+        for dispatch in prepared:
+            command, exit_code = execute_harbor_config(
+                config_path=dispatch.config_path,
+                project_root=self.project_root,
+                executor=executor,
+                execute=True,
+            )
+            completed.append(replace(dispatch, command=command, exit_code=exit_code))
+            if exit_code != 0:
+                raise HarborDispatchError(f"Harbor dispatch failed with exit code {exit_code}")
+        return HarborPlannedDispatchResult(run_identity=run_identity, dispatches=tuple(completed))
+
+    def dispatch_planned_trial(
+        self,
+        *,
+        run_spec: ResolvedRunSpec,
+        run_plan: RunPlan,
+        planned_trial: PlannedTrial,
+        manifest: ExperimentManifest,
+        task: ResolvedTaskInstance,
+        config_path: Path,
+        environment_binding: HarborEnvironmentBinding | None = None,
+        executor: HarborCommandExecutor | None = None,
+        execute: bool = True,
+    ) -> HarborDispatchResult:
+        """Dispatch one ready planned trial with a durable pre-effect mapping."""
+
+        if run_spec.run_identity != run_plan.run_identity:
+            raise HarborDispatchError("canonical Harbor run spec does not match the run plan")
+        if run_plan.schema_version != 2 or run_plan.state != "ready":
+            raise HarborDispatchError("canonical Harbor dispatch requires a ready schema-2 run plan")
+        planned_by_id = {trial.trial_identity.id: trial for trial in run_plan.trials}
+        if planned_by_id.get(planned_trial.trial_identity.id) != planned_trial:
+            raise HarborDispatchError("planned trial is not the exact trial from the run plan")
+        if planned_trial.execution_family != "artifact":
+            raise HarborDispatchError("canonical Harbor dispatch supports artifact planned trials only")
+        if task.task.task_id != planned_trial.task_release.task_id:
+            raise HarborDispatchError("canonical Harbor task does not match the planned task release")
+        if task.task.identity != planned_trial.task_release.task_identity:
+            raise HarborDispatchError("canonical Harbor task identity does not match the planned release")
+        try:
+            assert_task_snapshot_matches_directory(reference=planned_trial.task_release, task_dir=task.instance_dir)
+        except TaskSnapshotError as error:
+            raise HarborDispatchError("canonical Harbor task bytes do not match the planned release") from error
+        if manifest.experiment_id != str(run_spec.experiment_identity.key):
+            raise HarborDispatchError("canonical Harbor manifest does not match the resolved experiment")
+        if manifest.compute != planned_trial.compute or manifest.compute != run_spec.compute:
+            raise HarborDispatchError("canonical Harbor compute condition does not match the persisted plan")
+        agent_name = str(planned_trial.agent_condition.identity.key)
+        agent = next((candidate for candidate in manifest.agents if candidate.name == agent_name), None)
+        if agent is None:
+            raise HarborDispatchError("canonical Harbor planned agent is not present in the manifest")
+        if (
+            agent.adapter != planned_trial.agent_condition.adapter
+            or agent.model != planned_trial.agent_condition.model
+            or agent.client != planned_trial.agent_condition.client
+            or agent.system_prompt != planned_trial.agent_condition.system_prompt
+            or agent.parameters != planned_trial.agent_condition.parameters
+        ):
+            raise HarborDispatchError("canonical Harbor agent condition does not match the manifest")
+        if planned_trial.agent_condition.tool_versions or planned_trial.agent_condition.limits:
+            raise HarborDispatchError("canonical Harbor dispatch cannot represent planned agent tools or limits")
+        canonical_manifest = manifest.model_copy(update={"agents": [agent], "repetitions": 1})
+        transport = build_harbor_trial_transport((planned_trial,))
+        return self.dispatch(
+            manifest=canonical_manifest,
+            tasks=[task.task],
+            config_path=config_path,
+            task_path_overrides={task.task.task_id: task.instance_dir},
+            environment_binding=environment_binding,
+            executor=executor,
+            execute=execute,
+            planned_trials=(planned_trial,),
+            trial_transport=transport,
+            job_name=transport[0].harbor_job_name,
         )
 
 
@@ -170,6 +363,7 @@ def build_harbor_job_config(
     jobs_dir: Path | str = "jobs",
     task_path_overrides: Mapping[str, Path] | None = None,
     environment_binding: HarborEnvironmentBinding | None = None,
+    job_name: str | None = None,
 ) -> dict[str, Any]:
     agents = [_harbor_agent_config(agent) for agent in manifest.agents]
     if manifest.compute.timeout_override is not None:
@@ -204,6 +398,8 @@ def build_harbor_job_config(
     }
     if manifest.disable_verification:
         config["verifier"] = {"disable": True}
+    if job_name is not None:
+        config["job_name"] = job_name
     return config
 
 

--- a/src/aec_bench/harness/harbor_importing/core.py
+++ b/src/aec_bench/harness/harbor_importing/core.py
@@ -576,6 +576,10 @@ def _output_record(
             error_message=agent.output_error,
         ),
         agent_result={
+            # These are Harbor backend identifiers only. Canonical import binds
+            # TrialRecord.trial_id to the planned UUID in the reconciliation boundary.
+            "harbor_job_id": context.harbor_result.config.job_id,
+            "harbor_trial_name": context.harbor_result.trial_name,
             "failure_kind": (
                 execution_result.failure_kind.value
                 if (execution_result is not None and execution_result.failure_kind is not None)

--- a/src/aec_bench/harness/harbor_reconciliation.py
+++ b/src/aec_bench/harness/harbor_reconciliation.py
@@ -1,0 +1,259 @@
+# ABOUTME: Defines the canonical Harbor trial-ID transport and import reconciliation boundary.
+# ABOUTME: Keeps Harbor job and trial names as observed backend identifiers while binding records to RunPlan UUIDs.
+
+from __future__ import annotations
+
+import json
+import re
+from collections import Counter
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Literal
+from uuid import UUID
+
+from pydantic import field_validator, model_validator
+
+from aec_bench.contracts.resolved_run import ResolvedRunSpec
+from aec_bench.contracts.run_plan import PlannedTrial, RunPlan
+from aec_bench.contracts.task_snapshot import ArtifactTaskSnapshotRef, RepositoryTaskSnapshotRef
+from aec_bench.contracts.trial_record import TrialRecord
+from aec_bench.contracts.validators import FrozenStrictModel, NonEmptyStr
+from aec_bench.harness.planned_trial_reconciliation import planned_trial_binding
+
+
+class HarborTrialTransport(FrozenStrictModel):
+    """Map one pre-effect Harbor job name to one canonical planned trial UUID."""
+
+    schema_version: Literal[1] = 1
+    harbor_job_name: NonEmptyStr
+    planned_trial_id: UUID
+    harbor_trial_name: NonEmptyStr | None = None
+
+    @field_validator("harbor_job_name")
+    @classmethod
+    def validate_harbor_job_name(cls, value: str) -> str:
+        if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]*", value) is None:
+            raise ValueError("Harbor job names must be safe single path components")
+        return value
+
+
+class HarborImportReconciliation(FrozenStrictModel):
+    """Structured membership report for one exact Harbor import."""
+
+    schema_version: Literal[1] = 1
+    expected_trial_ids: tuple[UUID, ...]
+    observed_trial_ids: tuple[UUID, ...] = ()
+    observed_trial_names: tuple[NonEmptyStr, ...]
+    missing_trial_ids: tuple[UUID, ...] = ()
+    unexpected_trial_names: tuple[NonEmptyStr, ...] = ()
+    duplicate_trial_ids: tuple[UUID, ...] = ()
+    duplicate_trial_names: tuple[NonEmptyStr, ...] = ()
+    accepted_trial_ids: tuple[UUID, ...] = ()
+
+    @model_validator(mode="after")
+    def validate_report_sets(self) -> HarborImportReconciliation:
+        if len(self.expected_trial_ids) != len(set(self.expected_trial_ids)):
+            raise ValueError("expected Harbor trial IDs must be unique")
+        if any(trial_id not in self.expected_trial_ids for trial_id in self.observed_trial_ids):
+            raise ValueError("observed Harbor trial IDs must belong to the expected subset")
+        if len(self.accepted_trial_ids) != len(set(self.accepted_trial_ids)):
+            raise ValueError("accepted Harbor trial IDs must be unique")
+        if any(trial_id not in self.observed_trial_ids for trial_id in self.accepted_trial_ids):
+            raise ValueError("accepted Harbor trial IDs must have been observed")
+        return self
+
+
+class HarborImportReconciliationError(ValueError):
+    """Reject an import that cannot be bound to the exact planned trial set."""
+
+    def __init__(self, report: HarborImportReconciliation) -> None:
+        self.report = report
+        super().__init__(
+            "Harbor import does not match the exact planned trial set: "
+            f"missing={len(report.missing_trial_ids)}, "
+            f"unexpected={len(report.unexpected_trial_names)}, "
+            f"duplicates={len(report.duplicate_trial_names)}"
+        )
+
+
+def build_harbor_trial_transport(
+    trials: Sequence[PlannedTrial],
+    harbor_trial_names: Sequence[str | None] = (),
+) -> tuple[HarborTrialTransport, ...]:
+    """Create pre-effect Harbor job names for selected planned trial UUIDs.
+
+    Harbor currently generates backend trial names. The optional names are
+    accepted only when a caller already has an observed name; otherwise the
+    safe job name binds the one-job transport sidecar to its planned UUID.
+    """
+
+    selected = tuple(trials)
+    if not selected:
+        raise ValueError("Harbor trial transport requires at least one planned trial")
+    names = tuple(harbor_trial_names)
+    if names and len(names) != len(selected):
+        raise ValueError("Harbor trial transport names must match the selected trial count")
+    if len({trial.trial_identity.id for trial in selected}) != len(selected):
+        raise ValueError("Harbor trial transport planned trial IDs must be unique")
+    transport = tuple(
+        HarborTrialTransport(
+            harbor_job_name=f"aec-planned-{trial.trial_identity.id.hex}",
+            planned_trial_id=trial.trial_identity.id,
+            harbor_trial_name=(names[index] if names else None),
+        )
+        for index, trial in enumerate(selected)
+    )
+    observed_names = [item.harbor_trial_name for item in transport if item.harbor_trial_name is not None]
+    if len(set(observed_names)) != len(observed_names):
+        raise ValueError("Harbor trial transport names must be unique")
+    return transport
+
+
+def read_harbor_trial_transport(path: Path) -> tuple[HarborTrialTransport, ...]:
+    """Read the pre-effect job mapping written beside one Harbor config."""
+
+    selected_path = Path(path)
+    if selected_path.is_symlink() or not selected_path.is_file():
+        raise ValueError("Harbor trial transport must be a regular file")
+    try:
+        payload = json.loads(selected_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError("Harbor trial transport is not valid JSON") from error
+    if not isinstance(payload, list) or not payload:
+        raise ValueError("Harbor trial transport must contain a non-empty JSON list")
+    return tuple(HarborTrialTransport.model_validate(item) for item in payload)
+
+
+def reconcile_harbor_trial_records(
+    *,
+    records: Sequence[TrialRecord],
+    run_spec: ResolvedRunSpec,
+    run_plan: RunPlan,
+    transport: Sequence[HarborTrialTransport],
+) -> tuple[list[TrialRecord], HarborImportReconciliation]:
+    """Bind imported Harbor records to the exact planned UUID subset."""
+
+    planned_by_id = {trial.trial_identity.id: trial for trial in run_plan.trials}
+    if run_spec.run_identity != run_plan.run_identity:
+        raise ValueError("Harbor import run identity does not match the resolved run plan")
+    if len(planned_by_id) != len(run_plan.trials):
+        raise ValueError("run plan trial IDs must be unique")
+    named_transport = tuple(item for item in transport if item.harbor_trial_name is not None)
+    transport_by_name = {item.harbor_trial_name: item for item in named_transport}
+    transport_ids = [item.planned_trial_id for item in transport]
+    job_names = [item.harbor_job_name for item in transport]
+    if len(set(job_names)) != len(transport) or len(set(transport_ids)) != len(transport):
+        raise ValueError("Harbor trial transport mapping must have unique job names and planned IDs")
+    if len(transport_by_name) != len(named_transport):
+        raise ValueError("observed Harbor trial names must be unique")
+    if any(item.planned_trial_id not in planned_by_id for item in transport):
+        raise ValueError("Harbor trial transport references a trial outside the run plan")
+
+    observed_names = tuple(record.trial_id for record in records)
+    counts = Counter(observed_names)
+    duplicate_names = tuple(sorted(name for name, count in counts.items() if count > 1))
+    if not named_transport:
+        if len(transport) != 1 or len(records) != 1:
+            raise HarborImportReconciliationError(
+                HarborImportReconciliation(
+                    expected_trial_ids=tuple(transport_ids),
+                    observed_trial_names=tuple(sorted(observed_names)),
+                    missing_trial_ids=tuple(transport_ids),
+                    unexpected_trial_names=tuple(sorted(observed_names)),
+                    duplicate_trial_names=duplicate_names,
+                )
+            )
+        transport_by_name[records[0].trial_id] = transport[0]
+    unexpected_names = tuple(sorted(name for name in counts if name not in transport_by_name))
+    observed_ids = {transport_by_name[name].planned_trial_id for name in counts if name in transport_by_name}
+    duplicate_ids = {transport_by_name[name].planned_trial_id for name in duplicate_names if name in transport_by_name}
+    expected_ids = tuple(item.planned_trial_id for item in transport)
+    missing_ids = tuple(sorted(set(expected_ids) - observed_ids, key=str))
+    report = HarborImportReconciliation(
+        expected_trial_ids=expected_ids,
+        observed_trial_ids=tuple(trial_id for trial_id in expected_ids if trial_id in observed_ids),
+        observed_trial_names=tuple(sorted(observed_names)),
+        missing_trial_ids=missing_ids,
+        unexpected_trial_names=unexpected_names,
+        duplicate_trial_ids=tuple(trial_id for trial_id in expected_ids if trial_id in duplicate_ids),
+        duplicate_trial_names=duplicate_names,
+    )
+    if missing_ids or unexpected_names or duplicate_names:
+        raise HarborImportReconciliationError(report)
+
+    records_by_id: dict[UUID, TrialRecord] = {}
+    for record in records:
+        planned = planned_by_id[transport_by_name[record.trial_id].planned_trial_id]
+        _validate_imported_record(record, planned)
+        canonical = _bind_record(record, planned, run_spec)
+        records_by_id[planned.trial_identity.id] = canonical
+    ordered = [
+        records_by_id[trial.trial_identity.id] for trial in run_plan.trials if trial.trial_identity.id in records_by_id
+    ]
+    accepted = report.model_copy(
+        update={
+            "accepted_trial_ids": tuple(
+                record.planned_trial_binding.trial_identity.id
+                for record in ordered
+                if record.planned_trial_binding is not None
+            )
+        }
+    )
+    return ordered, accepted
+
+
+def _validate_imported_record(record: TrialRecord, planned: PlannedTrial) -> None:
+    if record.task_id != planned.task_release.task_id:
+        raise ValueError("Harbor record task ID does not match the planned trial")
+    if record.input.task_kind != planned.execution_family:
+        raise ValueError("Harbor record execution family does not match the planned trial")
+    if record.agent.adapter != planned.agent_condition.adapter or record.agent.model != planned.agent_condition.model:
+        raise ValueError("Harbor record agent condition does not match the planned trial")
+    if record.environment.compute_backend != planned.compute.backend:
+        raise ValueError("Harbor record compute backend does not match the planned trial")
+    if isinstance(planned.task_release, ArtifactTaskSnapshotRef):
+        expected_revision = planned.task_release.artifact.sha256
+    elif isinstance(planned.task_release, RepositoryTaskSnapshotRef):
+        expected_revision = planned.task_release.source_revision
+    else:
+        expected_revision = None
+    if expected_revision is not None and record.input.task_revision != expected_revision:
+        raise ValueError("Harbor record task release does not match the planned snapshot")
+    if record.attempt != 1:
+        raise ValueError("Harbor records must contain one attempt receipt")
+
+
+def _bind_record(record: TrialRecord, planned: PlannedTrial, run_spec: ResolvedRunSpec) -> TrialRecord:
+    binding = planned_trial_binding(planned, run_spec)
+    canonical_run_id = str(run_spec.run_identity.id)
+    manifest = record.run_manifest.model_copy(
+        update={
+            "run_id": canonical_run_id,
+            "experiment_id": str(run_spec.experiment_identity.id),
+        }
+    )
+    output = record.output
+    if output is not None:
+        backend_ids = dict(output.agent_result or {})
+        backend_ids.setdefault("harbor_trial_name", record.trial_id)
+        output = output.model_copy(update={"agent_result": backend_ids})
+    canonical = record.model_copy(
+        update={
+            "trial_id": str(planned.trial_identity.id),
+            "run_id": canonical_run_id,
+            "task_id": planned.task_release.task_id,
+            "planned_trial_binding": binding,
+            "output": output,
+        }
+    )
+    return canonical.bind_run_manifest(manifest)
+
+
+__all__ = (
+    "HarborImportReconciliation",
+    "HarborImportReconciliationError",
+    "HarborTrialTransport",
+    "build_harbor_trial_transport",
+    "read_harbor_trial_transport",
+    "reconcile_harbor_trial_records",
+)

--- a/tests/fixtures/harbor/planned_trial_transport.json
+++ b/tests/fixtures/harbor/planned_trial_transport.json
@@ -1,0 +1,8 @@
+[
+  {
+    "schema_version": 1,
+    "harbor_job_name": "aec-planned-0190abcd12347abc8def0123456789ab",
+    "planned_trial_id": "0190abcd-1234-7abc-8def-0123456789ab",
+    "harbor_trial_name": null
+  }
+]

--- a/tests/harness/test_harbor_reconciliation.py
+++ b/tests/harness/test_harbor_reconciliation.py
@@ -1,0 +1,318 @@
+# ABOUTME: Tests exact Harbor trial transport and planned-trial import reconciliation.
+# ABOUTME: Uses provider-free TrialRecord fixtures to prove backend names never become canonical trial IDs.
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+import yaml
+
+from aec_bench.contracts.execution_environment import HarborEnvironmentBinding
+from aec_bench.contracts.experiment_manifest import AgentConfig, ExperimentManifest, TaskSelector
+from aec_bench.contracts.identity import EntityIdentity, EntityKind, new_entity_id
+from aec_bench.contracts.resolved_run import ResolvedRunSpec
+from aec_bench.contracts.run_plan import RunPlan, plan_run
+from aec_bench.contracts.task_definition import Visibility
+from aec_bench.contracts.trial_record import (
+    AgentConfiguration,
+    ExecutionEnvironmentRef,
+    TrialRecord,
+)
+from aec_bench.harness.harbor_dispatch import HarborCommandExecutor, HarborDispatchError, HarborExperimentDispatcher
+from aec_bench.harness.harbor_reconciliation import (
+    HarborImportReconciliationError,
+    build_harbor_trial_transport,
+    read_harbor_trial_transport,
+    reconcile_harbor_trial_records,
+)
+from tests.contracts.test_run_plan import _PLAN_CREATED_AT, _accept_combination, _resolved_run, _task_profiles
+from tests.harness.test_persisted_artifact_plan import _ready_store, _spec, _task
+from tests.support.trial_record_factories import make_trial_record
+
+
+def _plan() -> tuple[ResolvedRunSpec, RunPlan]:
+    spec = _resolved_run(repetitions=1)
+    return spec, plan_run(
+        spec,
+        plan_identity=EntityIdentity(id=new_entity_id(EntityKind.PLAN), key="pump-study-plan", version=1),
+        created_at=_PLAN_CREATED_AT,
+        task_profiles=_task_profiles(spec, second_family="artifact"),
+        validate_combination=_accept_combination,
+    )
+
+
+def _record(*, trial_name: str, task_id: str, model: str = "model-a") -> TrialRecord:
+    return make_trial_record(
+        trial_id=trial_name,
+        task={"task_id": task_id, "task_revision": "a" * 64},
+        agent=AgentConfiguration(
+            adapter="direct",
+            model=model,
+            adapter_revision="adapter-revision",
+            configuration={},
+        ),
+        environment=ExecutionEnvironmentRef(
+            runtime_image="test-image",
+            compute_backend="local",
+            tool_versions={},
+        ),
+    )
+
+
+def _manifest(spec: ResolvedRunSpec, plan: RunPlan) -> ExperimentManifest:
+    agents = [
+        AgentConfig(
+            name=str(trial.agent_condition.identity.key),
+            adapter=trial.agent_condition.adapter,
+            model=trial.agent_condition.model,
+            client=trial.agent_condition.client,
+            parameters=trial.agent_condition.parameters,
+            system_prompt=trial.agent_condition.system_prompt,
+        )
+        for trial in plan.trials
+    ]
+    return ExperimentManifest(
+        experiment_id=str(spec.experiment_identity.key),
+        name=spec.run_name,
+        tasks=TaskSelector(visibility_filter=[Visibility.PUBLIC]),
+        agents=agents,
+        compute=spec.compute,
+        repetitions=spec.repetitions,
+        disable_verification=not spec.verification_enabled,
+    )
+
+
+class _InspectingExecutor(HarborCommandExecutor):
+    def __init__(self, config_dir: Path, expected_count: int) -> None:
+        self.config_dir = config_dir
+        self.expected_count = expected_count
+        self.calls: list[Path] = []
+
+    def execute(self, *, command: list[str], cwd: Path) -> int:
+        del cwd
+        config_path = Path(command[-1])
+        self.calls.append(config_path)
+        assert len(tuple(self.config_dir.glob("*.trial-transport.json"))) == self.expected_count
+        config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert config["n_attempts"] == 1
+        assert len(config["tasks"]) == 1
+        assert len(config["agents"]) == 1
+        transport = json.loads(
+            config_path.with_suffix(config_path.suffix + ".trial-transport.json").read_text(encoding="utf-8")
+        )
+        assert transport[0]["harbor_job_name"] == config["job_name"]
+        return 0
+
+
+_LOCAL_ENVIRONMENT = HarborEnvironmentBinding(
+    backend="local",
+    import_path="tests.support.harbor_local_environment:LocalFilesystemHarborEnvironment",
+)
+
+
+def test_persisted_dispatch_prepares_all_exact_one_trial_jobs_before_effect(tmp_path: Path) -> None:
+    task = _task(tmp_path)
+    spec = _spec(task, condition_count=2)
+    store, plan = _ready_store(tmp_path, spec)
+    config_dir = tmp_path / "configs"
+    executor = _InspectingExecutor(config_dir, expected_count=2)
+
+    result = HarborExperimentDispatcher(project_root=tmp_path, jobs_dir=tmp_path / "jobs").dispatch_persisted_plan(
+        store=store,
+        run_identity=spec.run_identity,
+        manifest=_manifest(spec, plan),
+        tasks=[task],
+        config_dir=config_dir,
+        started_at=datetime(2026, 8, 30, 12, 2, tzinfo=UTC),
+        environment_binding=_LOCAL_ENVIRONMENT,
+        executor=executor,
+    )
+
+    assert store.read_run(spec.run_identity).state.state == "started"
+    assert len(result.dispatches) == 2
+    assert len(executor.calls) == 2
+    assert all(dispatch.exit_code == 0 for dispatch in result.dispatches)
+    assert [dispatch.planned_trial_ids[0] for dispatch in result.dispatches] == [
+        trial.trial_identity.id for trial in plan.trials
+    ]
+
+
+def test_persisted_dispatch_rejects_task_drift_before_effect(tmp_path: Path) -> None:
+    task = _task(tmp_path)
+    spec = _spec(task)
+    store, plan = _ready_store(tmp_path, spec)
+    (task.instance_dir / "instruction.md").write_text("drifted\n", encoding="utf-8")
+    executor = _InspectingExecutor(tmp_path / "configs", expected_count=0)
+
+    with pytest.raises(HarborDispatchError, match="task bytes"):
+        HarborExperimentDispatcher(project_root=tmp_path).dispatch_persisted_plan(
+            store=store,
+            run_identity=spec.run_identity,
+            manifest=_manifest(spec, plan),
+            tasks=[task],
+            config_dir=tmp_path / "configs",
+            started_at=datetime(2026, 8, 30, 12, 2, tzinfo=UTC),
+            environment_binding=_LOCAL_ENVIRONMENT,
+            executor=executor,
+        )
+
+    assert executor.calls == []
+    assert store.read_run(spec.run_identity).state.state == "ready"
+
+
+def test_transport_uses_safe_names_and_exact_planned_uuids() -> None:
+    _, plan = _plan()
+
+    transport = build_harbor_trial_transport(plan.trials[:2])
+
+    assert [item.planned_trial_id for item in transport] == [trial.trial_id for trial in plan.trials[:2]]
+    assert [item.harbor_job_name for item in transport] == [
+        f"aec-planned-{trial.trial_id.hex}" for trial in plan.trials[:2]
+    ]
+    assert all(item.harbor_trial_name is None for item in transport)
+
+
+def test_transport_sidecar_fixture_is_strict_and_readable() -> None:
+    path = Path(__file__).parents[1] / "fixtures" / "harbor" / "planned_trial_transport.json"
+
+    transport = read_harbor_trial_transport(path)
+
+    assert transport[0].harbor_job_name.startswith("aec-planned-")
+    assert transport[0].harbor_trial_name is None
+
+
+def test_reconciliation_binds_records_in_plan_order_and_keeps_backend_ids() -> None:
+    spec, plan = _plan()
+    transport = build_harbor_trial_transport(plan.trials[:2], ["harbor-task-a", "harbor-task-b"])
+    records = [
+        _record(
+            trial_name="harbor-task-b",
+            task_id=plan.trials[1].task_release.task_id,
+            model=plan.trials[1].agent_condition.model,
+        ),
+        _record(
+            trial_name="harbor-task-a",
+            task_id=plan.trials[0].task_release.task_id,
+            model=plan.trials[0].agent_condition.model,
+        ),
+    ]
+    records[0].output.agent_result["harbor_job_id"] = "job-123"
+
+    reconciled, report = reconcile_harbor_trial_records(
+        records=records,
+        run_spec=spec,
+        run_plan=plan,
+        transport=transport,
+    )
+
+    assert [record.trial_id for record in reconciled] == [str(item.planned_trial_id) for item in transport]
+    assert [record.planned_trial_binding.ordinal for record in reconciled] == [1, 2]
+    assert reconciled[0].output.agent_result["harbor_trial_name"] == "harbor-task-a"
+    assert reconciled[0].output.agent_result.get("harbor_job_id") is None
+    assert reconciled[1].output.agent_result["harbor_job_id"] == "job-123"
+    assert report.observed_trial_ids == tuple(item.planned_trial_id for item in transport)
+    assert report.accepted_trial_ids == tuple(UUID(record.trial_id) for record in reconciled)
+    assert all(record.trial_id != "job-123" for record in reconciled)
+
+
+def test_single_job_transport_binds_the_observed_generated_harbor_name() -> None:
+    spec, plan = _plan()
+    transport = build_harbor_trial_transport(plan.trials[:1])
+    record = _record(
+        trial_name="task-name__backend-generated-id",
+        task_id=plan.trials[0].task_release.task_id,
+    )
+
+    reconciled, report = reconcile_harbor_trial_records(
+        records=[record],
+        run_spec=spec,
+        run_plan=plan,
+        transport=transport,
+    )
+
+    assert reconciled[0].trial_id == str(transport[0].planned_trial_id)
+    assert report.observed_trial_names == ("task-name__backend-generated-id",)
+
+
+def test_reconciliation_reports_duplicate_mapped_harbor_name() -> None:
+    spec, plan = _plan()
+    transport = build_harbor_trial_transport(plan.trials[:1], ["harbor-task-a"])
+    records = [
+        _record(trial_name="harbor-task-a", task_id=plan.trials[0].task_release.task_id),
+        _record(trial_name="harbor-task-a", task_id=plan.trials[0].task_release.task_id),
+    ]
+
+    with pytest.raises(HarborImportReconciliationError, match="duplicates=1") as error:
+        reconcile_harbor_trial_records(
+            records=records,
+            run_spec=spec,
+            run_plan=plan,
+            transport=transport,
+        )
+
+    assert error.value.report.duplicate_trial_names == ("harbor-task-a",)
+    assert error.value.report.duplicate_trial_ids == (transport[0].planned_trial_id,)
+
+
+def test_single_job_reconciliation_reports_a_missing_planned_uuid() -> None:
+    spec, plan = _plan()
+    transport = build_harbor_trial_transport(plan.trials[:1])
+
+    with pytest.raises(HarborImportReconciliationError, match="missing=1") as error:
+        reconcile_harbor_trial_records(
+            records=[],
+            run_spec=spec,
+            run_plan=plan,
+            transport=transport,
+        )
+
+    assert error.value.report.observed_trial_ids == ()
+    assert error.value.report.missing_trial_ids == (transport[0].planned_trial_id,)
+
+
+@pytest.mark.parametrize(
+    ("names", "expected"),
+    [
+        (["missing"], "missing=2"),
+        (["unexpected", "unexpected"], "unexpected=1"),
+    ],
+)
+def test_reconciliation_reports_exact_membership_failures(names: list[str], expected: str) -> None:
+    spec, plan = _plan()
+    transport = build_harbor_trial_transport(plan.trials[:2], ["harbor-task-a", "harbor-task-b"])
+    records = [_record(trial_name=name, task_id=plan.trials[0].task_release.task_id) for name in names]
+
+    with pytest.raises(HarborImportReconciliationError, match=expected) as error:
+        reconcile_harbor_trial_records(
+            records=records,
+            run_spec=spec,
+            run_plan=plan,
+            transport=transport,
+        )
+
+    report = error.value.report
+    assert report.missing_trial_ids
+    if names == ["missing"]:
+        assert report.unexpected_trial_names == ("missing",)
+    else:
+        assert report.unexpected_trial_names == ("unexpected",)
+
+
+def test_reconciliation_rejects_record_drift_even_when_transport_name_matches() -> None:
+    spec, plan = _plan()
+    transport = build_harbor_trial_transport(plan.trials[:1], ["harbor-task-a"])
+    drifted = _record(
+        trial_name="harbor-task-a",
+        task_id=plan.trials[0].task_release.task_id,
+        model="different-model",
+    )
+
+    with pytest.raises(ValueError, match="agent condition"):
+        reconcile_harbor_trial_records(
+            records=[drifted],
+            run_spec=spec,
+            run_plan=plan,
+            transport=transport,
+        )


### PR DESCRIPTION
## Summary

- prepare every one-trial Harbor job and UUID transport sidecar before the first execution effect
- bind imported Harbor results to exact persisted planned trial UUIDs
- reject missing, unexpected, duplicate, or drifted results before ledger writes
- retain Harbor job and generated trial names as backend metadata only

This is PRD2 PR8. It is stacked on PR7 (#186).

## Checks

- `tests/harness/test_harbor_reconciliation.py`: 11 passed
- relevant wider suite: 58 passed, 2 skipped, 7 failed
- the same 7 failures reproduce on the PR7 parent; old proposal fixtures do not contain PRD1 required task identity metadata
- Ruff check: passed
- Ruff format check: passed
- scoped mypy: passed
- provenance field audit: passed, 0 violations
- `git diff --check`: passed

## Limits

No hosted Harbor or provider execution was run. The tests use the real Harbor `JobConfig` validation boundary and a local command executor.