### PR TITLE
PRD3: bind Harbor work to scheduler attempts

### DIFF
--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -149,6 +149,16 @@ planned task release, agent condition, compute backend, execution family, and
 attempt. Accepted records retain Harbor job and trial names only as observed
 backend metadata and return in plan ordinal order.
 
+The scheduler-facing `HarborBackend` binds one lease-bound attempt to a strict
+`HarborAttemptTransport` containing the canonical run, plan, trial, work,
+ordinal, attempt, and submission identities. It records the submission and
+transport mapping before the Harbor effect, binds the returned external ID,
+and writes the receipt, finalization, and `TrialRecord` in the portable evidence
+run directory. A
+missing or unknown remote result produces an unknown receipt and no final
+record; it does not close the planned trial. Duplicate publication and any
+identity or membership drift fail closed.
+
 The transport and reconciliation values have this JSON shape (UUIDs are
 illustrative):
 

--- a/provenance-registry.toml
+++ b/provenance-registry.toml
@@ -4093,6 +4093,27 @@ compatibility_behavior = "read v1 and v2 explicitly; reject unsupported runtime-
 compatibility_kind = "external_schema"
 
 [[field]]
+symbol = "aec_bench.harness.harbor_backend.HarborAttemptTransport.schema_version"
+surface = "pydantic_model"
+wire_name = "schema_version"
+category = "compatibility"
+domain_owner = "harbor_execution"
+authority = "harbor_scheduler_backend"
+authoritative = true
+exposure = "persisted"
+status = "current"
+payload_contract = "strict AEC-Bench attempt to Harbor transport mapping schema 1"
+canonicalization = "fixed integer literal 1"
+consumer = "scheduler-facing Harbor backend and reconciliation readers"
+validation_behavior = "HarborAttemptTransport accepts schema version 1 and requires UUIDv7 run, plan, trial, work, attempt, and submission identities"
+mismatch_behavior = "reject an unsupported or incomplete Harbor attempt mapping"
+retention = "harbor_attempt_lifetime"
+rationale = "The mapping binds one remote Harbor effect to the exact scheduler-owned attempt without changing canonical trial identity."
+duplication = "unique"
+compatibility_behavior = "the canonical Harbor backend accepts schema 1 only"
+compatibility_kind = "external_schema"
+
+[[field]]
 symbol = "aec_bench.harness.harbor_reconciliation.HarborImportReconciliation.schema_version"
 surface = "pydantic_model"
 wire_name = "schema_version"

--- a/src/aec_bench/execution/models.py
+++ b/src/aec_bench/execution/models.py
@@ -486,12 +486,18 @@ class WorkerOutcome(FrozenStrictModel):
     schema_version: Literal[1] = 1
     terminal_state: Literal["succeeded", "failed", "unknown"]
     receipts: tuple[AttemptReceipt, ...]
-    finalization: TrialFinalization
+    finalization: TrialFinalization | None = None
 
     @model_validator(mode="after")
     def validate_receipts(self) -> Self:
         if not self.receipts:
             raise ValueError("worker outcome requires at least one attempt receipt")
+        if self.terminal_state == "unknown" and self.finalization is not None:
+            raise ValueError("unknown worker outcome must not have a finalization")
+        if self.terminal_state != "unknown" and self.finalization is None:
+            raise ValueError("known worker outcome requires a finalization")
+        if self.finalization is None:
+            return self
         if self.finalization.attempt_id not in {receipt.attempt_id for receipt in self.receipts}:
             raise ValueError("worker outcome finalization attempt must have a receipt")
         selected = next(receipt for receipt in self.receipts if receipt.attempt_id == self.finalization.attempt_id)

--- a/src/aec_bench/execution/operational/store.py
+++ b/src/aec_bench/execution/operational/store.py
@@ -822,6 +822,37 @@ class OperationalStore:
                 ).fetchone()
             )
 
