### PR TITLE
Add stable world and lifecycle definition identities

### DIFF
--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -43,7 +43,7 @@ verification remains because it is the current artifact integrity contract.
 | Task release reference | Task generation and harness | One exact Git or detached-artifact task source retains its task UUID, readable key, and version | Current format requires the identity; no PRD2 legacy reader is retained | [`TaskSnapshotRef`](../src/aec_bench/contracts/task_snapshot.py) and [`build_task_snapshot`](../src/aec_bench/harness/compilation/task_snapshot.py) | Internal snapshot reference |
 | Task genome review | Tasks and feedback | A derived genome and its source spans become review evidence for one exact task snapshot | Internal; independently retained reviews use current-format artifacts | [`TaskGenomeReview`](../src/aec_bench/contracts/task_genome.py), `TaskSnapshotRef`, and `ArtifactRef` | Regenerable review; optional persisted artifact |
 | Generated-task handoff and replay | Task generation | Generated runnable paths pass in process to normal task loading; template sources and sampling inputs remain optional reproducibility data | `GeneratedTaskSet` is an in-process value; the schema 1 sidecar is not a runtime task contract | [`GeneratedTaskSet`](../src/aec_bench/generation/contracts.py), [`GenerationManifest`](../src/aec_bench/generation/replay.py), and the `generate replay` command | Internal handoff and optional persisted sidecar |
-| Finite lifecycle execution | Lifecycle task and host | Stage-specific task evidence and actor results become one bounded host-controlled progression | Internal package and runtime contract; persisted accepted evidence is current-format only | [`EvidenceLifecycleSpec`](../src/aec_bench/contracts/evidence_lifecycle.py) and the [staged evidence protocol](protocols/staged-evidence-and-publication.md) | Packaged task, runtime state, and persisted accepted evidence |
+| Finite lifecycle execution | Lifecycle task and host | A stable lifecycle identity, stage-specific task evidence, and actor results become one bounded host-controlled progression | Internal package and runtime contract; persisted accepted evidence is current-format only | [`LifecycleTaskMetadata` and `EvidenceLifecycleSpec`](../src/aec_bench/contracts/evidence_lifecycle.py), [`EntityIdentity`](../src/aec_bench/contracts/identity.py), and the [staged evidence protocol](protocols/staged-evidence-and-publication.md) | Packaged task, runtime state, and persisted accepted evidence |
 | Experiment manifest | Experiment orchestration | User configuration becomes an executable plan | Internal, except documented CLI/config behavior | [`ExperimentManifest`](../src/aec_bench/contracts/experiment_manifest.py) | Persisted configuration |
 | Agent condition | Experiment orchestration | One requested adapter/model condition retains a stable UUID-backed identity and explicit runtime inputs | Internal foundation; callers supply stable conditions when resolving a run | [`AgentCondition`](../src/aec_bench/contracts/experiment_manifest.py) and [`EntityIdentity`](../src/aec_bench/contracts/identity.py) | In-process resolved condition |
 | Resolved run specification | Experiment orchestration | One experiment manifest, exact task releases, stable agent conditions, and a resolved execution policy become one explicit requested run condition | Internal schema 2; strict local persistence before execution | [`ResolvedRunSpec`](../src/aec_bench/contracts/resolved_run.py) and [`resolve_run_spec`](../src/aec_bench/contracts/resolved_run.py) | Requested run condition and persisted spec |
@@ -72,7 +72,7 @@ verification remains because it is the current artifact integrity contract.
 | Prime package and evaluation integration | Prime integration | Current public task or lifecycle material becomes an independently installed package; hosted samples return as untrusted provider evidence | Public command and external package behavior; samples normalize into current records | [`exporter.py`](../src/aec_bench/prime_lab/exporter.py), [`lifecycle_exporter.py`](../src/aec_bench/prime_lab/lifecycle_exporter.py), and [`eval_import.py`](../src/aec_bench/prime_lab/eval_import.py) | External package and provider ingestion |
 | Artifact and evidence reference | Harness, ledger, and the producing domain | Filesystem or provider output becomes content-bound evidence | Protected when stored in a trial, dataset, freeze, or published record | `ArtifactRef` in [`artifacts.py`](../src/aec_bench/contracts/artifacts.py), `ArtifactReference` in [`trial_record.py`](../src/aec_bench/contracts/trial_record.py), and narrower owner-specific references | Persisted reference |
 | Visibility classification | Task ownership and evaluation policy | Material enters public, calibration, or holdout handling | Protected | `Visibility` in [`task_definition.py`](../src/aec_bench/contracts/task_definition.py) and visibility checks in persisted records | Persisted and policy-bearing |
