### PR TITLE
PRD2: account for exact run results

### DIFF
--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -39,6 +39,7 @@ readable.
 | Resolved run specification | Experiment orchestration | One experiment manifest, exact task releases, and stable agent conditions become one explicit requested run condition | Internal schema 1; strict local persistence before execution | [`ResolvedRunSpec`](../src/aec_bench/contracts/resolved_run.py) and [`resolve_run_spec`](../src/aec_bench/contracts/resolved_run.py) | Requested run condition and persisted spec |
 | Runtime observation and provider resolution | Harness and provider boundary | Requested provider state is compared with observed runtime state under an explicit versioned resolution mapping | Internal schema 1; strict typed outcomes | [`RuntimeObservation`, `ProviderResolutionMapping`, and `observe_runtime`](../src/aec_bench/contracts/runtime_observation.py) | Persisted runtime observation |
 | Canonical run plan and planned trial | Experiment orchestration and harness | One resolved run becomes UUID-backed, ordered, complete work with typed execution details | Internal schema; pure planning remains separate from storage and execution | [`RunPlan`, `PlannedTrial`, and `plan_run`](../src/aec_bench/contracts/run_plan.py) | In-process requested work plan |
+| Run accounting and aggregate safeguards | Harness and evaluation boundary | Exact planned trial UUID membership becomes typed run status and accepted aggregate input | Internal schema 1; unexpected and invalid results are quarantined | [`RunAccounting`, `TrialAccountingObservation`, and `account_run`](../src/aec_bench/contracts/run_accounting.py) | Run status, counts, and accepted records |
 | Evidence run store | Experiment orchestration and ledger | Requested run state is durably retained before execution and cannot change after start | Internal schema 1; strict local reader with no legacy migration | [`EvidenceRunStore`](../src/aec_bench/ledger/evidence_run_store.py) | Local persisted resolved specification, plan, and operational state |
 | Learning Study design and evidence | Experimentation | An authored protocol composes exact task members and family relations, then compiles to existing trials; committed state and explicit comparison-validity evidence stay outside `TrialRecord` | Internal Release A persisted contracts | [`LearningStudyProtocolSpec`, `LearningStudySpec`](../src/aec_bench/contracts/learning_study.py), [`LearningFamilySpec`](../src/aec_bench/contracts/learning_family.py), [`learning_study_evidence.py`](../src/aec_bench/contracts/learning_study_evidence.py), [`learning_study_assessment.py`](../src/aec_bench/contracts/learning_study_assessment.py), and the [Gate A decision](adr/learning-studies-gate-a.md) | Maintained or caller-selected protocol directory, compiled plan, append-only receipts and sequenced events, ordinary trial ledger, and pair-level paired-difference assessment |
 | Evolution workspace candidate lineage | Experimentation and feedback | Mutable workspace files become exact Git source and explicit candidate lineage | Workspace manifest schema 1; legacy labels require an explicit migration plan | [`WorkspaceCandidateVersion`, `WorkspaceManifest`, and `WorkspaceMigrationPlan`](../src/aec_bench/contracts/evolution.py) plus [`Workspace`](../src/aec_bench/evolution/workspace.py) | Persisted workspace Git metadata and manifest |