+    def bind_backend_submission_external_id(
+        self, submission_id: UUID | str, *, external_id: str, now: datetime | None = None
+    ) -> BackendSubmissionRecord:
+        """Bind the provider identifier after a submission is accepted."""
+
+        selected_id = _required_id(submission_id, "submission_id")
+        selected_external_id = _required_text(external_id, "external_id")
+        stamp = _timestamp(_aware(now or datetime.now(UTC), "now"))
+        with self._connection(immediate=True) as connection:
+            current = self._require_row(connection, "operational_backend_submissions", "submission_id", selected_id)
+            if current[3] is not None and current[3] != selected_external_id:
+                raise OperationalStoreConflict(f"submission already has a different external ID: {selected_id}")
+            owner = connection.execute(
+                "SELECT submission_id FROM operational_backend_submissions "
+                "WHERE external_id = ? AND submission_id != ?",
+                (selected_external_id, selected_id),
+            ).fetchone()
+            if owner is not None:
+                raise OperationalStoreConflict(
+                    f"external ID already belongs to another submission: {selected_external_id}"
+                )
+            connection.execute(
+                "UPDATE operational_backend_submissions SET external_id = ?, updated_at = ? WHERE submission_id = ?",
+                (selected_external_id, stamp, selected_id),
+            )
+            return self._submission_from_row(
+                connection.execute(
+                    "SELECT * FROM operational_backend_submissions WHERE submission_id = ?", (selected_id,)
+                ).fetchone()
+            )
+
     def get_backend_submission(self, submission_id: UUID | str) -> BackendSubmissionRecord:
         selected_id = _required_id(submission_id, "submission_id")
         with self._connection() as connection:

