### PR TITLE
PRD3: adapt Interactive World trials to scheduler work

### DIFF
--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -126,6 +126,15 @@ planned trial UUID. The adapter writes one portable receipt per candidate, one
 stable final `TrialRecord`, and one `TrialFinalization`. A second finalization for the same planned
 trial fails before another adapter call.
 
+`WorldTrialAdapter` is the scheduler-facing Interactive World boundary. It
+accepts one exact `RunPlan` and one running lease-bound operational attempt,
+validates the world build, profile, release, and work identity, and delegates
+the complete episode to the existing canonical world runner. World actions and
+host controls remain task-owned runtime effects, not scheduler attempts. The
+adapter writes one receipt, one stable final `TrialRecord`, and one
+`TrialFinalization`; a completed execution with a failed evaluation remains a
+successful execution result.
+
 Canonical Harbor dispatch validates the persisted ready plan and writes all
 one-trial job configurations and transport sidecars before the first Harbor
 effect. Each job contains one task, one agent, and one attempt.

--- a/src/aec_bench/harness/world_trials.py
+++ b/src/aec_bench/harness/world_trials.py
@@ -3,8 +3,10 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Awaitable, Callable, Sequence
-from datetime import datetime
+from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Protocol
 
@@ -13,9 +15,16 @@ from aec_bench.contracts.authority_evidence import AuthorityEvidenceKind
 from aec_bench.contracts.evaluation_result import EvaluationResult
 from aec_bench.contracts.execution_release import WorldExecutionRelease
 from aec_bench.contracts.experiment_manifest import AgentConfig
-from aec_bench.contracts.identity import EntityIdentity
+from aec_bench.contracts.identity import (
+    EntityIdentity,
+    EntityKey,
+    EntityKind,
+    PortableRelativePath,
+    new_entity_id,
+    validate_uuidv7,
+)
 from aec_bench.contracts.resolved_run import ResolvedRunSpec
