### PR TITLE
PRD4: extract artifact values and recipes

### DIFF
--- a/src/aec_bench/cli/commands/run.py
+++ b/src/aec_bench/cli/commands/run.py
@@ -938,7 +938,7 @@ def _execute_manifest(
     console.print(f"[bold]Running: {manifest.name}[/bold]")
     console.print(f"  {len(plan)} trials across {len(selected_tasks)} tasks")
 
-    from aec_bench.harness.artifact_tasks import SingleAttemptSpec
+    from aec_bench.contracts.run_plan import SingleAttemptRecipe
     from aec_bench.harness.artifact_tasks import run_experiment as run_task_experiment
     from aec_bench.harness.harbor_runtime import HarborExperimentRuntime
     from aec_bench.harness.harbor_workflow import SynchronousHarborWorkflow
@@ -975,7 +975,7 @@ def _execute_manifest(
                 runtime=runtime,
                 tasks=[resolve_instance_paths(task, tasks_root / task.task_id) for task in artifact_tasks],
                 trials=[trial for trial in plan if trial.task_id in artifact_ids],
-                recipe=SingleAttemptSpec(),
+                recipe=SingleAttemptRecipe(),
                 reviewer=reviewer_config,
                 verify=not manifest.disable_verification,
             )

--- a/src/aec_bench/cli/commands/run_local.py
+++ b/src/aec_bench/cli/commands/run_local.py
@@ -16,16 +16,10 @@ import typer
 from aec_bench.cli.optional_dependencies import require_optional_extra
 from aec_bench.cli.output import StructuredError, console, emit
 from aec_bench.contracts.experiment_manifest import AgentConfig, ComputeConfig
+from aec_bench.contracts.run_plan import BestOfAttemptRecipe, SingleAttemptRecipe
 from aec_bench.contracts.trial_record import TrialRecord
-from aec_bench.harness.artifact_tasks import (
-    BestOfSpec,
-    LocalTaskRuntime,
-    SelfSelectorSpec,
-    SingleAttemptSpec,
-    build_attempt_recipe,
-    run_trial,
-    run_trial_with_verifier_feedback,
-)
+from aec_bench.harness.artifact.recipes import build_attempt_recipe
+from aec_bench.harness.artifact_tasks import LocalTaskRuntime, run_trial, run_trial_with_verifier_feedback
 from aec_bench.harness.model_execution.llm_reviewer import (
     ReviewerEndpointConfig,
     ReviewerRunConfig,
@@ -274,9 +268,9 @@ def run_local(
         fail_on_error=fail_on_reviewer_error,
     )
     recipe_spec = (
-        SingleAttemptSpec()
+        SingleAttemptRecipe()
         if best_of_candidates == 1
-        else BestOfSpec(candidates=best_of_candidates, selector=SelfSelectorSpec())
+        else BestOfAttemptRecipe(candidates=best_of_candidates, selector="self")
     )
     recipe = build_attempt_recipe(recipe_spec)
 

--- a/src/aec_bench/evolution/application.py
+++ b/src/aec_bench/evolution/application.py
@@ -802,8 +802,9 @@ def _build_harbor_candidate_evaluator(
 ) -> Callable[[WorkspaceSnapshot, CandidateEvaluationBatch], tuple[TrialRecord, ...]]:
     """Compose remote candidate evaluation from a preplanned batch."""
     from aec_bench.contracts.experiment_manifest import ComputeConfig, ExperimentManifest, TaskSelector
+    from aec_bench.contracts.run_plan import SingleAttemptRecipe
     from aec_bench.evolution.snapshot import serialise_snapshot
-    from aec_bench.harness.artifact_tasks import SingleAttemptSpec, run_experiment
+    from aec_bench.harness.artifact_tasks import run_experiment
     from aec_bench.harness.harbor_runtime import HarborExperimentRuntime
     from aec_bench.harness.harbor_workflow import SynchronousHarborWorkflow
 
@@ -844,7 +845,7 @@ def _build_harbor_candidate_evaluator(
                 runtime=runtime,
                 tasks=list(batch.tasks),
                 trials=trials,
-                recipe=SingleAttemptSpec(),
+                recipe=SingleAttemptRecipe(),
             )
         )
 

--- a/src/aec_bench/evolution/backends/local.py
+++ b/src/aec_bench/evolution/backends/local.py
@@ -16,7 +16,8 @@ from aec_bench.evolution.evaluation import (
     validate_trial_records,
 )
 from aec_bench.evolution.snapshot import serialise_snapshot
-from aec_bench.harness.artifact_tasks import LocalTaskRuntime, run_experiment, single_attempt
+from aec_bench.harness.artifact.recipes import single_attempt
+from aec_bench.harness.artifact_tasks import LocalTaskRuntime, run_experiment
 from aec_bench.tasks.instance import ResolvedTaskInstance, resolve_instance_paths
 from aec_bench.tasks.loader import load_task_definition
 from aec_bench.trials import build_trial_id, plan_trials

--- a/src/aec_bench/experimentation/learning_studies/artifact_tasks.py
+++ b/src/aec_bench/experimentation/learning_studies/artifact_tasks.py
@@ -27,7 +27,8 @@ from aec_bench.experimentation.learning_studies.runtime import (
     LearningStudyOperations,
     ReleaseFeedbackRequest,
 )
-from aec_bench.harness.artifact_tasks import AdapterBuilder, LocalTaskRuntime, run_trial, single_attempt
+from aec_bench.harness.artifact.recipes import single_attempt
+from aec_bench.harness.artifact_tasks import AdapterBuilder, LocalTaskRuntime, run_trial
 from aec_bench.ledger.artifact_repository import ArtifactRepository
 from aec_bench.tasks.instance import ResolvedTaskInstance, resolve_instance_paths
 from aec_bench.tasks.loader import load_task_definition

--- a/src/aec_bench/harness/artifact/__init__.py
+++ b/src/aec_bench/harness/artifact/__init__.py
@@ -1,0 +1,2 @@
+# ABOUTME: Owns effect-free artifact attempt values and recipe policies.
+# ABOUTME: Keeps local task execution orchestration separate from its small value contracts.

--- a/src/aec_bench/harness/artifact/recipes.py
+++ b/src/aec_bench/harness/artifact/recipes.py
@@ -1,0 +1,139 @@
+# ABOUTME: Defines effect-free recipe and selector policies for artifact attempts.
+# ABOUTME: Keeps candidate selection bounded and separate from filesystem effects.
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Protocol
+
+from aec_bench.contracts.run_plan import AttemptRecipe as CanonicalAttemptRecipe
+from aec_bench.contracts.run_plan import BestOfAttemptRecipe, SingleAttemptRecipe
+from aec_bench.harness.artifact.values import (
+    AttemptSelection,
+    AttemptSelectionEvidence,
+    CandidateAttemptEvidence,
+    SelectorCandidate,
+    SelectorDecision,
+    SelectorEvidence,
+    TaskAttempt,
+)
+
+
+class AttemptRunner(Protocol):
+    def __call__(
+        self,
+        *,
+        attempt_id: str,
+        parent: TaskAttempt | None = None,
+        instruction: str | None = None,
+    ) -> TaskAttempt: ...
+
+
+class AttemptRecipe(Protocol):
+    def __call__(self, run_once: AttemptRunner) -> AttemptSelection: ...
+
+
+class AttemptSelector(Protocol):
+    def __call__(self, candidates: Sequence[SelectorCandidate]) -> SelectorDecision: ...
+
+
+def single_attempt() -> AttemptRecipe:
+    def recipe(run_once: AttemptRunner) -> AttemptSelection:
+        attempt = run_once(attempt_id="attempt-0")
+        return AttemptSelection.selected(attempt, reason="single attempt")
+
+    return recipe
+
+
+def self_select() -> AttemptSelector:
+    """Select the first eligible candidate with deterministic index tie-breaking."""
+
+    def selector(candidates: Sequence[SelectorCandidate]) -> SelectorDecision:
+        selected = next((candidate for candidate in candidates if candidate.eligible), None)
+        selected_index = None if selected is None else selected.index
+        return SelectorDecision(
+            selected_index=selected_index,
+            reason=("no candidate completed with a primary output" if selected is None else "first eligible candidate"),
+            configuration={"policy": "first_eligible", "tie_break": "lowest_candidate_index"},
+        )
+
+    return selector
+
+
+def best_of(*, k: int, selector: AttemptSelector) -> AttemptRecipe:
+    if k < 1:
+        raise ValueError("best-of candidate count must be positive")
+    if k == 1:
+        return single_attempt()
+
+    def recipe(run_once: AttemptRunner) -> AttemptSelection:
+        attempts = [run_once(attempt_id=f"attempt-{index}") for index in range(k)]
+        candidates = tuple(_selector_candidate(index=index, attempt=attempt) for index, attempt in enumerate(attempts))
+        decision = selector(candidates)
+        selected_index = decision.selected_index
+        if selected_index is not None and not 0 <= selected_index < len(attempts):
+            raise ValueError("selector returned an out-of-range candidate index")
+        selected: TaskAttempt | None = None if selected_index is None else attempts[selected_index]
+        if selected is not None:
+            assert selected_index is not None
+            if not candidates[selected_index].eligible:
+                raise ValueError("selector returned an ineligible candidate")
+        evidence = AttemptSelectionEvidence(
+            candidates=tuple(
+                CandidateAttemptEvidence(
+                    index=candidate.index,
+                    attempt_id=candidate.attempt_id,
+                    status=candidate.status,
+                    elapsed_seconds=attempts[candidate.index].elapsed_seconds,
+                    eligible=candidate.eligible,
+                    selector_visible_output=candidate.output_reference,
+                )
+                for candidate in candidates
+            ),
+            selector=SelectorEvidence(
+                configuration=dict(decision.configuration),
+                model_calls=decision.model_calls,
+                input_tokens=decision.input_tokens,
+                output_tokens=decision.output_tokens,
+                cache_read_tokens=decision.cache_read_tokens,
+                cache_write_tokens=decision.cache_write_tokens,
+                selected_index=selected_index,
+            ),
+            decision="failed" if selected is None else "selected",
+            reason=decision.reason,
+            selected_index=selected_index,
+        )
+        if selected is None:
+            return AttemptSelection.failed(reason=decision.reason, evidence=evidence)
+        return AttemptSelection.selected(selected, reason=decision.reason, evidence=evidence)
+
+    return recipe
+
+
+def build_attempt_recipe(spec: CanonicalAttemptRecipe) -> AttemptRecipe:
+    if isinstance(spec, SingleAttemptRecipe):
+        return single_attempt()
+    if isinstance(spec, BestOfAttemptRecipe):
+        return best_of(k=spec.candidates, selector=self_select())
+    raise TypeError(f"unsupported attempt recipe specification: {type(spec).__name__}")
+
+
+def _selector_candidate(*, index: int, attempt: TaskAttempt) -> SelectorCandidate:
+    return SelectorCandidate(
+        index=index,
+        attempt_id=attempt.attempt_id,
+        status=attempt.status,
+        primary_output=attempt.selector_visible_output,
+        output_reference=attempt.output_reference,
+    )
+
+
+__all__ = (
+    "AttemptRecipe",
+    "AttemptRunner",
+    "AttemptSelector",
+    "best_of",
+    "build_attempt_recipe",
+    "self_select",
+    "single_attempt",
+)

--- a/src/aec_bench/harness/artifact/values.py
+++ b/src/aec_bench/harness/artifact/values.py
@@ -1,0 +1,122 @@
+# ABOUTME: Defines effect-free values used by local artifact task attempts.
+# ABOUTME: Owns attempts, selection candidates, decisions, and persisted attempt evidence.
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from aec_bench.adapters.base import AdapterRequest, AdapterResult
+from aec_bench.contracts.agent_output import AgentOutputStatus
+from aec_bench.contracts.trial_extensions import ArtifactReference
+from aec_bench.contracts.validators import StrictModel
+
+
+@dataclass(frozen=True)
+class SelectorCandidate:
+    index: int
+    attempt_id: str
+    status: AgentOutputStatus
+    primary_output: bytes | None
+    output_reference: ArtifactReference | None
+
+    @property
+    def eligible(self) -> bool:
+        return self.status is AgentOutputStatus.COMPLETED and bool(self.primary_output)
+
+
+@dataclass(frozen=True)
+class SelectorDecision:
+    selected_index: int | None
+    reason: str
+    configuration: Mapping[str, object]
+    model_calls: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+
+
+class CandidateAttemptEvidence(StrictModel):
+    index: int
+    attempt_id: str
+    status: AgentOutputStatus
+    elapsed_seconds: float
+    eligible: bool
+    selector_visible_output: ArtifactReference | None = None
+
+
+class SelectorEvidence(StrictModel):
+    kind: Literal["self"] = "self"
+    configuration: dict[str, object]
+    model_calls: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+    selected_index: int | None = None
+
+
+class AttemptSelectionEvidence(StrictModel):
+    candidates: tuple[CandidateAttemptEvidence, ...]
+    selector: SelectorEvidence
+    decision: Literal["selected", "failed"]
+    reason: str
+    selected_index: int | None = None
+
+
+@dataclass(frozen=True)
+class TaskAttempt:
+    attempt_id: str
+    trial_id: str
+    parent_attempt_id: str | None
+    workspace: Path
+    request: AdapterRequest
+    result: AdapterResult
+    elapsed_seconds: float
+    selector_visible_output: bytes | None = None
+    output_reference: ArtifactReference | None = None
+
+    @property
+    def status(self) -> AgentOutputStatus:
+        return self.result.agent_output.status
+
+
+@dataclass(frozen=True)
+class AttemptSelection:
+    attempt: TaskAttempt | None
+    decision: str
+    reason: str
+    evidence: AttemptSelectionEvidence | None = None
+
+    @classmethod
+    def selected(
+        cls,
+        attempt: TaskAttempt,
+        *,
+        reason: str,
+        evidence: AttemptSelectionEvidence | None = None,
+    ) -> AttemptSelection:
+        return cls(attempt=attempt, decision="selected", reason=reason, evidence=evidence)
+
+    @classmethod
+    def failed(
+        cls,
+        *,
+        reason: str,
+        evidence: AttemptSelectionEvidence | None = None,
+    ) -> AttemptSelection:
+        return cls(attempt=None, decision="failed", reason=reason, evidence=evidence)
+
+
+__all__ = (
+    "AttemptSelection",
+    "AttemptSelectionEvidence",
+    "CandidateAttemptEvidence",
+    "SelectorCandidate",
+    "SelectorDecision",
+    "SelectorEvidence",
+    "TaskAttempt",
+)

--- a/src/aec_bench/harness/artifact_tasks.py
+++ b/src/aec_bench/harness/artifact_tasks.py
@@ -13,9 +13,9 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Annotated, Any, Literal, Protocol, cast
+from typing import Any, Literal, Protocol, cast
 
-from pydantic import BaseModel, Field, PositiveInt
+from pydantic import BaseModel
 
 from aec_bench.adapters.base import Adapter, AdapterRequest, AdapterResult
 from aec_bench.contracts.agent_output import AgentOutputStatus
@@ -31,6 +31,7 @@ from aec_bench.contracts.identity import (
     validate_uuidv7,
 )
 from aec_bench.contracts.resolved_run import ResolvedRunSpec
+from aec_bench.contracts.run_plan import AttemptRecipe as CanonicalAttemptRecipe
 from aec_bench.contracts.run_plan import BestOfAttemptRecipe, RunPlan
 from aec_bench.contracts.run_plan import PlannedTrial as CanonicalPlannedTrial
 from aec_bench.contracts.run_plan import SingleAttemptRecipe as CanonicalSingleAttemptRecipe
@@ -42,7 +43,6 @@ from aec_bench.contracts.trial_record import (
     PlannedTrialBinding,
     TrialRecord,
 )
-from aec_bench.contracts.validators import StrictModel
 from aec_bench.evaluation.normalisation import NormalisationResult, normalise_output
 from aec_bench.evaluation.verifier_outcome import map_verifier_execution
 from aec_bench.execution.models import (
@@ -59,6 +59,15 @@ from aec_bench.execution.models import (
     WorkerOutcome,
 )
 from aec_bench.execution.operational import AttemptRecord, OperationalStore, WorkItemRecord
+from aec_bench.harness.artifact.recipes import (
+    AttemptRecipe,
+    AttemptRunner,
+    best_of,
+    build_attempt_recipe,
+    self_select,
+    single_attempt,
+)
+from aec_bench.harness.artifact.values import AttemptSelection, AttemptSelectionEvidence, TaskAttempt
 from aec_bench.harness.compilation.task_snapshot import TaskSnapshotError, assert_task_snapshot_matches_directory
 from aec_bench.harness.local_runtime import (
     cleanup_workspace,
@@ -108,146 +117,16 @@ _VERIFIER_RETRY_ARTIFACT_SUFFIXES = (
 _VERIFIER_RETRY_EXCLUDED_PREFIXES = ("expected_", "input_", "prior_", "source_")
 
 
-class AttemptRunner(Protocol):
-    def __call__(
-        self,
-        *,
-        attempt_id: str,
-        parent: TaskAttempt | None = None,
-        instruction: str | None = None,
-    ) -> TaskAttempt: ...
-
-
-class AttemptRecipe(Protocol):
-    def __call__(self, run_once: AttemptRunner) -> AttemptSelection: ...
-
-
 class ImportedExperimentRuntime(Protocol):
     def run_experiment(
         self,
         *,
         tasks: Sequence[ResolvedTaskInstance],
         trials: Sequence[PlannedTrial],
-        recipe_spec: AttemptRecipeSpec,
+        recipe_spec: CanonicalAttemptRecipe,
         reviewer: ReviewerRunConfig | None,
         verify: bool,
     ) -> list[TrialRecord]: ...
-
-
-class AttemptSelector(Protocol):
-    def __call__(self, candidates: Sequence[SelectorCandidate]) -> SelectorDecision: ...
-
-
-@dataclass(frozen=True)
-class SelectorCandidate:
-    index: int
-    attempt_id: str
-    status: AgentOutputStatus
-    primary_output: bytes | None
-    output_reference: ArtifactReference | None
-
-    @property
-    def eligible(self) -> bool:
-        return self.status is AgentOutputStatus.COMPLETED and bool(self.primary_output)
-
-
-@dataclass(frozen=True)
-class SelectorDecision:
-    selected_index: int | None
-    reason: str
-    configuration: Mapping[str, object]
-    model_calls: int = 0
-    input_tokens: int = 0
-    output_tokens: int = 0
-    cache_read_tokens: int = 0
-    cache_write_tokens: int = 0
-
-
-class CandidateAttemptEvidence(StrictModel):
-    index: int
-    attempt_id: str
-    status: AgentOutputStatus
-    elapsed_seconds: float
-    eligible: bool
-    selector_visible_output: ArtifactReference | None = None
-
-
-class SelectorEvidence(StrictModel):
-    kind: Literal["self"] = "self"
-    configuration: dict[str, object]
-    model_calls: int = 0
-    input_tokens: int = 0
-    output_tokens: int = 0
-    cache_read_tokens: int = 0
-    cache_write_tokens: int = 0
-    selected_index: int | None = None
-
-
-class AttemptSelectionEvidence(StrictModel):
-    candidates: tuple[CandidateAttemptEvidence, ...]
-    selector: SelectorEvidence
-    decision: Literal["selected", "failed"]
-    reason: str
-    selected_index: int | None = None
-
-
-class SelfSelectorSpec(StrictModel):
-    kind: Literal["self"] = "self"
-
-
-class SingleAttemptSpec(StrictModel):
-    kind: Literal["single_attempt"] = "single_attempt"
-
-
-class BestOfSpec(StrictModel):
-    kind: Literal["best_of"] = "best_of"
-    candidates: PositiveInt
-    selector: SelfSelectorSpec = Field(default_factory=SelfSelectorSpec)
-
-
-AttemptRecipeSpec = Annotated[SingleAttemptSpec | BestOfSpec, Field(discriminator="kind")]
-
-
-@dataclass(frozen=True)
-class TaskAttempt:
-    attempt_id: str
-    trial_id: str
-    parent_attempt_id: str | None
-    workspace: Path
-    request: AdapterRequest
-    result: AdapterResult
-    elapsed_seconds: float
-
-    @property
-    def status(self) -> AgentOutputStatus:
-        return self.result.agent_output.status
-
-
-@dataclass(frozen=True)
-class AttemptSelection:
-    attempt: TaskAttempt | None
-    decision: str
-    reason: str
-    evidence: AttemptSelectionEvidence | None = None
-
-    @classmethod
-    def selected(
-        cls,
-        attempt: TaskAttempt,
-        *,
-        reason: str,
-        evidence: AttemptSelectionEvidence | None = None,
-    ) -> AttemptSelection:
-        return cls(attempt=attempt, decision="selected", reason=reason, evidence=evidence)
-
-    @classmethod
-    def failed(
-        cls,
-        *,
-        reason: str,
-        evidence: AttemptSelectionEvidence | None = None,
-    ) -> AttemptSelection:
-        return cls(attempt=None, decision="failed", reason=reason, evidence=evidence)
 
 
 class LocalTaskRuntime:
@@ -405,6 +284,17 @@ class LocalTaskRuntime:
             result=result,
             output_source=output_source,
         )
+        selector_visible_output = output_path.read_bytes() if output_path.is_file() else None
+        output_reference = (
+            ArtifactReference(
+                kind="primary_output",
+                path=request.output_path,
+                sha256=hashlib.sha256(selector_visible_output).hexdigest(),
+                media_type="application/octet-stream",
+            )
+            if selector_visible_output
+            else None
+        )
         return TaskAttempt(
             attempt_id=attempt_id,
             trial_id=trial.trial_id,
@@ -413,6 +303,8 @@ class LocalTaskRuntime:
             request=request,
             result=result,
             elapsed_seconds=elapsed_seconds,
+            selector_visible_output=selector_visible_output,
+            output_reference=output_reference,
         )
 
     def _create_workspace(self, *, task: ResolvedTaskInstance, parent: TaskAttempt | None) -> Path:
@@ -420,7 +312,7 @@ class LocalTaskRuntime:
             self._work_root.mkdir(parents=True, exist_ok=True)
         if parent is None:
             capture_workspace_manifest(task.instance_dir, include_checksums=False)
-            workspace = Path(setup_workspace(str(task.instance_dir), work_root=self._work_root))
+            workspace = Path(setup_workspace(str(task.instance_dir), work_root=self._work_root)).resolve()
             self._copy_agent_files(workspace)
             patch_workspace_paths(str(workspace))
             self._workspace_manifests[workspace] = capture_workspace_manifest(workspace)
@@ -439,7 +331,7 @@ class LocalTaskRuntime:
             source_roles=parent_roles,
             default_source_role="actor_output",
         )
-        workspace = Path(tempfile.mkdtemp(prefix="aec-bench-local-", dir=self._work_root))
+        workspace = Path(tempfile.mkdtemp(prefix="aec-bench-local-", dir=self._work_root)).resolve()
         shutil.copytree(parent.workspace, workspace, dirs_exist_ok=True)
         shutil.rmtree(workspace / "tests", ignore_errors=True)
         shutil.rmtree(workspace / "logs" / "verifier", ignore_errors=True)
@@ -523,6 +415,24 @@ class LocalTaskRuntime:
             output_path=output_path,
             output_format="markdown" if Path(output_path).suffix.lower() == ".md" else "jsonl",
         )
+
+
+def resolve_workspace_path(workspace: Path, configured_path: str) -> Path:
+    """Resolve one configured artifact path below its attempt workspace."""
+
+    path = Path(configured_path)
+    if path.parts and path.parts[0] == "workspace":
+        path = Path(*path.parts[1:])
+    elif path.is_absolute() and path.parts[:2] == ("/", "workspace"):
+        path = Path(*path.parts[2:])
+    elif path.is_absolute() and path.parts[:2] == ("/", "logs"):
+        path = Path(*path.parts[1:])
+    elif path.is_absolute():
+        raise ValueError("task output path must resolve inside the attempt workspace")
+    candidate = (workspace / path).resolve()
+    if candidate != workspace.resolve() and workspace.resolve() not in candidate.parents:
+        raise ValueError("task output path must resolve inside the attempt workspace")
+    return candidate
 
 
 class ArtifactTrialAdapterError(RuntimeError):
@@ -610,14 +520,14 @@ class ArtifactTrialAdapter:
         finalization_path = self._finalization_path(trial)
         if record_path.exists() or finalization_path.exists():
             raise ArtifactTrialAdapterError(f"trial finalization already exists: {trial.trial_identity.id}")
-        legacy_trial = _legacy_trial_for_canonical(trial, stored.spec)
+        runtime_trial = _runtime_trial_for_planned_trial(trial, stored.spec)
         candidate_states: list[_CandidateState] = []
         recipe = self._bound_recipe(trial, work_item, attempt, candidate_states)
         try:
             record = run_trial(
                 runtime=self._runtime,
                 task=task,
-                trial=legacy_trial,
+                trial=runtime_trial,
                 recipe=recipe,
                 verify=self._verify,
                 keep_workspaces=self._keep_workspaces,
@@ -728,7 +638,7 @@ class ArtifactTrialAdapter:
         scheduler_attempt: AttemptRecord,
         candidate_states: list[_CandidateState],
     ) -> AttemptRecipe:
-        base_recipe = _legacy_recipe_for_canonical(trial)
+        base_recipe = _recipe_for_planned_trial(trial)
         candidate_count = (
             1 if isinstance(trial.attempt_recipe, CanonicalSingleAttemptRecipe) else trial.attempt_recipe.candidates
         )
@@ -921,22 +831,6 @@ class ArtifactTrialAdapter:
             target.publish_bytes(data=source.read_bytes(reference), media_type=reference.media_type)
 
 
-def resolve_workspace_path(workspace: Path, configured_path: str) -> Path:
-    path = Path(configured_path)
-    if path.parts and path.parts[0] == "workspace":
-        path = Path(*path.parts[1:])
-    elif path.is_absolute() and path.parts[:2] == ("/", "workspace"):
-        path = Path(*path.parts[2:])
-    elif path.is_absolute() and path.parts[:2] == ("/", "logs"):
-        path = Path(*path.parts[1:])
-    elif path.is_absolute():
-        raise ValueError("task output path must resolve inside the attempt workspace")
-    candidate = (workspace / path).resolve()
-    if candidate != workspace.resolve() and workspace.resolve() not in candidate.parents:
-        raise ValueError("task output path must resolve inside the attempt workspace")
-    return candidate
-
-
 def load_canonical_refs(task_toml_path: Path) -> CanonicalRefSet:
     if not task_toml_path.exists():
         return CanonicalRefSet()
@@ -1020,109 +914,6 @@ def _write_agent_result(
         "output_source": output_source,
     }
     (workspace / "agent_result.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
-
-
-def single_attempt() -> AttemptRecipe:
-    def recipe(run_once: AttemptRunner) -> AttemptSelection:
-        attempt = run_once(attempt_id="attempt-0")
-        return AttemptSelection.selected(attempt, reason="single attempt")
-
-    return recipe
-
-
-def self_select() -> AttemptSelector:
-    """Select the first eligible candidate with deterministic index tie-breaking."""
-
-    def selector(candidates: Sequence[SelectorCandidate]) -> SelectorDecision:
-        selected = next((candidate for candidate in candidates if candidate.eligible), None)
-        selected_index = None if selected is None else selected.index
-        return SelectorDecision(
-            selected_index=selected_index,
-            reason=("no candidate completed with a primary output" if selected is None else "first eligible candidate"),
-            configuration={"policy": "first_eligible", "tie_break": "lowest_candidate_index"},
-        )
-
-    return selector
-
-
-def best_of(*, k: int, selector: AttemptSelector) -> AttemptRecipe:
-    if k < 1:
-        raise ValueError("best-of candidate count must be positive")
-    if k == 1:
-        return single_attempt()
-
-    def recipe(run_once: AttemptRunner) -> AttemptSelection:
-        attempts = [run_once(attempt_id=f"attempt-{index}") for index in range(k)]
-        candidates = tuple(_selector_candidate(index=index, attempt=attempt) for index, attempt in enumerate(attempts))
-        decision = selector(candidates)
-        selected_index = decision.selected_index
-        if selected_index is not None and not 0 <= selected_index < len(attempts):
-            raise ValueError("selector returned an out-of-range candidate index")
-        selected: TaskAttempt | None
-        if selected_index is None:
-            selected = None
-        else:
-            selected = attempts[selected_index]
-            if not candidates[selected_index].eligible:
-                raise ValueError("selector returned an ineligible candidate")
-        evidence = AttemptSelectionEvidence(
-            candidates=tuple(
-                CandidateAttemptEvidence(
-                    index=candidate.index,
-                    attempt_id=candidate.attempt_id,
-                    status=candidate.status,
-                    elapsed_seconds=attempts[candidate.index].elapsed_seconds,
-                    eligible=candidate.eligible,
-                    selector_visible_output=candidate.output_reference,
-                )
-                for candidate in candidates
-            ),
-            selector=SelectorEvidence(
-                configuration=dict(decision.configuration),
-                model_calls=decision.model_calls,
-                input_tokens=decision.input_tokens,
-                output_tokens=decision.output_tokens,
-                cache_read_tokens=decision.cache_read_tokens,
-                cache_write_tokens=decision.cache_write_tokens,
-                selected_index=selected_index,
-            ),
-            decision="failed" if selected is None else "selected",
-            reason=decision.reason,
-            selected_index=selected_index,
-        )
-        if selected is None:
-            return AttemptSelection.failed(reason=decision.reason, evidence=evidence)
-        return AttemptSelection.selected(selected, reason=decision.reason, evidence=evidence)
-
-    return recipe
-
-
-def build_attempt_recipe(spec: AttemptRecipeSpec) -> AttemptRecipe:
-    if isinstance(spec, SingleAttemptSpec):
-        return single_attempt()
-    if isinstance(spec, BestOfSpec):
-        return best_of(k=spec.candidates, selector=self_select())
-    raise TypeError(f"unsupported attempt recipe specification: {type(spec).__name__}")
-
-
-def _selector_candidate(*, index: int, attempt: TaskAttempt) -> SelectorCandidate:
-    output_path = resolve_workspace_path(attempt.workspace, attempt.request.output_path)
-    content = output_path.read_bytes() if output_path.is_file() else None
-    reference = None
-    if content:
-        reference = ArtifactReference(
-            kind="primary_output",
-            path=attempt.request.output_path,
-            sha256=hashlib.sha256(content).hexdigest(),
-            media_type="application/octet-stream",
-        )
-    return SelectorCandidate(
-        index=index,
-        attempt_id=attempt.attempt_id,
-        status=attempt.status,
-        primary_output=content,
-        output_reference=reference,
-    )
 
 
 def run_trial(
@@ -1284,7 +1075,7 @@ def run_experiment(
     runtime: LocalTaskRuntime | ImportedExperimentRuntime,
     tasks: Sequence[ResolvedTaskInstance],
     trials: Sequence[PlannedTrial],
-    recipe: AttemptRecipe | AttemptRecipeSpec,
+    recipe: AttemptRecipe | CanonicalAttemptRecipe,
     reviewer: ReviewerRunConfig | None = None,
     verify: bool = True,
     keep_workspaces: bool = False,
@@ -1292,8 +1083,8 @@ def run_experiment(
     """Apply one attempt recipe directly to every planned artifact-task trial."""
 
     if not isinstance(runtime, LocalTaskRuntime):
-        if not isinstance(recipe, SingleAttemptSpec | BestOfSpec):
-            raise TypeError("imported experiment runtimes require an AttemptRecipeSpec")
+        if not isinstance(recipe, CanonicalSingleAttemptRecipe | BestOfAttemptRecipe):
+            raise TypeError("imported experiment runtimes require a canonical attempt recipe")
         return runtime.run_experiment(
             tasks=tasks,
             trials=trials,
@@ -1302,7 +1093,11 @@ def run_experiment(
             verify=verify,
         )
 
-    selected_recipe = build_attempt_recipe(recipe) if isinstance(recipe, SingleAttemptSpec | BestOfSpec) else recipe
+    selected_recipe = (
+        build_attempt_recipe(recipe)
+        if isinstance(recipe, CanonicalSingleAttemptRecipe | BestOfAttemptRecipe)
+        else recipe
+    )
 
     tasks_by_id: dict[str, ResolvedTaskInstance] = {}
     for task in tasks:
@@ -1369,13 +1164,13 @@ def run_persisted_artifact_plan(
     for trial in artifact_trials:
         task = tasks_by_id[trial.task_release.task_id]
         _validate_canonical_task_release(trial, task)
-        legacy_trial = _legacy_trial_for_canonical(trial, stored.spec)
+        runtime_trial = _runtime_trial_for_planned_trial(trial, stored.spec)
         records.append(
             run_trial(
                 runtime=runtime,
                 task=task,
-                trial=legacy_trial,
-                recipe=_legacy_recipe_for_canonical(trial),
+                trial=runtime_trial,
+                recipe=_recipe_for_planned_trial(trial),
                 reviewer=reviewer,
                 verify=verify,
                 keep_workspaces=keep_workspaces,
@@ -1397,7 +1192,7 @@ def _validate_canonical_task_release(trial: CanonicalPlannedTrial, task: Resolve
         raise ValueError(f"task release does not match planned snapshot: {reference.task_id}") from error
 
 
-def _legacy_trial_for_canonical(trial: CanonicalPlannedTrial, spec: ResolvedRunSpec) -> PlannedTrial:
+def _runtime_trial_for_planned_trial(trial: CanonicalPlannedTrial, spec: ResolvedRunSpec) -> PlannedTrial:
     from aec_bench.contracts.experiment_manifest import AgentConfig
 
     condition = trial.agent_condition
@@ -1419,7 +1214,7 @@ def _legacy_trial_for_canonical(trial: CanonicalPlannedTrial, spec: ResolvedRunS
     )
 
 
-def _legacy_recipe_for_canonical(trial: CanonicalPlannedTrial) -> AttemptRecipe:
+def _recipe_for_planned_trial(trial: CanonicalPlannedTrial) -> AttemptRecipe:
     if isinstance(trial.attempt_recipe, CanonicalSingleAttemptRecipe):
         return single_attempt()
     if isinstance(trial.attempt_recipe, BestOfAttemptRecipe):
@@ -2060,30 +1855,13 @@ def _aggregate_attempt_usage(
 
 
 __all__ = (
-    "AttemptRecipeSpec",
-    "AttemptRecipe",
-    "AttemptRunner",
-    "AttemptSelection",
-    "AttemptSelectionEvidence",
-    "AttemptSelector",
     "ArtifactTrialAdapter",
     "ArtifactTrialAdapterError",
     "ArtifactTrialExecution",
-    "BestOfSpec",
-    "CandidateAttemptEvidence",
     "ImportedExperimentRuntime",
     "LocalTaskRuntime",
-    "SelectorCandidate",
-    "SelectorDecision",
-    "SelfSelectorSpec",
-    "SingleAttemptSpec",
-    "TaskAttempt",
-    "best_of",
-    "build_attempt_recipe",
     "run_experiment",
     "run_persisted_artifact_plan",
     "run_trial",
     "run_trial_with_verifier_feedback",
-    "self_select",
-    "single_attempt",
 )

--- a/src/aec_bench/harness/harbor_runtime.py
+++ b/src/aec_bench/harness/harbor_runtime.py
@@ -9,8 +9,9 @@ from pathlib import Path
 
 from aec_bench.contracts.execution_environment import HarborEnvironmentBinding
 from aec_bench.contracts.experiment_manifest import ExperimentManifest
+from aec_bench.contracts.run_plan import AttemptRecipe as CanonicalAttemptRecipe
+from aec_bench.contracts.run_plan import SingleAttemptRecipe
 from aec_bench.contracts.trial_record import TrialRecord
-from aec_bench.harness.artifact_tasks import AttemptRecipeSpec, SingleAttemptSpec
 from aec_bench.harness.harbor_dispatch import HarborCommandExecutor
 from aec_bench.harness.harbor_workflow import HarborWorkflowResult, SynchronousHarborWorkflow
 from aec_bench.harness.model_execution.llm_reviewer import ReviewerRunConfig
@@ -36,11 +37,11 @@ class HarborExperimentRuntime:
         *,
         tasks: Sequence[ResolvedTaskInstance],
         trials: Sequence[PlannedTrial],
-        recipe_spec: AttemptRecipeSpec,
+        recipe_spec: CanonicalAttemptRecipe,
         reviewer: ReviewerRunConfig | None,
         verify: bool,
     ) -> list[TrialRecord]:
-        if not isinstance(recipe_spec, SingleAttemptSpec):
+        if not isinstance(recipe_spec, SingleAttemptRecipe):
             raise ValueError(f"Harbor does not support attempt recipe: {recipe_spec.kind}")
         resolved_tasks = tuple(task.task for task in tasks)
         effective_manifest = self.manifest.model_copy(update={"disable_verification": not verify})

--- a/tests/cli/test_run_local.py
+++ b/tests/cli/test_run_local.py
@@ -134,7 +134,10 @@ for event in [
     task_dir.mkdir(parents=True)
     (task_dir / "instruction.md").write_text("Write /workspace/output.md", encoding="utf-8")
     (task_dir / "task.toml").write_text(
-        'version = "1.0"\n\n[metadata]\ndifficulty = "easy"\ncategory = "reasoning"\ntags = []\n'
+        'version = "1.0"\n\n[identity]\nid = "019c2c7a-5a33-7b8d-a702-8f7f3e8c21aa"\n'
+        'key = "test/public-task"\nversion = 1\n'
+        '\n[metadata]\nlifecycle = "active"\nvisibility = "public"\n'
+        'difficulty = "easy"\ncategory = "reasoning"\ntags = []\n'
         "\n[agent]\ntimeout_sec = 30.0\n\n[verifier]\ntimeout_sec = 30.0\n"
         "\n[environment]\nextensions = []\nbuild_timeout_sec = 30.0\ncpus = 1\nmemory_mb = 512\n"
         "storage_mb = 512\nallow_internet = false\n",

--- a/tests/harness/test_artifact_adapter.py
+++ b/tests/harness/test_artifact_adapter.py
@@ -17,10 +17,10 @@ from aec_bench.contracts.trial_record import EvaluationStatus
 from aec_bench.execution.models import RetryPolicy
 from aec_bench.execution.operational import AttemptRecord, OperationalStore, WorkItemRecord
 from aec_bench.execution.scheduler import LocalScheduler
+from aec_bench.harness.artifact.values import AttemptSelectionEvidence
 from aec_bench.harness.artifact_tasks import (
     ArtifactTrialAdapter,
     ArtifactTrialAdapterError,
-    AttemptSelectionEvidence,
     LocalTaskRuntime,
 )
 from aec_bench.ledger.artifact_repository import ArtifactRepository

--- a/tests/harness/test_artifact_recipes.py
+++ b/tests/harness/test_artifact_recipes.py
@@ -1,0 +1,97 @@
+# ABOUTME: Tests effect-free artifact attempt recipe and selector policies.
+# ABOUTME: Proves selectors use runtime-provided values without reading attempt workspaces.
+
+from pathlib import Path
+
+import pytest
+
+from aec_bench.adapters.base import AdapterRequest, AdapterResult
+from aec_bench.contracts.agent_output import AgentOutput, AgentOutputStatus
+from aec_bench.harness.artifact.recipes import best_of, self_select, single_attempt
+from aec_bench.harness.artifact.values import SelectorDecision, TaskAttempt
+
+
+def _attempt(attempt_id: str, output: bytes | None) -> TaskAttempt:
+    request = AdapterRequest(instruction="instruction", output_path="/workspace/output.md")
+    result = AdapterResult(
+        adapter_name="direct",
+        resolved_model="test-model",
+        configuration_record={},
+        agent_output=AgentOutput(
+            status=AgentOutputStatus.COMPLETED if output else AgentOutputStatus.FAILED,
+            output_path=request.output_path,
+            output_format="markdown",
+        ),
+        transcript=[],
+    )
+    return TaskAttempt(
+        attempt_id=attempt_id,
+        trial_id="trial-1",
+        parent_attempt_id=None,
+        workspace=Path("/workspace-does-not-exist"),
+        request=request,
+        result=result,
+        elapsed_seconds=0.1,
+        selector_visible_output=output,
+    )
+
+
+def test_best_of_selector_uses_attempt_values_without_workspace_reads() -> None:
+    attempts = [_attempt("attempt-0", None), _attempt("attempt-1", b"complete")]
+
+    def run_once(*, attempt_id: str, parent=None, instruction=None) -> TaskAttempt:  # noqa: ANN001
+        return attempts[int(attempt_id.rsplit("-", maxsplit=1)[1])]
+
+    selection = best_of(k=2, selector=self_select())(run_once)
+
+    assert selection.attempt is attempts[1]
+    assert selection.evidence is not None
+    assert [candidate.eligible for candidate in selection.evidence.candidates] == [False, True]
+
+
+def test_single_attempt_runs_once_and_selects_the_attempt() -> None:
+    attempt = _attempt("attempt-0", b"complete")
+    calls: list[str] = []
+
+    def run_once(*, attempt_id: str, parent=None, instruction=None) -> TaskAttempt:  # noqa: ANN001
+        calls.append(attempt_id)
+        return attempt
+
+    selection = single_attempt()(run_once)
+
+    assert calls == ["attempt-0"]
+    assert selection.attempt is attempt
+    assert selection.reason == "single attempt"
+
+
+def test_best_of_reports_failure_when_no_candidate_is_eligible() -> None:
+    attempts = [_attempt("attempt-0", None), _attempt("attempt-1", None)]
+
+    def run_once(*, attempt_id: str, parent=None, instruction=None) -> TaskAttempt:  # noqa: ANN001
+        return attempts[int(attempt_id.rsplit("-", maxsplit=1)[1])]
+
+    selection = best_of(k=2, selector=self_select())(run_once)
+
+    assert selection.attempt is None
+    assert selection.decision == "failed"
+    assert selection.evidence is not None
+    assert selection.evidence.selected_index is None
+
+
+def test_best_of_rejects_out_of_range_selector_choice() -> None:
+    def selector(_candidates):  # noqa: ANN001
+        return SelectorDecision(selected_index=2, reason="bad", configuration={})
+
+    with pytest.raises(ValueError, match="out-of-range"):
+        best_of(k=2, selector=selector)(lambda **kwargs: _attempt(kwargs["attempt_id"], b"complete"))
+
+
+def test_best_of_rejects_ineligible_selector_choice() -> None:
+    def selector(_candidates):  # noqa: ANN001
+        return SelectorDecision(selected_index=0, reason="bad", configuration={})
+
+    def run_once(*, attempt_id: str, parent=None, instruction=None) -> TaskAttempt:  # noqa: ANN001
+        return _attempt(attempt_id, None if attempt_id == "attempt-0" else b"complete")
+
+    with pytest.raises(ValueError, match="ineligible"):
+        best_of(k=2, selector=selector)(run_once)

--- a/tests/harness/test_artifact_tasks.py
+++ b/tests/harness/test_artifact_tasks.py
@@ -9,21 +9,16 @@ import pytest
 from aec_bench.adapters.base import AdapterRequest, AdapterResult
 from aec_bench.contracts.agent_output import AgentOutput, AgentOutputStatus
 from aec_bench.contracts.experiment_manifest import AgentConfig, ComputeConfig
+from aec_bench.contracts.run_plan import BestOfAttemptRecipe
 from aec_bench.contracts.task_definition import EnvironmentSpec, VerifierSpec
 from aec_bench.contracts.trial_record import EvaluationStatus
+from aec_bench.harness.artifact.recipes import best_of, build_attempt_recipe, self_select, single_attempt
+from aec_bench.harness.artifact.values import AttemptSelection, AttemptSelectionEvidence, SelectorDecision
 from aec_bench.harness.artifact_tasks import (
-    AttemptSelection,
-    AttemptSelectionEvidence,
-    BestOfSpec,
     LocalTaskRuntime,
-    SelectorDecision,
-    best_of,
-    build_attempt_recipe,
     run_experiment,
     run_trial,
     run_trial_with_verifier_feedback,
-    self_select,
-    single_attempt,
 )
 from aec_bench.tasks.instance import resolve_instance_paths
 from aec_bench.trials import PlannedTrial
@@ -601,7 +596,7 @@ def test_best_of_returns_failed_trial_without_verification_when_all_candidates_f
         runtime=runtime,
         task=task,
         trial=_planned_trial(),
-        recipe=build_attempt_recipe(BestOfSpec(candidates=3)),
+        recipe=build_attempt_recipe(BestOfAttemptRecipe(candidates=3, selector="self")),
     )
 
     assert record.execution_status.value == "failed"

--- a/tests/harness/test_harbor_runtime.py
+++ b/tests/harness/test_harbor_runtime.py
@@ -7,7 +7,8 @@ from types import SimpleNamespace
 import pytest
 
 from aec_bench.contracts.experiment_manifest import AgentConfig, ComputeConfig, ExperimentManifest, TaskSelector
-from aec_bench.harness.artifact_tasks import BestOfSpec, SingleAttemptSpec, run_experiment
+from aec_bench.contracts.run_plan import BestOfAttemptRecipe, SingleAttemptRecipe
+from aec_bench.harness.artifact_tasks import run_experiment
 from aec_bench.harness.harbor_runtime import HarborExperimentRuntime
 from aec_bench.ledger.writer import write_trial_record
 from aec_bench.tasks.instance import resolve_instance_paths
@@ -75,7 +76,7 @@ def test_recorded_harbor_baseline_returns_exact_imported_trial_meaning(tmp_path:
         runtime=runtime,
         tasks=[task],
         trials=trials,
-        recipe=SingleAttemptSpec(),
+        recipe=SingleAttemptRecipe(),
     )
 
     assert [record.model_dump(mode="json") for record in records] == [expected.model_dump(mode="json")]
@@ -93,7 +94,7 @@ def test_harbor_rejects_unsupported_best_of_before_dispatch(tmp_path: Path) -> N
             runtime=runtime,
             tasks=[task],
             trials=trials,
-            recipe=BestOfSpec(candidates=2),
+            recipe=BestOfAttemptRecipe(candidates=2, selector="self"),
         )
 
     assert workflow.calls == []
@@ -102,7 +103,7 @@ def test_harbor_rejects_unsupported_best_of_before_dispatch(tmp_path: Path) -> N
 def test_imported_runtime_requires_serializable_recipe_spec(tmp_path: Path) -> None:
     task, trials, _expected, _workflow, runtime = _inputs(tmp_path)
 
-    with pytest.raises(TypeError, match="AttemptRecipeSpec"):
+    with pytest.raises(TypeError, match="canonical attempt recipe"):
         run_experiment(
             runtime=runtime,
             tasks=[task],


### PR DESCRIPTION
## Summary

- extract effect-free artifact attempt values into `harness/artifact/values.py`
- extract single-attempt, best-of, and selector policy into `harness/artifact/recipes.py`
- use the canonical run-plan attempt recipe contracts across local, Harbor, evolution, and learning-study callers
- supply selector-visible output values once at the runtime boundary, so recipe selection does not read workspaces
- remove the duplicate artifact attempt specification models and compatibility exports

## Review guide

1. Review `values.py` for the effect-free attempt, candidate, decision, and evidence values.
2. Review `recipes.py` for bounded candidate creation and deterministic selection.
3. Review `artifact_tasks.py` for the runtime handoff and removal of the former embedded definitions.
4. Review caller updates for the canonical `SingleAttemptRecipe` and `BestOfAttemptRecipe` contracts.
5. Review `test_artifact_recipes.py` for selection, failure, invalid-index, and no-workspace-read coverage.

## Validation

- `55 passed` in the focused artifact, Harbor, and local CLI suite
- Ruff check passed for `src/` and `tests/`
- Ruff format check passed for all 15 changed Python paths
- mypy passed for 10 affected source files
- generated catalogue check passed
- provenance field audit passed with no violations
- Python source distribution and wheel build passed

## Known unrelated baseline findings

- evolution tests could not collect in this worktree because the optional `ribs` dependency is not installed
- the package ownership audit reports existing lifecycle dependency violations; PRD4 PR11 owns that dependency-matrix work
- the learning-study artifact suite reports existing task-key case mismatches after the identity conversion