--- a/src/aec_bench/harness/harbor_backend.py
+++ b/src/aec_bench/harness/harbor_backend.py
@@ -1,0 +1,467 @@
+# ABOUTME: Provides the strict scheduler-facing Harbor backend adapter.
+# ABOUTME: Binds remote Harbor transport state to canonical attempts and portable trial evidence.
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Literal, Protocol
+from uuid import UUID
+
+from pydantic import PositiveInt, field_validator
+
+from aec_bench.contracts.identity import (
+    EntityKey,
+    EntityKind,
+    PortableRelativePath,
+    new_entity_id,
+    validate_uuidv7,
+)
+from aec_bench.contracts.resolved_run import ResolvedRunSpec
+from aec_bench.contracts.run_plan import PlannedTrial, RunPlan, SingleAttemptRecipe
+from aec_bench.contracts.task_snapshot import ArtifactTaskSnapshotRef, RepositoryTaskSnapshotRef
+from aec_bench.contracts.trial_record import ExecutionStatus, TrialRecord
+from aec_bench.contracts.validators import FrozenStrictModel, NonEmptyStr
+from aec_bench.execution.models import (
+    AttemptProcessStatus,
+    AttemptReceipt,
+    AttemptResourceUsage,
+    CancellationStatus,
+    FailureClass,
+    FailureClassification,
+    FailureKind,
+    FinalizationState,
+    ReconciliationState,
+    TrialFinalization,
+    WorkerOutcome,
+)
+from aec_bench.execution.operational import AttemptRecord, OperationalStore, OperationalStoreError, WorkItemRecord
+from aec_bench.harness.harbor_reconciliation import HarborTrialTransport, reconcile_harbor_trial_records
+from aec_bench.harness.planned_trial_reconciliation import validate_planned_trial_record
+from aec_bench.ledger.evidence_run_store import EvidenceRunStore
+from aec_bench.ledger.writer import (
+    DuplicateAppendOnlyFileError,
+    DuplicateTrialRecordError,
+    materialize_trial_record,
+    write_append_only_json_at,
+    write_trial_record_at,
+)
+
+
+class HarborBackendError(RuntimeError):
+    """Raised when Harbor cannot be bound to or reconciled with one planned attempt."""
+
+
+class HarborRemoteState(FrozenStrictModel):
+    """One observed Harbor state returned by an injected backend client."""
+
+    state: Literal["submitted", "running", "completed", "failed", "unknown"]
+
+
+class HarborSubmission(FrozenStrictModel):
+    """Provider identifiers returned after Harbor accepts one submission."""
+
+    external_id: NonEmptyStr
+    harbor_trial_name: NonEmptyStr
+
+
+class HarborAttemptTransport(FrozenStrictModel):
+    """Strict mapping between one AEC-Bench attempt and one Harbor trial."""
+
+    schema_version: Literal[1] = 1
+    run_id: UUID
+    plan_id: UUID
+    trial_id: UUID
+    work_id: UUID
+    attempt_id: UUID
+    submission_id: UUID
+    ordinal: PositiveInt
+    harbor_job_name: NonEmptyStr
+    harbor_trial_name: NonEmptyStr | None = None
+
+    @field_validator("run_id", "plan_id", "trial_id", "work_id", "attempt_id", "submission_id", mode="before")
+    @classmethod
+    def validate_ids(cls, value: UUID | str) -> UUID:
+        return validate_uuidv7(value)
+
+    @field_validator("harbor_job_name")
+    @classmethod
+    def validate_harbor_job_name(cls, value: str) -> str:
+        if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]*", value) is None:
+            raise ValueError("Harbor job names must be safe single path components")
+        return value
+
+
+class HarborBackendClient(Protocol):
+    """Minimal fakeable Harbor transport boundary."""
+
+    def submit(self, transport: HarborAttemptTransport) -> HarborSubmission: ...
+
+    def inspect(self, submission: HarborSubmission) -> HarborRemoteState: ...
+
+    def collect(self, submission: HarborSubmission) -> TrialRecord | None: ...
+
+
+class HarborBackend:
+    """Run and reconcile one exact scheduler-owned Harbor attempt."""
+
+    def __init__(
+        self,
+        *,
+        evidence_store: EvidenceRunStore,
+        operational_store: OperationalStore,
+        plan: RunPlan,
+        client: HarborBackendClient,
+    ) -> None:
+        self._evidence_store = evidence_store
+        self._operational_store = operational_store
+        self._plan = plan
+        self._client = client
+
+    def __call__(self, work_item: WorkItemRecord, attempt: AttemptRecord) -> WorkerOutcome:
+        return self.execute(work_item, attempt)
+
+    def execute(self, work_item: WorkItemRecord, attempt: AttemptRecord) -> WorkerOutcome:
+        stored = self._evidence_store.read_run(self._plan.run_identity)
+        if stored.plan != self._plan or stored.plan is None:
+            raise HarborBackendError("authoritative run plan does not match the persisted plan")
+        if stored.state.state not in {"ready", "started"}:
+            raise HarborBackendError("Harbor execution requires a ready or started evidence run")
+        planned = self._planned_trial(work_item)
+        self._validate_attempt(work_item, attempt)
+        if not isinstance(planned.attempt_recipe, SingleAttemptRecipe):
+            raise HarborBackendError("Harbor supports only the single_attempt recipe")
+        if stored.state.state == "ready":
+            self._evidence_store.start_run(
+                self._plan.run_identity,
+                started_at=attempt.started_at or attempt.created_at,
+            )
+        if self._operational_store.list_backend_submissions(attempt.attempt_id):
+            raise HarborBackendError("Harbor attempt already has a backend submission")
+        record_path = self._record_path(planned)
+        finalization_path = self._finalization_path(planned)
+        if record_path.exists() or finalization_path.exists():
+            raise HarborBackendError(f"trial finalization already exists: {planned.trial_id}")
+
+        submission_id = new_entity_id(EntityKind.BACKEND_SUBMISSION)
+        started_at = attempt.started_at or attempt.created_at
+        self._operational_store.record_backend_submission(
+            submission_id,
+            attempt_id=attempt.attempt_id,
+            backend=work_item.backend,
+            now=started_at,
+        )
+        transport = HarborAttemptTransport(
+            run_id=self._plan.run_id,
+            plan_id=self._plan.plan_id,
+            trial_id=planned.trial_id,
+            work_id=validate_uuidv7(work_item.work_id),
+            attempt_id=validate_uuidv7(attempt.attempt_id),
+            submission_id=submission_id,
+            ordinal=planned.ordinal,
+            harbor_job_name=f"aec-planned-{planned.trial_id.hex}",
+        )
+        try:
+            self._persist_transport(transport)
+            try:
+                submission = self._client.submit(transport)
+            except Exception:
+                return self._unknown_outcome(work_item, attempt, planned, submission_id, started_at)
+            self._operational_store.bind_backend_submission_external_id(
+                submission_id,
+                external_id=submission.external_id,
+                now=datetime.now(UTC),
+            )
+            self._operational_store.transition_backend_submission(
+                submission_id,
+                state="running",
+                now=datetime.now(UTC),
+            )
+            try:
+                observed = self._client.inspect(submission)
+            except Exception:
+                return self._unknown_outcome(work_item, attempt, planned, submission_id, started_at)
+            if observed.state == "unknown":
+                return self._unknown_outcome(work_item, attempt, planned, submission_id, started_at)
+            if observed.state not in {"completed", "failed"}:
+                return self._unknown_outcome(work_item, attempt, planned, submission_id, started_at)
+            try:
+                record = self._client.collect(submission)
+            except Exception:
+                return self._unknown_outcome(work_item, attempt, planned, submission_id, started_at)
+            if record is None:
+                return self._unknown_outcome(work_item, attempt, planned, submission_id, started_at)
+            canonical = self._canonical_record(
+                record,
+                planned,
+                stored.spec,
+                harbor_trial_name=submission.harbor_trial_name,
+                external_id=submission.external_id,
+            )
+            return self._publish_result(
+                work_item=work_item,
+                attempt=attempt,
+                planned=planned,
+                submission_id=submission_id,
+                record=canonical,
+                started_at=started_at,
+                process_failed=observed.state == "failed",
+                record_path=record_path,
+                finalization_path=finalization_path,
+            )
+        except Exception as error:
+            finished_at = datetime.now(UTC)
+            self._operational_store.transition_attempt(attempt.attempt_id, state="failed", now=finished_at)
+            self._operational_store.transition_backend_submission(submission_id, state="failed", now=finished_at)
+            raise HarborBackendError(str(error)) from error
+
+    def _publish_result(
+        self,
+        *,
+        work_item: WorkItemRecord,
+        attempt: AttemptRecord,
+        planned: PlannedTrial,
+        submission_id: UUID,
+        record: TrialRecord,
+        started_at: datetime,
+        process_failed: bool,
+        record_path: Path,
+        finalization_path: Path,
+    ) -> WorkerOutcome:
+        finished_at = record.completed_at or datetime.now(UTC)
+        process_succeeded = not process_failed and record.execution_status is ExecutionStatus.COMPLETED
+        record = materialize_trial_record(
+            artifact_root=record_path.parent / "_artifacts",
+            record=record,
+        )
+        receipt = self._receipt(
+            work_item=work_item,
+            attempt=attempt,
+            planned=planned,
+            submission_id=submission_id,
+            record=record,
+            started_at=started_at,
+            finished_at=finished_at,
+            succeeded=process_succeeded,
+        )
+        try:
+            write_trial_record_at(path=record_path, record=record)
+            self._persist_receipt(receipt)
+            finalization = TrialFinalization(
+                finalization_id=new_entity_id(EntityKind.RECEIPT),
+                trial_id=planned.trial_id,
+                attempt_id=validate_uuidv7(attempt.attempt_id),
+                record_version=1,
+                trial_record_ref=PortableRelativePath(record_path.relative_to(self._evidence_store.root).as_posix()),
+                published_at=finished_at,
+                state=FinalizationState.CURRENT,
+            )
+            write_append_only_json_at(
+                path=finalization_path,
+                payload=finalization.model_dump_json(indent=2) + "\n",
+            )
+        except (DuplicateTrialRecordError, DuplicateAppendOnlyFileError) as error:
+            self._mark_failed(attempt, submission_id)
+            raise HarborBackendError(f"trial finalization already exists: {planned.trial_id}") from error
+        except Exception:
+            self._mark_failed(attempt, submission_id)
+            raise
+        self._operational_store.transition_attempt(
+            attempt.attempt_id,
+            state="failed" if not process_succeeded else "succeeded",
+            now=finished_at,
+        )
+        self._operational_store.transition_backend_submission(
+            submission_id,
+            state="failed" if not process_succeeded else "completed",
+            now=finished_at,
+        )
+        return WorkerOutcome(
+            terminal_state="failed" if not process_succeeded else "succeeded",
+            receipts=(receipt,),
+            finalization=finalization,
+        )
+
+    def _unknown_outcome(
+        self,
+        work_item: WorkItemRecord,
+        attempt: AttemptRecord,
+        planned: PlannedTrial,
+        submission_id: UUID,
+        started_at: datetime,
+    ) -> WorkerOutcome:
+        finished_at = datetime.now(UTC)
+        receipt = AttemptReceipt(
+            receipt_id=new_entity_id(EntityKind.RECEIPT),
+            receipt_key=EntityKey(f"{work_item.work_key}/attempt-{attempt.attempt_number}"),
+            attempt_id=validate_uuidv7(attempt.attempt_id),
+            backend=work_item.backend,
+            submission_id=submission_id,
+            requested_condition=planned.agent_condition.identity,
+            started_at=started_at,
+            finished_at=finished_at,
+            process_status=AttemptProcessStatus.UNKNOWN,
+            cancellation_status=CancellationStatus.NOT_REQUESTED,
+            resource_usage=AttemptResourceUsage(wall_seconds=max(0.0, (finished_at - started_at).total_seconds())),
+            failure=FailureClassification(
+                failure_class=FailureClass.UNKNOWN,
+                kind=FailureKind.UNKNOWN_EXTERNAL_STATE,
+                message="Harbor did not provide a reconciled terminal result",
+            ),
+            reconciliation_status=ReconciliationState.PENDING,
+        )
+        self._persist_receipt(receipt)
+        self._operational_store.transition_attempt(attempt.attempt_id, state="unknown", now=finished_at)
+        self._operational_store.transition_backend_submission(submission_id, state="unknown", now=finished_at)
+        return WorkerOutcome(terminal_state="unknown", receipts=(receipt,))
+
+    def _canonical_record(
+        self,
+        record: TrialRecord,
+        planned: PlannedTrial,
+        spec: ResolvedRunSpec,
+        *,
+        harbor_trial_name: str,
+        external_id: str,
+    ) -> TrialRecord:
+        task_revision = (
+            planned.task_release.artifact.sha256
+            if isinstance(planned.task_release, ArtifactTaskSnapshotRef)
+            else planned.task_release.source_revision
+            if isinstance(planned.task_release, RepositoryTaskSnapshotRef)
+            else record.input.task_revision
+        )
+        if record.trial_id == str(planned.trial_id):
+            validate_planned_trial_record(record, planned, spec, task_revision=task_revision)
+            return self._with_backend_ids(record, harbor_trial_name=harbor_trial_name, external_id=external_id)
+        transport = HarborTrialTransport(
+            harbor_job_name=f"aec-planned-{planned.trial_id.hex}",
+            planned_trial_id=planned.trial_id,
+            harbor_trial_name=harbor_trial_name,
+        )
+        records, _ = reconcile_harbor_trial_records(
+            records=(record,),
+            run_spec=spec,
+            run_plan=self._plan,
+            transport=(transport,),
+        )
+        canonical = records[0]
+        validate_planned_trial_record(canonical, planned, spec, task_revision=task_revision)
+        return self._with_backend_ids(canonical, harbor_trial_name=harbor_trial_name, external_id=external_id)
+
+    @staticmethod
+    def _with_backend_ids(record: TrialRecord, *, harbor_trial_name: str, external_id: str) -> TrialRecord:
+        if record.output is None:
+            return record
+        backend_ids = dict(record.output.agent_result or {})
+        backend_ids["harbor_trial_name"] = harbor_trial_name
+        backend_ids["harbor_external_id"] = external_id
+        return record.model_copy(update={"output": record.output.model_copy(update={"agent_result": backend_ids})})
+
+    def _planned_trial(self, work_item: WorkItemRecord) -> PlannedTrial:
+        if work_item.run_id != str(self._plan.run_id) or work_item.plan_id != str(self._plan.plan_id):
+            raise HarborBackendError("work item does not belong to the authoritative run plan")
+        matches = [trial for trial in self._plan.trials if str(trial.trial_id) == work_item.trial_id]
+        if len(matches) != 1:
+            raise HarborBackendError(f"work item does not identify one planned trial: {work_item.trial_id}")
+        planned = matches[0]
+        if planned.execution_family != "artifact":
+            raise HarborBackendError("Harbor currently supports artifact trials only")
+        if planned.ordinal != work_item.ordinal or planned.compute.backend != work_item.backend:
+            raise HarborBackendError("work item does not match the authoritative planned trial")
+        return planned
+
+    @staticmethod
+    def _validate_attempt(work_item: WorkItemRecord, attempt: AttemptRecord) -> None:
+        if work_item.state != "running" or attempt.state != "running":
+            raise HarborBackendError("Harbor execution requires a running work item and attempt")
+        if attempt.work_id != work_item.work_id or attempt.trial_id != work_item.trial_id:
+            raise HarborBackendError("scheduler attempt does not match the work item")
+        if attempt.run_id != work_item.run_id or attempt.lease_id is None:
+            raise HarborBackendError("Harbor execution requires a matching lease-bound attempt")
+
+    def _persist_transport(self, transport: HarborAttemptTransport) -> None:
+        path = (
+            self._evidence_store.run_directory(self._plan.run_identity)
+            / "harbor-mappings"
+            / f"{transport.submission_id}.json"
+        )
+        try:
+            write_append_only_json_at(path=path, payload=transport.model_dump_json(indent=2) + "\n")
+        except DuplicateAppendOnlyFileError as error:
+            raise HarborBackendError(f"Harbor transport mapping already exists: {transport.submission_id}") from error
+
+    def _persist_receipt(self, receipt: AttemptReceipt) -> None:
+        path = self._evidence_store.run_directory(self._plan.run_identity) / "receipts" / f"{receipt.receipt_id}.json"
+        try:
+            write_append_only_json_at(path=path, payload=receipt.model_dump_json(indent=2) + "\n")
+        except DuplicateAppendOnlyFileError as error:
+            raise HarborBackendError(f"attempt receipt already exists: {receipt.receipt_id}") from error
+
+    def _record_path(self, planned: PlannedTrial) -> Path:
+        return (
+            self._evidence_store.run_directory(self._plan.run_identity) / "trial-records" / f"{planned.trial_id}.json"
+        )
+
+    def _finalization_path(self, planned: PlannedTrial) -> Path:
+        return (
+            self._evidence_store.run_directory(self._plan.run_identity) / "finalizations" / f"{planned.trial_id}.json"
+        )
+
+    def _receipt(
+        self,
+        *,
+        work_item: WorkItemRecord,
+        attempt: AttemptRecord,
+        planned: PlannedTrial,
+        submission_id: UUID,
+        record: TrialRecord,
+        started_at: datetime,
+        finished_at: datetime,
+        succeeded: bool,
+    ) -> AttemptReceipt:
+        output_references = () if record.output is None else tuple(item.artifact for item in record.output.artifacts)
+        return AttemptReceipt(
+            receipt_id=new_entity_id(EntityKind.RECEIPT),
+            receipt_key=EntityKey(f"{work_item.work_key}/attempt-{attempt.attempt_number}"),
+            attempt_id=validate_uuidv7(attempt.attempt_id),
+            backend=work_item.backend,
+            submission_id=submission_id,
+            requested_condition=planned.agent_condition.identity,
+            started_at=started_at,
+            finished_at=finished_at,
+            process_status=AttemptProcessStatus.SUCCEEDED if succeeded else AttemptProcessStatus.FAILED,
+            cancellation_status=CancellationStatus.NOT_REQUESTED,
+            resource_usage=AttemptResourceUsage(wall_seconds=record.timing.total_seconds),
+            output_references=output_references,
+            authority_evidence=record.authority_evidence,
+            failure=(
+                None
+                if succeeded
+                else FailureClassification(
+                    failure_class=FailureClass.BENCHMARK,
+                    kind=FailureKind.TASK_FAILURE,
+                    message="Harbor reported failed execution",
+                )
+            ),
+            reconciliation_status=ReconciliationState.RECONCILED,
+        )
+
+    def _mark_failed(self, attempt: AttemptRecord, submission_id: UUID) -> None:
+        now = datetime.now(UTC)
+        try:
+            self._operational_store.transition_attempt(attempt.attempt_id, state="failed", now=now)
+            self._operational_store.transition_backend_submission(submission_id, state="failed", now=now)
+        except OperationalStoreError:
+            pass
+
+
+__all__ = (
+    "HarborAttemptTransport",
+    "HarborBackend",
+    "HarborBackendClient",
+    "HarborBackendError",
+    "HarborRemoteState",
+    "HarborSubmission",
+)