@@ -139,6 +140,18 @@ illustrative):
   }
 }
 ```
+
+`TrialAccountingObservation` is the typed final outcome at the run boundary.
+It includes `succeeded`, `failed`, `cancelled`, `timed_out`, `invalid`, and
+`missing`; timeout is never inferred from free-text result fields. `account_run`
+matches observations to the exact `ResolvedRunSpec` and `RunPlan`, and requires
+the canonical schema-2 planned binding on every accepted record. An identical
+duplicate is idempotent and counted once. A conflicting duplicate, invalid
+evidence, or unexpected UUID makes the run invalid. Missing results make the
+run incomplete. Cancellation requested with reconciled cancelled trials gives
+the `cancelled` status; other terminal failures give
+`complete_with_failures`. Only accepted terminal records are returned for
+downstream aggregates. Quarantined and unexpected records are excluded.
 
 ## Task specification
 

--- a/provenance-registry.toml
+++ b/provenance-registry.toml
@@ -1854,6 +1854,27 @@ compatibility_behavior = "accept schema 1 and reject every other value"
 compatibility_kind = "external_schema"
 
 [[field]]
+symbol = "aec_bench.contracts.run_accounting.RunAccounting.schema_version"
+surface = "pydantic_model"
+wire_name = "schema_version"
+category = "compatibility"
+domain_owner = "harness"
+authority = "run_accounting_reader"
+authoritative = true
+exposure = "persisted"
+status = "current"
+payload_contract = "run accounting schema 1"
+canonicalization = "fixed integer literal 1"
+consumer = "run status and aggregate readers"
+validation_behavior = "RunAccounting accepts schema version 1 only"
+mismatch_behavior = "reject_run_accounting"
+retention = "run_accounting_lifetime"
+rationale = "Run status and accepted aggregate membership require a stable reader contract."
+duplication = "unique"
+compatibility_behavior = "accept schema 1 only"
+compatibility_kind = "external_schema"
+
+[[field]]
 symbol = "aec_bench.contracts.run_bundle.PublishedRunPackage.schema_version"
 surface = "pydantic_model"
 wire_name = "schema_version"

--- a/src/aec_bench/contracts/run_accounting.py
+++ b/src/aec_bench/contracts/run_accounting.py
@@ -1,0 +1,393 @@
+# ABOUTME: Defines run-level membership, outcome, and aggregate accounting contracts.
+# ABOUTME: Keeps quarantined results out of accepted records while exposing completeness and validity.
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Literal, Self
+from uuid import UUID
+
+from pydantic import NonNegativeInt, field_validator, model_validator
+
+from aec_bench.contracts.identity import validate_uuidv7
+from aec_bench.contracts.resolved_run import ResolvedRunSpec
+from aec_bench.contracts.run_plan import PlannedTrial, RunPlan
+from aec_bench.contracts.task_snapshot import ArtifactTaskSnapshotRef, RepositoryTaskSnapshotRef
+from aec_bench.contracts.trial_record import (
+    EvaluationStatus,
+    EvidenceStatus,
+    ExecutionStatus,
+    PlannedTrialBinding,
+    TrialRecord,
+)
+from aec_bench.contracts.validators import FrozenStrictModel, NonEmptyStr
+
+RunAccountingStatus = Literal["complete", "complete_with_failures", "cancelled", "incomplete", "invalid"]
+RunTrialOutcome = Literal["succeeded", "failed", "cancelled", "timed_out", "invalid", "missing"]
+RunCompleteness = Literal["complete", "incomplete"]
+RunValidity = Literal["valid", "invalid"]
+
+
+class TrialAccountingObservation(FrozenStrictModel):
+    """One typed outcome reported for one result or planned trial."""
+
+    trial_id: NonEmptyStr
+    outcome: RunTrialOutcome
+    record: TrialRecord | None = None
+
+    @model_validator(mode="after")
+    def validate_record_requirement(self) -> Self:
+        if self.outcome == "missing" and self.record is not None:
+            raise ValueError("missing trial outcomes must not carry a TrialRecord")
+        if self.outcome in {"succeeded", "failed", "cancelled", "timed_out"} and self.record is None:
+            raise ValueError(f"{self.outcome} trial outcomes require a TrialRecord")
+        if self.record is not None and self.record.trial_id != self.trial_id:
+            raise ValueError("trial accounting observation ID must match its TrialRecord")
+        return self
+
+
+class RunAccountingCounts(FrozenStrictModel):
+    """Mutually exclusive expected-trial outcome counts plus membership counts."""
+
+    planned: NonNegativeInt
+    succeeded: NonNegativeInt = 0
+    failed: NonNegativeInt = 0
+    cancelled: NonNegativeInt = 0
+    timed_out: NonNegativeInt = 0
+    invalid: NonNegativeInt = 0
+    missing: NonNegativeInt = 0
+    duplicate: NonNegativeInt = 0
+    unexpected: NonNegativeInt = 0
+
+    @model_validator(mode="after")
+    def validate_outcome_partition(self) -> Self:
+        terminal = self.succeeded + self.failed + self.cancelled + self.timed_out + self.invalid + self.missing
+        if terminal != self.planned:
+            raise ValueError("run accounting outcome counts must partition planned trials")
+        return self
+
+
+class RunAccounting(FrozenStrictModel):
+    """The accepted membership and status summary for one canonical run plan."""
+
+    schema_version: Literal[1] = 1
+    run_id: UUID
+    plan_id: UUID
+    status: RunAccountingStatus
+    completeness: RunCompleteness
+    validity: RunValidity
+    counts: RunAccountingCounts
+    cancellation_requested: bool = False
+    accepted_trial_ids: tuple[UUID, ...] = ()
+    missing_trial_ids: tuple[UUID, ...] = ()
+    invalid_trial_ids: tuple[UUID, ...] = ()
+    duplicate_trial_ids: tuple[UUID, ...] = ()
+    conflicting_duplicate_trial_ids: tuple[UUID, ...] = ()
+    unexpected_trial_ids: tuple[NonEmptyStr, ...] = ()
+    unexpected_duplicate_trial_ids: tuple[NonEmptyStr, ...] = ()
+
+    @field_validator("run_id", "plan_id")
+    @classmethod
+    def validate_entity_ids(cls, value: UUID) -> UUID:
+        return validate_uuidv7(value)
+
+    @field_validator(
+        "accepted_trial_ids",
+        "missing_trial_ids",
+        "invalid_trial_ids",
+        "duplicate_trial_ids",
+        "conflicting_duplicate_trial_ids",
+    )
+    @classmethod
+    def validate_unique_planned_ids(cls, value: tuple[UUID, ...]) -> tuple[UUID, ...]:
+        if len(value) != len(set(value)):
+            raise ValueError("run accounting trial ID lists must be unique")
+        for trial_id in value:
+            validate_uuidv7(trial_id)
+        return value
+
+    @field_validator("unexpected_trial_ids", "unexpected_duplicate_trial_ids")
+    @classmethod
+    def validate_unique_unexpected_ids(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if len(value) != len(set(value)):
+            raise ValueError("run accounting unexpected trial ID lists must be unique")
+        return value
+
+    @model_validator(mode="after")
+    def validate_summary(self) -> Self:
+        accepted = set(self.accepted_trial_ids)
+        missing = set(self.missing_trial_ids)
+        invalid = set(self.invalid_trial_ids)
+        if accepted & missing or accepted & invalid or missing & invalid:
+            raise ValueError("accepted, missing, and invalid planned trial IDs must be disjoint")
+        if not set(self.conflicting_duplicate_trial_ids).issubset(set(self.duplicate_trial_ids) & invalid):
+            raise ValueError("conflicting duplicate trial IDs must also be duplicate and invalid")
+        if not set(self.unexpected_duplicate_trial_ids).issubset(self.unexpected_trial_ids):
+            raise ValueError("unexpected duplicate trial IDs must also be unexpected")
+        if (
+            len(self.accepted_trial_ids)
+            != self.counts.succeeded + self.counts.failed + self.counts.cancelled + self.counts.timed_out
+        ):
+            raise ValueError("accepted trial IDs must match accepted terminal outcome counts")
+        if len(self.missing_trial_ids) != self.counts.missing:
+            raise ValueError("missing trial IDs must match the missing count")
+        if len(self.invalid_trial_ids) != self.counts.invalid:
+            raise ValueError("invalid trial IDs must match the invalid count")
+        if len(self.duplicate_trial_ids) + len(self.unexpected_duplicate_trial_ids) != self.counts.duplicate:
+            raise ValueError("duplicate trial IDs must match the duplicate count")
+        if len(self.unexpected_trial_ids) != self.counts.unexpected:
+            raise ValueError("unexpected trial IDs must match the unexpected count")
+        if self.completeness != ("incomplete" if self.counts.missing else "complete"):
+            raise ValueError("run accounting completeness does not match missing results")
+        invalid_evidence = bool(self.counts.invalid or self.counts.unexpected or self.conflicting_duplicate_trial_ids)
+        if self.validity != ("invalid" if invalid_evidence else "valid"):
+            raise ValueError("run accounting validity does not match evidence")
+        expected_status: RunAccountingStatus
+        if invalid_evidence:
+            expected_status = "invalid"
+        elif self.counts.missing:
+            expected_status = "incomplete"
+        elif self.cancellation_requested and self.counts.cancelled:
+            expected_status = "cancelled"
+        elif self.counts.failed or self.counts.cancelled or self.counts.timed_out:
+            expected_status = "complete_with_failures"
+        else:
+            expected_status = "complete"
+        if self.status != expected_status:
+            raise ValueError("run accounting status does not match its counts")
+        return self
+
+
+@dataclass(frozen=True)
+class RunAccountingResult:
+    """Accounting summary and records eligible for downstream aggregation."""
+
+    accounting: RunAccounting
+    accepted_records: tuple[TrialRecord, ...]
+    quarantined_records: tuple[TrialRecord, ...]
+
+
+def account_run(
+    run_spec: ResolvedRunSpec,
+    run_plan: RunPlan,
+    observations: Sequence[TrialAccountingObservation],
+    *,
+    cancellation_requested: bool = False,
+) -> RunAccountingResult:
+    """Reconcile typed trial outcomes with one plan and retain only accepted records."""
+
+    if run_spec.run_identity != run_plan.run_identity:
+        raise ValueError("run accounting specification does not match the run plan")
+    spec_releases = {release.task_id: release for release in run_spec.task_releases}
+    spec_conditions = {condition.identity.id: condition for condition in run_spec.agent_conditions}
+    for trial in run_plan.trials:
+        if spec_releases.get(trial.task_release.task_id) != trial.task_release:
+            raise ValueError("run accounting plan task release does not match the specification")
+        if spec_conditions.get(trial.agent_condition.identity.id) != trial.agent_condition:
+            raise ValueError("run accounting plan agent condition does not match the specification")
+        if trial.compute != run_spec.compute or trial.evaluation_profile != run_spec.evaluation_regime:
+            raise ValueError("run accounting plan execution condition does not match the specification")
+    planned_by_id = {str(trial.trial_identity.id): trial for trial in run_plan.trials}
+    if len(planned_by_id) != len(run_plan.trials):
+        raise ValueError("run accounting requires unique planned trial identities")
+    grouped: dict[str, list[TrialAccountingObservation]] = defaultdict(list)
+    for observation in observations:
+        grouped[observation.trial_id].append(observation)
+
+    accepted: dict[str, TrialRecord] = {}
+    quarantined: list[TrialRecord] = []
+    missing_ids: list[UUID] = []
+    invalid_ids: list[UUID] = []
+    duplicate_ids: list[UUID] = []
+    conflicting_duplicate_ids: list[UUID] = []
+    accepted_outcomes: dict[str, RunTrialOutcome] = {}
+    unexpected_ids = sorted(trial_id for trial_id in grouped if trial_id not in planned_by_id)
+    unexpected_duplicate_ids = sorted(trial_id for trial_id in unexpected_ids if len(grouped[trial_id]) > 1)
+
+    for trial_id in unexpected_ids:
+        for observation in grouped[trial_id]:
+            if observation.record is not None:
+                quarantined.append(observation.record)
+
+    for planned_id, trial in planned_by_id.items():
+        current = grouped.get(planned_id, [])
+        if not current:
+            missing_ids.append(trial.trial_identity.id)
+            continue
+        if len(current) > 1:
+            duplicate_ids.append(trial.trial_identity.id)
+            if not _observations_equal(current):
+                conflicting_duplicate_ids.append(trial.trial_identity.id)
+                quarantined.extend(observation.record for observation in current if observation.record is not None)
+                invalid_ids.append(trial.trial_identity.id)
+                continue
+        observation = current[0]
+        if observation.outcome == "missing":
+            missing_ids.append(trial.trial_identity.id)
+            continue
+        if observation.outcome == "invalid":
+            invalid_ids.append(trial.trial_identity.id)
+            if observation.record is not None:
+                quarantined.append(observation.record)
+            continue
+        if observation.record is None or not _record_matches_plan(
+            observation.record,
+            trial,
+            run_spec,
+            observation.outcome,
+        ):
+            invalid_ids.append(trial.trial_identity.id)
+            if observation.record is not None:
+                quarantined.append(observation.record)
+            continue
+        assert observation.record is not None
+        accepted[planned_id] = observation.record
+
+        accepted_outcomes[planned_id] = observation.outcome
+    succeeded = sum(outcome == "succeeded" for outcome in accepted_outcomes.values())
+    failed = sum(outcome == "failed" for outcome in accepted_outcomes.values())
+    cancelled = sum(outcome == "cancelled" for outcome in accepted_outcomes.values())
+    timed_out = sum(outcome == "timed_out" for outcome in accepted_outcomes.values())
+    counts = RunAccountingCounts(
+        planned=len(planned_by_id),
+        succeeded=succeeded,
+        failed=failed,
+        cancelled=cancelled,
+        timed_out=timed_out,
+        invalid=len(invalid_ids),
+        missing=len(missing_ids),
+        duplicate=len(duplicate_ids) + len(unexpected_duplicate_ids),
+        unexpected=len(unexpected_ids),
+    )
+    accounting = RunAccounting(
+        run_id=run_plan.run_identity.id,
+        plan_id=run_plan.plan_identity.id,
+        status=_status_for(counts, conflicting_duplicate_ids, cancellation_requested=cancellation_requested),
+        cancellation_requested=cancellation_requested,
+        completeness="incomplete" if counts.missing else "complete",
+        validity="invalid" if counts.invalid or counts.unexpected or conflicting_duplicate_ids else "valid",
+        counts=counts,
+        accepted_trial_ids=tuple(UUID(trial_id) for trial_id in planned_by_id if trial_id in accepted),
+        missing_trial_ids=tuple(missing_ids),
+        invalid_trial_ids=tuple(invalid_ids),
+        duplicate_trial_ids=tuple(duplicate_ids),
+        conflicting_duplicate_trial_ids=tuple(conflicting_duplicate_ids),
+        unexpected_trial_ids=tuple(unexpected_ids),
+        unexpected_duplicate_trial_ids=tuple(unexpected_duplicate_ids),
+    )
+    return RunAccountingResult(
+        accounting=accounting,
+        accepted_records=tuple(accepted[trial_id] for trial_id in planned_by_id if trial_id in accepted),
+        quarantined_records=tuple(quarantined),
+    )
+
+
+def _observations_equal(observations: Sequence[TrialAccountingObservation]) -> bool:
+    first = observations[0]
+    return all(
+        observation.outcome == first.outcome
+        and (observation.record is None) == (first.record is None)
+        and (
+            observation.record is None
+            or first.record is None
+            or observation.record.model_dump(mode="json") == first.record.model_dump(mode="json")
+        )
+        for observation in observations[1:]
+    )
+
+
+def _record_matches_plan(
+    record: TrialRecord,
+    trial: PlannedTrial,
+    run_spec: ResolvedRunSpec,
+    outcome: RunTrialOutcome,
+) -> bool:
+    if record.run_id != str(trial.run_identity.id):
+        return False
+    if record.task_id != trial.task_release.task_id or record.input.task_kind != trial.execution_family:
+        return False
+    if record.input.visibility != trial.task_metadata.visibility:
+        return False
+    if record.agent.adapter != trial.agent_condition.adapter or record.agent.model != trial.agent_condition.model:
+        return False
+    if record.environment.compute_backend != trial.compute.backend:
+        return False
+    if record.attempt != 1:
+        return False
+    expected_revision = (
+        trial.task_release.artifact.sha256
+        if isinstance(trial.task_release, ArtifactTaskSnapshotRef)
+        else trial.task_release.source_revision
+        if isinstance(trial.task_release, RepositoryTaskSnapshotRef)
+        else None
+    )
+    if expected_revision is not None and record.input.task_revision != expected_revision:
+        return False
+    if record.evidence_status in {EvidenceStatus.PENDING, EvidenceStatus.INCOMPLETE, EvidenceStatus.INVALID}:
+        return False
+    if record.evaluation_status in {EvaluationStatus.PENDING, EvaluationStatus.INVALID}:
+        return False
+    if outcome == "succeeded":
+        if record.execution_status is not ExecutionStatus.COMPLETED or record.evaluation_status not in {
+            EvaluationStatus.COMPLETED,
+            EvaluationStatus.NOT_REQUESTED,
+        }:
+            return False
+    elif outcome == "failed":
+        if not (
+            record.execution_status is ExecutionStatus.FAILED
+            or (
+                record.execution_status is ExecutionStatus.COMPLETED
+                and record.evaluation_status is EvaluationStatus.FAILED
+            )
+        ):
+            return False
+    elif outcome == "cancelled":
+        if record.execution_status is not ExecutionStatus.CANCELLED:
+            return False
+    elif outcome == "timed_out" and record.execution_status is not ExecutionStatus.FAILED:
+        return False
+    expected_binding = PlannedTrialBinding(
+        schema_version=2,
+        run_identity=run_spec.run_identity,
+        trial_identity=trial.trial_identity,
+        task_release=trial.task_release,
+        agent_condition_identity=trial.agent_condition.identity,
+        ordinal=trial.ordinal,
+        repetition=trial.repetition,
+        compute=trial.compute,
+        family_release=trial.family_release,
+        execution_family=trial.execution_family,
+        evaluation_profile=trial.evaluation_profile,
+        expected_authorities=run_spec.expected_authorities,
+    )
+    return record.planned_trial_binding == expected_binding
+
+
+def _status_for(
+    counts: RunAccountingCounts, conflicting_duplicate_ids: Sequence[UUID], *, cancellation_requested: bool = False
+) -> RunAccountingStatus:
+    if counts.invalid or counts.unexpected or conflicting_duplicate_ids:
+        return "invalid"
+    if counts.missing:
+        return "incomplete"
+    if cancellation_requested and counts.cancelled:
+        return "cancelled"
+    if counts.failed or counts.cancelled or counts.timed_out:
+        return "complete_with_failures"
+    return "complete"
+
+
+__all__ = (
+    "RunAccounting",
+    "RunAccountingCounts",
+    "RunAccountingResult",
+    "RunAccountingStatus",
+    "RunCompleteness",
+    "RunTrialOutcome",
+    "RunValidity",
+    "TrialAccountingObservation",
+    "account_run",
+)

--- a/tests/fixtures/run/run-accounting-complete.json
+++ b/tests/fixtures/run/run-accounting-complete.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": 1,
+  "run_id": "0190abcd-1234-7abc-8def-0123456789ab",
+  "plan_id": "0190abcd-1234-7abd-8def-0123456789ab",
+  "status": "complete_with_failures",
+  "completeness": "complete",
+  "validity": "valid",
+  "cancellation_requested": false,
+  "counts": {
+    "planned": 4,
+    "succeeded": 1,
+    "failed": 1,
+    "cancelled": 1,
+    "timed_out": 1,
+    "invalid": 0,
+    "missing": 0,
+    "duplicate": 0,
+    "unexpected": 0
+  },
+  "accepted_trial_ids": [
+    "0190abcd-1234-7abe-8def-0123456789ab",
+    "0190abcd-1234-7abf-8def-0123456789ab",
+    "0190abcd-1234-7ab0-8def-0123456789ab",
+    "0190abcd-1234-7ab1-8def-0123456789ab"
+  ],
+  "missing_trial_ids": [],
+  "invalid_trial_ids": [],
+  "duplicate_trial_ids": [],
+  "conflicting_duplicate_trial_ids": [],
+  "unexpected_trial_ids": [],
+  "unexpected_duplicate_trial_ids": []
+}

--- a/tests/harness/test_run_accounting.py
+++ b/tests/harness/test_run_accounting.py
@@ -1,0 +1,311 @@
+# ABOUTME: Tests exact run-plan membership and typed terminal outcome accounting.
+# ABOUTME: Proves duplicate and unexpected results cannot enter accepted aggregates.
+
+import json
+from pathlib import Path
+from typing import Literal
+
+import pytest
+from pydantic import ValidationError
+
+from aec_bench.contracts.identity import EntityIdentity, EntityKind, new_entity_id
+from aec_bench.contracts.resolved_run import ResolvedRunSpec
+from aec_bench.contracts.run_accounting import (
+    RunAccounting,
+    TrialAccountingObservation,
+    account_run,
+)
+from aec_bench.contracts.run_plan import PlannedTrial, RunPlan, plan_run
+from aec_bench.contracts.trial_record import (
+    AgentConfiguration,
+    EvaluationStatus,
+    EvidenceStatus,
+    ExecutionEnvironmentRef,
+    ExecutionStatus,
+    TrialRecord,
+)
+from aec_bench.harness.planned_trial_reconciliation import planned_trial_binding
+from tests.contracts.test_run_plan import _PLAN_CREATED_AT, _accept_combination, _resolved_run, _task_profiles
+from tests.support.trial_record_factories import make_trial_record
+
+
+def _plan() -> tuple[ResolvedRunSpec, RunPlan]:
+    spec = _resolved_run(repetitions=1)
+    return spec, plan_run(
+        spec,
+        plan_identity=EntityIdentity(id=new_entity_id(EntityKind.PLAN), key="accounting-plan", version=1),
+        created_at=_PLAN_CREATED_AT,
+        task_profiles=_task_profiles(spec),
+        validate_combination=_accept_combination,
+    )
+
+
+def _record(
+    spec: ResolvedRunSpec,
+    plan_trial: PlannedTrial,
+    *,
+    status: ExecutionStatus = ExecutionStatus.COMPLETED,
+    evaluation_status: EvaluationStatus = EvaluationStatus.COMPLETED,
+    evidence_status: EvidenceStatus = EvidenceStatus.NOT_REQUIRED,
+) -> TrialRecord:
+    trial = plan_trial
+    revision = (
+        trial.task_release.artifact.sha256
+        if hasattr(trial.task_release, "artifact")
+        else trial.task_release.source_revision
+    )
+    return make_trial_record(
+        trial_id=str(trial.trial_identity.id),
+        run_id=str(trial.run_identity.id),
+        task_id=trial.task_release.task_id,
+        task={
+            "task_id": trial.task_release.task_id,
+            "task_revision": revision,
+            "visibility": trial.task_metadata.visibility,
+        },
+        agent=AgentConfiguration(adapter=trial.agent_condition.adapter, model=trial.agent_condition.model),
+        environment=ExecutionEnvironmentRef(
+            runtime_image="test-image",
+            compute_backend=trial.compute.backend,
+            tool_versions={},
+        ),
+        inputs={
+            "instruction": "Run the planned task.",
+            "task_revision": revision,
+            "task_kind": trial.execution_family,
+            "visibility": trial.task_metadata.visibility,
+        },
+        execution_status=status,
+        evaluation_status=evaluation_status,
+        evidence_status=evidence_status,
+        planned_trial_binding=planned_trial_binding(trial, spec),
+    )
+
+
+def _observation(
+    spec: ResolvedRunSpec,
+    plan_trial: PlannedTrial,
+    outcome: Literal["succeeded", "failed", "cancelled", "timed_out", "invalid", "missing"],
+    *,
+    status: ExecutionStatus = ExecutionStatus.COMPLETED,
+) -> TrialAccountingObservation:
+    return TrialAccountingObservation(
+        trial_id=str(plan_trial.trial_identity.id),
+        outcome=outcome,
+        record=None if outcome == "missing" else _record(spec, plan_trial, status=status),
+    )
+
+
+def test_account_run_accepts_terminal_records_in_plan_order() -> None:
+    spec, plan = _plan()
+    observations = [_observation(spec, trial, "succeeded") for trial in reversed(plan.trials)]
+
+    result = account_run(spec, plan, observations)
+
+    assert result.accounting.status == "complete"
+    assert result.accounting.validity == "valid"
+    assert result.accounting.counts.model_dump() == {
+        "planned": 4,
+        "succeeded": 4,
+        "failed": 0,
+        "cancelled": 0,
+        "timed_out": 0,
+        "invalid": 0,
+        "missing": 0,
+        "duplicate": 0,
+        "unexpected": 0,
+    }
+    assert [record.trial_id for record in result.accepted_records] == [str(trial.trial_id) for trial in plan.trials]
+
+
+def test_account_run_uses_explicit_timeout_outcome_and_failure_status() -> None:
+    spec, plan = _plan()
+    outcomes = ["failed", "timed_out", "cancelled", "succeeded"]
+    observations = [
+        _observation(
+            spec,
+            trial,
+            outcome,
+            status=ExecutionStatus.FAILED
+            if outcome in {"failed", "timed_out"}
+            else ExecutionStatus.CANCELLED
+            if outcome == "cancelled"
+            else ExecutionStatus.COMPLETED,
+        )
+        for trial, outcome in zip(plan.trials, outcomes, strict=True)
+    ]
+
+    result = account_run(spec, plan, observations)
+
+    assert result.accounting.status == "complete_with_failures"
+    assert result.accounting.counts.failed == 1
+    assert result.accounting.counts.timed_out == 1
+    assert result.accounting.counts.cancelled == 1
+
+
+def test_evaluation_failure_is_an_accepted_failed_outcome() -> None:
+    spec, plan = _plan()
+    failed = TrialAccountingObservation(
+        trial_id=str(plan.trials[0].trial_id),
+        outcome="failed",
+        record=_record(spec, plan.trials[0], evaluation_status=EvaluationStatus.FAILED),
+    )
+    observations = [failed] + [_observation(spec, trial, "succeeded") for trial in plan.trials[1:]]
+
+    result = account_run(spec, plan, observations)
+
+    assert result.accounting.status == "complete_with_failures"
+    assert result.accounting.counts.failed == 1
+    assert result.accepted_records[0].trial_id == str(plan.trials[0].trial_id)
+
+
+def test_account_run_reports_cancelled_when_requested() -> None:
+    spec, plan = _plan()
+    observations = [_observation(spec, trial, "cancelled", status=ExecutionStatus.CANCELLED) for trial in plan.trials]
+
+    result = account_run(spec, plan, observations, cancellation_requested=True)
+
+    assert result.accounting.status == "cancelled"
+
+
+def test_account_run_reports_missing_and_excludes_it_from_accepted_records() -> None:
+    spec, plan = _plan()
+    observations = [_observation(spec, trial, "succeeded") for trial in plan.trials[:-1]]
+
+    result = account_run(spec, plan, observations)
+
+    assert result.accounting.status == "incomplete"
+    assert result.accounting.counts.missing == 1
+    assert len(result.accepted_records) == 3
+
+
+def test_account_run_accepts_idempotent_duplicate_once() -> None:
+    spec, plan = _plan()
+    first = _observation(spec, plan.trials[0], "succeeded")
+    observations = [first, first] + [_observation(spec, trial, "succeeded") for trial in plan.trials[1:]]
+
+    result = account_run(spec, plan, observations)
+
+    assert result.accounting.status == "complete"
+    assert result.accounting.counts.duplicate == 1
+    assert len(result.accepted_records) == len(plan.trials)
+    assert result.quarantined_records == ()
+
+
+def test_account_run_rejects_conflicting_duplicate_as_invalid() -> None:
+    spec, plan = _plan()
+    first = _observation(spec, plan.trials[0], "succeeded")
+    second = _observation(spec, plan.trials[0], "failed", status=ExecutionStatus.FAILED)
+    observations = [first, second] + [_observation(spec, trial, "succeeded") for trial in plan.trials[1:]]
+
+    result = account_run(spec, plan, observations)
+
+    assert result.accounting.status == "invalid"
+    assert result.accounting.counts.invalid == 1
+    assert result.accounting.counts.duplicate == 1
+    assert result.accounting.conflicting_duplicate_trial_ids == (plan.trials[0].trial_id,)
+    assert all(record.trial_id != str(plan.trials[0].trial_id) for record in result.accepted_records)
+
+
+def test_account_run_excludes_invalid_evidence_from_aggregates() -> None:
+    spec, plan = _plan()
+    invalid = TrialAccountingObservation(
+        trial_id=str(plan.trials[0].trial_id),
+        outcome="invalid",
+        record=_record(spec, plan.trials[0], status=ExecutionStatus.INVALID),
+    )
+    observations = [invalid] + [_observation(spec, trial, "succeeded") for trial in plan.trials[1:]]
+
+    result = account_run(spec, plan, observations)
+
+    assert result.accounting.status == "invalid"
+    assert result.accounting.counts.invalid == 1
+    assert all(record.trial_id != str(plan.trials[0].trial_id) for record in result.accepted_records)
+    assert len(result.quarantined_records) == 1
+
+
+def test_account_run_requires_the_exact_planned_binding() -> None:
+    spec, plan = _plan()
+    unbound = _record(spec, plan.trials[0]).model_copy(update={"planned_trial_binding": None})
+    observation = TrialAccountingObservation(
+        trial_id=str(plan.trials[0].trial_id),
+        outcome="succeeded",
+        record=unbound,
+    )
+
+    result = account_run(
+        spec,
+        plan,
+        [observation] + [_observation(spec, trial, "succeeded") for trial in plan.trials[1:]],
+    )
+
+    assert result.accounting.status == "invalid"
+    assert result.accounting.invalid_trial_ids == (plan.trials[0].trial_id,)
+    assert unbound in result.quarantined_records
+
+
+def test_account_run_excludes_invalid_evidence_status() -> None:
+    spec, plan = _plan()
+    record = _record(spec, plan.trials[0], evidence_status=EvidenceStatus.INVALID)
+    observation = TrialAccountingObservation(
+        trial_id=str(plan.trials[0].trial_id),
+        outcome="succeeded",
+        record=record,
+    )
+
+    result = account_run(
+        spec,
+        plan,
+        [observation] + [_observation(spec, trial, "succeeded") for trial in plan.trials[1:]],
+    )
+
+    assert result.accounting.status == "invalid"
+    assert record not in result.accepted_records
+
+
+def test_account_run_quarantines_unexpected_results() -> None:
+    spec, plan = _plan()
+    unexpected = _record(spec, plan.trials[0]).model_copy(
+        update={"trial_id": "backend-unexpected", "planned_trial_binding": None}
+    )
+    observations = [_observation(spec, trial, "succeeded") for trial in plan.trials]
+    observations.append(
+        TrialAccountingObservation(trial_id="backend-unexpected", outcome="succeeded", record=unexpected)
+    )
+
+    result = account_run(spec, plan, observations)
+
+    assert result.accounting.status == "invalid"
+    assert result.accounting.counts.unexpected == 1
+    assert result.accounting.counts.planned == len(result.accepted_records)
+    assert [record.trial_id for record in result.quarantined_records] == ["backend-unexpected"]
+
+
+def test_accounting_fixture_is_readable() -> None:
+    path = Path(__file__).parents[1] / "fixtures" / "run" / "run-accounting-complete.json"
+
+    accounting = RunAccounting.model_validate(json.loads(path.read_text(encoding="utf-8")))
+
+    assert accounting.status == "complete_with_failures"
+    assert accounting.counts.timed_out == 1
+
+
+def test_persisted_accounting_rejects_overlapping_membership_sets() -> None:
+    spec, plan = _plan()
+    result = account_run(spec, plan, [_observation(spec, trial, "succeeded") for trial in plan.trials])
+    payload = result.accounting.model_dump(mode="json")
+    payload["counts"]["succeeded"] = 3
+    payload["counts"]["invalid"] = 1
+    payload["accepted_trial_ids"] = payload["accepted_trial_ids"][:3]
+    payload["invalid_trial_ids"] = [payload["accepted_trial_ids"][0]]
+    payload["status"] = "invalid"
+    payload["validity"] = "invalid"
+
+    with pytest.raises(ValidationError, match="must be disjoint"):
+        RunAccounting.model_validate(payload)
+
+
+@pytest.mark.parametrize("outcome", ["timed_out", "succeeded", "failed", "cancelled"])
+def test_terminal_outcomes_require_records(outcome: str) -> None:
+    with pytest.raises(ValueError, match="require a TrialRecord"):
+        TrialAccountingObservation(trial_id="trial", outcome=outcome)


### PR DESCRIPTION
## Summary

- reconcile typed finalized outcomes against the exact resolved specification and run plan
- require canonical schema-2 planned bindings before records can enter aggregates
- report succeeded, failed, cancelled, timed out, invalid, missing, duplicate, and unexpected counts
- treat exact duplicate replay as idempotent and conflicting duplicates as invalid
- quarantine invalid and unexpected records while returning accepted records in plan order
- expose completeness, validity, and terminal run status in a structured schema and fixture

This is PRD2 PR10. It is stacked on PR9 (#188).

## Checks

- focused run accounting: 17 passed
- wider PRD2 plan and reconciliation set: 50 passed
- Ruff check and format check: passed
- scoped mypy: passed
- provenance field audit: passed, 0 violations
- `git diff --check`: passed

## Design note

Timeout is a typed finalized outcome. It is never inferred from free-text `TrialRecord` fields. This PR does not change the existing `TrialRecord` schema and does not add event sourcing or a second persistence path.