-from aec_bench.contracts.run_plan import PlannedTrial
+from aec_bench.contracts.run_plan import PlannedTrial, RunPlan, SingleAttemptRecipe
 from aec_bench.contracts.trial_record import (
     AgentConfiguration,
     AuthorityExpectation,
@@ -33,6 +42,20 @@ from aec_bench.contracts.trial_record import (
     TrialRecord,
     UnresolvedSourceRef,
 )
+from aec_bench.execution.models import (
+    AttemptProcessStatus,
+    AttemptReceipt,
+    AttemptResourceUsage,
+    CancellationStatus,
+    FailureClass,
+    FailureClassification,
+    FailureKind,
+    FinalizationState,
+    ReconciliationState,
+    TrialFinalization,
+    WorkerOutcome,
+)
+from aec_bench.execution.operational import AttemptRecord, OperationalStore, WorkItemRecord
 from aec_bench.harness.planned_trial_reconciliation import (
     planned_trial_binding,
     validate_planned_trial_record,
@@ -40,6 +63,12 @@ from aec_bench.harness.planned_trial_reconciliation import (
 from aec_bench.harness.prime_world_actor import WorldActorSession
 from aec_bench.harness.world_actor import ACTOR_INVOCATION_EVIDENCE_SCHEMA, WorldActorHost
 from aec_bench.ledger.evidence_run_store import EvidenceRunStore
+from aec_bench.ledger.writer import (
+    DuplicateAppendOnlyFileError,
+    DuplicateTrialRecordError,
+    write_append_only_json_at,
+    write_trial_record_at,
+)
 from aec_bench.trials import PlannedTrial as LegacyPlannedTrial
 from aec_bench.worlds.tasks import WorldTask
 
@@ -59,6 +88,302 @@ class WorldActorSessionRunner(Protocol):
         skills: Sequence[Path] = (),
         private_paths: Sequence[Path] = (),
     ) -> WorldActorSession: ...
+
+
+class WorldTrialAdapterError(RuntimeError):
+    """Raised when a scheduled world trial cannot be bound or published safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class WorldTrialExecution:
+    """Portable result returned after one complete scheduler-owned world episode."""
+
+    record: TrialRecord
+    receipt: AttemptReceipt
+    finalization: TrialFinalization
+
+    @property
+    def outcome(self) -> WorkerOutcome:
+        return WorkerOutcome(
+            terminal_state="succeeded" if self.record.execution_status is ExecutionStatus.COMPLETED else "failed",
+            receipts=(self.receipt,),
+            finalization=self.finalization,
+        )
+
+
+class WorldTrialAdapter:
+    """Run one exact world trial through the existing task-owned episode runtime."""
+
+    def __init__(
+        self,
+        *,
+        evidence_store: EvidenceRunStore,
+        operational_store: OperationalStore,
+        plan: RunPlan,
+        tasks: Sequence[WorldTask],
+        run_trial: CanonicalWorldTrialRunner,
+    ) -> None:
+        self._evidence_store = evidence_store
+        self._operational_store = operational_store
+        self._plan = plan
+        self._tasks = self._index_tasks(tasks)
+        self._run_trial = run_trial
+
+    def __call__(self, work_item: WorkItemRecord, attempt: AttemptRecord) -> WorkerOutcome:
+        """Execute one complete world episode from a scheduler worker thread."""
+
+        return self.execute(work_item, attempt).outcome
+
+    def execute(self, work_item: WorkItemRecord, attempt: AttemptRecord) -> WorldTrialExecution:
+        """Run the detailed world adapter API from a synchronous caller."""
+
+        return asyncio.run(self.execute_async(work_item, attempt))
+
+    async def execute_async(self, work_item: WorkItemRecord, attempt: AttemptRecord) -> WorldTrialExecution:
+        """Bind scheduler identities, run the complete episode, and publish its portable result."""
+
+        stored = self._evidence_store.read_run(self._plan.run_identity)
+        if stored.plan != self._plan or stored.plan is None:
+            raise WorldTrialAdapterError("authoritative run plan does not match the persisted plan")
+        if stored.state.state not in {"ready", "started"}:
+            raise WorldTrialAdapterError("world execution requires a ready or started evidence run")
+        trial = self._planned_trial(work_item)
+        self._validate_attempt(work_item, attempt)
+        task = self._tasks.get(trial.task_release.task_id)
+        if task is None:
+            raise WorldTrialAdapterError(
+                f"planned world trial references an unresolved task: {trial.task_release.task_id}"
+            )
+        try:
+            _validate_world_release(trial, task)
+        except ValueError as error:
+            raise WorldTrialAdapterError(str(error)) from error
+
+        record_path = self._record_path(trial)
+        finalization_path = self._finalization_path(trial)
+        if record_path.exists() or finalization_path.exists():
+            raise WorldTrialAdapterError(f"trial finalization already exists: {trial.trial_identity.id}")
+        if stored.state.state == "ready":
+            self._evidence_store.start_run(
+                self._plan.run_identity,
+                started_at=attempt.started_at or attempt.created_at,
+            )
+        legacy_trial = _legacy_world_trial(trial, stored.spec)
+        binding = planned_trial_binding(trial, stored.spec)
+        submission_id = str(new_entity_id(EntityKind.BACKEND_SUBMISSION))
+        self._operational_store.record_backend_submission(
+            submission_id,
+            attempt_id=attempt.attempt_id,
+            backend=work_item.backend,
+            now=attempt.started_at or attempt.created_at,
+        )
+        self._operational_store.transition_backend_submission(
+            submission_id,
+            state="running",
+            now=attempt.started_at or attempt.created_at,
+        )
+        started_at = attempt.started_at or attempt.created_at
+        try:
+            record = await self._run_trial(task, legacy_trial, binding)
+            validate_planned_trial_record(record, trial, stored.spec, task_revision=task.task_revision)
+        except Exception as error:
+            finished_at = datetime.now(UTC)
+            self._operational_store.transition_attempt(attempt.attempt_id, state="failed", now=finished_at)
+            self._operational_store.transition_backend_submission(submission_id, state="failed", now=finished_at)
+            self._persist_receipt(
+                self._failure_receipt(
+                    work_item=work_item,
+                    attempt=attempt,
+                    condition=trial.agent_condition.identity,
+                    submission_id=submission_id,
+                    started_at=started_at,
+                    finished_at=finished_at,
+                    message=str(error),
+                )
+            )
+            raise
+
+        finished_at = record.completed_at or datetime.now(UTC)
+        process_succeeded = record.execution_status is ExecutionStatus.COMPLETED
+        receipt_published = False
+        try:
+            write_trial_record_at(path=record_path, record=record)
+            receipt = self._receipt_from_record(
+                work_item=work_item,
+                attempt=attempt,
+                condition=trial.agent_condition.identity,
+                submission_id=submission_id,
+                record=record,
+                started_at=started_at,
+                finished_at=finished_at,
+            )
+            self._persist_receipt(receipt)
+            receipt_published = True
+            finalization = TrialFinalization(
+                finalization_id=new_entity_id(EntityKind.RECEIPT),
+                trial_id=trial.trial_id,
+                attempt_id=validate_uuidv7(attempt.attempt_id),
+                record_version=1,
+                trial_record_ref=PortableRelativePath(record_path.relative_to(self._evidence_store.root).as_posix()),
+                published_at=finished_at,
+                state=FinalizationState.CURRENT,
+            )
+            write_append_only_json_at(path=finalization_path, payload=finalization.model_dump_json(indent=2) + "\n")
+        except Exception as error:
+            failed_at = datetime.now(UTC)
+            self._operational_store.transition_attempt(attempt.attempt_id, state="failed", now=failed_at)
+            self._operational_store.transition_backend_submission(submission_id, state="failed", now=failed_at)
+            if not receipt_published:
+                self._persist_receipt(
+                    self._failure_receipt(
+                        work_item=work_item,
+                        attempt=attempt,
+                        condition=trial.agent_condition.identity,
+                        submission_id=submission_id,
+                        started_at=started_at,
+                        finished_at=failed_at,
+                        message=str(error),
+                    )
+                )
+            if isinstance(error, DuplicateAppendOnlyFileError | DuplicateTrialRecordError):
+                raise WorldTrialAdapterError(f"trial finalization already exists: {trial.trial_identity.id}") from error
+            raise
+        self._operational_store.transition_attempt(
+            attempt.attempt_id,
+            state="succeeded" if process_succeeded else "failed",
+            now=finished_at,
+        )
+        self._operational_store.transition_backend_submission(
+            submission_id,
+            state="completed" if process_succeeded else "failed",
+            now=finished_at,
+        )
+        return WorldTrialExecution(record=record, receipt=receipt, finalization=finalization)
+
+    @staticmethod
+    def _index_tasks(tasks: Sequence[WorldTask]) -> dict[str, WorldTask]:
+        indexed: dict[str, WorldTask] = {}
+        for task in tasks:
+            if task.task_id in indexed:
+                raise WorldTrialAdapterError(f"world tasks must have unique task ids: {task.task_id}")
+            indexed[task.task_id] = task
+        return indexed
+
+    def _planned_trial(self, work_item: WorkItemRecord) -> PlannedTrial:
+        if work_item.run_id != str(self._plan.run_id) or work_item.plan_id != str(self._plan.plan_id):
+            raise WorldTrialAdapterError("work item does not belong to the authoritative run plan")
+        matches = [trial for trial in self._plan.trials if str(trial.trial_id) == work_item.trial_id]
+        if len(matches) != 1:
+            raise WorldTrialAdapterError(f"work item does not identify one planned trial: {work_item.trial_id}")
+        trial = matches[0]
+        if trial.execution_family != "world":
+            raise WorldTrialAdapterError("scheduled work item is not a world trial")
+        if trial.ordinal != work_item.ordinal:
+            raise WorldTrialAdapterError("work item ordinal does not match the authoritative trial")
+        if work_item.backend != trial.compute.backend:
+            raise WorldTrialAdapterError("work item backend does not match the authoritative trial")
+        if not isinstance(trial.attempt_recipe, SingleAttemptRecipe):
+            raise WorldTrialAdapterError("world trials require the single_attempt recipe")
+        return trial
+
+    @staticmethod
+    def _validate_attempt(work_item: WorkItemRecord, attempt: AttemptRecord) -> None:
+        if work_item.state != "running":
+            raise WorldTrialAdapterError("world execution requires a running scheduler work item")
+        if attempt.work_id != work_item.work_id or attempt.trial_id != work_item.trial_id:
+            raise WorldTrialAdapterError("scheduler attempt does not match the work item")
+        if attempt.run_id != work_item.run_id:
+            raise WorldTrialAdapterError("scheduler attempt does not match the work item run")
+        if attempt.lease_id is None:
+            raise WorldTrialAdapterError("world execution requires a lease-bound attempt")
+        if attempt.state != "running":
+            raise WorldTrialAdapterError("world execution requires a running scheduler attempt")
+        if attempt.candidate_index != 1:
+            raise WorldTrialAdapterError("world execution requires candidate 1")
+
+    def _record_path(self, trial: PlannedTrial) -> Path:
+        return self._evidence_store.run_directory(self._plan.run_identity) / "trial-records" / f"{trial.trial_id}.json"
+
+    def _finalization_path(self, trial: PlannedTrial) -> Path:
+        return self._evidence_store.run_directory(self._plan.run_identity) / "finalizations" / f"{trial.trial_id}.json"
+
+    def _persist_receipt(self, receipt: AttemptReceipt) -> None:
+        path = self._evidence_store.run_directory(self._plan.run_identity) / "receipts" / f"{receipt.receipt_id}.json"
+        try:
+            write_append_only_json_at(path=path, payload=receipt.model_dump_json(indent=2) + "\n")
+        except DuplicateAppendOnlyFileError as error:
+            raise WorldTrialAdapterError(f"attempt receipt already exists: {receipt.receipt_id}") from error
+
+    @staticmethod
+    def _failure_receipt(
+        *,
+        work_item: WorkItemRecord,
+        attempt: AttemptRecord,
+        condition: EntityIdentity,
+        submission_id: str,
+        started_at: datetime,
+        finished_at: datetime,
+        message: str,
+    ) -> AttemptReceipt:
+        return AttemptReceipt(
+            receipt_id=new_entity_id(EntityKind.RECEIPT),
+            receipt_key=EntityKey(f"{work_item.work_key}/attempt-{attempt.attempt_number}"),
+            attempt_id=validate_uuidv7(attempt.attempt_id),
+            backend=work_item.backend,
+            submission_id=validate_uuidv7(submission_id),
+            requested_condition=condition,
+            started_at=started_at,
+            finished_at=finished_at,
+            process_status=AttemptProcessStatus.FAILED,
+            cancellation_status=CancellationStatus.NOT_REQUESTED,
+            resource_usage=AttemptResourceUsage(wall_seconds=max(0.0, (finished_at - started_at).total_seconds())),
+            failure=FailureClassification(
+                failure_class=FailureClass.INFRASTRUCTURE,
+                kind=FailureKind.RESULT_IMPORT_FAILED,
+                message=message or "world episode failed",
+            ),
+            reconciliation_status=ReconciliationState.NOT_REQUIRED,
+        )
+
+    @staticmethod
+    def _receipt_from_record(
+        *,
+        work_item: WorkItemRecord,
+        attempt: AttemptRecord,
+        condition: EntityIdentity,
+        submission_id: str,
+        record: TrialRecord,
+        started_at: datetime,
+        finished_at: datetime,
+    ) -> AttemptReceipt:
+        output_references = () if record.output is None else tuple(item.artifact for item in record.output.artifacts)
+        authorities = record.authority_evidence
+        succeeded = record.execution_status is ExecutionStatus.COMPLETED
+        return AttemptReceipt(
+            receipt_id=new_entity_id(EntityKind.RECEIPT),
+            receipt_key=EntityKey(f"{work_item.work_key}/attempt-{attempt.attempt_number}"),
+            attempt_id=validate_uuidv7(attempt.attempt_id),
+            backend=work_item.backend,
+            submission_id=validate_uuidv7(submission_id),
+            requested_condition=condition,
+            started_at=started_at,
+            finished_at=finished_at,
+            process_status=AttemptProcessStatus.SUCCEEDED if succeeded else AttemptProcessStatus.FAILED,
+            cancellation_status=CancellationStatus.NOT_REQUESTED,
+            resource_usage=AttemptResourceUsage(wall_seconds=max(0.0, (finished_at - started_at).total_seconds())),
+            output_references=output_references,
+            authority_evidence=authorities,
+            failure=(
+                None
+                if succeeded
+                else FailureClassification(
+                    failure_class=FailureClass.BENCHMARK,
+                    kind=FailureKind.TASK_FAILURE,
+                    message="world episode did not complete",
+                )
+            ),
+            reconciliation_status=ReconciliationState.NOT_REQUIRED,
+        )
 
 
 async def run_world_experiment(
@@ -302,6 +627,9 @@ def _validate_world_record(task: WorldTask, trial: LegacyPlannedTrial, record: T
 __all__ = (
     "CanonicalWorldTrialRunner",
     "WorldActorSessionRunner",
+    "WorldTrialAdapter",
+    "WorldTrialAdapterError",
+    "WorldTrialExecution",
     "WorldTrialRunner",
     "build_prime_world_trial_record",
     "run_persisted_world_plan",

--- a/tests/harness/test_world_adapter.py
+++ b/tests/harness/test_world_adapter.py
@@ -1,0 +1,383 @@
+# ABOUTME: Tests the scheduler-facing Interactive World trial adapter.
+# ABOUTME: Proves exact binding, one complete episode attempt, durable publication, and failure handling.
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from aec_bench.contracts.agent_output import AgentOutput, AgentOutputStatus
+from aec_bench.contracts.evaluation_result import EvaluationResult, ValidityCheck
+from aec_bench.contracts.identity import EntityKind, new_entity_id
+from aec_bench.contracts.resolved_run import ResolvedRunSpec
+from aec_bench.contracts.run_plan import BestOfAttemptRecipe, PlannedTrial, RunPlan
+from aec_bench.contracts.trial_record import (
+    AgentConfiguration,
+    EvaluationStatus,
+    EvidenceStatus,
+    ExecutionEnvironmentRef,
+    ExecutionStatus,
+    PlannedTrialBinding,
+    ProviderRoute,
+    RunManifest,
+    TimingRecord,
+    TrialInput,
+    TrialOutput,
+    TrialRecord,
+    UnresolvedSourceRef,
+)
+from aec_bench.execution import ExecutionPolicy, LocalScheduler, RetryPolicy, TrialWorkItem, WorkItemState
+from aec_bench.execution.operational import OperationalStore
+from aec_bench.harness.planned_trial_reconciliation import planned_trial_binding
+from aec_bench.harness.world_trials import WorldTrialAdapter, WorldTrialAdapterError
+from aec_bench.ledger.evidence_run_store import EvidenceRunStore
+from aec_bench.trials import PlannedTrial as LegacyPlannedTrial
+from aec_bench.worlds.tasks import WorldTask
+from tests.harness.test_persisted_family_plans import _spec_and_plan, _store, _world_task
+
+
+def _record(
+    spec: ResolvedRunSpec,
+    trial: PlannedTrial,
+    task: WorldTask,
+    *,
+    completed: bool = True,
+    evaluation_failed: bool = False,
+    artifact_root: Path | None = None,
+) -> TrialRecord:
+    started = datetime(2026, 8, 30, 12, 2, tzinfo=UTC)
+    finished = datetime(2026, 8, 30, 12, 2, 1, tzinfo=UTC)
+    manifest = RunManifest(
+        run_id=str(spec.run_identity.id),
+        experiment_id=str(spec.experiment_identity.id),
+        source=UnresolvedSourceRef(reason="test"),
+        agent=AgentConfiguration(adapter=trial.agent_condition.adapter, model=trial.agent_condition.model),
+        execution_environment=ExecutionEnvironmentRef(runtime_image="test", compute_backend=trial.compute.backend),
+        provider_route=ProviderRoute(provider="test", route="test"),
+    )
+    record = TrialRecord(
+        trial_id=str(trial.trial_id),
+        run_id=str(spec.run_identity.id),
+        task_id=task.task_id,
+        planned_trial_binding=planned_trial_binding(trial, spec),
+        execution_status=ExecutionStatus.COMPLETED if completed else ExecutionStatus.FAILED,
+        evaluation_status=EvaluationStatus.FAILED if evaluation_failed else EvaluationStatus.COMPLETED,
+        evidence_status=EvidenceStatus.NOT_REQUIRED,
+        started_at=started,
+        completed_at=finished,
+        input=TrialInput(instruction=task.instruction, task_revision=task.task_revision, task_kind="world"),
+        output=(
+            TrialOutput(
+                agent_output=AgentOutput(
+                    status=AgentOutputStatus.COMPLETED if completed else AgentOutputStatus.FAILED,
+                    output_path="outputs/world.json",
+                    output_format="json",
+                ),
+                artifacts=(),
+            )
+            if completed
+            else None
+        ),
+        evaluation=EvaluationResult(
+            reward=1.0 if completed else 0.0,
+            validity=ValidityCheck(output_parseable=completed, schema_valid=completed, verifier_completed=True),
+        ),
+        timing=TimingRecord(total_seconds=1),
+    ).bind_run_manifest(manifest)
+    if artifact_root is not None:
+        artifact_root.mkdir(parents=True, exist_ok=True)
+        output_path = artifact_root / "world-output.json"
+        provider_path = artifact_root / "provider.json"
+        authority_path = artifact_root / "authority.json"
+        output_path.write_bytes(b"world output bytes\n")
+        provider_path.write_bytes(b"provider evidence bytes\n")
+        authority_path.write_bytes(b"world authority bytes\n")
+        record.attach_artifact("output:world-output", output_path, media_type="application/json")
+        record.attach_artifact("provider_evidence", provider_path, media_type="application/json")
+        record.attach_artifact("authority:world:aec-bench/test-world/1", authority_path, media_type="application/json")
+    return record
+
+
+def _boundary(
+    tmp_path: Path,
+    *,
+    attempt_recipe: BestOfAttemptRecipe | None = None,
+) -> tuple[WorldTask, ResolvedRunSpec, RunPlan, EvidenceRunStore, OperationalStore, TrialWorkItem]:
+    task, release, _ = _world_task()
+    spec, plan = _spec_and_plan(tmp_path)
+    if attempt_recipe is not None:
+        plan = plan.model_copy(
+            update={"trials": (plan.trials[0].model_copy(update={"attempt_recipe": attempt_recipe}),)}
+        )
+    evidence = _store(tmp_path, spec, plan)
+    operational = OperationalStore(tmp_path / "operational.sqlite3")
+    now = datetime(2026, 8, 30, 12, 2, tzinfo=UTC)
+    operational.create_run(str(plan.run_id), spec_ref="resolved-run-spec.json", status="ready", now=now)
+    operational.put_plan(str(plan.plan_id), run_id=str(plan.run_id), plan_ref="run-plan.json", state="ready", now=now)
+    trial = plan.trials[0]
+    item = TrialWorkItem(
+        work_id=new_entity_id(EntityKind.WORK_ITEM),
+        work_key=trial.trial_key,
+        run_id=plan.run_id,
+        plan_id=plan.plan_id,
+        trial_id=trial.trial_id,
+        ordinal=trial.ordinal,
+        execution_family="world",
+        backend=trial.compute.backend,
+        provider_route="prime-agent",
+        model_route=trial.agent_condition.model,
+        resource_class="default",
+        retry_policy=RetryPolicy(maximum_attempts=1),
+        state=WorkItemState.PLANNED,
+        created_at=now,
+        available_at=now,
+    )
+    return task, spec, plan, evidence, operational, item
+
+
+def test_scheduler_runs_one_complete_world_episode_and_publishes_portable_result(tmp_path: Path) -> None:
+    task, spec, plan, evidence, operational, item = _boundary(tmp_path)
+    seen: list[str] = []
+
+    async def runner(
+        world_task: WorldTask,
+        legacy_trial: LegacyPlannedTrial,
+        binding: PlannedTrialBinding,
+    ) -> TrialRecord:
+        seen.append(legacy_trial.trial_id)
+        assert world_task is task
+        assert binding.trial_identity == plan.trials[0].trial_identity
+        return _record(spec, plan.trials[0], task, artifact_root=tmp_path / "source-artifacts")
+
+    adapter = WorldTrialAdapter(
+        evidence_store=evidence,
+        operational_store=operational,
+        plan=plan,
+        tasks=[task],
+        run_trial=runner,
+    )
+    scheduler = LocalScheduler(operational, ExecutionPolicy(max_concurrency=1))
+    scheduler.enqueue_ready_plan(plan, (item,))
+    report = scheduler.dispatch_once(adapter, owner="scheduler", now=datetime(2026, 8, 30, 12, 2, tzinfo=UTC))
+
+    assert report.succeeded_count == 1
+    assert seen == [str(plan.trials[0].trial_id)]
+    assert len(operational.list_attempts(plan.trials[0].trial_id)) == 1
+    submissions = operational.list_backend_submissions_for_run(plan.run_id)
+    assert len(submissions) == 1
+    run_dir = evidence.run_directory(spec.run_identity)
+    receipt_path = next(run_dir.glob("receipts/*.json"))
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert receipt["submission_id"] == submissions[0].submission_id
+    record_path = next(run_dir.glob("trial-records/*.json"))
+    persisted = json.loads(record_path.read_text(encoding="utf-8"))
+    artifact_root = record_path.parent / "_artifacts"
+    output_reference = persisted["output"]["artifacts"][0]["artifact"]
+    assert (artifact_root / output_reference["artifact_id"]).read_bytes() == b"world output bytes\n"
+    provider_reference = persisted["provider_evidence"]
+    assert (artifact_root / provider_reference["artifact_id"]).read_bytes() == b"provider evidence bytes\n"
+    authority_reference = persisted["authority_evidence"][0]["artifact"]
+    assert (artifact_root / authority_reference["artifact_id"]).read_bytes() == b"world authority bytes\n"
+    assert receipt["output_references"][0]["artifact_id"] == output_reference["artifact_id"]
+    assert receipt["authority_evidence"][0]["artifact"]["artifact_id"] == authority_reference["artifact_id"]
+    assert list(run_dir.glob("receipts/*.json"))
+    assert list(evidence.run_directory(spec.run_identity).glob("finalizations/*.json"))
+    assert list(evidence.run_directory(spec.run_identity).glob("trial-records/*.json"))
+
+
+def test_world_adapter_persists_failed_receipt_without_finalization_on_exception(tmp_path: Path) -> None:
+    task, spec, plan, evidence, operational, item = _boundary(tmp_path)
+
+    async def runner(*_args: object) -> TrialRecord:
+        raise RuntimeError("episode failed")
+
+    adapter = WorldTrialAdapter(
+        evidence_store=evidence,
+        operational_store=operational,
+        plan=plan,
+        tasks=[task],
+        run_trial=runner,
+    )
+    scheduler = LocalScheduler(operational, ExecutionPolicy(max_concurrency=1))
+    scheduler.enqueue_ready_plan(plan, (item,))
+    report = scheduler.dispatch_once(adapter, owner="scheduler", now=datetime(2026, 8, 30, 12, 2, tzinfo=UTC))
+
+    assert report.failed_count == 1
+    assert len(list(evidence.run_directory(spec.run_identity).glob("receipts/*.json"))) == 1
+    assert not list(evidence.run_directory(spec.run_identity).glob("finalizations/*.json"))
+    assert not list(evidence.run_directory(spec.run_identity).glob("trial-records/*.json"))
+    assert operational.list_backend_submissions_for_run(plan.run_id)[0].state == "failed"
+    receipt = json.loads(next(evidence.run_directory(spec.run_identity).glob("receipts/*.json")).read_text())
+    assert receipt["failure"]["kind"] == "result_import_failed"
+
+
+def test_world_adapter_keeps_execution_success_when_evaluation_fails(tmp_path: Path) -> None:
+    task, spec, plan, evidence, operational, item = _boundary(tmp_path)
+
+    async def runner(*_args: object) -> TrialRecord:
+        return _record(spec, plan.trials[0], task, evaluation_failed=True, artifact_root=tmp_path / "source-artifacts")
+
+    adapter = WorldTrialAdapter(
+        evidence_store=evidence,
+        operational_store=operational,
+        plan=plan,
+        tasks=[task],
+        run_trial=runner,
+    )
+    scheduler = LocalScheduler(operational, ExecutionPolicy(max_concurrency=1))
+    scheduler.enqueue_ready_plan(plan, (item,))
+    report = scheduler.dispatch_once(adapter, owner="scheduler", now=datetime(2026, 8, 30, 12, 2, tzinfo=UTC))
+
+    assert report.succeeded_count == 1
+    assert operational.list_attempts(plan.trials[0].trial_id)[0].state == "succeeded"
+
+
+def test_world_adapter_publishes_terminal_failed_execution(tmp_path: Path) -> None:
+    task, spec, plan, evidence, operational, item = _boundary(tmp_path)
+
+    async def runner(*_args: object) -> TrialRecord:
+        return _record(spec, plan.trials[0], task, completed=False)
+
+    adapter = WorldTrialAdapter(
+        evidence_store=evidence,
+        operational_store=operational,
+        plan=plan,
+        tasks=[task],
+        run_trial=runner,
+    )
+    scheduler = LocalScheduler(operational, ExecutionPolicy(max_concurrency=1))
+    scheduler.enqueue_ready_plan(plan, (item,))
+    report = scheduler.dispatch_once(adapter, owner="scheduler", now=datetime(2026, 8, 30, 12, 2, tzinfo=UTC))
+
+    assert report.failed_count == 1
+    assert operational.get_work_item(item.work_id).state == "failed"
+    assert operational.get_planned_trial(plan.trials[0].trial_id).state == "failed"
+    assert operational.list_attempts(plan.trials[0].trial_id)[0].state == "failed"
+    assert operational.list_backend_submissions_for_run(plan.run_id)[0].state == "failed"
+    run_dir = evidence.run_directory(spec.run_identity)
+    assert len(list(run_dir.glob("receipts/*.json"))) == 1
+    assert len(list(run_dir.glob("trial-records/*.json"))) == 1
+    assert len(list(run_dir.glob("finalizations/*.json"))) == 1
+
+
+def test_world_adapter_rejects_best_of_world_recipe_before_effects(tmp_path: Path) -> None:
+    task, spec, plan, evidence, operational, item = _boundary(
+        tmp_path,
+        attempt_recipe=BestOfAttemptRecipe(candidates=2, selector="self"),
+    )
+    calls = 0
+
+    async def runner(*_args: object) -> TrialRecord:
+        nonlocal calls
+        calls += 1
+        return _record(spec, plan.trials[0], task)
+
+    adapter = WorldTrialAdapter(
+        evidence_store=evidence,
+        operational_store=operational,
+        plan=plan,
+        tasks=[task],
+        run_trial=runner,
+    )
+    scheduler = LocalScheduler(operational, ExecutionPolicy(max_concurrency=1))
+    scheduler.enqueue_ready_plan(plan, (item,))
+    report = scheduler.dispatch_once(adapter, owner="scheduler", now=datetime(2026, 8, 30, 12, 2, tzinfo=UTC))
+
+    assert report.failed_count == 1
+    assert calls == 0
+    assert not operational.list_backend_submissions_for_run(plan.run_id)
+    assert not list(evidence.run_directory(spec.run_identity).glob("receipts/*.json"))
+    assert not list(evidence.run_directory(spec.run_identity).glob("trial-records/*.json"))
+
+
+def test_world_adapter_accepts_a_scheduler_retry_as_the_single_world_attempt(tmp_path: Path) -> None:
+    task, spec, plan, evidence, operational, item = _boundary(tmp_path)
+
+    async def runner(*_args: object) -> TrialRecord:
+        return _record(spec, plan.trials[0], task, artifact_root=tmp_path / "source-artifacts")
+
+    scheduler = LocalScheduler(operational, ExecutionPolicy(max_concurrency=1))
+    scheduler.enqueue_ready_plan(plan, (item,))
+    now = datetime(2026, 8, 30, 12, 2, tzinfo=UTC)
+    lease = operational.acquire_lease(item.work_id, owner="retry-owner", now=now, ttl=timedelta(minutes=5))
+    operational.update_work_item(item.work_id, state="running", now=now)
+    operational.update_planned_trial(item.trial_id, state="running", now=now)
+    attempt = operational.create_attempt_for_lease(
+        item.work_id,
+        trial_id=item.trial_id,
+        lease_id=lease.lease_id,
+        candidate_index=1,
+        retry_number=2,
+        now=now,
+    )
+    attempt = operational.transition_attempt(attempt.attempt_id, state="running", now=now)
+    adapter = WorldTrialAdapter(
+        evidence_store=evidence,
+        operational_store=operational,
+        plan=plan,
+        tasks=[task],
+        run_trial=runner,
+    )
+
+    result = adapter.execute(operational.get_work_item(item.work_id), attempt)
+
+    assert result.receipt.process_status == "succeeded"
+    assert operational.list_attempts(plan.trials[0].trial_id)[0].retry_number == 2
+
+
+def test_world_adapter_rejects_world_profile_drift_before_runner(tmp_path: Path) -> None:
+    from dataclasses import replace
+
+    from aec_bench.contracts.interactive_world import InteractiveWorldProfileRef
+
+    task, spec, plan, evidence, operational, item = _boundary(tmp_path)
+    drifted = replace(task, profile=InteractiveWorldProfileRef(task.world.task_world_id, "other", "d" * 64))
+    calls = 0
+
+    async def runner(*_args: object) -> TrialRecord:
+        nonlocal calls
+        calls += 1
+        return _record(spec, plan.trials[0], task)
+
+    adapter = WorldTrialAdapter(
+        evidence_store=evidence,
+        operational_store=operational,
+        plan=plan,
+        tasks=[drifted],
+        run_trial=runner,
+    )
+    scheduler = LocalScheduler(operational, ExecutionPolicy(max_concurrency=1))
+    scheduler.enqueue_ready_plan(plan, (item,))
+    report = scheduler.dispatch_once(adapter, owner="scheduler", now=datetime(2026, 8, 30, 12, 2, tzinfo=UTC))
+
+    assert report.failed_count == 1
+    assert calls == 0
+    assert not list(evidence.run_directory(spec.run_identity).glob("receipts/*.json"))
+
+
+def test_world_adapter_rejects_duplicate_publication_before_runner(tmp_path: Path) -> None:
+    task, spec, plan, evidence, operational, item = _boundary(tmp_path)
+    calls = 0
+
+    async def runner(*_args: object) -> TrialRecord:
+        nonlocal calls
+        calls += 1
+        return _record(spec, plan.trials[0], task)
+
+    adapter = WorldTrialAdapter(
+        evidence_store=evidence,
+        operational_store=operational,
+        plan=plan,
+        tasks=[task],
+        run_trial=runner,
+    )
+    scheduler = LocalScheduler(operational, ExecutionPolicy(max_concurrency=1))
+    scheduler.enqueue_ready_plan(plan, (item,))
+    scheduler.dispatch_once(adapter, owner="scheduler", now=datetime(2026, 8, 30, 12, 2, tzinfo=UTC))
+    with pytest.raises(WorldTrialAdapterError):
+        adapter(
+            operational.get_work_item(item.work_id),
+            operational.list_attempts(plan.trials[0].trial_id)[0],
+        )
+    assert calls == 1


### PR DESCRIPTION
## Summary

- add one scheduler-facing adapter for complete Interactive World trials
- validate exact run-plan, world-build, profile, work-item, attempt, and backend identity before execution
- keep world actions and host controls inside the existing task-owned world runtime
- publish one operational submission, portable receipt, stable trial record, and finalization per world attempt
- support scheduler retries as complete world attempts without exposing internal actions
- keep task and operational formats current-only; no migration scripts or compatibility readers are included

## Review order

1. `src/aec_bench/harness/world_trials.py`
2. `tests/harness/test_world_adapter.py`
3. `docs/CONTRACTS.md`

## Evidence

- focused world, execution, artifact-regression, and ledger suite: 80 passed
- world-adapter tests: 8 passed
- Ruff check and format: passed
- scoped mypy: passed
- provenance audit: passed, 0 violations
- wheel build: passed
- package ownership suite: 26 passed, with the same 3 failures present on the stacked base

## Local limitation

Two existing Prime world-runtime tests require the optional `acp` package, which is not installed in the borrowed local virtual environment. One test in that module passed. The required GitHub Prime world job remains the integration gate.

## Stack

This PR is based on `feat/prd3-artifact-adapter` and must be reviewed after PR #196.