-| Interactive-world execution | Interactive-world runtime and registered task worlds | A `WorldTask`, exact build, and profile become one complete evaluated world trial | Supported Python discovery, task, planning, and trial API; task-owned persisted records remain protected | [`worlds`](../src/aec_bench/worlds/__init__.py), [`tasks.py`](../src/aec_bench/worlds/tasks.py), [`world_trials.py`](../src/aec_bench/harness/world_trials.py), and the [runtime protocol](protocols/interactive-world-runtime.md) | Python API, persisted task package, and trial evidence |
+| Interactive-world execution | Interactive-world runtime and registered task worlds | A stable world and profile identity, `WorldTask`, exact build, and profile become one complete evaluated world trial | Supported Python discovery, task, planning, and trial API; task-owned persisted records remain protected | [`InteractiveWorldDefinition`](../src/aec_bench/worlds/runtime/definition.py), [`worlds`](../src/aec_bench/worlds/__init__.py), [`world_trials.py`](../src/aec_bench/harness/world_trials.py), and the [runtime protocol](protocols/interactive-world-runtime.md) | Python API, persisted task package, and trial evidence |
 | Installed world actor and host calls | Interactive-world runtime and concrete integration owners | An actor or host request crosses a process boundary and reaches the permitted task-owned authority | Versioned local actor protocol; pump-owned persisted run records | [`world_interface.py`](../src/aec_bench/contracts/world_interface.py), the shared [`world_actor`](../src/aec_bench/harness/world_actor/) authority, protocol, endpoint, and staged client, plus the [runtime protocol](protocols/interactive-world-runtime.md) | Internal, persisted, and installed JSON |
 
 ## Task release and agent condition
@@ -359,6 +359,15 @@ belong to execution evidence. Changing execution metadata alone must not
 change a world profile identity. Changing a causal profile input or executable
 world source must change the applicable profile or build identity.
 
+Each registered `InteractiveWorldDefinition` has one UUIDv7-backed
+`EntityIdentity`. Each registered profile has one `MemberIdentity` with its
+own UUIDv7, readable key, positive version, parent world UUID, and exact
+owner registration ID. The owner registration ID selects the current profile;
+the readable key and UUID identify the profile in catalogues and review output.
+`WorldBuildRef.artifact_sha256` and profile content checksums verify exact
+executable and scenario bytes. They remain separate from the world and profile
+entity identities.
+
 ## Task instance and revision identity
 
 `ResolvedTaskInstance` joins a validated task definition to the paths used by
@@ -404,6 +413,12 @@ contract.
 
 The current implementation uses the staged-evidence subtype described in
 [Staged evidence and publication](protocols/staged-evidence-and-publication.md).
+Each materialized `LifecycleTaskMetadata` includes one UUIDv7-backed
+`EntityIdentity` with a readable lifecycle key and positive version. Registered
+variants use `MemberIdentity` values that bind their UUIDs and readable keys to
+the parent lifecycle UUID and the exact owner registration ID. The lifecycle
+catalogue validates UUID, key, registration, and parent uniqueness before it
+resolves a definition.
 The internal application values are `CompiledLifecycle`, `LifecycleTrial`, and
 `LifecycleExecution`. They are ordinary in-memory values, not persisted
 schemas. `CompiledLifecycle` binds current package bytes to the lifecycle,

--- a/src/aec_bench/contracts/evidence_lifecycle.py
+++ b/src/aec_bench/contracts/evidence_lifecycle.py
@@ -8,10 +8,12 @@ from pathlib import PurePosixPath
 
 from pydantic import Field, PositiveInt, field_validator, model_validator
 
+from aec_bench.contracts.identity import EntityIdentity
 from aec_bench.contracts.validators import NonEmptyStr, StrictModel
 
 
 class LifecycleTaskMetadata(StrictModel):
+    identity: EntityIdentity
     template_id: NonEmptyStr
     name: NonEmptyStr
     discipline: NonEmptyStr

--- a/src/aec_bench/contracts/identity.py
+++ b/src/aec_bench/contracts/identity.py
@@ -142,6 +142,31 @@ class EntityIdentity(FrozenStrictModel):
         return self
 
 