--- a/tests/execution/test_operational_store.py
+++ b/tests/execution/test_operational_store.py
@@ -81,7 +81,9 @@ def test_store_initializes_current_schema_and_keeps_operational_records_mutable(
     attempt = store.create_attempt(
         attempt_id, work_id=item.work_id, trial_id=trial.trial_id, candidate_index=1, retry_number=0
     )
-    store.record_backend_submission(submission_id, attempt_id=attempt.attempt_id, backend="local", external_id="job-1")
+    store.record_backend_submission(submission_id, attempt_id=attempt.attempt_id, backend="local")
+    store.bind_backend_submission_external_id(submission_id, external_id="job-1")
+    store.bind_backend_submission_external_id(submission_id, external_id="job-1")
 
     assert store.schema_version() == 3
     assert store.get_run(run_id).spec_ref == "runs/run-1/spec.json"
@@ -91,6 +93,8 @@ def test_store_initializes_current_schema_and_keeps_operational_records_mutable(
     assert store.get_work_item(work_id).work_key == "0001-monitoring-dam-seepage"
     assert store.get_attempt(attempt_id).state == "created"
     assert store.get_backend_submission(submission_id).external_id == "job-1"
+    with pytest.raises(OperationalStoreConflict, match="different external ID"):
+        store.bind_backend_submission_external_id(submission_id, external_id="job-2")
 
     store.update_work_item(work_id, state="running")
     assert store.get_work_item(work_id).state == "running"

--- a/tests/harness/test_harbor_backend.py
+++ b/tests/harness/test_harbor_backend.py
@@ -1,0 +1,178 @@
+# ABOUTME: Tests the strict scheduler-facing Harbor backend boundary.
+# ABOUTME: Uses a provider-free client fake to prove exact identity binding and portable publication.
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Literal
+
+import pytest
+
+from aec_bench.contracts.execution_policy import ExecutionPolicy
+from aec_bench.contracts.identity import EntityKind, new_entity_id
+from aec_bench.contracts.trial_record import AgentConfiguration as RecordAgentConfiguration
+from aec_bench.contracts.trial_record import ExecutionEnvironmentRef
+from aec_bench.execution.models import RetryPolicy, TrialWorkItem
+from aec_bench.execution.operational import OperationalStore
+from aec_bench.execution.scheduler import LocalScheduler
+from aec_bench.harness.harbor_backend import HarborBackend, HarborBackendError, HarborRemoteState, HarborSubmission
+from aec_bench.harness.planned_trial_reconciliation import planned_trial_binding
+from tests.harness.test_persisted_artifact_plan import _ready_store, _spec, _task
+from tests.support.trial_record_factories import make_trial_record
+
+
+class _Client:
+    def __init__(
+        self,
+        record,  # noqa: ANN001
+        *,
+        state: Literal["completed", "unknown"] = "completed",
+        submit_error: bool = False,
+        missing_result: bool = False,
+    ) -> None:
+        self.record = record
+        self.state = state
+        self.submit_error = submit_error
+        self.missing_result = missing_result
+        self.transport = None
+        self.submit_calls = 0
+
+    def submit(self, transport):  # noqa: ANN001
+        if self.submit_error:
+            raise RuntimeError("Harbor submission response was lost")
+        self.submit_calls += 1
+        self.transport = transport
+        return HarborSubmission(external_id="job-1", harbor_trial_name="trial-1")
+
+    def inspect(self, submission):  # noqa: ANN001
+        return HarborRemoteState(state=self.state)
+
+    def collect(self, submission):  # noqa: ANN001
+        return None if self.missing_result else self.record
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    ("completed", "remote_unknown", "submit_uncertain", "missing_result", "identity_drift"),
+)
+def test_harbor_backend_reconciles_one_scheduler_attempt(tmp_path: Path, scenario: str) -> None:
+    task = _task(tmp_path)
+    spec = _spec(task)
+    evidence, plan = _ready_store(tmp_path, spec)
+    trial = plan.trials[0]
+    output = tmp_path / "harbor-output.md"
+    output.write_text("complete\n", encoding="utf-8")
+    record = make_trial_record(
+        timestamp=datetime(2026, 8, 30, 12, 2, tzinfo=UTC),
+        experiment_id=str(spec.experiment_identity.id),
+        trial_id=str(trial.trial_id),
+        run_id=str(spec.run_identity.id),
+        task_id=trial.task_release.task_id,
+        task={"task_id": trial.task_release.task_id, "task_revision": trial.task_release.artifact.sha256},
+        agent=RecordAgentConfiguration(
+            adapter=trial.agent_condition.adapter,
+            model=trial.agent_condition.model,
+            adapter_revision="adapter-revision",
+            configuration={"parameters": trial.agent_condition.parameters},
+        ),
+        environment=ExecutionEnvironmentRef(
+            runtime_image="test-image",
+            compute_backend=trial.compute.backend,
+            tool_versions={},
+        ),
+    )
+    record.attach_artifact("raw_output", output, media_type="text/markdown")
+    record = record.model_copy(update={"planned_trial_binding": planned_trial_binding(trial, spec)})
+    if scenario == "identity_drift":
+        record = record.model_copy(update={"input": record.input.model_copy(update={"task_revision": "0" * 64})})
+
+    operational = OperationalStore(tmp_path / "operational.sqlite3")
+    operational.create_run(plan.run_id, spec_ref="runs/run/spec.json", status="ready")
+    operational.put_plan(plan.plan_id, run_id=plan.run_id, plan_ref="runs/run/plan.json", state="ready")
+    now = datetime(2026, 8, 30, 12, 2, tzinfo=UTC)
+    scheduler = LocalScheduler(operational, ExecutionPolicy(max_concurrency=1))
+    scheduler.enqueue_ready_plan(
+        plan,
+        (
+            TrialWorkItem(
+                work_id=new_entity_id(EntityKind.WORK_ITEM),
+                work_key="work-1",
+                run_id=plan.run_id,
+                plan_id=plan.plan_id,
+                trial_id=trial.trial_id,
+                ordinal=trial.ordinal,
+                execution_family="artifact",
+                backend=trial.compute.backend,
+                provider_route="default",
+                model_route="default",
+                resource_class="cpu-small",
+                priority=0,
+                retry_policy=RetryPolicy(),
+                state="planned",
+                created_at=now,
+                available_at=now,
+            ),
+        ),
+    )
+    client = _Client(
+        record,
+        state="unknown" if scenario == "remote_unknown" else "completed",
+        submit_error=scenario == "submit_uncertain",
+        missing_result=scenario == "missing_result",
+    )
+    backend = HarborBackend(evidence_store=evidence, operational_store=operational, plan=plan, client=client)
+
+    report = scheduler.dispatch_once(backend, owner="scheduler", now=now)
+
+    expected_success = scenario == "completed"
+    expected_failure = scenario == "identity_drift"
+    assert report.succeeded_count == int(expected_success)
+    assert report.failed_count == int(expected_failure)
+    assert len(operational.list_attempts(trial.trial_id)) == 1
+    submissions = operational.list_backend_submissions_for_run(plan.run_id)
+    assert len(submissions) == 1
+    run_directory = evidence.run_directory(spec.run_identity)
+    mapping_paths = tuple((run_directory / "harbor-mappings").glob("*.json"))
+    assert len(mapping_paths) == 1
+    mapping = json.loads(mapping_paths[0].read_text(encoding="utf-8"))
+    assert mapping["trial_id"] == str(trial.trial_id)
+    assert mapping["attempt_id"] == operational.list_attempts(trial.trial_id)[0].attempt_id
+    assert mapping["harbor_trial_name"] is None
+    if expected_success:
+        assert client.transport is not None
+        assert client.transport.trial_id == trial.trial_id
+        assert client.transport.ordinal == trial.ordinal
+        assert submissions[0].external_id == "job-1"
+        assert submissions[0].state == "completed"
+        assert (run_directory / "trial-records" / f"{trial.trial_id}.json").is_file()
+        persisted = json.loads((run_directory / "trial-records" / f"{trial.trial_id}.json").read_text(encoding="utf-8"))
+        assert persisted["output"]["agent_result"]["harbor_trial_name"] == "trial-1"
+        assert persisted["output"]["agent_result"]["harbor_external_id"] == "job-1"
+        assert len(tuple((run_directory / "receipts").glob("*.json"))) == 1
+        assert len(tuple((run_directory / "finalizations").glob("*.json"))) == 1
+        with pytest.raises(HarborBackendError):
+            backend(
+                replace(operational.list_work_items(plan.run_id)[0], state="running"),
+                replace(operational.list_attempts(trial.trial_id)[0], state="running"),
+            )
+        assert len(tuple((run_directory / "finalizations").glob("*.json"))) == 1
+        assert client.submit_calls == 1
+        with pytest.raises(HarborBackendError, match="does not match"):
+            backend(
+                replace(operational.list_work_items(plan.run_id)[0], state="running", ordinal=trial.ordinal + 1),
+                replace(operational.list_attempts(trial.trial_id)[0], state="running"),
+            )
+    elif expected_failure:
+        assert submissions[0].state == "failed"
+        assert operational.get_attempt(operational.list_attempts(trial.trial_id)[0].attempt_id).state == "failed"
+        assert not (run_directory / "trial-records" / f"{trial.trial_id}.json").exists()
+        assert not (run_directory / "finalizations" / f"{trial.trial_id}.json").exists()
+    else:
+        assert submissions[0].state == "unknown"
+        assert operational.get_attempt(operational.list_attempts(trial.trial_id)[0].attempt_id).state == "unknown"
+        assert len(tuple((run_directory / "receipts").glob("*.json"))) == 1
+        assert not (run_directory / "trial-records" / f"{trial.trial_id}.json").exists()
+        assert not (run_directory / "finalizations" / f"{trial.trial_id}.json").exists()


### PR DESCRIPTION
## Summary

- add a provider-free Harbor backend adapter for one exact scheduler-owned attempt
- persist run, plan, trial, work, attempt, submission, ordinal, and Harbor transport identity before submission
- bind the external Harbor ID after acceptance
- import and validate the exact planned trial record, receipt, and finalization
- leave missing, uncertain, or incomplete remote work in unknown state with no final record
- reject duplicate execution and identity drift
- add direct external-ID binding to the disposable operational store

## Validation

- 96 passed, 2 skipped in the broader provider-free execution and adapter suite
- 54 provenance tests passed
- provenance audit passed with 0 violations
- full Ruff check passed
- changed-file Ruff format check passed
- scoped mypy passed
- wheel build passed and contains no migration or private-path files
- package ownership stayed at its existing baseline: 26 passed, same 3 known failures

## Existing repository failures

- full format check still finds four unrelated files
- full mypy still reports existing optional-dependency and older typing errors
- Harbor tests that import the optional Harbor package cannot collect in this local environment

## Review order

1. src/aec_bench/harness/harbor_backend.py
2. src/aec_bench/execution/operational/store.py
3. src/aec_bench/execution/models.py
4. tests/harness/test_harbor_backend.py
5. docs/CONTRACTS.md

No migration scripts, schema-history support, legacy readers, or compatibility shims are included.