### PR TITLE
PRD3: adapt finite lifecycle trials to scheduler work

### DIFF
--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -389,6 +389,13 @@ normal protected `TrialRecord`. Persistence is an explicit optional effect and
 uses that same record. `run_lifecycle_experiment()` returns the records that it
 creates, so a caller does not read the ledger to recover its immediate results.
 
+The scheduler-facing lifecycle adapter binds one canonical lifecycle trial to
+one lease-bound operational attempt. The lifecycle runtime owns its complete
+episode, including checkpoints and recovery; those internal actions remain
+invisible to scheduler progress. The adapter publishes one stable final
+`TrialRecord`, one `AttemptReceipt`, and one `TrialFinalization` in the
+portable run package.
+
 New lifecycle invocation manifests use schema version 2. They bind the planned
 trial identity and the complete compiled lifecycle envelope. Schema version 1
 is read and recovered only as historical retained evidence; new runs do not

--- a/src/aec_bench/harness/lifecycle_trials.py
+++ b/src/aec_bench/harness/lifecycle_trials.py
@@ -1,0 +1,338 @@
+# ABOUTME: Provides the scheduler-facing finite lifecycle trial adapter.
+# ABOUTME: Binds lifecycle-owned execution and evidence retention to one operational attempt.
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from aec_bench.contracts.identity import (
+    EntityKey,
+    EntityKind,
+    PortableRelativePath,
+    new_entity_id,
+    validate_uuidv7,
+)
+from aec_bench.contracts.run_plan import PlannedTrial, RunPlan, SingleAttemptRecipe
+from aec_bench.contracts.trial_record import ExecutionStatus, TrialRecord
+from aec_bench.execution.models import (
+    AttemptProcessStatus,
+    AttemptReceipt,
+    AttemptResourceUsage,
+    CancellationStatus,
+    FailureClass,
+    FailureClassification,
+    FailureKind,
+    FinalizationState,
+    ReconciliationState,
+    TrialFinalization,
+    WorkerOutcome,
+)
+from aec_bench.execution.operational import AttemptRecord, OperationalStore, WorkItemRecord
+from aec_bench.harness.planned_trial_reconciliation import planned_trial_binding, validate_planned_trial_record
+from aec_bench.ledger.evidence_run_store import EvidenceRunStore
+from aec_bench.ledger.writer import (
+    DuplicateAppendOnlyFileError,
+    DuplicateTrialRecordError,
+    write_append_only_json_at,
+    write_trial_record_at,
+)
+from aec_bench.lifecycles.application import (
+    LifecycleEvidenceRetention,
+    LifecycleTrialExecutor,
+    LifecycleVerifier,
+    run_lifecycle_trial,
+    validate_lifecycle_release,
+)
+from aec_bench.lifecycles.finalization import live_lifecycle_finalization_source
+from aec_bench.lifecycles.values import LifecycleTrial
+
+
+class LifecycleTrialAdapterError(RuntimeError):
+    """Raised when a scheduled lifecycle trial cannot be bound or published safely."""
+
+
+class LifecycleTrialAdapter:
+    """Run one exact finite lifecycle through the existing lifecycle application path."""
+
+    def __init__(
+        self,
+        *,
+        evidence_store: EvidenceRunStore,
+        operational_store: OperationalStore,
+        plan: RunPlan,
+        trials: Sequence[LifecycleTrial],
+        execute: LifecycleTrialExecutor,
+        verify: LifecycleVerifier,
+        retain: LifecycleEvidenceRetention = live_lifecycle_finalization_source,
+    ) -> None:
+        self._evidence_store = evidence_store
+        self._operational_store = operational_store
+        self._plan = plan
+        self._trials = self._index_trials(trials)
+        self._execute = execute
+        self._verify = verify
+        self._retain = retain
+
+    def __call__(self, work_item: WorkItemRecord, attempt: AttemptRecord) -> WorkerOutcome:
+        """Execute one complete lifecycle attempt and return its strict outcome."""
+
+        return self.execute(work_item, attempt).outcome
+
+    def execute(self, work_item: WorkItemRecord, attempt: AttemptRecord) -> LifecycleTrialExecution:
+        """Bind scheduler identities, invoke lifecycle execution, and publish its portable result."""
+
+        stored = self._evidence_store.read_run(self._plan.run_identity)
+        if stored.plan != self._plan or stored.plan is None:
+            raise LifecycleTrialAdapterError("authoritative run plan does not match the persisted plan")
+        if stored.state.state not in {"ready", "started"}:
+            raise LifecycleTrialAdapterError("lifecycle execution requires a ready or started evidence run")
+        planned = self._planned_trial(work_item)
+        self._validate_attempt(work_item, attempt)
+        lifecycle = self._trials.get(str(planned.trial_identity.id))
+        if lifecycle is None:
+            raise LifecycleTrialAdapterError(
+                f"planned lifecycle trial has no supplied trial: {planned.trial_identity.id}"
+            )
+        try:
+            validate_lifecycle_release(planned, lifecycle, stored.spec)
+        except ValueError as error:
+            raise LifecycleTrialAdapterError(str(error)) from error
+        record_path = self._record_path(planned)
+        finalization_path = self._finalization_path(planned)
+        if record_path.exists() or finalization_path.exists():
+            raise LifecycleTrialAdapterError(f"trial finalization already exists: {planned.trial_identity.id}")
+        if stored.state.state == "ready":
+            self._evidence_store.start_run(
+                self._plan.run_identity,
+                started_at=attempt.started_at or attempt.created_at,
+            )
+
+        started_at = attempt.started_at or attempt.created_at
+        submission_id = str(new_entity_id(EntityKind.BACKEND_SUBMISSION))
+        self._operational_store.record_backend_submission(
+            submission_id,
+            attempt_id=attempt.attempt_id,
+            backend=work_item.backend,
+            now=started_at,
+        )
+        self._operational_store.transition_backend_submission(submission_id, state="running", now=started_at)
+        binding = planned_trial_binding(planned, stored.spec)
+        try:
+            record = run_lifecycle_trial(
+                trial=lifecycle,
+                execute=self._execute,
+                verify=self._verify,
+                retain=self._retain,
+                planned_trial_binding=binding,
+            )
+            validate_planned_trial_record(
+                record,
+                planned,
+                stored.spec,
+                task_revision=lifecycle.compiled.envelope.package_sha256,
+            )
+        except Exception as error:
+            finished_at = datetime.now(UTC)
+            self._mark_failed(attempt, submission_id, finished_at)
+            self._persist_receipt(
+                self._failure_receipt(work_item, attempt, planned, submission_id, started_at, finished_at, error)
+            )
+            raise
+
+        finished_at = record.completed_at or datetime.now(UTC)
+        succeeded = record.execution_status is ExecutionStatus.COMPLETED
+        receipt_published = False
+        try:
+            write_trial_record_at(path=record_path, record=record)
+            receipt = self._receipt_from_record(
+                work_item, attempt, planned, submission_id, record, started_at, finished_at
+            )
+            self._persist_receipt(receipt)
+            receipt_published = True
+            finalization = TrialFinalization(
+                finalization_id=new_entity_id(EntityKind.RECEIPT),
+                trial_id=planned.trial_id,
+                attempt_id=validate_uuidv7(attempt.attempt_id),
+                record_version=1,
+                trial_record_ref=PortableRelativePath(record_path.relative_to(self._evidence_store.root).as_posix()),
+                published_at=finished_at,
+                state=FinalizationState.CURRENT,
+            )
+            write_append_only_json_at(path=finalization_path, payload=finalization.model_dump_json(indent=2) + "\n")
+        except Exception as error:
+            failed_at = datetime.now(UTC)
+            self._mark_failed(attempt, submission_id, failed_at)
+            if not receipt_published:
+                self._persist_receipt(
+                    self._failure_receipt(work_item, attempt, planned, submission_id, started_at, failed_at, error)
+                )
+            if isinstance(error, DuplicateAppendOnlyFileError | DuplicateTrialRecordError):
+                raise LifecycleTrialAdapterError(
+                    f"trial finalization already exists: {planned.trial_identity.id}"
+                ) from error
+            raise
+        self._operational_store.transition_attempt(
+            attempt.attempt_id,
+            state="succeeded" if succeeded else "failed",
+            now=finished_at,
+        )
+        self._operational_store.transition_backend_submission(
+            submission_id,
+            state="completed" if succeeded else "failed",
+            now=finished_at,
+        )
+        return LifecycleTrialExecution(record=record, receipt=receipt, finalization=finalization)
+
+    @staticmethod
+    def _index_trials(trials: Sequence[LifecycleTrial]) -> dict[str, LifecycleTrial]:
+        indexed: dict[str, LifecycleTrial] = {}
+        for trial in trials:
+            trial_id = trial.planned.trial_id
+            if trial_id in indexed:
+                raise LifecycleTrialAdapterError(f"lifecycle trials must have unique trial IDs: {trial_id}")
+            indexed[trial_id] = trial
+        return indexed
+
+    def _planned_trial(self, work_item: WorkItemRecord) -> PlannedTrial:
+        if work_item.run_id != str(self._plan.run_id) or work_item.plan_id != str(self._plan.plan_id):
+            raise LifecycleTrialAdapterError("work item does not belong to the authoritative run plan")
+        matches = [trial for trial in self._plan.trials if str(trial.trial_id) == work_item.trial_id]
+        if len(matches) != 1:
+            raise LifecycleTrialAdapterError(f"work item does not identify one planned trial: {work_item.trial_id}")
+        planned = matches[0]
+        if planned.execution_family != "lifecycle":
+            raise LifecycleTrialAdapterError("scheduled work item is not a lifecycle trial")
+        if planned.ordinal != work_item.ordinal:
+            raise LifecycleTrialAdapterError("work item ordinal does not match the authoritative trial")
+        if planned.compute.backend != work_item.backend:
+            raise LifecycleTrialAdapterError("work item backend does not match the authoritative trial")
+        if not isinstance(planned.attempt_recipe, SingleAttemptRecipe):
+            raise LifecycleTrialAdapterError("lifecycle trials require the single_attempt recipe")
+        return planned
+
+    @staticmethod
+    def _validate_attempt(work_item: WorkItemRecord, attempt: AttemptRecord) -> None:
+        if work_item.state != "running":
+            raise LifecycleTrialAdapterError("lifecycle execution requires a running scheduler work item")
+        if attempt.work_id != work_item.work_id or attempt.trial_id != work_item.trial_id:
+            raise LifecycleTrialAdapterError("scheduler attempt does not match the work item")
+        if attempt.run_id != work_item.run_id:
+            raise LifecycleTrialAdapterError("scheduler attempt does not match the work item run")
+        if attempt.lease_id is None:
+            raise LifecycleTrialAdapterError("lifecycle execution requires a lease-bound attempt")
+        if attempt.state != "running":
+            raise LifecycleTrialAdapterError("lifecycle execution requires a running scheduler attempt")
+        if attempt.candidate_index != 1:
+            raise LifecycleTrialAdapterError("lifecycle execution requires candidate 1")
+
+    def _record_path(self, planned: PlannedTrial) -> Path:
+        return (
+            self._evidence_store.run_directory(self._plan.run_identity) / "trial-records" / f"{planned.trial_id}.json"
+        )
+
+    def _finalization_path(self, planned: PlannedTrial) -> Path:
+        return (
+            self._evidence_store.run_directory(self._plan.run_identity) / "finalizations" / f"{planned.trial_id}.json"
+        )
+
+    def _persist_receipt(self, receipt: AttemptReceipt) -> None:
+        path = self._evidence_store.run_directory(self._plan.run_identity) / "receipts" / f"{receipt.receipt_id}.json"
+        try:
+            write_append_only_json_at(path=path, payload=receipt.model_dump_json(indent=2) + "\n")
+        except DuplicateAppendOnlyFileError as error:
+            raise LifecycleTrialAdapterError(f"attempt receipt already exists: {receipt.receipt_id}") from error
+
+    def _mark_failed(self, attempt: AttemptRecord, submission_id: str, now: datetime) -> None:
+        self._operational_store.transition_attempt(attempt.attempt_id, state="failed", now=now)
+        self._operational_store.transition_backend_submission(submission_id, state="failed", now=now)
+
+    @staticmethod
+    def _failure_receipt(
+        work_item: WorkItemRecord,
+        attempt: AttemptRecord,
+        planned: PlannedTrial,
+        submission_id: str,
+        started_at: datetime,
+        finished_at: datetime,
+        error: Exception,
+    ) -> AttemptReceipt:
+        return AttemptReceipt(
+            receipt_id=new_entity_id(EntityKind.RECEIPT),
+            receipt_key=EntityKey(f"{work_item.work_key}/attempt-{attempt.attempt_number}"),
+            attempt_id=validate_uuidv7(attempt.attempt_id),
+            backend=work_item.backend,
+            submission_id=validate_uuidv7(submission_id),
+            requested_condition=planned.agent_condition.identity,
+            started_at=started_at,
+            finished_at=finished_at,
+            process_status=AttemptProcessStatus.FAILED,
+            cancellation_status=CancellationStatus.NOT_REQUESTED,
+            resource_usage=AttemptResourceUsage(wall_seconds=max(0.0, (finished_at - started_at).total_seconds())),
+            failure=FailureClassification(
+                failure_class=FailureClass.INFRASTRUCTURE,
+                kind=FailureKind.RESULT_IMPORT_FAILED,
+                message=str(error) or "lifecycle execution failed",
+            ),
+            reconciliation_status=ReconciliationState.NOT_REQUIRED,
+        )
+
+    @staticmethod
+    def _receipt_from_record(
+        work_item: WorkItemRecord,
+        attempt: AttemptRecord,
+        planned: PlannedTrial,
+        submission_id: str,
+        record: TrialRecord,
+        started_at: datetime,
+        finished_at: datetime,
+    ) -> AttemptReceipt:
+        output_references = () if record.output is None else tuple(item.artifact for item in record.output.artifacts)
+        succeeded = record.execution_status is ExecutionStatus.COMPLETED
+        return AttemptReceipt(
+            receipt_id=new_entity_id(EntityKind.RECEIPT),
+            receipt_key=EntityKey(f"{work_item.work_key}/attempt-{attempt.attempt_number}"),
+            attempt_id=validate_uuidv7(attempt.attempt_id),
+            backend=work_item.backend,
+            submission_id=validate_uuidv7(submission_id),
+            requested_condition=planned.agent_condition.identity,
+            started_at=started_at,
+            finished_at=finished_at,
+            process_status=AttemptProcessStatus.SUCCEEDED if succeeded else AttemptProcessStatus.FAILED,
+            cancellation_status=CancellationStatus.NOT_REQUESTED,
+            resource_usage=AttemptResourceUsage(wall_seconds=max(0.0, (finished_at - started_at).total_seconds())),
+            output_references=output_references,
+            authority_evidence=record.authority_evidence,
+            failure=(
+                None
+                if succeeded
+                else FailureClassification(
+                    failure_class=FailureClass.BENCHMARK,
+                    kind=FailureKind.TASK_FAILURE,
+                    message="lifecycle execution did not complete",
+                )
+            ),
+            reconciliation_status=ReconciliationState.NOT_REQUIRED,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class LifecycleTrialExecution:
+    """Portable lifecycle record, attempt receipt, and finalization."""
+
+    record: TrialRecord
+    receipt: AttemptReceipt
+    finalization: TrialFinalization
+
+    @property
+    def outcome(self) -> WorkerOutcome:
+        return WorkerOutcome(
+            terminal_state="succeeded" if self.record.execution_status is ExecutionStatus.COMPLETED else "failed",
+            receipts=(self.receipt,),
+            finalization=self.finalization,
+        )
+
+
+__all__ = ("LifecycleTrialAdapter", "LifecycleTrialAdapterError", "LifecycleTrialExecution")

--- a/src/aec_bench/lifecycles/application.py
+++ b/src/aec_bench/lifecycles/application.py
@@ -185,13 +185,13 @@ def run_persisted_lifecycle_plan(
         lifecycle = by_id.get(str(planned.trial_identity.id))
         if lifecycle is None:
             raise ValueError(f"planned lifecycle trial has no supplied trial: {planned.trial_identity.id}")
-        _validate_lifecycle_release(planned, lifecycle, stored.spec)
+        validate_lifecycle_release(planned, lifecycle, stored.spec)
 
     store.start_run(run_identity, started_at=started_at)
     records: list[TrialRecord] = []
     for planned in lifecycle_trials:
         lifecycle = by_id[str(planned.trial_identity.id)]
-        _validate_lifecycle_release(planned, lifecycle, stored.spec)
+        validate_lifecycle_release(planned, lifecycle, stored.spec)
         binding = planned_trial_binding(planned, stored.spec)
         record = run_lifecycle_trial(
             trial=lifecycle,
@@ -212,7 +212,7 @@ def run_persisted_lifecycle_plan(
     return sorted(records, key=lambda record: _planned_ordinal(record, lifecycle_trials))
 
 
-def _validate_lifecycle_release(
+def validate_lifecycle_release(
     planned: PlannedTrial,
     trial: LifecycleTrial,
     spec: ResolvedRunSpec,
@@ -293,5 +293,6 @@ __all__ = (
     "run_lifecycle_experiment",
     "run_persisted_lifecycle_plan",
     "run_lifecycle_trial",
+    "validate_lifecycle_release",
     "submit_checkpoint",
 )

--- a/tests/harness/test_lifecycle_adapter.py
+++ b/tests/harness/test_lifecycle_adapter.py
@@ -1,0 +1,484 @@
+# ABOUTME: Tests the scheduler-facing finite lifecycle trial adapter.
+# ABOUTME: Proves lifecycle release binding, one scheduler attempt, durable evidence, and terminal failures.
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from aec_bench.contracts.agent_output import AgentOutput, AgentOutputStatus
+from aec_bench.contracts.evaluation_result import EvaluationResult, ValidityCheck
+from aec_bench.contracts.execution_release import LifecycleExecutionRelease
+from aec_bench.contracts.experiment_manifest import AgentConfig
+from aec_bench.contracts.identity import EntityKind, new_entity_id
+from aec_bench.contracts.resolved_run import ResolvedRunSpec
+from aec_bench.contracts.run_plan import BestOfAttemptRecipe, PlannedTrial
+from aec_bench.contracts.trial_record import (
+    AgentConfiguration,
+    EvaluationStatus,
+    EvidenceStatus,
+    ExecutionEnvironmentRef,
+    ExecutionStatus,
+    ProviderRoute,
+    RunManifest,
+    TimingRecord,
+    TrialInput,
+    TrialOutput,
+    TrialRecord,
+    UnresolvedSourceRef,
+)
+from aec_bench.execution import ExecutionPolicy, LocalScheduler, RetryPolicy, TrialWorkItem, WorkItemState
+from aec_bench.execution.operational import OperationalStore
+from aec_bench.harness import lifecycle_trials
+from aec_bench.harness.lifecycle_trials import LifecycleTrialAdapter, LifecycleTrialAdapterError
+from aec_bench.harness.planned_trial_reconciliation import planned_trial_binding
+from aec_bench.lifecycles.compiled import CompiledLifecycle, CompiledLifecycleEnvelope
+from aec_bench.lifecycles.runtime.episode import LifecycleExecutionMode, LifecycleVisibilityPolicy
+from aec_bench.lifecycles.values import LifecycleExecution, LifecycleTrial
+from aec_bench.trials import PlannedTrial as LegacyPlannedTrial
+from tests.harness.test_persisted_family_plans import _spec_and_plan, _store
+
+
+def _release() -> tuple[CompiledLifecycleEnvelope, LifecycleExecutionRelease]:
+    envelope = CompiledLifecycleEnvelope(
+        visibility="public",
+        template_id="test-template",
+        lifecycle_id="test-lifecycle",
+        variant_id="test-variant",
+        lifecycle_spec_sha256="a" * 64,
+        package_sha256="b" * 64,
+        executable_artifact_sha256="c" * 64,
+        operation_protocol_sha256=None,
+    )
+    release = LifecycleExecutionRelease(
+        lifecycle_identity=_identity(EntityKind.LIFECYCLE, "test-lifecycle", version=2),
+        variant_identity=_identity(EntityKind.VARIANT, "test-variant", version=3),
+        visibility="public",
+        template_id=envelope.template_id,
+        lifecycle_id=envelope.lifecycle_id,
+        variant_id=envelope.variant_id,
+        lifecycle_spec_sha256=envelope.lifecycle_spec_sha256,
+        package_sha256=envelope.package_sha256,
+        executable_artifact_sha256=envelope.executable_artifact_sha256,
+        operation_protocol_sha256=None,
+    )
+    return envelope, release
+
+
+def _identity(kind: EntityKind, key: str, version: int = 1):
+    from aec_bench.contracts.identity import EntityIdentity
+
+    return EntityIdentity(id=new_entity_id(kind), key=key, version=version)
+
+
+def _record(spec: ResolvedRunSpec, trial: PlannedTrial, *, completed: bool = True) -> TrialRecord:
+    started = datetime(2026, 8, 30, 12, 2, tzinfo=UTC)
+    finished = started + timedelta(seconds=1)
+    manifest = RunManifest(
+        run_id=str(spec.run_identity.id),
+        experiment_id=str(spec.experiment_identity.id),
+        source=UnresolvedSourceRef(reason="test"),
+        agent=AgentConfiguration(adapter=trial.agent_condition.adapter, model=trial.agent_condition.model),
+        execution_environment=ExecutionEnvironmentRef(runtime_image="test", compute_backend=trial.compute.backend),
+        provider_route=ProviderRoute(provider="test", route="test"),
+    )
+    return TrialRecord(
+        trial_id=str(trial.trial_id),
+        run_id=str(spec.run_identity.id),
+        task_id=trial.task_release.task_id,
+        planned_trial_binding=planned_trial_binding(trial, spec),
+        execution_status=ExecutionStatus.COMPLETED if completed else ExecutionStatus.FAILED,
+        evaluation_status=EvaluationStatus.COMPLETED,
+        evidence_status=EvidenceStatus.NOT_REQUIRED,
+        started_at=started,
+        completed_at=finished,
+        input=TrialInput(instruction="Run lifecycle", task_revision="b" * 64, task_kind="lifecycle"),
+        output=(
+            TrialOutput(
+                agent_output=AgentOutput(
+                    status=AgentOutputStatus.COMPLETED if completed else AgentOutputStatus.FAILED,
+                    output_path="outputs/result.json",
+                    output_format="json",
+                )
+            )
+            if completed
+            else None
+        ),
+        evaluation=EvaluationResult(
+            reward=1.0 if completed else 0.0,
+            validity=ValidityCheck(output_parseable=completed, schema_valid=completed, verifier_completed=True),
+        ),
+        timing=TimingRecord(total_seconds=1),
+    ).bind_run_manifest(manifest)
+
+
+def _boundary(tmp_path: Path, *, recipe: BestOfAttemptRecipe | None = None):
+    envelope, release = _release()
+    spec, plan = _spec_and_plan(tmp_path, family="lifecycle", family_release=release)
+    if recipe is not None:
+        plan = plan.model_copy(update={"trials": (plan.trials[0].model_copy(update={"attempt_recipe": recipe}),)})
+    evidence = _store(tmp_path, spec, plan)
+    operational = OperationalStore(tmp_path / "operational.sqlite3")
+    now = datetime(2026, 8, 30, 12, 2, tzinfo=UTC)
+    operational.create_run(str(plan.run_id), spec_ref="resolved-run-spec.json", status="ready", now=now)
+    operational.put_plan(str(plan.plan_id), run_id=str(plan.run_id), plan_ref="run-plan.json", state="ready", now=now)
+    trial = plan.trials[0]
+    item = TrialWorkItem(
+        work_id=new_entity_id(EntityKind.WORK_ITEM),
+        work_key=trial.trial_key,
+        run_id=plan.run_id,
+        plan_id=plan.plan_id,
+        trial_id=trial.trial_id,
+        ordinal=trial.ordinal,
+        execution_family="lifecycle",
+        backend=trial.compute.backend,
+        provider_route="lifecycle",
+        model_route=trial.agent_condition.model,
+        resource_class="default",
+        retry_policy=RetryPolicy(maximum_attempts=1),
+        state=WorkItemState.PLANNED,
+        created_at=now,
+        available_at=now,
+    )
+    compiled = object.__new__(CompiledLifecycle)
+    object.__setattr__(compiled, "package_dir", tmp_path / "package")
+    object.__setattr__(compiled, "envelope", envelope)
+    legacy = LegacyPlannedTrial(
+        trial_id=str(trial.trial_id),
+        experiment_id=str(spec.experiment_identity.id),
+        task_id=trial.task_release.task_id,
+        agent=AgentConfig(
+            name=str(trial.agent_condition.identity.key),
+            adapter=trial.agent_condition.adapter,
+            model=trial.agent_condition.model,
+            parameters=trial.agent_condition.parameters,
+            client=trial.agent_condition.client,
+            system_prompt=trial.agent_condition.system_prompt,
+        ),
+        compute=trial.compute,
+        repetition=trial.repetition,
+    )
+    lifecycle = LifecycleTrial(
+        planned=legacy,
+        compiled=compiled,
+        run_dir=tmp_path / "lifecycle-run",
+        execution_mode=LifecycleExecutionMode.FRESH_CONTEXT,
+        visibility_policy=LifecycleVisibilityPolicy.ARTIFACT_MEMORY,
+    )
+    return spec, plan, evidence, operational, item, lifecycle
+
+
+def test_lifecycle_adapter_publishes_one_attempt_and_record(tmp_path: Path, monkeypatch) -> None:
+    spec, plan, evidence, operational, item, lifecycle = _boundary(tmp_path)
+    output = tmp_path / "output.json"
+    output.write_bytes(b"lifecycle output\n")
+    lifecycle.run_dir.mkdir(parents=True)
+    (lifecycle.run_dir / "pre-existing-checkpoint.marker").write_bytes(b"preserve lifecycle state")
+    observed_trials: list[LifecycleTrial] = []
+
+    def fake_run(**kwargs):
+        observed_trials.append(kwargs["trial"])
+        for checkpoint in ("checkpoint-1", "checkpoint-2", "checkpoint-3"):
+            (lifecycle.run_dir / checkpoint).write_text("lifecycle-owned\n")
+        record = _record(spec, plan.trials[0])
+        record.attach_artifact("output:result", output, media_type="application/json")
+        return record
+
+    monkeypatch.setattr(lifecycle_trials, "run_lifecycle_trial", fake_run)
+    adapter = LifecycleTrialAdapter(
+        evidence_store=evidence,
+        operational_store=operational,
+        plan=plan,
+        trials=[lifecycle],
+        execute=lambda _: LifecycleExecution(state={}, agent={}, tool_schema=()),
+        verify=lambda _package, _run: {},
+    )
+    scheduler = LocalScheduler(operational, ExecutionPolicy(max_concurrency=1))
+    scheduler.enqueue_ready_plan(plan, (item,))
+    report = scheduler.dispatch_once(adapter, owner="scheduler", now=datetime(2026, 8, 30, 12, 2, tzinfo=UTC))
+
+    assert report.succeeded_count == 1
+    assert observed_trials == [lifecycle]
+    assert observed_trials[0].run_dir == lifecycle.run_dir
+    assert (lifecycle.run_dir / "pre-existing-checkpoint.marker").read_bytes() == b"preserve lifecycle state"
+    assert len(operational.list_attempts(plan.trials[0].trial_id)) == 1
+    submission = operational.list_backend_submissions_for_run(plan.run_id)[0]
+    assert len(operational.list_backend_submissions_for_run(plan.run_id)) == 1
+    run_dir = evidence.run_directory(spec.run_identity)
+    record_path = next(run_dir.glob("trial-records/*.json"))
+    record = json.loads(record_path.read_text())
+    artifact = record["output"]["artifacts"][0]["artifact"]
+    assert (record_path.parent / "_artifacts" / artifact["artifact_id"]).read_bytes() == b"lifecycle output\n"
+    receipt = json.loads(next(run_dir.glob("receipts/*.json")).read_text())
+    assert receipt["submission_id"] == submission.submission_id
+    assert receipt["output_references"][0]["artifact_id"] == artifact["artifact_id"]
+    assert len(tuple(run_dir.glob("receipts/*.json"))) == 1
+    assert len(tuple(run_dir.glob("finalizations/*.json"))) == 1
+
+
+def test_lifecycle_adapter_rejects_best_of_before_submission(tmp_path: Path, monkeypatch) -> None:
+    spec, plan, evidence, operational, item, lifecycle = _boundary(
+        tmp_path,
+        recipe=BestOfAttemptRecipe(candidates=2, selector="self"),
+    )
+    calls = 0
+
+    def fake_run(**_kwargs):
+        nonlocal calls
+        calls += 1
+        return _record(spec, plan.trials[0])
+
+    monkeypatch.setattr(lifecycle_trials, "run_lifecycle_trial", fake_run)
+    adapter = LifecycleTrialAdapter(
+        evidence_store=evidence,
+        operational_store=operational,
+        plan=plan,
+        trials=[lifecycle],
+        execute=lambda _: LifecycleExecution(state={}, agent={}, tool_schema=()),
+        verify=lambda _package, _run: {},
+    )
+    scheduler = LocalScheduler(operational, ExecutionPolicy(max_concurrency=1))
+    scheduler.enqueue_ready_plan(plan, (item,))
+    report = scheduler.dispatch_once(adapter, owner="scheduler", now=datetime(2026, 8, 30, 12, 2, tzinfo=UTC))
+
+    assert report.failed_count == 1
+    assert calls == 0
+    assert not operational.list_backend_submissions_for_run(plan.run_id)
+    assert not list(evidence.run_directory(spec.run_identity).glob("finalizations/*.json"))
+
+
+@pytest.mark.parametrize("field", ("variant_id", "package_sha256"))
+def test_lifecycle_adapter_rejects_release_drift_before_effects(tmp_path: Path, monkeypatch, field: str) -> None:
+    spec, plan, evidence, operational, item, lifecycle = _boundary(tmp_path)
+    drifted_envelope = lifecycle.compiled.envelope.model_copy(
+        update={field: "drifted-variant" if field == "variant_id" else "d" * 64}
+    )
+    drifted_compiled = object.__new__(CompiledLifecycle)
+    object.__setattr__(drifted_compiled, "package_dir", lifecycle.package_dir)
+    object.__setattr__(drifted_compiled, "envelope", drifted_envelope)
+    drifted_lifecycle = LifecycleTrial(
+        planned=lifecycle.planned,
+        compiled=drifted_compiled,
+        run_dir=lifecycle.run_dir,
+        execution_mode=lifecycle.execution_mode,
+        visibility_policy=lifecycle.visibility_policy,
+    )
+    calls = 0
+
+    def fake_run(**_kwargs):
+        nonlocal calls
+        calls += 1
+        return _record(spec, plan.trials[0])
+
+    monkeypatch.setattr(lifecycle_trials, "run_lifecycle_trial", fake_run)
+    adapter = LifecycleTrialAdapter(
+        evidence_store=evidence,
+        operational_store=operational,
+        plan=plan,
+        trials=[drifted_lifecycle],
+        execute=lambda _: LifecycleExecution(state={}, agent={}, tool_schema=()),
+        verify=lambda _package, _run: {},
+    )
+    scheduler = LocalScheduler(operational, ExecutionPolicy(max_concurrency=1))
+    scheduler.enqueue_ready_plan(plan, (item,))
+    report = scheduler.dispatch_once(adapter, owner="scheduler", now=datetime(2026, 8, 30, 12, 2, tzinfo=UTC))
+
+    assert report.failed_count == 1
+    assert calls == 0
+    assert not operational.list_backend_submissions_for_run(plan.run_id)
+    run_dir = evidence.run_directory(spec.run_identity)
+    assert not list(run_dir.glob("trial-records/*.json"))
+    assert not list(run_dir.glob("receipts/*.json"))
+    assert not list(run_dir.glob("finalizations/*.json"))
+
+
+def test_lifecycle_adapter_publishes_a_valid_failed_execution(tmp_path: Path, monkeypatch) -> None:
+    spec, plan, evidence, operational, item, lifecycle = _boundary(tmp_path)
+
+    def fake_run(**_kwargs):
+        return _record(spec, plan.trials[0], completed=False)
+
+    monkeypatch.setattr(lifecycle_trials, "run_lifecycle_trial", fake_run)
+    adapter = LifecycleTrialAdapter(
+        evidence_store=evidence,
+        operational_store=operational,
+        plan=plan,
+        trials=[lifecycle],
+        execute=lambda _: LifecycleExecution(state={}, agent={}, tool_schema=()),
+        verify=lambda _package, _run: {},
+    )
+    scheduler = LocalScheduler(operational, ExecutionPolicy(max_concurrency=1))
+    scheduler.enqueue_ready_plan(plan, (item,))
+    report = scheduler.dispatch_once(adapter, owner="scheduler", now=datetime(2026, 8, 30, 12, 2, tzinfo=UTC))
+
+    assert report.failed_count == 1
+    attempt = operational.list_attempts(plan.trials[0].trial_id)[0]
+    assert attempt.state == "failed"
+    submission = operational.list_backend_submissions_for_run(plan.run_id)[0]
+    assert submission.state == "failed"
+    assert operational.get_work_item(item.work_id).state == "failed"
+    assert operational.get_planned_trial(plan.trials[0].trial_id).state == "failed"
+    run_dir = evidence.run_directory(spec.run_identity)
+    assert len(tuple(run_dir.glob("receipts/*.json"))) == 1
+    assert len(tuple(run_dir.glob("trial-records/*.json"))) == 1
+    assert len(tuple(run_dir.glob("finalizations/*.json"))) == 1
+
+
+def test_lifecycle_adapter_keeps_failed_evaluation_as_successful_execution(tmp_path: Path, monkeypatch) -> None:
+    spec, plan, evidence, operational, item, lifecycle = _boundary(tmp_path)
+    output = tmp_path / "evaluation-failed-output.json"
+    output.write_bytes(b"evaluation failed after execution\n")
+
+    def fake_run(**_kwargs):
+        record = _record(spec, plan.trials[0])
+        record.evaluation_status = EvaluationStatus.FAILED
+        record.attach_artifact("output:result", output, media_type="application/json")
+        return record
+
+    monkeypatch.setattr(lifecycle_trials, "run_lifecycle_trial", fake_run)
+    adapter = LifecycleTrialAdapter(
+        evidence_store=evidence,
+        operational_store=operational,
+        plan=plan,
+        trials=[lifecycle],
+        execute=lambda _: LifecycleExecution(state={}, agent={}, tool_schema=()),
+        verify=lambda _package, _run: {},
+    )
+    scheduler = LocalScheduler(operational, ExecutionPolicy(max_concurrency=1))
+    scheduler.enqueue_ready_plan(plan, (item,))
+    report = scheduler.dispatch_once(adapter, owner="scheduler", now=datetime(2026, 8, 30, 12, 2, tzinfo=UTC))
+
+    assert report.succeeded_count == 1
+    attempt = operational.list_attempts(plan.trials[0].trial_id)[0]
+    assert operational.get_attempt(attempt.attempt_id).state == "succeeded"
+    assert operational.list_backend_submissions_for_run(plan.run_id)[0].state == "completed"
+    assert operational.get_work_item(item.work_id).state == "succeeded"
+    assert operational.get_planned_trial(plan.trials[0].trial_id).state == "succeeded"
+    record_path = next(evidence.run_directory(spec.run_identity).glob("trial-records/*.json"))
+    assert json.loads(record_path.read_text())["evaluation_status"] == "failed"
+
+
+def test_lifecycle_adapter_exception_publishes_infrastructure_receipt_only(tmp_path: Path, monkeypatch) -> None:
+    spec, plan, evidence, operational, item, lifecycle = _boundary(tmp_path)
+
+    def fake_run(**_kwargs):
+        raise RuntimeError("runner stopped")
+
+    monkeypatch.setattr(lifecycle_trials, "run_lifecycle_trial", fake_run)
+    adapter = LifecycleTrialAdapter(
+        evidence_store=evidence,
+        operational_store=operational,
+        plan=plan,
+        trials=[lifecycle],
+        execute=lambda _: LifecycleExecution(state={}, agent={}, tool_schema=()),
+        verify=lambda _package, _run: {},
+    )
+    scheduler = LocalScheduler(operational, ExecutionPolicy(max_concurrency=1))
+    scheduler.enqueue_ready_plan(plan, (item,))
+    report = scheduler.dispatch_once(adapter, owner="scheduler", now=datetime(2026, 8, 30, 12, 2, tzinfo=UTC))
+
+    assert report.failed_count == 1
+    run_dir = evidence.run_directory(spec.run_identity)
+    receipts = tuple(run_dir.glob("receipts/*.json"))
+    assert len(receipts) == 1
+    receipt = json.loads(receipts[0].read_text())
+    assert receipt["process_status"] == "failed"
+    assert receipt["failure"]["kind"] == "result_import_failed"
+    assert not list(run_dir.glob("trial-records/*.json"))
+    assert not list(run_dir.glob("finalizations/*.json"))
+
+
+def test_lifecycle_adapter_accepts_scheduler_retry_as_one_complete_attempt(tmp_path: Path, monkeypatch) -> None:
+    spec, plan, evidence, operational, item, lifecycle = _boundary(tmp_path)
+    output = tmp_path / "retry-output.json"
+    output.write_bytes(b"retry output\n")
+
+    def fake_run(**_kwargs):
+        record = _record(spec, plan.trials[0])
+        record.attach_artifact("output:result", output, media_type="application/json")
+        return record
+
+    monkeypatch.setattr(lifecycle_trials, "run_lifecycle_trial", fake_run)
+    adapter = LifecycleTrialAdapter(
+        evidence_store=evidence,
+        operational_store=operational,
+        plan=plan,
+        trials=[lifecycle],
+        execute=lambda _: LifecycleExecution(state={}, agent={}, tool_schema=()),
+        verify=lambda _package, _run: {},
+    )
+    scheduler = LocalScheduler(operational, ExecutionPolicy(max_concurrency=1))
+    scheduler.enqueue_ready_plan(plan, (item,))
+    now = datetime(2026, 8, 30, 12, 2, tzinfo=UTC)
+    selected = operational.lease_next_work_item(owner="scheduler", now=now, ttl=timedelta(minutes=1))
+    assert selected is not None
+    leased_item, lease = selected
+    attempt = operational.create_attempt_for_lease(
+        leased_item.work_id,
+        trial_id=leased_item.trial_id,
+        lease_id=lease.lease_id,
+        candidate_index=1,
+        retry_number=2,
+        now=now,
+    )
+    running_item = operational.update_work_item(leased_item.work_id, state="running", now=now)
+    operational.update_planned_trial(running_item.trial_id, state="running", now=now)
+    running_attempt = operational.transition_attempt(attempt.attempt_id, state="running", now=now)
+
+    outcome = adapter(running_item, running_attempt)
+
+    assert outcome.terminal_state == "succeeded"
+    assert operational.get_attempt(attempt.attempt_id).retry_number == 2
+
+
+def test_lifecycle_adapter_rejects_duplicate_before_runtime_effects(tmp_path: Path, monkeypatch) -> None:
+    spec, plan, evidence, operational, item, lifecycle = _boundary(tmp_path)
+    output = tmp_path / "duplicate-output.json"
+    output.write_bytes(b"duplicate output\n")
+    calls = 0
+
+    def fake_run(**_kwargs):
+        nonlocal calls
+        calls += 1
+        record = _record(spec, plan.trials[0])
+        record.attach_artifact("output:result", output, media_type="application/json")
+        return record
+
+    monkeypatch.setattr(lifecycle_trials, "run_lifecycle_trial", fake_run)
+    adapter = LifecycleTrialAdapter(
+        evidence_store=evidence,
+        operational_store=operational,
+        plan=plan,
+        trials=[lifecycle],
+        execute=lambda _: LifecycleExecution(state={}, agent={}, tool_schema=()),
+        verify=lambda _package, _run: {},
+    )
+    scheduler = LocalScheduler(operational, ExecutionPolicy(max_concurrency=1))
+    scheduler.enqueue_ready_plan(plan, (item,))
+    now = datetime(2026, 8, 30, 12, 2, tzinfo=UTC)
+    first = scheduler.dispatch_once(adapter, owner="scheduler", now=now)
+    assert first.succeeded_count == 1
+    submission_count = len(operational.list_backend_submissions_for_run(plan.run_id))
+
+    operational.update_work_item(item.work_id, state="queued", now=now)
+    operational.update_planned_trial(plan.trials[0].trial_id, state="queued", now=now)
+    selected = operational.lease_next_work_item(owner="scheduler", now=now, ttl=timedelta(minutes=1))
+    assert selected is not None
+    leased_item, lease = selected
+    retry_attempt = operational.create_attempt_for_lease(
+        leased_item.work_id,
+        trial_id=leased_item.trial_id,
+        lease_id=lease.lease_id,
+        candidate_index=1,
+        retry_number=1,
+        now=now,
+    )
+    running_item = operational.update_work_item(leased_item.work_id, state="running", now=now)
+    running_attempt = operational.transition_attempt(retry_attempt.attempt_id, state="running", now=now)
+
+    with pytest.raises(LifecycleTrialAdapterError, match="trial finalization already exists"):
+        adapter(running_item, running_attempt)
+
+    assert calls == 1
+    assert len(operational.list_backend_submissions_for_run(plan.run_id)) == submission_count


### PR DESCRIPTION
## Summary

- add one scheduler-facing harness adapter for complete finite lifecycle trials
- reuse the existing lifecycle application, checkpoint, verification, retention, and recovery path
- validate exact lifecycle template, lifecycle, variant, package, protocol, agent, compute, and trial identity before execution
- keep checkpoint actions inside one lifecycle attempt and outside scheduler progress
- publish one operational submission, portable receipt, stable trial record, and finalization per lifecycle attempt
- keep lifecycle and task formats current-only; no migration scripts or compatibility readers are included

## Review order

1. `src/aec_bench/harness/lifecycle_trials.py`
2. `src/aec_bench/lifecycles/application.py`
3. `tests/harness/test_lifecycle_adapter.py`
4. `docs/CONTRACTS.md`

## Evidence

- adapter and cross-family regression suite: 89 passed
- existing lifecycle application suite: 13 passed
- lifecycle adapter tests: 9 passed
- Ruff check and format: passed
- scoped mypy: passed
- provenance audit: passed, 0 violations
- wheel build: passed
- package ownership suite: 26 passed, with the same 3 failures present on the stacked base

## Ownership

The scheduler adapter is under `aec_bench.harness`. The lifecycle domain does not import execution control. Its only domain change exposes the existing exact release validator for reuse.

## Stack

This PR is based on `feat/prd3-world-adapter` and must be reviewed after PR #197.