+class MemberIdentity(EntityIdentity):
+    """Stable identity for a profile or variant owned by one definition."""
+
+    parent_id: UUID
+    registration_id: str
+
+    @field_validator("parent_id", mode="before")
+    @classmethod
+    def validate_parent_id(cls, value: UUID | str) -> UUID:
+        return validate_uuidv7(value)
+
+    @field_validator("registration_id")
+    @classmethod
+    def validate_registration_id(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("member registration ID must be non-empty")
+        return value
+
+    @model_validator(mode="after")
+    def validate_parent(self) -> MemberIdentity:
+        if self.parent_id == self.id:
+            raise ValueError("member identity must differ from its parent identity")
+        return self
+
+
 _WINDOWS_RESERVED_NAMES = (
     frozenset({"CON", "PRN", "AUX", "NUL"})
     | {f"COM{number}" for number in range(1, 10)}
@@ -216,6 +241,7 @@ __all__ = (
     "EntityIdentity",
     "EntityKey",
     "EntityKind",
+    "MemberIdentity",
     "PortableRelativePath",
     "format_display_ref",
     "new_entity_id",

--- a/src/aec_bench/lifecycles/catalogue.py
+++ b/src/aec_bench/lifecycles/catalogue.py
@@ -9,8 +9,10 @@ from dataclasses import dataclass
 from functools import cache
 from pathlib import Path
 from typing import Any
+from uuid import UUID
 
 from aec_bench.contracts.evidence_lifecycle import EvidenceLifecycleSpec, LifecycleTaskMetadata
+from aec_bench.contracts.identity import EntityIdentity, EntityKey, MemberIdentity
 from aec_bench.lifecycles.compiled import source_tree_artifact_sha256
 from aec_bench.lifecycles.runtime.episode import LifecycleEpisodeEnvironment
 from aec_bench.lifecycles.runtime.lifecycle import validate_lifecycle_verification
@@ -34,11 +36,36 @@ class _LifecycleDefinition:
     materializer: Callable[..., Path]
     verifier: Callable[[Path, Path], dict[str, Any]]
     executable_source_roots: tuple[Path, ...]
+    variant_identities: tuple[MemberIdentity, ...] = ()
     variant_validator: Callable[[Path], dict[str, Any]] | None = None
     variant_ids: Callable[[], tuple[str, ...]] | None = None
     variant_metadata: Callable[[str], Any] | None = None
     operation_resolver: Callable[[Path, Path], LifecycleOperationResolver] | None = None
     smoke_environment: Callable[[Path], LifecycleEpisodeEnvironment] | None = None
+
+    @property
+    def identity(self) -> EntityIdentity:
+        """Return the stable identity registered for this lifecycle."""
+
+        return self.metadata.identity
+
+    def __post_init__(self) -> None:
+        if self.variant_ids is None and self.variant_identities:
+            raise ValueError("lifecycle without variants must not declare member identities")
+        if self.variant_ids is not None:
+            registered_variant_ids = tuple(self.variant_ids())
+            if len(registered_variant_ids) != len(set(registered_variant_ids)):
+                raise ValueError("lifecycle registered variant IDs must be unique")
+            variant_ids = tuple(sorted(registered_variant_ids))
+            member_ids = tuple(identity.registration_id for identity in self.variant_identities)
+            if member_ids != variant_ids:
+                raise ValueError("lifecycle variant identities must match registered variants in stable order")
+        if len(self.variant_identities) != len({identity.id for identity in self.variant_identities}):
+            raise ValueError("lifecycle variant UUIDs must be unique")
+        if len(self.variant_identities) != len({identity.key for identity in self.variant_identities}):
+            raise ValueError("lifecycle variant keys must be unique")
+        if any(identity.parent_id != self.identity.id for identity in self.variant_identities):
+            raise ValueError("lifecycle variant identities must belong to the lifecycle")
 
 
 _AEC_BENCH_ROOT = Path(__file__).resolve().parents[1]
@@ -90,6 +117,23 @@ _DEFINITIONS = {
                 Path(drainage_model.__file__),
                 Path(drainage_variants.__file__),
             ),
+            variant_identities=tuple(
+                MemberIdentity(
+                    id=UUID(identity_id),
+                    key=EntityKey(f"{drainage_model.METADATA.identity.key}/{variant_id}"),
+                    version=1,
+                    parent_id=drainage_model.METADATA.identity.id,
+                    registration_id=variant_id,
+                )
+                for variant_id, identity_id in (
+                    ("memo_closeout_missing", "01a056f3-741c-7f76-8646-d100d0b7a571"),
+                    ("response_assertion_only", "01a056f3-741c-704c-8eda-aeb793452501"),
+                    ("semantic_no_op_release", "01a056f3-741c-7957-81d4-7e946a88136b"),
+                    ("staged_full_correction", "01a056f1-af83-7500-bf33-a94f202eacab"),
+                    ("staged_full_correction_guided", "01a056f1-af83-7531-a4ec-645676de4949"),
+                    ("staged_full_correction_reduced", "01a056f1-af83-7079-a7b1-24ff1e8f3d2e"),
+                )
+            ),
             variant_validator=drainage_model.validated_drainage_model_variant,
             variant_ids=drainage_variants.list_drainage_model_variant_ids,
             variant_metadata=drainage_variants.get_drainage_model_variant,
@@ -108,6 +152,21 @@ _DEFINITIONS = {
                 _STORMWATER_ROOT / "hydraulic_operations.py",
                 _STORMWATER_ROOT / "hydraulic_review_verifier.py",
                 _STORMWATER_ROOT / "hydraulics",
+            ),
+            variant_identities=tuple(
+                MemberIdentity(
+                    id=UUID(identity_id),
+                    key=EntityKey(f"{hydraulic_review.METADATA.identity.key}/{variant_id}"),
+                    version=1,
+                    parent_id=hydraulic_review.METADATA.identity.id,
+                    registration_id=variant_id,
+                )
+                for variant_id, identity_id in (
+                    ("administrative_no_op", "01a056f1-af83-7517-a1d6-2796e1c0f075"),
+                    ("major_idf_revision", "01a056f1-af83-7f1a-8121-6d2800314a19"),
+                    ("outlet_geometry_revision", "01a056f1-af83-71a1-84e7-16ed7ec1fd69"),
+                    ("tailwater_revision", "01a056f1-af83-7eb1-920d-acc8734ecdd5"),
+                )
             ),
             variant_validator=hydraulic_review.validated_hydraulic_review_variant,
             variant_ids=hydraulic_review_variants.list_hydraulic_review_variant_ids,
@@ -137,6 +196,21 @@ _DEFINITIONS = {
 }
 
 
+def _validate_definition_identities() -> None:
+    identities = [
+        identity
+        for definition in _DEFINITIONS.values()
+        for identity in (definition.identity, *definition.variant_identities)
+    ]
+    if len(identities) != len({identity.id for identity in identities}):
+        raise ValueError("lifecycle catalogue entity UUIDs must be unique")
+    if len(identities) != len({identity.key for identity in identities}):
+        raise ValueError("lifecycle catalogue entity keys must be unique")
+
+
+_validate_definition_identities()
+
+
 def lifecycle_template_ids() -> set[str]:
     return set(_DEFINITIONS)
 
@@ -149,14 +223,37 @@ def lifecycle_definition(template_id: str) -> _LifecycleDefinition:
         raise KeyError(f"No lifecycle task for {template_id!r}. Known: {known}") from exc
 
 
+def lifecycle_identity(template_id: str) -> EntityIdentity:
+    """Return the stable identity for one registered lifecycle template."""
+
+    return lifecycle_definition(template_id).identity
+
+
 @cache
 def lifecycle_executable_artifact_sha256(template_id: str) -> str:
     return source_tree_artifact_sha256(lifecycle_definition(template_id).executable_source_roots)
 
 
 def lifecycle_variant_ids(template_id: str) -> tuple[str, ...]:
-    variants = lifecycle_definition(template_id).variant_ids
-    return () if variants is None else tuple(variants())
+    definition = lifecycle_definition(template_id)
+    variants = definition.variant_ids
+    if variants is None:
+        return ()
+    registered = tuple(variants())
+    expected = tuple(identity.registration_id for identity in definition.variant_identities)
+    if tuple(sorted(registered)) != expected:
+        raise ValueError("lifecycle variant identities are out of sync with registered variants")
+    return registered
+
+
+def lifecycle_variant_identity(template_id: str, variant_id: str) -> MemberIdentity:
+    """Return the stable identity for one registered lifecycle variant."""
+
+    definition = lifecycle_definition(template_id)
+    for identity in definition.variant_identities:
+        if identity.registration_id == variant_id:
+            return identity
+    raise KeyError(f"unknown lifecycle variant identity: {template_id}/{variant_id}")
 
 
 def lifecycle_variant_metadata(template_id: str, variant_id: str) -> dict[str, Any]:

--- a/src/aec_bench/lifecycles/stormwater_design/design_response.py
+++ b/src/aec_bench/lifecycles/stormwater_design/design_response.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 from pathlib import Path
 from typing import Any
+from uuid import UUID
 
 from aec_bench.contracts.evidence_lifecycle import (
     ConditionalOperationSpec,
@@ -15,6 +16,7 @@ from aec_bench.contracts.evidence_lifecycle import (
     LifecycleOperationSpec,
     LifecycleTaskMetadata,
 )
+from aec_bench.contracts.identity import EntityIdentity, EntityKey
 from aec_bench.lifecycles.stormwater_design.hydraulics.interventions import (
     build_hydraulic_intervention_source_state,
     build_hydraulic_problem_source_state,
@@ -30,6 +32,11 @@ from aec_bench.lifecycles.stormwater_design.hydraulics.package import (
 TEMPLATE_ID = "hydraulic-design-response-lifecycle-review"
 LIFECYCLE_ID = "hydraulic-design-response"
 METADATA = LifecycleTaskMetadata(
+    identity=EntityIdentity(
+        id=UUID("01a056f1-af83-730c-8202-7d9e49df1fc2"),
+        key=EntityKey("stormwater/hydraulic-design-response"),
+        version=1,
+    ),
     template_id=TEMPLATE_ID,
     name="Hydraulic Design Response Lifecycle Review",
     discipline="civil",

--- a/src/aec_bench/lifecycles/stormwater_design/drainage_model.py
+++ b/src/aec_bench/lifecycles/stormwater_design/drainage_model.py
@@ -8,12 +8,14 @@ import json
 import re
 from pathlib import Path
 from typing import Any
+from uuid import UUID
 
 from aec_bench.contracts.evidence_lifecycle import (
     EvidenceCheckpointSpec,
     EvidenceLifecycleSpec,
     LifecycleTaskMetadata,
 )
+from aec_bench.contracts.identity import EntityIdentity, EntityKey
 from aec_bench.evaluation.lifecycle import score_semantic_transitions
 from aec_bench.lifecycles.runtime.lifecycle import load_validated_lifecycle_submissions
 from aec_bench.lifecycles.stormwater_design.drainage_variants import (
@@ -27,6 +29,11 @@ CHECKPOINT_IDS = ("initial_review", "response_review", "closeout_review")
 TEMPLATE_ID = "drainage-model-evidence-lifecycle-review"
 LIFECYCLE_ID = "drainage-model-review"
 METADATA = LifecycleTaskMetadata(
+    identity=EntityIdentity(
+        id=UUID("01a056f1-af83-7fce-a600-86c386e9e6a9"),
+        key=EntityKey("stormwater/drainage-model-review"),
+        version=1,
+    ),
     template_id=TEMPLATE_ID,
     name="Drainage Model Evidence Lifecycle Review",
     discipline="civil",

--- a/src/aec_bench/lifecycles/stormwater_design/hydraulic_review.py
+++ b/src/aec_bench/lifecycles/stormwater_design/hydraulic_review.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Any
+from uuid import UUID
 
 from aec_bench.contracts.evidence_lifecycle import (
     ConditionalOperationSpec,
@@ -14,6 +15,7 @@ from aec_bench.contracts.evidence_lifecycle import (
     LifecycleOperationSpec,
     LifecycleTaskMetadata,
 )
+from aec_bench.contracts.identity import EntityIdentity, EntityKey
 from aec_bench.lifecycles.stormwater_design.hydraulic_operations import HydraulicOperationResolver
 from aec_bench.lifecycles.stormwater_design.hydraulic_review_variants import (
     DEFAULT_VARIANT_ID,
@@ -31,6 +33,11 @@ from aec_bench.lifecycles.stormwater_design.hydraulics.source import build_sourc
 TEMPLATE_ID = "hydraulic-interaction-lifecycle-review"
 LIFECYCLE_ID = "hydraulic-interaction-review"
 METADATA = LifecycleTaskMetadata(
+    identity=EntityIdentity(
+        id=UUID("01a056f1-af83-7ae7-81a4-d310477fe4f1"),
+        key=EntityKey("stormwater/hydraulic-interaction-review"),
+        version=1,
+    ),
     template_id=TEMPLATE_ID,
     name="Hydraulic Interaction Lifecycle Review",
     discipline="civil",

--- a/src/aec_bench/lifecycles/structural_review/facade_submittal.py
+++ b/src/aec_bench/lifecycles/structural_review/facade_submittal.py
@@ -7,6 +7,7 @@ import json
 import tomllib
 from pathlib import Path
 from typing import Any, Literal
+from uuid import UUID
 
 from pydantic import Field, ValidationError, field_validator
 
@@ -15,6 +16,7 @@ from aec_bench.contracts.evidence_lifecycle import (
     EvidenceLifecycleSpec,
     LifecycleTaskMetadata,
 )
+from aec_bench.contracts.identity import EntityIdentity, EntityKey
 from aec_bench.contracts.lifecycle_evaluation import LifecycleGateResult, LifecycleVerificationResult
 from aec_bench.contracts.trial_record import TrialRecord
 from aec_bench.contracts.validators import NonEmptyStr, StrictModel
@@ -37,6 +39,11 @@ GATE_IDS = (
 )
 
 METADATA = LifecycleTaskMetadata(
+    identity=EntityIdentity(
+        id=UUID("01a056f1-af83-70b0-ab56-f0e3cd2716d4"),
+        key=EntityKey("structural/facade-submittal-review"),
+        version=1,
+    ),
     template_id=TEMPLATE_ID,
     name="Facade Submittal Review Lifecycle",
     discipline="structural",

--- a/src/aec_bench/worlds/catalogue.py
+++ b/src/aec_bench/worlds/catalogue.py
@@ -26,6 +26,15 @@ class WorldCatalogue:
         task_world_ids = tuple(definition.build.task_world_id for definition in self.definitions)
         if len(task_world_ids) != len(set(task_world_ids)):
             raise ValueError("Interactive World catalogue task world ids must be unique")
+        identities = [
+            identity
+            for definition in self.definitions
+            for identity in (definition.identity, *definition.profile_identities)
+        ]
+        if len(identities) != len({identity.id for identity in identities}):
+            raise ValueError("Interactive World catalogue entity UUIDs must be unique")
+        if len(identities) != len({identity.key for identity in identities}):
+            raise ValueError("Interactive World catalogue entity keys must be unique")
         object.__setattr__(
             self,
             "definitions",

--- a/src/aec_bench/worlds/monitoring/dam_seepage/definition.py
+++ b/src/aec_bench/worlds/monitoring/dam_seepage/definition.py
@@ -7,7 +7,9 @@ import hashlib
 from dataclasses import dataclass
 from functools import cache
 from pathlib import Path
+from uuid import UUID
 
+from aec_bench.contracts.identity import EntityIdentity, EntityKey, MemberIdentity
 from aec_bench.contracts.interactive_world import InteractiveWorldProfileRef, WorldBuildRef
 from aec_bench.contracts.task_definition import Difficulty, Lifecycle, Visibility
 from aec_bench.worlds.monitoring.dam_seepage.variants import dam_seepage_profile_variants
@@ -26,6 +28,41 @@ from aec_bench.worlds.runtime.definition import (
 
 _BASE_SCENARIO_PATH = Path(__file__).with_name("rising-seepage.json")
 _BASE_PROFILE_ID = "synthetic-rising-seepage"
+_WORLD_IDENTITY = EntityIdentity(
+    id=UUID("01a056f1-af83-7516-90f6-ceddb36390bd"),
+    key=EntityKey("monitoring/dam-seepage"),
+    version=1,
+)
+_PROFILE_IDENTITIES = {
+    _BASE_PROFILE_ID: MemberIdentity(
+        id=UUID("01a056f1-af83-7971-a160-8974515e3464"),
+        key=EntityKey(f"{_WORLD_IDENTITY.key}/{_BASE_PROFILE_ID}"),
+        version=1,
+        parent_id=_WORLD_IDENTITY.id,
+        registration_id=_BASE_PROFILE_ID,
+    ),
+    "reliable-routine-surveillance": MemberIdentity(
+        id=UUID("01a056f1-af83-7ab8-b9e8-172a45b6a385"),
+        key=EntityKey(f"{_WORLD_IDENTITY.key}/reliable-routine-surveillance"),
+        version=1,
+        parent_id=_WORLD_IDENTITY.id,
+        registration_id="reliable-routine-surveillance",
+    ),
+    "unreliable-instrument-escalation": MemberIdentity(
+        id=UUID("01a056f1-af83-7809-a226-ef872a3d8369"),
+        key=EntityKey(f"{_WORLD_IDENTITY.key}/unreliable-instrument-escalation"),
+        version=1,
+        parent_id=_WORLD_IDENTITY.id,
+        registration_id="unreliable-instrument-escalation",
+    ),
+    "unreliable-instrument-surface-transfer": MemberIdentity(
+        id=UUID("01a056f1-af83-7f7f-9b90-754696fbe511"),
+        key=EntityKey(f"{_WORLD_IDENTITY.key}/unreliable-instrument-surface-transfer"),
+        version=1,
+        parent_id=_WORLD_IDENTITY.id,
+        registration_id="unreliable-instrument-surface-transfer",
+    ),
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -128,6 +165,7 @@ def dam_seepage_world_definition() -> InteractiveWorldDefinition:
     profile_ids = tuple(sorted(registered))
     profiles = tuple(_profile_ref(profile_id) for profile_id in profile_ids)
     return InteractiveWorldDefinition(
+        identity=_WORLD_IDENTITY,
         build=_world_build(),
         title="Dam seepage monitoring",
         summary="Monitor rising seepage conditions and take safe, timely actions.",
@@ -135,6 +173,7 @@ def dam_seepage_world_definition() -> InteractiveWorldDefinition:
         tags=("dam", "monitoring", "seepage"),
         capabilities=frozenset(),
         profiles=profiles,
+        profile_identities=tuple(_PROFILE_IDENTITIES[profile_id] for profile_id in profile_ids),
         profile_metadata=tuple(
             InteractiveWorldProfileMetadata(
                 profile_id=profile_id,

--- a/src/aec_bench/worlds/runtime/definition.py
+++ b/src/aec_bench/worlds/runtime/definition.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
+from aec_bench.contracts.identity import EntityIdentity, MemberIdentity
 from aec_bench.contracts.interactive_world import InteractiveWorldProfileRef, WorldBuildRef
 from aec_bench.contracts.task_definition import Difficulty, Lifecycle, Visibility
 
@@ -46,6 +47,7 @@ class LoadedInteractiveWorldProfile:
 class InteractiveWorldDefinition:
     """One registered executable build and its current supported profiles."""
 
+    identity: EntityIdentity
     build: WorldBuildRef
     title: str
     summary: str
@@ -53,6 +55,7 @@ class InteractiveWorldDefinition:
     tags: tuple[str, ...]
     capabilities: frozenset[str]
     profiles: tuple[InteractiveWorldProfileRef, ...]
+    profile_identities: tuple[MemberIdentity, ...]
     profile_metadata: tuple[InteractiveWorldProfileMetadata, ...]
     profile_loader: Callable[[InteractiveWorldProfileRef], LoadedInteractiveWorldProfile]
 
@@ -75,6 +78,14 @@ class InteractiveWorldDefinition:
         metadata_ids = tuple(item.profile_id for item in self.profile_metadata)
         if metadata_ids != profile_ids:
             raise ValueError("Interactive World profile metadata must match profiles in stable order")
+        if tuple(identity.registration_id for identity in self.profile_identities) != profile_ids:
+            raise ValueError("Interactive World profile identities must match profiles in stable order")
+        if len(self.profile_identities) != len({identity.id for identity in self.profile_identities}):
+            raise ValueError("Interactive World profile UUIDs must be unique")
+        if len(self.profile_identities) != len({identity.key for identity in self.profile_identities}):
+            raise ValueError("Interactive World profile keys must be unique")
+        if any(identity.parent_id != self.identity.id for identity in self.profile_identities):
+            raise ValueError("Interactive World profile identities must belong to the definition")
 
     @property
     def ref(self) -> WorldBuildRef:
@@ -89,6 +100,14 @@ class InteractiveWorldDefinition:
             if profile.profile_id == profile_id:
                 return profile
         raise KeyError(f"unknown Interactive World profile: {profile_id}")
+
+    def profile_identity(self, profile_id: str) -> MemberIdentity:
+        """Resolve one profile entity by its exact owner registration ID."""
+
+        for identity in self.profile_identities:
+            if identity.registration_id == profile_id:
+                return identity
+        raise KeyError(f"unknown Interactive World profile identity: {profile_id}")
 
     def metadata_for(self, profile_id: str) -> InteractiveWorldProfileMetadata:
         """Return discovery and selection metadata for one supported profile."""

--- a/src/aec_bench/worlds/stewardship/wastewater_pump_station/continual_definition.py
+++ b/src/aec_bench/worlds/stewardship/wastewater_pump_station/continual_definition.py
@@ -7,7 +7,9 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from functools import cache
 from pathlib import Path
+from uuid import UUID
 
+from aec_bench.contracts.identity import EntityIdentity, EntityKey, MemberIdentity
 from aec_bench.contracts.interactive_world import InteractiveWorldProfileRef, WorldBuildRef
 from aec_bench.contracts.task_definition import Difficulty, Lifecycle, Visibility
 from aec_bench.worlds.runtime.definition import (
@@ -33,6 +35,8 @@ from aec_bench.worlds.stewardship.wastewater_pump_station.reference_package_mode
     ReferencePackage,
 )
 from aec_bench.worlds.stewardship.wastewater_pump_station.reference_system import (
+    PUMP_STATION_REFERENCE_SYSTEM_ID,
+    PUMP_STATION_REFERENCE_SYSTEM_RS2_ID,
     PumpStationReferenceSystem,
     list_reference_system_ids,
     load_reference_system,
@@ -50,6 +54,29 @@ class PumpStationContinualProfile:
     station_package: ReferencePackage
     model: PumpStationCoupledModel
     opening_state: PumpStationStewardshipState
+
+
+_WORLD_IDENTITY = EntityIdentity(
+    id=UUID("01a056f1-af83-7b07-8764-4e92fea81070"),
+    key=EntityKey("stewardship/wastewater-pump-station"),
+    version=1,
+)
+_PROFILE_IDENTITIES = {
+    PUMP_STATION_REFERENCE_SYSTEM_ID: MemberIdentity(
+        id=UUID("01a056f1-af83-760b-baf8-525a9b37e150"),
+        key=EntityKey(f"{_WORLD_IDENTITY.key}/pump-station-reference-system-asw-8-rs1-v1"),
+        version=1,
+        parent_id=_WORLD_IDENTITY.id,
+        registration_id=PUMP_STATION_REFERENCE_SYSTEM_ID,
+    ),
+    PUMP_STATION_REFERENCE_SYSTEM_RS2_ID: MemberIdentity(
+        id=UUID("01a056f1-af83-7e24-b17a-1c5d1327447a"),
+        key=EntityKey(f"{_WORLD_IDENTITY.key}/pump-station-reference-system-asw-8-rs2-v1"),
+        version=1,
+        parent_id=_WORLD_IDENTITY.id,
+        registration_id=PUMP_STATION_REFERENCE_SYSTEM_RS2_ID,
+    ),
+}
 
 
 def pump_station_profile_ref(profile: LoadedInteractiveWorldProfile) -> InteractiveWorldProfileRef:
@@ -134,6 +161,7 @@ def pump_station_continual_world_definition() -> InteractiveWorldDefinition:
 
     profiles = tuple(_profile_ref(reference_system_id) for reference_system_id in list_reference_system_ids())
     return InteractiveWorldDefinition(
+        identity=_WORLD_IDENTITY,
         build=_pump_station_world_build(),
         title="Wastewater pump-station stewardship",
         summary="Operate a persistent pump station safely across changing conditions.",
@@ -141,6 +169,7 @@ def pump_station_continual_world_definition() -> InteractiveWorldDefinition:
         tags=("operations", "pump-station", "stewardship", "wastewater"),
         capabilities=frozenset({"branching", "host-controls", "persistence"}),
         profiles=profiles,
+        profile_identities=tuple(_PROFILE_IDENTITIES[profile.profile_id] for profile in profiles),
         profile_metadata=tuple(
             InteractiveWorldProfileMetadata(
                 profile_id=profile.profile_id,

--- a/tests/cli/test_lifecycle.py
+++ b/tests/cli/test_lifecycle.py
@@ -67,7 +67,7 @@ def test_task_lifecycle_materializes_current_metadata(tmp_path: Path) -> None:
 
     assert result.exit_code == 0
     metadata = json.loads((output / "template.json").read_text(encoding="utf-8"))
-    assert set(metadata) == {"template_id", "name", "discipline"}
+    assert set(metadata) == {"identity", "template_id", "name", "discipline"}
     assert (output / "lifecycle.json").is_file()
     assert not (output / "world.json").exists()
 

--- a/tests/contracts/test_continual_world.py
+++ b/tests/contracts/test_continual_world.py
@@ -12,6 +12,7 @@ from aec_bench.contracts.continual_world import (
     ContinualControlCapabilitiesRequest,
     ContinualWorldControlRequest,
 )
+from aec_bench.contracts.identity import EntityIdentity, EntityKey, MemberIdentity, new_entity_id
 from aec_bench.contracts.interactive_world import InteractiveWorldProfileRef, WorldBuildRef
 from aec_bench.contracts.task_definition import Difficulty, Lifecycle, Visibility
 from aec_bench.worlds.runtime.definition import (
@@ -43,7 +44,9 @@ def _build(*, task_world_id: str = "world-a", digest: str = "b" * 64) -> WorldBu
 
 
 def _definition(*profiles: InteractiveWorldProfileRef) -> InteractiveWorldDefinition:
+    identity = EntityIdentity(id=new_entity_id("world"), key=EntityKey("worlds/example"), version=1)
     return InteractiveWorldDefinition(
+        identity=identity,
         build=_build(),
         title="Example world",
         summary="Example world for contract tests.",
@@ -51,6 +54,16 @@ def _definition(*profiles: InteractiveWorldProfileRef) -> InteractiveWorldDefini
         tags=("test",),
         capabilities=frozenset({"actions"}),
         profiles=profiles,
+        profile_identities=tuple(
+            MemberIdentity(
+                id=new_entity_id("world_profile"),
+                key=EntityKey(f"{identity.key}/{profile.profile_id}"),
+                version=1,
+                parent_id=identity.id,
+                registration_id=profile.profile_id,
+            )
+            for profile in profiles
+        ),
         profile_metadata=tuple(
             InteractiveWorldProfileMetadata(
                 profile_id=profile.profile_id,

--- a/tests/contracts/test_owner_descriptors.py
+++ b/tests/contracts/test_owner_descriptors.py
@@ -1,0 +1,110 @@
+# ABOUTME: Tests stable identities and member ownership for registered worlds and lifecycles.
+# ABOUTME: Proves UUIDv7, key, version, parent, uniqueness, and registration coverage rules.
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+
+from aec_bench.contracts.identity import EntityIdentity, EntityKey, MemberIdentity
+from aec_bench.lifecycles.catalogue import (
+    lifecycle_definition,
+    lifecycle_identity,
+    lifecycle_template_ids,
+    lifecycle_variant_identity,
+)
+from aec_bench.worlds.catalogue import _catalogue
+
+
+def test_entity_identity_requires_uuidv7_readable_key_and_positive_version() -> None:
+    valid = EntityIdentity(
+        id=UUID("01a056f1-af83-7516-90f6-ceddb36390bd"),
+        key=EntityKey("worlds/example"),
+        version=1,
+    )
+
+    assert valid.id.version == 7
+    assert isinstance(valid.key, EntityKey)
+    assert valid.version == 1
+
+    with pytest.raises(ValueError, match="UUIDv7"):
+        EntityIdentity(id=uuid4(), key=EntityKey("worlds/example"), version=1)
+    with pytest.raises(ValueError, match="lowercase ASCII"):
+        EntityIdentity.model_validate({"id": valid.id, "key": "Worlds/Example", "version": 1})
+    with pytest.raises(ValueError, match="greater than 0"):
+        EntityIdentity(id=valid.id, key=EntityKey("worlds/example"), version=0)
+
+
+def test_member_identity_requires_uuidv7_parent_and_definition_membership() -> None:
+    parent = EntityIdentity(
+        id=UUID("01a056f1-af83-7516-90f6-ceddb36390bd"),
+        key=EntityKey("worlds/example"),
+        version=1,
+    )
+    member = MemberIdentity(
+        id=UUID("01a056f1-af83-760b-baf8-525a9b37e150"),
+        key=EntityKey("worlds/example/profile"),
+        version=1,
+        parent_id=parent.id,
+        registration_id="profile.external.v1",
+    )
+
+    assert member.parent_id == parent.id
+    with pytest.raises(ValueError, match="UUIDv7"):
+        MemberIdentity(
+            id=member.id,
+            key=member.key,
+            version=1,
+            parent_id=UUID(int=0),
+            registration_id=member.registration_id,
+        )
+    with pytest.raises(ValueError, match="must differ"):
+        MemberIdentity(
+            id=member.id,
+            key=member.key,
+            version=1,
+            parent_id=member.id,
+            registration_id=member.registration_id,
+        )
+    with pytest.raises(ValueError, match="non-empty"):
+        MemberIdentity(
+            id=member.id,
+            key=member.key,
+            version=1,
+            parent_id=member.parent_id,
+            registration_id=" ",
+        )
+
+
+def test_current_world_and_lifecycle_registrations_have_unique_complete_identity_sets() -> None:
+    worlds = _catalogue().definitions
+    lifecycles = tuple(lifecycle_definition(template_id) for template_id in sorted(lifecycle_template_ids()))
+    identities = [
+        identity for definition in worlds for identity in (definition.identity, *definition.profile_identities)
+    ] + [identity for definition in lifecycles for identity in (definition.identity, *definition.variant_identities)]
+
+    assert all(identity.id.version == 7 for identity in identities)
+    assert all(identity.version == 1 for identity in identities)
+    assert len(identities) == len({identity.id for identity in identities})
+    assert len(identities) == len({identity.key for identity in identities})
+    for world_definition in worlds:
+        assert all(member.parent_id == world_definition.identity.id for member in world_definition.profile_identities)
+        for profile in world_definition.profiles:
+            assert world_definition.profile_identity(profile.profile_id).registration_id == profile.profile_id
+    for lifecycle_definition_value in lifecycles:
+        assert (
+            lifecycle_identity(lifecycle_definition_value.metadata.template_id) == lifecycle_definition_value.identity
+        )
+        assert all(
+            member.parent_id == lifecycle_definition_value.identity.id
+            for member in lifecycle_definition_value.variant_identities
+        )
+        for variant in lifecycle_definition_value.variant_identities:
+            assert (
+                lifecycle_variant_identity(
+                    lifecycle_definition_value.metadata.template_id,
+                    variant.registration_id,
+                )
+                == variant
+            )

--- a/tests/lifecycles/test_compiled.py
+++ b/tests/lifecycles/test_compiled.py
@@ -147,6 +147,7 @@ def test_compiled_hydraulic_review_package_uses_current_identity(tmp_path: Path,
     assert _package_stats(compiled.package_dir)[0] > 0
     assert not (compiled.package_dir / "world.json").exists()
     assert set(json.loads((compiled.package_dir / "template.json").read_text())) == {
+        "identity",
         "template_id",
         "name",
         "discipline",


### PR DESCRIPTION
## Summary

Add stable entity identity to the current Interactive World and Finite Lifecycle registrations.

- Every maintained world and lifecycle now has a UUIDv7, readable key, and explicit version.
- Every registered world profile and lifecycle variant now has its own UUIDv7 identity and parent definition UUID.
- `registration_id` keeps the exact owner selector separate from the canonical readable key.
- World and lifecycle catalogues reject duplicate UUIDs, keys, registration IDs, and invalid parent membership.
- Materialized lifecycle metadata now includes the lifecycle identity.

## Review order

1. `src/aec_bench/contracts/identity.py`
2. `src/aec_bench/worlds/runtime/definition.py`
3. World owner definitions and `src/aec_bench/worlds/catalogue.py`
4. Lifecycle owner metadata and `src/aec_bench/lifecycles/catalogue.py`
5. `tests/contracts/test_owner_descriptors.py`
6. `docs/CONTRACTS.md`

## Important boundary

Entity identity uses UUIDv7, readable keys, and explicit versions. Existing build and profile checksums continue to identify exact executable or scenario bytes for integrity and reproducibility. They do not become entity IDs.

The change updates the current lifecycle package format directly. It adds no migration script or retained legacy reader.

## Verification

- 880 world, lifecycle, identity, and lifecycle CLI tests passed.
- 98 final focused contract and catalogue tests passed after review changes.
- Ruff lint passed for all changed Python paths.
- Ruff format check passed for all changed Python paths.
- Wheel and source distribution build passed.
- Targeted mypy found the same four unrelated evaluation errors on this branch and fresh `origin/main`. It found no new errors in the changed files.
