### PR TITLE
PRD4: extract artifact execution ports

### DIFF
--- a/src/aec_bench/harness/artifact/execution.py
+++ b/src/aec_bench/harness/artifact/execution.py
@@ -1,0 +1,248 @@
+# ABOUTME: Owns artifact output normalisation, commit validation, and agent result evidence.
+# ABOUTME: Keeps execution-facing output rules outside the filesystem workspace port.
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+from aec_bench.adapters.base import Adapter, AdapterRequest, AdapterResult
+from aec_bench.contracts.canonical_refs import CanonicalRefSet, parse_canonical_refs
+from aec_bench.contracts.task_definition import ToolSpec
+from aec_bench.contracts.trial_extensions import ArtifactReference
+from aec_bench.evaluation.normalisation import NormalisationResult, normalise_output
+from aec_bench.harness.artifact.values import TaskAttempt
+from aec_bench.harness.artifact.workspace_port import resolve_workspace_path
+from aec_bench.harness.local_runtime import read_instruction
+from aec_bench.tasks.instance import ResolvedTaskInstance
+from aec_bench.trajectory.writer import TrajectoryWriter
+from aec_bench.trials import PlannedTrial
+
+
+def load_canonical_refs(task_toml_path: Path) -> CanonicalRefSet:
+    if not task_toml_path.exists():
+        return CanonicalRefSet()
+    import tomllib
+
+    data = tomllib.loads(task_toml_path.read_text(encoding="utf-8"))
+    return parse_canonical_refs(data.get("canonical_refs", {}))
+
+
+def apply_normalisation(
+    output_path: Path,
+    refs: CanonicalRefSet,
+    report_path: Path,
+    *,
+    committed_result: AdapterResult | None = None,
+) -> NormalisationResult:
+    text = output_path.read_text(encoding="utf-8")
+    result = normalise_output(text, refs)
+    if result.substitutions_count == 0:
+        return result
+    if committed_result is not None and committed_result.completion_commit is not None:
+        raise ValueError("canonical-reference normalisation cannot change committed output bytes")
+    output_path.write_text(result.normalised, encoding="utf-8")
+    report_path.write_text(
+        json.dumps(
+            {
+                "substitutions_count": result.substitutions_count,
+                "audit_log": [
+                    {
+                        "matched_text": match.matched_text,
+                        "canonical_value": match.canonical_value,
+                        "distance": match.distance,
+                        "count": match.count,
+                    }
+                    for match in result.audit_log
+                ],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return result
+
+
+def validate_output_commit(*, result: AdapterResult, output_path: Path, expected_output_path: str) -> None:
+    attestation = result.completion_commit
+    if attestation is None:
+        return
+    if attestation.output_path != expected_output_path:
+        raise ValueError("output commit path does not match the task expected output path")
+    content = output_path.read_bytes()
+    if hashlib.sha256(content).hexdigest() != attestation.output_sha256:
+        raise ValueError("output commit SHA-256 does not match the attempt output")
+    if len(content) != attestation.output_size_bytes:
+        raise ValueError("output commit byte size does not match the attempt output")
+
+
+def write_agent_result(
+    *,
+    workspace: Path,
+    requested_model: str,
+    adapter_kind: str,
+    result: AdapterResult,
+    output_source: str,
+) -> None:
+    payload = {
+        "status": result.agent_output.status.value,
+        "model": requested_model,
+        "resolved_model": result.resolved_model,
+        "adapter": adapter_kind,
+        "adapter_configuration": result.configuration_record,
+        "model_calls": result.usage_model_calls,
+        "input_tokens": result.usage_input_tokens,
+        "output_tokens": result.usage_output_tokens,
+        "cache_read_tokens": result.usage_cache_read_tokens,
+        "cache_write_tokens": result.usage_cache_write_tokens,
+        "turns_used": result.turns_used,
+        "max_turns": result.max_turns,
+        "failure_kind": result.failure_kind.value if result.failure_kind is not None else None,
+        "provider_error": result.provider_error,
+        "output_source": output_source,
+    }
+    (workspace / "agent_result.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def execute_attempt(
+    *,
+    task: ResolvedTaskInstance,
+    trial: PlannedTrial,
+    workspace: Path,
+    attempt_id: str,
+    parent_attempt_id: str | None,
+    instruction: str | None,
+    adapter_builder: Callable[..., Adapter] | None,
+    constitutional_model: str | None,
+    normalise: bool,
+) -> TaskAttempt:
+    """Execute one adapter call and produce its selector-visible attempt values."""
+    request = _build_request(task=task, trial=trial, workspace=workspace, instruction=instruction)
+    adapter = _build_adapter(
+        trial=trial,
+        workspace=workspace,
+        adapter_builder=adapter_builder,
+        constitutional_model=constitutional_model,
+    )
+    started = time.monotonic()
+    result = adapter.execute(request)
+    elapsed_seconds = time.monotonic() - started
+
+    output_path = resolve_workspace_path(workspace, task.task.verifier.expected_output_path)
+    output_source = "adapter"
+    if output_path.is_file() and output_path.read_text(encoding="utf-8", errors="replace").strip():
+        output_source = "direct_write"
+    elif result.raw_output_text:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(result.raw_output_text, encoding="utf-8")
+        output_source = "raw_output"
+    if normalise and output_path.is_file():
+        refs = load_canonical_refs(task.instance_dir / "task.toml")
+        if refs.refs:
+            apply_normalisation(
+                output_path,
+                refs,
+                workspace / "normalisation_report.json",
+                committed_result=result,
+            )
+    validate_output_commit(
+        result=result,
+        output_path=output_path,
+        expected_output_path=task.task.verifier.expected_output_path,
+    )
+    write_agent_result(
+        workspace=workspace,
+        requested_model=trial.agent.model,
+        adapter_kind=trial.agent.adapter,
+        result=result,
+        output_source=output_source,
+    )
+    selector_visible_output = output_path.read_bytes() if output_path.is_file() else None
+    output_reference = (
+        ArtifactReference(
+            kind="primary_output",
+            path=request.output_path,
+            sha256=hashlib.sha256(selector_visible_output).hexdigest(),
+            media_type="application/octet-stream",
+        )
+        if selector_visible_output
+        else None
+    )
+    return TaskAttempt(
+        attempt_id=attempt_id,
+        trial_id=trial.trial_id,
+        parent_attempt_id=parent_attempt_id,
+        workspace=workspace,
+        request=request,
+        result=result,
+        elapsed_seconds=elapsed_seconds,
+        selector_visible_output=selector_visible_output,
+        output_reference=output_reference,
+    )
+
+
+def _build_adapter(
+    *,
+    trial: PlannedTrial,
+    workspace: Path,
+    adapter_builder: Callable[..., Adapter] | None,
+    constitutional_model: str | None,
+) -> Adapter:
+    builder = adapter_builder
+    if builder is None:
+        from aec_bench.adapters.local_registry import build_local_adapter
+
+        builder = build_local_adapter
+    trajectory_writer = TrajectoryWriter(path=str(workspace / "trajectory.jsonl"))
+    return builder(
+        adapter_kind=trial.agent.adapter,
+        model_name=trial.agent.model,
+        workspace=str(workspace),
+        trajectory_writer=trajectory_writer,
+        constitutional_model=constitutional_model,
+    )
+
+
+def _build_request(
+    *,
+    task: ResolvedTaskInstance,
+    trial: PlannedTrial,
+    workspace: Path,
+    instruction: str | None,
+) -> AdapterRequest:
+    selected_instruction = instruction if instruction is not None else read_instruction(str(workspace))
+    if not selected_instruction:
+        raise ValueError("task workspace does not contain an instruction")
+    system_prompt = trial.agent.system_prompt
+    if trial.agent.system_prompt_file is not None:
+        system_prompt = resolve_workspace_path(workspace, trial.agent.system_prompt_file).read_text(encoding="utf-8")
+    tools: list[ToolSpec] = []
+    if trial.agent.adapter == "tool_loop":
+        tools = [ToolSpec(name="bash", source="builtin", description="Execute a bash command in the workspace")]
+    configuration = dict(trial.agent.parameters)
+    timeout = trial.compute.timeout_override or task.task.timeout_seconds
+    if trial.agent.adapter == "prime-agent":
+        configuration["timeout_seconds"] = timeout
+    elif trial.agent.adapter == "deepseek_harness":
+        configuration["timeout_sec"] = timeout
+    output_path = task.task.verifier.expected_output_path
+    return AdapterRequest(
+        instruction=selected_instruction,
+        system_prompt=system_prompt,
+        tools=tools,
+        configuration=configuration,
+        output_path=output_path,
+        output_format="markdown" if Path(output_path).suffix.lower() == ".md" else "jsonl",
+    )
+
+
+__all__ = (
+    "apply_normalisation",
+    "execute_attempt",
+    "load_canonical_refs",
+    "validate_output_commit",
+    "write_agent_result",
+)

--- a/src/aec_bench/harness/artifact/recording.py
+++ b/src/aec_bench/harness/artifact/recording.py
@@ -1,0 +1,299 @@
+# ABOUTME: Builds canonical artifact trial records from validated attempts and receipts.
+# ABOUTME: Owns workspace evidence attachment, output retention, usage aggregation, and materialization.
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+import time
+from collections.abc import Callable
+from dataclasses import replace
+from pathlib import Path
+from typing import Protocol, cast
+
+from pydantic import BaseModel
+
+from aec_bench.adapters.base import AdapterResult
+from aec_bench.contracts.evaluation_result import EvaluationResult
+from aec_bench.contracts.resolved_run import ResolvedRunSpec
+from aec_bench.contracts.trial_extensions import VerifierExecutionReceipt
+from aec_bench.contracts.trial_record import EvaluationStatus, ExecutionStatus, PlannedTrialBinding, TrialRecord
+from aec_bench.harness.artifact.values import AttemptSelection, AttemptSelectionEvidence, TaskAttempt
+from aec_bench.harness.artifact.workspace_port import resolve_workspace_path
+from aec_bench.harness.trial_record_builder import build_trial_record
+from aec_bench.harness.workspace_evidence import WorkspaceDelta, WorkspaceManifest
+from aec_bench.ledger.writer import materialize_trial_record
+from aec_bench.tasks.instance import ResolvedTaskInstance
+from aec_bench.trials import PlannedTrial
+
+
+class RecordingRuntime(Protocol):
+    @property
+    def artifact_root(self) -> Path: ...
+
+    def task_revision(self, task: ResolvedTaskInstance) -> str: ...
+
+
+def _attach_workspace_delta(
+    *,
+    record: TrialRecord,
+    workspace: Path,
+    base_manifest: WorkspaceManifest,
+    final_manifest: WorkspaceManifest,
+    delta: WorkspaceDelta,
+    primary_output_path: str,
+    inherited_paths: frozenset[str] = frozenset(),
+) -> None:
+    """Retain declared outputs and meaningful actor changes, not unchanged inputs."""
+    named_paths = {
+        Path(value).resolve() for value, _media, _logical in record.pending_artifacts.values() if Path(value).is_file()
+    }
+    primary_relative = resolve_workspace_path(workspace, primary_output_path).relative_to(workspace).as_posix()
+    retained_paths = {str(item.relative_path) for item in delta.changed_files}
+    retained_paths.add(primary_relative)
+    retained_paths.update(inherited_paths)
+    for item in final_manifest.files:
+        if item.file_type != "file" or str(item.relative_path) not in retained_paths:
+            continue
+        path = workspace / item.relative_path
+        if path.resolve() in named_paths or item.size_bytes == 0:
+            continue
+        record.attach_artifact(
+            f"output:workspace:{item.relative_path}",
+            path,
+            media_type="application/octet-stream",
+            logical_path=item.relative_path,
+            expected_sha256=item.sha256,
+        )
+
+    attached_bytes = sum(
+        item.size_bytes
+        for item in final_manifest.files
+        if item.file_type == "file" and str(item.relative_path) in retained_paths and item.size_bytes > 0
+    )
+    final_manifest = final_manifest.model_copy(update={"bytes_attached": attached_bytes})
+    manifest_dir = workspace / ".workspace-manifests"
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    for name, value in (("base.json", base_manifest), ("final.json", final_manifest), ("delta.json", delta)):
+        path = manifest_dir / name
+        path.write_text(value.model_dump_json(indent=2) + "\n", encoding="utf-8")
+        record.attach_artifact(
+            f"output:workspace-manifest:{name.removesuffix('.json')}",
+            path,
+            media_type="application/json",
+            logical_path=f"workspace/{name}",
+        )
+
+
+def _attach_post_execution_files(*, record: TrialRecord, workspace: Path) -> None:
+    for root in (workspace / "logs" / "verifier", workspace / "logs" / "reviewer"):
+        if not root.is_dir():
+            continue
+        for path in sorted(candidate for candidate in root.rglob("*") if candidate.is_file()):
+            if path.stat().st_size == 0:
+                continue
+            relative = path.relative_to(workspace).as_posix()
+            record.attach_artifact(
+                f"output:evidence:{relative}",
+                path,
+                media_type="application/octet-stream",
+                logical_path=relative,
+            )
+
+
+def _existing_path(path: Path) -> str | None:
+    return str(path) if path.is_file() else None
+
+
+def _aggregate_attempt_usage(
+    *,
+    selected: AdapterResult,
+    attempts: list[TaskAttempt],
+    selection_evidence: AttemptSelectionEvidence | None = None,
+) -> AdapterResult:
+    usage_fields = (
+        "usage_model_calls",
+        "usage_input_tokens",
+        "usage_output_tokens",
+        "usage_cache_read_tokens",
+        "usage_cache_write_tokens",
+        "usage_advisor_calls",
+        "usage_advisor_input_tokens",
+        "usage_advisor_output_tokens",
+    )
+    updates: dict[str, int | None] = {}
+    selector_usage = None if selection_evidence is None else selection_evidence.selector
+    for field_name in usage_fields:
+        values = [getattr(attempt.result, field_name) for attempt in attempts]
+        selector_field = {
+            "usage_model_calls": "model_calls",
+            "usage_input_tokens": "input_tokens",
+            "usage_output_tokens": "output_tokens",
+            "usage_cache_read_tokens": "cache_read_tokens",
+            "usage_cache_write_tokens": "cache_write_tokens",
+        }.get(field_name)
+        selector_value = (
+            0 if selector_usage is None or selector_field is None else getattr(selector_usage, selector_field)
+        )
+        updates[field_name] = (
+            None
+            if all(value is None for value in values) and selector_value == 0
+            else sum(value or 0 for value in values) + selector_value
+        )
+    adapter_replace = cast(Callable[..., AdapterResult], replace)
+    return adapter_replace(selected, **updates)
+
+
+def build_materialized_record(
+    *,
+    runtime: RecordingRuntime,
+    task: ResolvedTaskInstance,
+    trial: PlannedTrial,
+    selected: TaskAttempt,
+    attempts: list[TaskAttempt],
+    evaluation: EvaluationResult,
+    started: float,
+    verification_seconds: float | None,
+    actor_snapshot: Path,
+    evidence_workspace: Path,
+    selection_evidence: AttemptSelectionEvidence | None = None,
+    verifier_receipt: VerifierExecutionReceipt | None = None,
+    evaluation_status: EvaluationStatus | None = None,
+    planned_trial_binding: PlannedTrialBinding | None = None,
+    planned_run_spec: ResolvedRunSpec | None = None,
+    base_workspace_manifest: WorkspaceManifest | None = None,
+    final_workspace_manifest: WorkspaceManifest | None = None,
+    workspace_delta: WorkspaceDelta | None = None,
+    inherited_paths: frozenset[str] = frozenset(),
+) -> TrialRecord:
+    output_path = resolve_workspace_path(actor_snapshot, task.task.verifier.expected_output_path)
+    record = build_trial_record(
+        trial_id=trial.trial_id,
+        experiment_id=(
+            trial.experiment_id if planned_run_spec is None else str(planned_run_spec.experiment_identity.id)
+        ),
+        task=task.task,
+        task_revision=runtime.task_revision(task),
+        request=selected.request,
+        result=_aggregate_attempt_usage(
+            selected=selected.result,
+            attempts=attempts,
+            selection_evidence=selection_evidence,
+        ),
+        evaluation=evaluation,
+        total_seconds=time.monotonic() - started,
+        agent_seconds=sum(attempt.elapsed_seconds for attempt in attempts),
+        verification_seconds=verification_seconds,
+        runtime_image="local",
+        compute_backend=trial.compute.backend,
+        raw_output_path=str(output_path) if output_path.is_file() else None,
+        conversation_path=_existing_path(actor_snapshot / "conversation.jsonl"),
+        trajectory_path=_existing_path(actor_snapshot / "trajectory.jsonl"),
+        attempt=1 if planned_trial_binding is not None else trial.repetition,
+        extensions=_trial_extensions(trial, selection_evidence, verifier_receipt),
+        evaluation_status=evaluation_status,
+        planned_trial_binding=planned_trial_binding,
+        run_id=None if planned_run_spec is None else str(planned_run_spec.run_identity.id),
+        dataset=None if planned_run_spec is None else planned_run_spec.dataset,
+        expected_authorities=() if planned_run_spec is None else planned_run_spec.expected_authorities,
+        evaluation_regime=None if planned_run_spec is None else planned_run_spec.evaluation_regime,
+    )
+    if base_workspace_manifest is None or final_workspace_manifest is None or workspace_delta is None:
+        raise ValueError("artifact record requires workspace manifests")
+    _attach_workspace_delta(
+        record=record,
+        workspace=actor_snapshot,
+        base_manifest=base_workspace_manifest,
+        final_manifest=final_workspace_manifest,
+        delta=workspace_delta,
+        primary_output_path=task.task.verifier.expected_output_path,
+        inherited_paths=inherited_paths,
+    )
+    _attach_post_execution_files(record=record, workspace=evidence_workspace)
+    return materialize_trial_record(artifact_root=runtime.artifact_root, record=record)
+
+
+def build_failed_materialized_record(
+    *,
+    runtime: RecordingRuntime,
+    task: ResolvedTaskInstance,
+    trial: PlannedTrial,
+    attempts: list[TaskAttempt],
+    selection: AttemptSelection,
+    started: float,
+    planned_trial_binding: PlannedTrialBinding | None = None,
+    planned_run_spec: ResolvedRunSpec | None = None,
+    base_workspace_manifest: WorkspaceManifest | None = None,
+    final_workspace_manifest: WorkspaceManifest | None = None,
+    workspace_delta: WorkspaceDelta | None = None,
+    inherited_paths: frozenset[str] = frozenset(),
+) -> TrialRecord:
+    representative = attempts[0]
+    record = build_trial_record(
+        trial_id=trial.trial_id,
+        experiment_id=(
+            trial.experiment_id if planned_run_spec is None else str(planned_run_spec.experiment_identity.id)
+        ),
+        task=task.task,
+        task_revision=runtime.task_revision(task),
+        request=representative.request,
+        result=_aggregate_attempt_usage(
+            selected=representative.result,
+            attempts=attempts,
+            selection_evidence=selection.evidence,
+        ),
+        evaluation=None,
+        total_seconds=time.monotonic() - started,
+        agent_seconds=sum(attempt.elapsed_seconds for attempt in attempts),
+        verification_seconds=None,
+        runtime_image="local",
+        compute_backend=trial.compute.backend,
+        attempt=1 if planned_trial_binding is not None else trial.repetition,
+        extensions=_trial_extensions(trial, selection.evidence),
+        execution_status_override=ExecutionStatus.FAILED,
+        # A failed execution can still contain useful actor files and workspace
+        # manifests. Keep a TrialOutput so those artifacts remain referenced.
+        include_output=True,
+        planned_trial_binding=planned_trial_binding,
+        run_id=None if planned_run_spec is None else str(planned_run_spec.run_identity.id),
+        dataset=None if planned_run_spec is None else planned_run_spec.dataset,
+        expected_authorities=() if planned_run_spec is None else planned_run_spec.expected_authorities,
+        evaluation_regime=None if planned_run_spec is None else planned_run_spec.evaluation_regime,
+    )
+    if base_workspace_manifest is None or final_workspace_manifest is None or workspace_delta is None:
+        raise ValueError("failed artifact record requires workspace manifests")
+    snapshot_dir = Path(tempfile.mkdtemp(prefix="aec-bench-failed-selected-", dir=runtime.artifact_root.parent))
+    try:
+        shutil.copytree(representative.workspace, snapshot_dir, dirs_exist_ok=True)
+        _attach_workspace_delta(
+            record=record,
+            workspace=snapshot_dir,
+            base_manifest=base_workspace_manifest,
+            final_manifest=final_workspace_manifest,
+            delta=workspace_delta,
+            primary_output_path=task.task.verifier.expected_output_path,
+            inherited_paths=inherited_paths,
+        )
+        return materialize_trial_record(artifact_root=runtime.artifact_root, record=record)
+    finally:
+        shutil.rmtree(snapshot_dir, ignore_errors=True)
+
+
+def _trial_extensions(
+    trial: PlannedTrial,
+    selection_evidence: AttemptSelectionEvidence | None,
+    verifier_receipt: VerifierExecutionReceipt | None = None,
+) -> dict[str, BaseModel]:
+    extensions = dict(trial.extensions)
+    if selection_evidence is not None:
+        if "attempt_selection" in extensions:
+            raise ValueError("planned trial extension conflicts with attempt selection evidence")
+        extensions["attempt_selection"] = selection_evidence
+    if verifier_receipt is not None:
+        if "verifier_execution" in extensions:
+            raise ValueError("planned trial extension conflicts with verifier execution evidence")
+        extensions["verifier_execution"] = verifier_receipt
+    return extensions
+
+
+__all__ = ("build_failed_materialized_record", "build_materialized_record")

--- a/src/aec_bench/harness/artifact/verification.py
+++ b/src/aec_bench/harness/artifact/verification.py
@@ -1,0 +1,224 @@
+# ABOUTME: Runs task-owned artifact verification and maps process truth to evaluation.
+# ABOUTME: Keeps verifier staging, receipts, feedback, and redacted execution evidence at one boundary.
+
+from __future__ import annotations
+
+import json
+import shutil
+import time
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from aec_bench.contracts.agent_output import AgentOutputStatus
+from aec_bench.contracts.evaluation_result import EvaluationResult, ValidityCheck
+from aec_bench.contracts.trial_extensions import VerifierExecutionReceipt
+from aec_bench.contracts.trial_record import EvaluationStatus
+from aec_bench.evaluation.verifier_outcome import map_verifier_execution
+from aec_bench.harness.artifact.values import TaskAttempt
+from aec_bench.harness.artifact.workspace_port import resolve_workspace_path
+from aec_bench.harness.local_runtime import stage_verifier_assets
+from aec_bench.harness.verifier_execution import (
+    VERIFIER_PROTOCOL_VERSION,
+    execute_verifier,
+    localise_staged_verifier_paths,
+)
+from aec_bench.tasks.instance import ResolvedTaskInstance
+
+_VERIFIER_RETRY_PROMPT = "verifier_retry_prompt.md"
+DEFAULT_VERIFIER_RETRY_TARGET_REWARD = 1.0
+_VERIFIER_RETRY_ARTIFACT_SUFFIXES = (
+    "_record.json",
+    "_decision.json",
+    "_readback_check.json",
+    "_notice.json",
+    "_report.json",
+    "_marker.json",
+)
+_VERIFIER_RETRY_EXCLUDED_PREFIXES = ("expected_", "input_", "prior_", "source_")
+
+
+def _read_optional_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="replace") if path.is_file() else ""
+
+
+def should_run_verifier_feedback_retry(
+    workspace: Path,
+    *,
+    reward: float | None,
+    target_reward: float,
+) -> bool:
+    return reward is not None and reward < target_reward and (workspace / _VERIFIER_RETRY_PROMPT).is_file()
+
+
+def build_verifier_retry_instruction(
+    *, workspace: Path, output_path: Path, base_instruction: str, reward: float
+) -> str:
+    verifier_dir = workspace / "logs" / "verifier"
+    retry_instruction = _read_optional_text(workspace / "verifier_retry_instruction.md").strip()
+    governing_instruction = retry_instruction or base_instruction.strip()
+    parts = [
+        governing_instruction,
+        "---",
+        "# Verifier Feedback Retry",
+        _read_optional_text(workspace / _VERIFIER_RETRY_PROMPT).strip(),
+        f"Previous verifier reward: `{reward:.4f}`.",
+        "The previous output was:",
+        "```markdown",
+        _read_optional_text(output_path).strip(),
+        "```",
+    ]
+    feedback = _read_optional_text(verifier_dir / "feedback.md").strip()
+    details = _read_optional_text(verifier_dir / "details.json").strip()
+    if feedback:
+        parts.extend(("The verifier feedback was:", "```markdown", feedback, "```"))
+    if details:
+        parts.extend(("The verifier detail scores were:", "```json", details, "```"))
+    parts.append(
+        "Repair the workspace now. You may overwrite the required output and any required side-effect files. "
+        "Do not merely describe files that should be written."
+    )
+    return "\n\n".join(part for part in parts if part)
+
+
+def _is_verifier_retry_side_effect(path: Path) -> bool:
+    return (
+        path.is_file()
+        and path.suffix == ".json"
+        and not path.name.startswith(_VERIFIER_RETRY_EXCLUDED_PREFIXES)
+        and path.name.endswith(_VERIFIER_RETRY_ARTIFACT_SUFFIXES)
+    )
+
+
+def _archive_verifier_retry_attempt(workspace: Path, output_path: Path, attempt_name: str) -> Path:
+    archive_dir = workspace / "logs" / "verifier" / "attempts" / attempt_name
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    for relative in (
+        "agent_result.json",
+        "trajectory.jsonl",
+        "conversation.jsonl",
+        "prime-events.jsonl",
+        "prime-stderr.log",
+        "prime-run.json",
+        "logs/verifier/reward.json",
+        "logs/verifier/details.json",
+        "logs/verifier/feedback.md",
+    ):
+        source = workspace / relative
+        if source.is_file():
+            shutil.copy2(source, archive_dir / source.name)
+    if output_path.is_file():
+        shutil.copy2(output_path, archive_dir / output_path.name)
+    prime_sessions = workspace / "logs" / "prime" / "sessions"
+    if prime_sessions.is_dir():
+        shutil.copytree(prime_sessions, archive_dir / "prime-sessions", dirs_exist_ok=True)
+    for source in sorted(workspace.iterdir()):
+        if _is_verifier_retry_side_effect(source):
+            artifact_dir = archive_dir / "artifacts"
+            artifact_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, artifact_dir / source.name)
+    return archive_dir
+
+
+def prepare_verifier_retry_workspace(*, workspace: Path, output_path: Path, attempt_name: str) -> Path:
+    archive_dir = _archive_verifier_retry_attempt(workspace, output_path, attempt_name)
+    output_path.unlink(missing_ok=True)
+    return archive_dir
+
+
+def write_verifier_retry_summary(workspace: Path, payload: Mapping[str, object]) -> None:
+    retry_path = workspace / "logs" / "verifier" / "retry.json"
+    retry_path.parent.mkdir(parents=True, exist_ok=True)
+    retry_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def evaluate_selected_attempt(
+    *, task: ResolvedTaskInstance, attempt: TaskAttempt, verify: bool
+) -> tuple[EvaluationResult, float | None, VerifierExecutionReceipt | None, EvaluationStatus | None]:
+    output_path = resolve_workspace_path(attempt.workspace, task.task.verifier.expected_output_path)
+    verifier_seconds = None
+    verifier_receipt = None
+    reward_payload: dict[str, Any] | None = None
+    details_payload: dict[str, Any] | None = None
+    if verify:
+        stage_verifier_assets(task.instance_dir, attempt.workspace)
+        started = time.monotonic()
+        transform_version = localise_staged_verifier_paths(
+            workspace=attempt.workspace,
+            verifier_root=attempt.workspace / "tests",
+        )
+        execution = execute_verifier(
+            verifier_path=attempt.workspace / task.task.verifier.script,
+            workspace=attempt.workspace,
+            output_path=output_path,
+            reward_path=resolve_workspace_path(attempt.workspace, task.task.verifier.reward_path),
+            details_path=(
+                None
+                if task.task.verifier.details_path is None
+                else resolve_workspace_path(attempt.workspace, task.task.verifier.details_path)
+            ),
+            verifier_key=f"{task.task.task_id}/verifier",
+            verifier_version=VERIFIER_PROTOCOL_VERSION,
+            runtime_transform_version=transform_version,
+        )
+        verifier_seconds = time.monotonic() - started
+        verifier_receipt = execution.receipt
+        reward_payload = execution.reward_payload
+        details_payload = execution.details_payload
+    verifier_completed = verifier_receipt is not None and verifier_receipt.completed
+    output_present = output_path.is_file()
+    valid_output = attempt.status is AgentOutputStatus.COMPLETED and output_present
+    reward = 0.0
+    breakdown = details_payload
+    errors: list[str] = []
+    if verifier_completed and reward_payload is not None:
+        reward = float(reward_payload["reward"])
+    elif not verify:
+        errors.append("verification was disabled")
+    elif verifier_receipt is not None:
+        errors.append(verifier_receipt.failure_message or "verifier did not complete successfully")
+    else:
+        errors.append("verifier did not run")
+    if not valid_output and reward != 0.0:
+        errors.append("verifier reward was ignored because the selected attempt has no valid output")
+        reward = 0.0
+    evaluation = EvaluationResult(
+        reward=reward,
+        validity=ValidityCheck(
+            output_parseable=valid_output,
+            schema_valid=valid_output,
+            verifier_completed=verifier_completed,
+            errors=errors,
+        ),
+        breakdown=breakdown,
+    )
+    if verifier_receipt is not None:
+        mapped = map_verifier_execution(
+            receipt=verifier_receipt,
+            evaluation=evaluation,
+            expected_verifier_key=f"{task.task.task_id}/verifier",
+            expected_verifier_version=VERIFIER_PROTOCOL_VERSION,
+        )
+        return mapped.evaluation, verifier_seconds, verifier_receipt, mapped.status
+    return evaluation, verifier_seconds, verifier_receipt, None
+
+
+def with_reviewer_summary(evaluation: EvaluationResult, workspace: Path) -> EvaluationResult:
+    summary_path = workspace / "logs" / "reviewer" / "summary.json"
+    if not summary_path.is_file():
+        return evaluation
+    payload = json.loads(summary_path.read_text(encoding="utf-8"))
+    breakdown = dict(evaluation.breakdown or {})
+    breakdown["llm_reviewer"] = payload
+    return evaluation.model_copy(update={"breakdown": breakdown})
+
+
+__all__ = (
+    "DEFAULT_VERIFIER_RETRY_TARGET_REWARD",
+    "build_verifier_retry_instruction",
+    "evaluate_selected_attempt",
+    "prepare_verifier_retry_workspace",
+    "should_run_verifier_feedback_retry",
+    "with_reviewer_summary",
+    "write_verifier_retry_summary",
+)

--- a/src/aec_bench/harness/artifact/workspace_port.py
+++ b/src/aec_bench/harness/artifact/workspace_port.py
@@ -1,0 +1,167 @@
+# ABOUTME: Owns filesystem operations for isolated artifact-task workspaces.
+# ABOUTME: Keeps materialization, forking, snapshots, deltas, export, and disposal in one boundary.
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Literal
+
+from aec_bench.harness.local_runtime import (
+    cleanup_workspace,
+    copy_validated_workspace,
+    patch_workspace_paths,
+    setup_workspace,
+)
+from aec_bench.harness.workspace_evidence import (
+    WorkspaceDelta,
+    WorkspaceManifest,
+    capture_workspace_manifest,
+    compare_workspace_manifests,
+)
+from aec_bench.tasks.instance import ResolvedTaskInstance
+
+WorkspaceSourceRole = Literal["task_input", "primary_output", "actor_output"]
+
+
+def resolve_workspace_path(workspace: Path, configured_path: str) -> Path:
+    """Resolve one configured artifact path below its attempt workspace."""
+    path = Path(configured_path)
+    if path.parts and path.parts[0] == "workspace":
+        path = Path(*path.parts[1:])
+    elif path.is_absolute() and path.parts[:2] == ("/", "workspace"):
+        path = Path(*path.parts[2:])
+    elif path.is_absolute() and path.parts[:2] == ("/", "logs"):
+        path = Path(*path.parts[1:])
+    elif path.is_absolute():
+        raise ValueError("task output path must resolve inside the attempt workspace")
+    candidate = (workspace / path).resolve()
+    if candidate != workspace.resolve() and workspace.resolve() not in candidate.parents:
+        raise ValueError("task output path must resolve inside the attempt workspace")
+    return candidate
+
+
+def materialize_base_workspace(
+    task: ResolvedTaskInstance,
+    *,
+    work_root: Path | None,
+    agent_files: dict[str, Path],
+) -> tuple[Path, WorkspaceManifest]:
+    """Copy one task instance into a fresh actor-visible workspace."""
+    if work_root is not None:
+        work_root.mkdir(parents=True, exist_ok=True)
+    capture_workspace_manifest(task.instance_dir, include_checksums=False)
+    workspace = Path(setup_workspace(str(task.instance_dir), work_root=work_root)).resolve()
+    for logical_path, source in agent_files.items():
+        destination = resolve_workspace_path(workspace, logical_path)
+        if source.is_symlink():
+            raise ValueError(f"agent configuration file must not be a symbolic link: {source}")
+        if not source.is_file():
+            raise FileNotFoundError(f"agent configuration file is missing: {source}")
+        if source.stat().st_nlink != 1:
+            raise ValueError(f"agent configuration file must not have shared inode state: {source}")
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+    patch_workspace_paths(str(workspace))
+    return workspace, capture_workspace_manifest(workspace)
+
+
+def fork_attempt_workspace(
+    parent_workspace: Path,
+    *,
+    base_manifest: WorkspaceManifest,
+    inherited_paths: frozenset[str],
+    work_root: Path | None,
+) -> tuple[Path, WorkspaceManifest, frozenset[str]]:
+    """Copy one attempt workspace without sharing mutable task or actor files."""
+    parent_snapshot = capture_workspace_manifest(parent_workspace)
+    parent_delta = compare_workspace_manifests(base_manifest, parent_snapshot)
+    parent_roles: dict[str, WorkspaceSourceRole] = {
+        str(item.relative_path): item.source_role for item in base_manifest.files
+    }
+    parent_roles.update({str(item.relative_path): "actor_output" for item in parent_delta.changed_files})
+    parent_manifest = capture_workspace_manifest(
+        parent_workspace,
+        source_roles=parent_roles,
+        default_source_role="actor_output",
+    )
+    workspace = Path(tempfile.mkdtemp(prefix="aec-bench-local-", dir=work_root)).resolve()
+    try:
+        copy_validated_workspace(parent_workspace, workspace)
+    except Exception:
+        cleanup_workspace(workspace)
+        raise
+    shutil.rmtree(workspace / "tests", ignore_errors=True)
+    shutil.rmtree(workspace / "logs" / "verifier", ignore_errors=True)
+    patch_workspace_paths(str(workspace), source_workspace=str(parent_workspace))
+    child_manifest = capture_workspace_manifest(
+        workspace,
+        source_roles=parent_roles,
+        default_source_role="actor_output",
+    )
+    retained_paths = inherited_paths | {str(item.relative_path) for item in parent_delta.changed_files}
+    child_inherited = frozenset(
+        str(item.relative_path)
+        for item in child_manifest.files
+        if item.source_role in {"actor_output", "primary_output"}
+        and any(parent_item.relative_path == item.relative_path for parent_item in parent_manifest.files)
+        and str(item.relative_path) in retained_paths
+    )
+    return workspace, child_manifest, child_inherited
+
+
+def export_selected_workspace(snapshot: Path, destination: Path) -> None:
+    """Atomically export the selected actor snapshot before verification changes it."""
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if destination.exists():
+        if not destination.is_dir() or any(destination.iterdir()):
+            raise ValueError(f"selected workspace export destination must be empty: {destination}")
+        destination.rmdir()
+    staging = Path(tempfile.mkdtemp(prefix=f".{destination.name}-", dir=destination.parent))
+    try:
+        shutil.copytree(snapshot, staging, dirs_exist_ok=True)
+        os.replace(staging, destination)
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+
+
+def capture_final_workspace_manifest(
+    workspace: Path,
+    base_manifest: WorkspaceManifest,
+    primary_output_path: str,
+) -> WorkspaceManifest:
+    """Capture final workspace facts while preserving task and actor roles."""
+    roles: dict[str, WorkspaceSourceRole] = {str(item.relative_path): item.source_role for item in base_manifest.files}
+    primary_relative = resolve_workspace_path(workspace, primary_output_path).relative_to(workspace).as_posix()
+    roles[primary_relative] = "primary_output"
+    return capture_workspace_manifest(
+        workspace,
+        source_roles=roles,
+        default_source_role="actor_output",
+        bytes_copied=0,
+    )
+
+
+def workspace_delta(base_manifest: WorkspaceManifest, final_manifest: WorkspaceManifest) -> WorkspaceDelta:
+    """Return exact added, modified, deleted, and unchanged workspace paths."""
+    return compare_workspace_manifests(base_manifest, final_manifest)
+
+
+def dispose_workspace(workspace: Path) -> None:
+    """Remove one temporary workspace and all of its child state."""
+    cleanup_workspace(workspace)
+
+
+__all__ = (
+    "WorkspaceSourceRole",
+    "capture_final_workspace_manifest",
+    "dispose_workspace",
+    "export_selected_workspace",
+    "fork_attempt_workspace",
+    "materialize_base_workspace",
+    "resolve_workspace_path",
+    "workspace_delta",
+)

--- a/src/aec_bench/harness/artifact_tasks.py
+++ b/src/aec_bench/harness/artifact_tasks.py
@@ -4,24 +4,18 @@
 from __future__ import annotations
 
 import hashlib
-import json
-import os
 import shutil
 import tempfile
 import time
 from collections.abc import Callable, Mapping, Sequence
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Literal, Protocol, cast
+from typing import Protocol, cast
 
-from pydantic import BaseModel
-
-from aec_bench.adapters.base import Adapter, AdapterRequest, AdapterResult
+from aec_bench.adapters.base import Adapter, AdapterResult
 from aec_bench.contracts.agent_output import AgentOutputStatus
 from aec_bench.contracts.artifacts import ArtifactRef
-from aec_bench.contracts.canonical_refs import CanonicalRefSet, parse_canonical_refs
-from aec_bench.contracts.evaluation_result import EvaluationResult, ValidityCheck
 from aec_bench.contracts.identity import (
     EntityIdentity,
     EntityKey,
@@ -35,16 +29,12 @@ from aec_bench.contracts.run_plan import AttemptRecipe as CanonicalAttemptRecipe
 from aec_bench.contracts.run_plan import BestOfAttemptRecipe, RunPlan
 from aec_bench.contracts.run_plan import PlannedTrial as CanonicalPlannedTrial
 from aec_bench.contracts.run_plan import SingleAttemptRecipe as CanonicalSingleAttemptRecipe
-from aec_bench.contracts.task_definition import ToolSpec
-from aec_bench.contracts.trial_extensions import ArtifactReference, VerifierExecutionReceipt
+from aec_bench.contracts.trial_extensions import VerifierExecutionReceipt
 from aec_bench.contracts.trial_record import (
-    EvaluationStatus,
     ExecutionStatus,
     PlannedTrialBinding,
     TrialRecord,
 )
-from aec_bench.evaluation.normalisation import NormalisationResult, normalise_output
-from aec_bench.evaluation.verifier_outcome import map_verifier_execution
 from aec_bench.execution.models import (
     AttemptProcessStatus,
     AttemptReceipt,
@@ -59,6 +49,7 @@ from aec_bench.execution.models import (
     WorkerOutcome,
 )
 from aec_bench.execution.operational import AttemptRecord, OperationalStore, WorkItemRecord
+from aec_bench.harness.artifact.execution import execute_attempt
 from aec_bench.harness.artifact.recipes import (
     AttemptRecipe,
     AttemptRunner,
@@ -67,54 +58,47 @@ from aec_bench.harness.artifact.recipes import (
     self_select,
     single_attempt,
 )
+from aec_bench.harness.artifact.recording import (
+    build_failed_materialized_record,
+    build_materialized_record,
+)
 from aec_bench.harness.artifact.values import AttemptSelection, AttemptSelectionEvidence, TaskAttempt
+from aec_bench.harness.artifact.verification import (
+    DEFAULT_VERIFIER_RETRY_TARGET_REWARD,
+    build_verifier_retry_instruction,
+    evaluate_selected_attempt,
+    prepare_verifier_retry_workspace,
+    should_run_verifier_feedback_retry,
+    with_reviewer_summary,
+    write_verifier_retry_summary,
+)
+from aec_bench.harness.artifact.workspace_port import (
+    capture_final_workspace_manifest,
+    dispose_workspace,
+    export_selected_workspace,
+    fork_attempt_workspace,
+    materialize_base_workspace,
+    resolve_workspace_path,
+)
+from aec_bench.harness.artifact.workspace_port import (
+    workspace_delta as build_workspace_delta,
+)
 from aec_bench.harness.compilation.task_snapshot import TaskSnapshotError, assert_task_snapshot_matches_directory
-from aec_bench.harness.local_runtime import (
-    cleanup_workspace,
-    patch_workspace_paths,
-    read_instruction,
-    setup_workspace,
-    stage_verifier_assets,
-)
 from aec_bench.harness.model_execution.llm_reviewer import ReviewerRunConfig, run_workspace_reviewer
-from aec_bench.harness.trial_record_builder import build_trial_record
-from aec_bench.harness.verifier_execution import (
-    VERIFIER_PROTOCOL_VERSION,
-    execute_verifier,
-    localise_staged_verifier_paths,
-)
-from aec_bench.harness.workspace_evidence import (
-    WorkspaceDelta,
-    WorkspaceManifest,
-    capture_workspace_manifest,
-    compare_workspace_manifests,
-)
+from aec_bench.harness.workspace_evidence import WorkspaceManifest
 from aec_bench.ledger.artifact_repository import ArtifactRepository
 from aec_bench.ledger.evidence_run_store import EvidenceRunStore
 from aec_bench.ledger.writer import (
     DuplicateAppendOnlyFileError,
     DuplicateTrialRecordError,
-    materialize_trial_record,
     write_append_only_json_at,
     write_trial_record_at,
 )
 from aec_bench.tasks.instance import ResolvedTaskInstance
 from aec_bench.tasks.snapshot import build_task_snapshot_archive
-from aec_bench.trajectory.writer import TrajectoryWriter
 from aec_bench.trials import PlannedTrial
 
 AdapterBuilder = Callable[..., Adapter]
-_VERIFIER_RETRY_PROMPT = "verifier_retry_prompt.md"
-_VERIFIER_RETRY_TARGET_REWARD = 1.0
-_VERIFIER_RETRY_ARTIFACT_SUFFIXES = (
-    "_record.json",
-    "_decision.json",
-    "_readback_check.json",
-    "_notice.json",
-    "_report.json",
-    "_marker.json",
-)
-_VERIFIER_RETRY_EXCLUDED_PREFIXES = ("expected_", "input_", "prior_", "source_")
 
 
 class ImportedExperimentRuntime(Protocol):
@@ -250,189 +234,41 @@ class LocalTaskRuntime:
         parent_attempt_id: str | None,
         instruction: str | None,
     ) -> TaskAttempt:
-        request = self._build_request(task=task, trial=trial, workspace=workspace, instruction=instruction)
-        adapter = self._build_adapter(trial=trial, workspace=workspace)
-        started = time.monotonic()
-        result = adapter.execute(request)
-        elapsed_seconds = time.monotonic() - started
-
-        output_path = resolve_workspace_path(workspace, task.task.verifier.expected_output_path)
-        output_source = "adapter"
-        if output_path.is_file() and output_path.read_text(encoding="utf-8", errors="replace").strip():
-            output_source = "direct_write"
-        elif result.raw_output_text:
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-            output_path.write_text(result.raw_output_text, encoding="utf-8")
-            output_source = "raw_output"
-
-        if self._normalise and output_path.is_file():
-            refs = load_canonical_refs(task.instance_dir / "task.toml")
-            if refs.refs:
-                apply_normalisation(
-                    output_path,
-                    refs,
-                    workspace / "normalisation_report.json",
-                    committed_result=result,
-                )
-        validate_output_commit(
-            result=result, output_path=output_path, expected_output_path=task.task.verifier.expected_output_path
-        )
-        _write_agent_result(
+        return execute_attempt(
+            task=task,
+            trial=trial,
             workspace=workspace,
-            requested_model=trial.agent.model,
-            adapter_kind=trial.agent.adapter,
-            result=result,
-            output_source=output_source,
-        )
-        selector_visible_output = output_path.read_bytes() if output_path.is_file() else None
-        output_reference = (
-            ArtifactReference(
-                kind="primary_output",
-                path=request.output_path,
-                sha256=hashlib.sha256(selector_visible_output).hexdigest(),
-                media_type="application/octet-stream",
-            )
-            if selector_visible_output
-            else None
-        )
-        return TaskAttempt(
             attempt_id=attempt_id,
-            trial_id=trial.trial_id,
             parent_attempt_id=parent_attempt_id,
-            workspace=workspace,
-            request=request,
-            result=result,
-            elapsed_seconds=elapsed_seconds,
-            selector_visible_output=selector_visible_output,
-            output_reference=output_reference,
+            instruction=instruction,
+            adapter_builder=self._adapter_builder,
+            constitutional_model=self._constitutional_model,
+            normalise=self._normalise,
         )
 
     def _create_workspace(self, *, task: ResolvedTaskInstance, parent: TaskAttempt | None) -> Path:
         if self._work_root is not None:
             self._work_root.mkdir(parents=True, exist_ok=True)
         if parent is None:
-            capture_workspace_manifest(task.instance_dir, include_checksums=False)
-            workspace = Path(setup_workspace(str(task.instance_dir), work_root=self._work_root)).resolve()
-            self._copy_agent_files(workspace)
-            patch_workspace_paths(str(workspace))
-            self._workspace_manifests[workspace] = capture_workspace_manifest(workspace)
+            workspace, manifest = materialize_base_workspace(
+                task,
+                work_root=self._work_root,
+                agent_files=self._agent_files,
+            )
+            self._workspace_manifests[workspace] = manifest
             self._workspace_inherited_paths[workspace] = set()
             return workspace
 
         parent_base = self.base_workspace_manifest(parent.workspace)
-        parent_snapshot = capture_workspace_manifest(parent.workspace)
-        parent_delta = compare_workspace_manifests(parent_base, parent_snapshot)
-        parent_roles: dict[str, Literal["task_input", "primary_output", "actor_output"]] = {
-            str(item.relative_path): item.source_role for item in parent_base.files
-        }
-        parent_roles.update({str(item.relative_path): "actor_output" for item in parent_delta.changed_files})
-        parent_manifest = capture_workspace_manifest(
+        workspace, child_manifest, inherited = fork_attempt_workspace(
             parent.workspace,
-            source_roles=parent_roles,
-            default_source_role="actor_output",
-        )
-        workspace = Path(tempfile.mkdtemp(prefix="aec-bench-local-", dir=self._work_root)).resolve()
-        shutil.copytree(parent.workspace, workspace, dirs_exist_ok=True)
-        shutil.rmtree(workspace / "tests", ignore_errors=True)
-        shutil.rmtree(workspace / "logs" / "verifier", ignore_errors=True)
-        patch_workspace_paths(str(workspace), source_workspace=str(parent.workspace))
-        child_manifest = capture_workspace_manifest(
-            workspace,
-            source_roles=parent_roles,
-            default_source_role="actor_output",
+            base_manifest=parent_base,
+            inherited_paths=self.inherited_workspace_paths(parent.workspace),
+            work_root=self._work_root,
         )
         self._workspace_manifests[workspace] = child_manifest
-        inherited_paths = self.inherited_workspace_paths(parent.workspace) | {
-            str(item.relative_path) for item in parent_delta.changed_files
-        }
-        self._workspace_inherited_paths[workspace] = {
-            str(item.relative_path)
-            for item in child_manifest.files
-            if item.source_role in {"actor_output", "primary_output"}
-            and any(parent_item.relative_path == item.relative_path for parent_item in parent_manifest.files)
-            and str(item.relative_path) in inherited_paths
-        }
+        self._workspace_inherited_paths[workspace] = set(inherited)
         return workspace
-
-    def _copy_agent_files(self, workspace: Path) -> None:
-        for logical_path, source in self._agent_files.items():
-            destination = resolve_workspace_path(workspace, logical_path)
-            if source.is_symlink():
-                raise ValueError(f"agent configuration file must not be a symbolic link: {source}")
-            if not source.is_file():
-                raise FileNotFoundError(f"agent configuration file is missing: {source}")
-            if source.stat().st_nlink != 1:
-                raise ValueError(f"agent configuration file must not have shared inode state: {source}")
-            destination.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(source, destination)
-
-    def _build_adapter(self, *, trial: PlannedTrial, workspace: Path) -> Adapter:
-        builder = self._adapter_builder
-        if builder is None:
-            from aec_bench.adapters.local_registry import build_local_adapter
-
-            builder = build_local_adapter
-        trajectory_writer = TrajectoryWriter(path=str(workspace / "trajectory.jsonl"))
-        return builder(
-            adapter_kind=trial.agent.adapter,
-            model_name=trial.agent.model,
-            workspace=str(workspace),
-            trajectory_writer=trajectory_writer,
-            constitutional_model=self._constitutional_model,
-        )
-
-    def _build_request(
-        self,
-        *,
-        task: ResolvedTaskInstance,
-        trial: PlannedTrial,
-        workspace: Path,
-        instruction: str | None,
-    ) -> AdapterRequest:
-        selected_instruction = instruction if instruction is not None else read_instruction(str(workspace))
-        if not selected_instruction:
-            raise ValueError("task workspace does not contain an instruction")
-        system_prompt = trial.agent.system_prompt
-        if trial.agent.system_prompt_file is not None:
-            system_prompt = resolve_workspace_path(workspace, trial.agent.system_prompt_file).read_text(
-                encoding="utf-8"
-            )
-        tools: list[ToolSpec] = []
-        if trial.agent.adapter == "tool_loop":
-            tools = [ToolSpec(name="bash", source="builtin", description="Execute a bash command in the workspace")]
-        configuration = dict(trial.agent.parameters)
-        timeout = trial.compute.timeout_override or task.task.timeout_seconds
-        if trial.agent.adapter == "prime-agent":
-            configuration["timeout_seconds"] = timeout
-        elif trial.agent.adapter == "deepseek_harness":
-            configuration["timeout_sec"] = timeout
-        output_path = task.task.verifier.expected_output_path
-        return AdapterRequest(
-            instruction=selected_instruction,
-            system_prompt=system_prompt,
-            tools=tools,
-            configuration=configuration,
-            output_path=output_path,
-            output_format="markdown" if Path(output_path).suffix.lower() == ".md" else "jsonl",
-        )
-
-
-def resolve_workspace_path(workspace: Path, configured_path: str) -> Path:
-    """Resolve one configured artifact path below its attempt workspace."""
-
-    path = Path(configured_path)
-    if path.parts and path.parts[0] == "workspace":
-        path = Path(*path.parts[1:])
-    elif path.is_absolute() and path.parts[:2] == ("/", "workspace"):
-        path = Path(*path.parts[2:])
-    elif path.is_absolute() and path.parts[:2] == ("/", "logs"):
-        path = Path(*path.parts[1:])
-    elif path.is_absolute():
-        raise ValueError("task output path must resolve inside the attempt workspace")
-    candidate = (workspace / path).resolve()
-    if candidate != workspace.resolve() and workspace.resolve() not in candidate.parents:
-        raise ValueError("task output path must resolve inside the attempt workspace")
-    return candidate
 
 
 class ArtifactTrialAdapterError(RuntimeError):
@@ -831,91 +667,6 @@ class ArtifactTrialAdapter:
             target.publish_bytes(data=source.read_bytes(reference), media_type=reference.media_type)
 
 
-def load_canonical_refs(task_toml_path: Path) -> CanonicalRefSet:
-    if not task_toml_path.exists():
-        return CanonicalRefSet()
-    import tomllib
-
-    data = tomllib.loads(task_toml_path.read_text(encoding="utf-8"))
-    return parse_canonical_refs(data.get("canonical_refs", {}))
-
-
-def apply_normalisation(
-    output_path: Path,
-    refs: CanonicalRefSet,
-    report_path: Path,
-    *,
-    committed_result: AdapterResult | None = None,
-) -> NormalisationResult:
-    text = output_path.read_text(encoding="utf-8")
-    result = normalise_output(text, refs)
-    if result.substitutions_count == 0:
-        return result
-    if committed_result is not None and committed_result.completion_commit is not None:
-        raise ValueError("canonical-reference normalisation cannot change committed output bytes")
-    output_path.write_text(result.normalised, encoding="utf-8")
-    report_path.write_text(
-        json.dumps(
-            {
-                "substitutions_count": result.substitutions_count,
-                "audit_log": [
-                    {
-                        "matched_text": match.matched_text,
-                        "canonical_value": match.canonical_value,
-                        "distance": match.distance,
-                        "count": match.count,
-                    }
-                    for match in result.audit_log
-                ],
-            },
-            indent=2,
-        ),
-        encoding="utf-8",
-    )
-    return result
-
-
-def validate_output_commit(*, result: AdapterResult, output_path: Path, expected_output_path: str) -> None:
-    attestation = result.completion_commit
-    if attestation is None:
-        return
-    if attestation.output_path != expected_output_path:
-        raise ValueError("output commit path does not match the task expected output path")
-    content = output_path.read_bytes()
-    if hashlib.sha256(content).hexdigest() != attestation.output_sha256:
-        raise ValueError("output commit SHA-256 does not match the attempt output")
-    if len(content) != attestation.output_size_bytes:
-        raise ValueError("output commit byte size does not match the attempt output")
-
-
-def _write_agent_result(
-    *,
-    workspace: Path,
-    requested_model: str,
-    adapter_kind: str,
-    result: AdapterResult,
-    output_source: str,
-) -> None:
-    payload = {
-        "status": result.agent_output.status.value,
-        "model": requested_model,
-        "resolved_model": result.resolved_model,
-        "adapter": adapter_kind,
-        "adapter_configuration": result.configuration_record,
-        "model_calls": result.usage_model_calls,
-        "input_tokens": result.usage_input_tokens,
-        "output_tokens": result.usage_output_tokens,
-        "cache_read_tokens": result.usage_cache_read_tokens,
-        "cache_write_tokens": result.usage_cache_write_tokens,
-        "turns_used": result.turns_used,
-        "max_turns": result.max_turns,
-        "failure_kind": result.failure_kind.value if result.failure_kind is not None else None,
-        "provider_error": result.provider_error,
-        "output_source": output_source,
-    }
-    (workspace / "agent_result.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
-
-
 def run_trial(
     *,
     runtime: LocalTaskRuntime,
@@ -976,10 +727,10 @@ def run_trial(
                 .as_posix()
             )
             base_manifest = runtime.base_workspace_manifest(representative.workspace)
-            final_manifest = _capture_final_workspace_manifest(
+            final_manifest = capture_final_workspace_manifest(
                 representative.workspace, base_manifest, output_relative_path
             )
-            return _build_failed_materialized_record(
+            return build_failed_materialized_record(
                 runtime=runtime,
                 task=task,
                 trial=trial,
@@ -990,7 +741,7 @@ def run_trial(
                 planned_run_spec=planned_run_spec,
                 base_workspace_manifest=base_manifest,
                 final_workspace_manifest=final_manifest,
-                workspace_delta=compare_workspace_manifests(base_manifest, final_manifest),
+                workspace_delta=build_workspace_delta(base_manifest, final_manifest),
                 inherited_paths=runtime.inherited_workspace_paths(representative.workspace),
             )
         if all(selected is not item for item in attempts):
@@ -1002,13 +753,13 @@ def run_trial(
             .as_posix()
         )
         base_manifest = runtime.base_workspace_manifest(selected.workspace)
-        final_manifest = _capture_final_workspace_manifest(selected.workspace, base_manifest, output_relative_path)
-        workspace_delta = compare_workspace_manifests(base_manifest, final_manifest)
+        final_manifest = capture_final_workspace_manifest(selected.workspace, base_manifest, output_relative_path)
+        workspace_delta = build_workspace_delta(base_manifest, final_manifest)
         snapshot_dir = Path(tempfile.mkdtemp(prefix="aec-bench-selected-", dir=runtime.artifact_root.parent))
         shutil.copytree(selected.workspace, snapshot_dir, dirs_exist_ok=True)
         if selected_workspace_export is not None:
-            _export_selected_workspace(snapshot_dir, selected_workspace_export)
-        evaluation, verification_seconds, verifier_receipt, evaluation_status = _evaluate_selected_attempt(
+            export_selected_workspace(snapshot_dir, selected_workspace_export)
+        evaluation, verification_seconds, verifier_receipt, evaluation_status = evaluate_selected_attempt(
             task=task,
             attempt=selected,
             verify=verify,
@@ -1021,9 +772,9 @@ def run_trial(
             )
             if review_result.status != "complete" and reviewer.fail_on_error:
                 raise RuntimeError(f"workspace reviewer failed: {review_result.status}")
-            evaluation = _with_reviewer_summary(evaluation, selected.workspace)
+            evaluation = with_reviewer_summary(evaluation, selected.workspace)
 
-        return _build_materialized_record(
+        return build_materialized_record(
             runtime=runtime,
             task=task,
             trial=trial,
@@ -1049,25 +800,8 @@ def run_trial(
             shutil.rmtree(snapshot_dir, ignore_errors=True)
         if not keep_workspaces:
             for workspace in runtime.attempt_workspaces[first_workspace_index:]:
-                cleanup_workspace(workspace)
+                dispose_workspace(workspace)
                 runtime.release_workspace(workspace)
-
-
-def _export_selected_workspace(snapshot: Path, destination: Path) -> None:
-    """Atomically export the exact actor snapshot before verification changes the workspace."""
-
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    if destination.exists():
-        if not destination.is_dir() or any(destination.iterdir()):
-            raise ValueError(f"selected workspace export destination must be empty: {destination}")
-        destination.rmdir()
-    staging = Path(tempfile.mkdtemp(prefix=f".{destination.name}-", dir=destination.parent))
-    try:
-        shutil.copytree(snapshot, staging, dirs_exist_ok=True)
-        os.replace(staging, destination)
-    except Exception:
-        shutil.rmtree(staging, ignore_errors=True)
-        raise
 
 
 def run_experiment(
@@ -1263,7 +997,7 @@ def run_trial_with_verifier_feedback(
     trial: PlannedTrial,
     reviewer: ReviewerRunConfig | None = None,
     keep_workspace: bool = False,
-    target_reward: float = _VERIFIER_RETRY_TARGET_REWARD,
+    target_reward: float = DEFAULT_VERIFIER_RETRY_TARGET_REWARD,
 ) -> TrialRecord:
     """Run one optional reward-aware second pass in the first attempt workspace."""
 
@@ -1280,13 +1014,13 @@ def run_trial_with_verifier_feedback(
             .as_posix()
         )
         base_manifest = runtime.base_workspace_manifest(first.workspace)
-        final_manifest = _capture_final_workspace_manifest(first.workspace, base_manifest, output_relative_path)
+        final_manifest = capture_final_workspace_manifest(first.workspace, base_manifest, output_relative_path)
         (
             initial_evaluation,
             first_verification_seconds,
             first_verifier_receipt,
             first_evaluation_status,
-        ) = _evaluate_selected_attempt(
+        ) = evaluate_selected_attempt(
             task=task,
             attempt=first,
             verify=True,
@@ -1295,18 +1029,18 @@ def run_trial_with_verifier_feedback(
         evaluation = initial_evaluation
         verification_seconds = first_verification_seconds
 
-        if _should_run_verifier_feedback_retry(
+        if should_run_verifier_feedback_retry(
             first.workspace,
             reward=initial_evaluation.reward,
             target_reward=target_reward,
         ):
-            retry_instruction = _build_verifier_retry_instruction(
+            retry_instruction = build_verifier_retry_instruction(
                 workspace=first.workspace,
                 output_path=resolve_workspace_path(first.workspace, task.task.verifier.expected_output_path),
                 base_instruction=first.request.instruction,
                 reward=initial_evaluation.reward,
             )
-            _prepare_verifier_retry_workspace(
+            prepare_verifier_retry_workspace(
                 workspace=first.workspace,
                 output_path=resolve_workspace_path(first.workspace, task.task.verifier.expected_output_path),
                 attempt_name="attempt-01",
@@ -1329,16 +1063,16 @@ def run_trial_with_verifier_feedback(
                 instruction=retry_instruction,
             )
             attempts.append(selected)
-            final_manifest = _capture_final_workspace_manifest(selected.workspace, base_manifest, output_relative_path)
+            final_manifest = capture_final_workspace_manifest(selected.workspace, base_manifest, output_relative_path)
             snapshot_dir = Path(tempfile.mkdtemp(prefix="aec-bench-selected-", dir=runtime.artifact_root.parent))
             shutil.copytree(selected.workspace, snapshot_dir, dirs_exist_ok=True)
-            evaluation, second_verification_seconds, verifier_receipt, evaluation_status = _evaluate_selected_attempt(
+            evaluation, second_verification_seconds, verifier_receipt, evaluation_status = evaluate_selected_attempt(
                 task=task,
                 attempt=selected,
                 verify=True,
             )
             verification_seconds = (first_verification_seconds or 0.0) + (second_verification_seconds or 0.0)
-            _write_verifier_retry_summary(
+            write_verifier_retry_summary(
                 selected.workspace,
                 {
                     "performed": True,
@@ -1362,9 +1096,9 @@ def run_trial_with_verifier_feedback(
             )
             if review_result.status != "complete" and reviewer.fail_on_error:
                 raise RuntimeError(f"workspace reviewer failed: {review_result.status}")
-            evaluation = _with_reviewer_summary(evaluation, selected.workspace)
+            evaluation = with_reviewer_summary(evaluation, selected.workspace)
 
-        return _build_materialized_record(
+        return build_materialized_record(
             runtime=runtime,
             task=task,
             trial=trial,
@@ -1379,7 +1113,7 @@ def run_trial_with_verifier_feedback(
             evaluation_status=evaluation_status,
             base_workspace_manifest=base_manifest,
             final_workspace_manifest=final_manifest,
-            workspace_delta=compare_workspace_manifests(base_manifest, final_manifest),
+            workspace_delta=build_workspace_delta(base_manifest, final_manifest),
             inherited_paths=runtime.inherited_workspace_paths(selected.workspace),
         )
     finally:
@@ -1387,471 +1121,8 @@ def run_trial_with_verifier_feedback(
             shutil.rmtree(snapshot_dir, ignore_errors=True)
         if not keep_workspace:
             for workspace in runtime.attempt_workspaces[first_workspace_index:]:
-                cleanup_workspace(workspace)
+                dispose_workspace(workspace)
                 runtime.release_workspace(workspace)
-
-
-def _build_materialized_record(
-    *,
-    runtime: LocalTaskRuntime,
-    task: ResolvedTaskInstance,
-    trial: PlannedTrial,
-    selected: TaskAttempt,
-    attempts: list[TaskAttempt],
-    evaluation: EvaluationResult,
-    started: float,
-    verification_seconds: float | None,
-    actor_snapshot: Path,
-    evidence_workspace: Path,
-    selection_evidence: AttemptSelectionEvidence | None = None,
-    verifier_receipt: VerifierExecutionReceipt | None = None,
-    evaluation_status: EvaluationStatus | None = None,
-    planned_trial_binding: PlannedTrialBinding | None = None,
-    planned_run_spec: ResolvedRunSpec | None = None,
-    base_workspace_manifest: WorkspaceManifest | None = None,
-    final_workspace_manifest: WorkspaceManifest | None = None,
-    workspace_delta: WorkspaceDelta | None = None,
-    inherited_paths: frozenset[str] = frozenset(),
-) -> TrialRecord:
-    output_path = resolve_workspace_path(actor_snapshot, task.task.verifier.expected_output_path)
-    record = build_trial_record(
-        trial_id=trial.trial_id,
-        experiment_id=(
-            trial.experiment_id if planned_run_spec is None else str(planned_run_spec.experiment_identity.id)
-        ),
-        task=task.task,
-        task_revision=runtime.task_revision(task),
-        request=selected.request,
-        result=_aggregate_attempt_usage(
-            selected=selected.result,
-            attempts=attempts,
-            selection_evidence=selection_evidence,
-        ),
-        evaluation=evaluation,
-        total_seconds=time.monotonic() - started,
-        agent_seconds=sum(attempt.elapsed_seconds for attempt in attempts),
-        verification_seconds=verification_seconds,
-        runtime_image="local",
-        compute_backend=trial.compute.backend,
-        raw_output_path=str(output_path) if output_path.is_file() else None,
-        conversation_path=_existing_path(actor_snapshot / "conversation.jsonl"),
-        trajectory_path=_existing_path(actor_snapshot / "trajectory.jsonl"),
-        attempt=1 if planned_trial_binding is not None else trial.repetition,
-        extensions=_trial_extensions(trial, selection_evidence, verifier_receipt),
-        evaluation_status=evaluation_status,
-        planned_trial_binding=planned_trial_binding,
-        run_id=None if planned_run_spec is None else str(planned_run_spec.run_identity.id),
-        dataset=None if planned_run_spec is None else planned_run_spec.dataset,
-        expected_authorities=() if planned_run_spec is None else planned_run_spec.expected_authorities,
-        evaluation_regime=None if planned_run_spec is None else planned_run_spec.evaluation_regime,
-    )
-    if base_workspace_manifest is None or final_workspace_manifest is None or workspace_delta is None:
-        raise ValueError("artifact record requires workspace manifests")
-    _attach_workspace_delta(
-        record=record,
-        workspace=actor_snapshot,
-        base_manifest=base_workspace_manifest,
-        final_manifest=final_workspace_manifest,
-        delta=workspace_delta,
-        primary_output_path=task.task.verifier.expected_output_path,
-        inherited_paths=inherited_paths,
-    )
-    _attach_post_execution_files(record=record, workspace=evidence_workspace)
-    return materialize_trial_record(artifact_root=runtime.artifact_root, record=record)
-
-
-def _build_failed_materialized_record(
-    *,
-    runtime: LocalTaskRuntime,
-    task: ResolvedTaskInstance,
-    trial: PlannedTrial,
-    attempts: list[TaskAttempt],
-    selection: AttemptSelection,
-    started: float,
-    planned_trial_binding: PlannedTrialBinding | None = None,
-    planned_run_spec: ResolvedRunSpec | None = None,
-    base_workspace_manifest: WorkspaceManifest | None = None,
-    final_workspace_manifest: WorkspaceManifest | None = None,
-    workspace_delta: WorkspaceDelta | None = None,
-    inherited_paths: frozenset[str] = frozenset(),
-) -> TrialRecord:
-    representative = attempts[0]
-    record = build_trial_record(
-        trial_id=trial.trial_id,
-        experiment_id=(
-            trial.experiment_id if planned_run_spec is None else str(planned_run_spec.experiment_identity.id)
-        ),
-        task=task.task,
-        task_revision=runtime.task_revision(task),
-        request=representative.request,
-        result=_aggregate_attempt_usage(
-            selected=representative.result,
-            attempts=attempts,
-            selection_evidence=selection.evidence,
-        ),
-        evaluation=None,
-        total_seconds=time.monotonic() - started,
-        agent_seconds=sum(attempt.elapsed_seconds for attempt in attempts),
-        verification_seconds=None,
-        runtime_image="local",
-        compute_backend=trial.compute.backend,
-        attempt=1 if planned_trial_binding is not None else trial.repetition,
-        extensions=_trial_extensions(trial, selection.evidence),
-        execution_status_override=ExecutionStatus.FAILED,
-        # A failed execution can still contain useful actor files and workspace
-        # manifests. Keep a TrialOutput so those artifacts remain referenced.
-        include_output=True,
-        planned_trial_binding=planned_trial_binding,
-        run_id=None if planned_run_spec is None else str(planned_run_spec.run_identity.id),
-        dataset=None if planned_run_spec is None else planned_run_spec.dataset,
-        expected_authorities=() if planned_run_spec is None else planned_run_spec.expected_authorities,
-        evaluation_regime=None if planned_run_spec is None else planned_run_spec.evaluation_regime,
-    )
-    if base_workspace_manifest is None or final_workspace_manifest is None or workspace_delta is None:
-        raise ValueError("failed artifact record requires workspace manifests")
-    snapshot_dir = Path(tempfile.mkdtemp(prefix="aec-bench-failed-selected-", dir=runtime.artifact_root.parent))
-    try:
-        shutil.copytree(representative.workspace, snapshot_dir, dirs_exist_ok=True)
-        _attach_workspace_delta(
-            record=record,
-            workspace=snapshot_dir,
-            base_manifest=base_workspace_manifest,
-            final_manifest=final_workspace_manifest,
-            delta=workspace_delta,
-            primary_output_path=task.task.verifier.expected_output_path,
-            inherited_paths=inherited_paths,
-        )
-        return materialize_trial_record(artifact_root=runtime.artifact_root, record=record)
-    finally:
-        shutil.rmtree(snapshot_dir, ignore_errors=True)
-
-
-def _trial_extensions(
-    trial: PlannedTrial,
-    selection_evidence: AttemptSelectionEvidence | None,
-    verifier_receipt: VerifierExecutionReceipt | None = None,
-) -> dict[str, BaseModel]:
-    extensions = dict(trial.extensions)
-    if selection_evidence is not None:
-        if "attempt_selection" in extensions:
-            raise ValueError("planned trial extension conflicts with attempt selection evidence")
-        extensions["attempt_selection"] = selection_evidence
-    if verifier_receipt is not None:
-        if "verifier_execution" in extensions:
-            raise ValueError("planned trial extension conflicts with verifier execution evidence")
-        extensions["verifier_execution"] = verifier_receipt
-    return extensions
-
-
-def _read_optional_text(path: Path) -> str:
-    return path.read_text(encoding="utf-8", errors="replace") if path.is_file() else ""
-
-
-def _should_run_verifier_feedback_retry(
-    workspace: Path,
-    *,
-    reward: float | None,
-    target_reward: float,
-) -> bool:
-    return reward is not None and reward < target_reward and (workspace / _VERIFIER_RETRY_PROMPT).is_file()
-
-
-def _build_verifier_retry_instruction(
-    *, workspace: Path, output_path: Path, base_instruction: str, reward: float
-) -> str:
-    verifier_dir = workspace / "logs" / "verifier"
-    retry_instruction = _read_optional_text(workspace / "verifier_retry_instruction.md").strip()
-    governing_instruction = retry_instruction or base_instruction.strip()
-    parts = [
-        governing_instruction,
-        "---",
-        "# Verifier Feedback Retry",
-        _read_optional_text(workspace / _VERIFIER_RETRY_PROMPT).strip(),
-        f"Previous verifier reward: `{reward:.4f}`.",
-        "The previous output was:",
-        "```markdown",
-        _read_optional_text(output_path).strip(),
-        "```",
-    ]
-    feedback = _read_optional_text(verifier_dir / "feedback.md").strip()
-    details = _read_optional_text(verifier_dir / "details.json").strip()
-    if feedback:
-        parts.extend(("The verifier feedback was:", "```markdown", feedback, "```"))
-    if details:
-        parts.extend(("The verifier detail scores were:", "```json", details, "```"))
-    parts.append(
-        "Repair the workspace now. You may overwrite the required output and any required side-effect files. "
-        "Do not merely describe files that should be written."
-    )
-    return "\n\n".join(part for part in parts if part)
-
-
-def _is_verifier_retry_side_effect(path: Path) -> bool:
-    return (
-        path.is_file()
-        and path.suffix == ".json"
-        and not path.name.startswith(_VERIFIER_RETRY_EXCLUDED_PREFIXES)
-        and path.name.endswith(_VERIFIER_RETRY_ARTIFACT_SUFFIXES)
-    )
-
-
-def _archive_verifier_retry_attempt(workspace: Path, output_path: Path, attempt_name: str) -> Path:
-    archive_dir = workspace / "logs" / "verifier" / "attempts" / attempt_name
-    archive_dir.mkdir(parents=True, exist_ok=True)
-    for relative in (
-        "agent_result.json",
-        "trajectory.jsonl",
-        "conversation.jsonl",
-        "prime-events.jsonl",
-        "prime-stderr.log",
-        "prime-run.json",
-        "logs/verifier/reward.json",
-        "logs/verifier/details.json",
-        "logs/verifier/feedback.md",
-    ):
-        source = workspace / relative
-        if source.is_file():
-            shutil.copy2(source, archive_dir / source.name)
-    if output_path.is_file():
-        shutil.copy2(output_path, archive_dir / output_path.name)
-    prime_sessions = workspace / "logs" / "prime" / "sessions"
-    if prime_sessions.is_dir():
-        shutil.copytree(prime_sessions, archive_dir / "prime-sessions", dirs_exist_ok=True)
-    for source in sorted(workspace.iterdir()):
-        if _is_verifier_retry_side_effect(source):
-            artifact_dir = archive_dir / "artifacts"
-            artifact_dir.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(source, artifact_dir / source.name)
-    return archive_dir
-
-
-def _prepare_verifier_retry_workspace(*, workspace: Path, output_path: Path, attempt_name: str) -> Path:
-    archive_dir = _archive_verifier_retry_attempt(workspace, output_path, attempt_name)
-    output_path.unlink(missing_ok=True)
-    return archive_dir
-
-
-def _write_verifier_retry_summary(workspace: Path, payload: Mapping[str, object]) -> None:
-    retry_path = workspace / "logs" / "verifier" / "retry.json"
-    retry_path.parent.mkdir(parents=True, exist_ok=True)
-    retry_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
-
-
-def _evaluate_selected_attempt(
-    *, task: ResolvedTaskInstance, attempt: TaskAttempt, verify: bool
-) -> tuple[EvaluationResult, float | None, VerifierExecutionReceipt | None, EvaluationStatus | None]:
-    output_path = resolve_workspace_path(attempt.workspace, task.task.verifier.expected_output_path)
-    verifier_seconds = None
-    verifier_receipt = None
-    reward_payload: dict[str, Any] | None = None
-    details_payload: dict[str, Any] | None = None
-    if verify:
-        stage_verifier_assets(task.instance_dir, attempt.workspace)
-        started = time.monotonic()
-        transform_version = localise_staged_verifier_paths(
-            workspace=attempt.workspace,
-            verifier_root=attempt.workspace / "tests",
-        )
-        execution = execute_verifier(
-            verifier_path=attempt.workspace / task.task.verifier.script,
-            workspace=attempt.workspace,
-            output_path=output_path,
-            reward_path=resolve_workspace_path(attempt.workspace, task.task.verifier.reward_path),
-            details_path=(
-                None
-                if task.task.verifier.details_path is None
-                else resolve_workspace_path(attempt.workspace, task.task.verifier.details_path)
-            ),
-            verifier_key=f"{task.task.task_id}/verifier",
-            verifier_version=VERIFIER_PROTOCOL_VERSION,
-            runtime_transform_version=transform_version,
-        )
-        verifier_seconds = time.monotonic() - started
-        verifier_receipt = execution.receipt
-        reward_payload = execution.reward_payload
-        details_payload = execution.details_payload
-    verifier_completed = verifier_receipt is not None and verifier_receipt.completed
-    output_present = output_path.is_file()
-    valid_output = attempt.status is AgentOutputStatus.COMPLETED and output_present
-    reward = 0.0
-    breakdown = details_payload
-    errors: list[str] = []
-    if verifier_completed and reward_payload is not None:
-        reward = float(reward_payload["reward"])
-    elif not verify:
-        errors.append("verification was disabled")
-    elif verifier_receipt is not None:
-        errors.append(verifier_receipt.failure_message or "verifier did not complete successfully")
-    else:
-        errors.append("verifier did not run")
-    if not valid_output and reward != 0.0:
-        errors.append("verifier reward was ignored because the selected attempt has no valid output")
-        reward = 0.0
-    evaluation = EvaluationResult(
-        reward=reward,
-        validity=ValidityCheck(
-            output_parseable=valid_output,
-            schema_valid=valid_output,
-            verifier_completed=verifier_completed,
-            errors=errors,
-        ),
-        breakdown=breakdown,
-    )
-    if verifier_receipt is not None:
-        mapped = map_verifier_execution(
-            receipt=verifier_receipt,
-            evaluation=evaluation,
-            expected_verifier_key=f"{task.task.task_id}/verifier",
-            expected_verifier_version=VERIFIER_PROTOCOL_VERSION,
-        )
-        return mapped.evaluation, verifier_seconds, verifier_receipt, mapped.status
-    return evaluation, verifier_seconds, verifier_receipt, None
-
-
-def _with_reviewer_summary(evaluation: EvaluationResult, workspace: Path) -> EvaluationResult:
-    summary_path = workspace / "logs" / "reviewer" / "summary.json"
-    if not summary_path.is_file():
-        return evaluation
-    payload = json.loads(summary_path.read_text(encoding="utf-8"))
-    breakdown = dict(evaluation.breakdown or {})
-    breakdown["llm_reviewer"] = payload
-    return evaluation.model_copy(update={"breakdown": breakdown})
-
-
-def _capture_final_workspace_manifest(
-    workspace: Path,
-    base_manifest: WorkspaceManifest,
-    primary_output_path: str,
-) -> WorkspaceManifest:
-    """Keep original source roles while marking new actor files explicitly."""
-
-    roles: dict[str, Literal["task_input", "primary_output", "actor_output"]] = {
-        str(item.relative_path): item.source_role for item in base_manifest.files
-    }
-    primary_relative = resolve_workspace_path(workspace, primary_output_path).relative_to(workspace).as_posix()
-    roles[str(primary_relative)] = "primary_output"
-    return capture_workspace_manifest(
-        workspace,
-        source_roles=roles,
-        default_source_role="actor_output",
-        bytes_copied=0,
-    )
-
-
-def _attach_workspace_delta(
-    *,
-    record: TrialRecord,
-    workspace: Path,
-    base_manifest: WorkspaceManifest,
-    final_manifest: WorkspaceManifest,
-    delta: WorkspaceDelta,
-    primary_output_path: str,
-    inherited_paths: frozenset[str] = frozenset(),
-) -> None:
-    """Retain declared outputs and meaningful actor changes, not unchanged inputs."""
-
-    named_paths = {
-        Path(value).resolve() for value, _media, _logical in record.pending_artifacts.values() if Path(value).is_file()
-    }
-    primary_relative = resolve_workspace_path(workspace, primary_output_path).relative_to(workspace).as_posix()
-    retained_paths = {str(item.relative_path) for item in delta.changed_files}
-    retained_paths.add(primary_relative)
-    retained_paths.update(inherited_paths)
-    for item in final_manifest.files:
-        if item.file_type != "file" or str(item.relative_path) not in retained_paths:
-            continue
-        path = workspace / item.relative_path
-        if path.resolve() in named_paths or item.size_bytes == 0:
-            continue
-        record.attach_artifact(
-            f"output:workspace:{item.relative_path}",
-            path,
-            media_type="application/octet-stream",
-            logical_path=item.relative_path,
-            expected_sha256=item.sha256,
-        )
-
-    attached_bytes = sum(
-        item.size_bytes
-        for item in final_manifest.files
-        if item.file_type == "file" and str(item.relative_path) in retained_paths and item.size_bytes > 0
-    )
-    final_manifest = final_manifest.model_copy(update={"bytes_attached": attached_bytes})
-    manifest_dir = workspace / ".workspace-manifests"
-    manifest_dir.mkdir(parents=True, exist_ok=True)
-    files: tuple[tuple[str, BaseModel], ...] = (
-        ("base.json", base_manifest),
-        ("final.json", final_manifest),
-        ("delta.json", delta),
-    )
-    for name, value in files:
-        path = manifest_dir / name
-        path.write_text(value.model_dump_json(indent=2) + "\n", encoding="utf-8")
-        record.attach_artifact(
-            f"output:workspace-manifest:{name.removesuffix('.json')}",
-            path,
-            media_type="application/json",
-            logical_path=f"workspace/{name}",
-        )
-
-
-def _attach_post_execution_files(*, record: TrialRecord, workspace: Path) -> None:
-    for root in (workspace / "logs" / "verifier", workspace / "logs" / "reviewer"):
-        if not root.is_dir():
-            continue
-        for path in sorted(candidate for candidate in root.rglob("*") if candidate.is_file()):
-            if path.stat().st_size == 0:
-                continue
-            relative = path.relative_to(workspace).as_posix()
-            record.attach_artifact(
-                f"output:evidence:{relative}",
-                path,
-                media_type="application/octet-stream",
-                logical_path=relative,
-            )
-
-
-def _existing_path(path: Path) -> str | None:
-    return str(path) if path.is_file() else None
-
-
-def _aggregate_attempt_usage(
-    *,
-    selected: AdapterResult,
-    attempts: list[TaskAttempt],
-    selection_evidence: AttemptSelectionEvidence | None = None,
-) -> AdapterResult:
-    usage_fields = (
-        "usage_model_calls",
-        "usage_input_tokens",
-        "usage_output_tokens",
-        "usage_cache_read_tokens",
-        "usage_cache_write_tokens",
-        "usage_advisor_calls",
-        "usage_advisor_input_tokens",
-        "usage_advisor_output_tokens",
-    )
-    updates: dict[str, int | None] = {}
-    selector_usage = None if selection_evidence is None else selection_evidence.selector
-    for field_name in usage_fields:
-        values = [getattr(attempt.result, field_name) for attempt in attempts]
-        selector_field = {
-            "usage_model_calls": "model_calls",
-            "usage_input_tokens": "input_tokens",
-            "usage_output_tokens": "output_tokens",
-            "usage_cache_read_tokens": "cache_read_tokens",
-            "usage_cache_write_tokens": "cache_write_tokens",
-        }.get(field_name)
-        selector_value = (
-            0 if selector_usage is None or selector_field is None else getattr(selector_usage, selector_field)
-        )
-        updates[field_name] = (
-            None
-            if all(value is None for value in values) and selector_value == 0
-            else sum(value or 0 for value in values) + selector_value
-        )
-    adapter_replace = cast(Callable[..., AdapterResult], replace)
-    return adapter_replace(selected, **updates)
 
 
 __all__ = (

--- a/src/aec_bench/harness/local_runtime.py
+++ b/src/aec_bench/harness/local_runtime.py
@@ -76,6 +76,13 @@ def stage_verifier_assets(task_dir: str | Path, workspace: str | Path) -> None:
     shutil.copytree(source, destination, symlinks=False)
 
 
+def copy_validated_workspace(source: str | Path, destination: str | Path) -> None:
+    """Copy a workspace after validating that its tree stays inside its root."""
+    source_path = Path(source)
+    _validate_copy_source(source_path)
+    shutil.copytree(source_path, destination, symlinks=False, dirs_exist_ok=True)
+
+
 def unstage_verifier_assets(workspace: str | Path) -> None:
     """Remove private verifier assets before another agent turn."""
     destination = Path(workspace) / "tests"

--- a/src/aec_bench/harness/workspace_conformance.py
+++ b/src/aec_bench/harness/workspace_conformance.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
 
-from aec_bench.harness.artifact_tasks import resolve_workspace_path
+from aec_bench.harness.artifact.workspace_port import resolve_workspace_path
 from aec_bench.harness.local_runtime import (
     cleanup_workspace,
     setup_workspace,

--- a/tests/cli/test_run_local_normalisation.py
+++ b/tests/cli/test_run_local_normalisation.py
@@ -4,10 +4,7 @@
 import json
 from pathlib import Path
 
-from aec_bench.harness.artifact_tasks import (
-    apply_normalisation,
-    load_canonical_refs,
-)
+from aec_bench.harness.artifact.execution import apply_normalisation, load_canonical_refs
 
 
 def test_load_canonical_refs_from_task_toml(tmp_path: Path) -> None:

--- a/tests/harness/test_artifact_ports.py
+++ b/tests/harness/test_artifact_ports.py
@@ -1,0 +1,127 @@
+# ABOUTME: Focused tests for the extracted artifact workspace port.
+# ABOUTME: Proves full-copy isolation, exact deltas, confinement, export, and disposal.
+
+from pathlib import Path
+
+import pytest
+
+from aec_bench.contracts.task_definition import EnvironmentSpec, VerifierSpec
+from aec_bench.harness.artifact.workspace_port import (
+    dispose_workspace,
+    export_selected_workspace,
+    fork_attempt_workspace,
+    materialize_base_workspace,
+    resolve_workspace_path,
+    workspace_delta,
+)
+from aec_bench.harness.workspace_evidence import capture_workspace_manifest
+from aec_bench.tasks.instance import resolve_instance_paths
+from tests.support.task_factories import make_task_definition
+
+
+def _resolved_task(root: Path):  # noqa: ANN202
+    task_dir = root / "task"
+    task_dir.mkdir()
+    (task_dir / "instruction.md").write_text("Write the result", encoding="utf-8")
+    (task_dir / "input.txt").write_text("source", encoding="utf-8")
+    environment = task_dir / "environment"
+    environment.mkdir()
+    (environment / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+    tests = task_dir / "tests"
+    tests.mkdir()
+    (tests / "verify.py").write_text("# private\n", encoding="utf-8")
+    definition = make_task_definition(
+        task_id="test/artifact/ports",
+        environment=EnvironmentSpec(dockerfile="environment/Dockerfile"),
+        verifier=VerifierSpec(
+            script="tests/verify.py",
+            expected_output_path="/workspace/output.md",
+            reward_path="logs/verifier/reward.json",
+        ),
+    )
+    return resolve_instance_paths(definition, task_dir)
+
+
+def test_materialize_and_fork_keep_task_and_attempts_isolated(tmp_path: Path) -> None:
+    task = _resolved_task(tmp_path)
+    first, base_manifest = materialize_base_workspace(task, work_root=tmp_path / "attempts", agent_files={})
+    second = None
+    try:
+        assert (first / "input.txt").stat().st_ino != (task.instance_dir / "input.txt").stat().st_ino
+        (first / "input.txt").write_text("first", encoding="utf-8")
+        (first / "output.md").write_text("result", encoding="utf-8")
+        second, _child_manifest, inherited = fork_attempt_workspace(
+            first,
+            base_manifest=base_manifest,
+            inherited_paths=frozenset(),
+            work_root=tmp_path / "attempts",
+        )
+        assert (task.instance_dir / "input.txt").read_text(encoding="utf-8") == "source"
+        assert (second / "input.txt").read_text(encoding="utf-8") == "first"
+        assert "output.md" in inherited
+        (second / "input.txt").write_text("second", encoding="utf-8")
+        assert (first / "input.txt").read_text(encoding="utf-8") == "first"
+    finally:
+        dispose_workspace(first)
+        if second is not None:
+            dispose_workspace(second)
+
+
+def test_workspace_delta_export_and_dispose_are_exact(tmp_path: Path) -> None:
+    task = _resolved_task(tmp_path)
+    workspace, base_manifest = materialize_base_workspace(task, work_root=tmp_path / "attempts", agent_files={})
+    exported = tmp_path / "selected"
+    try:
+        (workspace / "input.txt").write_text("changed", encoding="utf-8")
+        (workspace / "new.txt").write_text("new", encoding="utf-8")
+        final_manifest = capture_workspace_manifest(workspace, default_source_role="actor_output")
+        delta = workspace_delta(base_manifest, final_manifest)
+        assert [str(item.relative_path) for item in delta.modified] == ["input.txt"]
+        assert [str(item.relative_path) for item in delta.added] == ["new.txt"]
+        export_selected_workspace(workspace, exported)
+        assert (exported / "new.txt").read_text(encoding="utf-8") == "new"
+    finally:
+        dispose_workspace(workspace)
+    assert not workspace.exists()
+
+
+def test_dispose_rejects_symlink_target_without_removing_destination(tmp_path: Path) -> None:
+    destination = tmp_path / "destination"
+    destination.mkdir()
+    (destination / "keep.txt").write_text("keep", encoding="utf-8")
+    link = tmp_path / "workspace-link"
+    link.symlink_to(destination, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="symbolic link"):
+        dispose_workspace(link)
+
+    assert link.is_symlink()
+    assert (destination / "keep.txt").read_text(encoding="utf-8") == "keep"
+
+
+def test_fork_rejects_actor_symlink_without_copying_external_bytes(tmp_path: Path) -> None:
+    task = _resolved_task(tmp_path)
+    first, base_manifest = materialize_base_workspace(task, work_root=tmp_path / "attempts", agent_files={})
+    outside = tmp_path / "outside.txt"
+    outside.write_text("private", encoding="utf-8")
+    (first / "actor-link").symlink_to(outside)
+    try:
+        with pytest.raises(ValueError, match="symbolic link"):
+            fork_attempt_workspace(
+                first,
+                base_manifest=base_manifest,
+                inherited_paths=frozenset(),
+                work_root=tmp_path / "attempts",
+            )
+        assert outside.read_text(encoding="utf-8") == "private"
+        assert [path for path in (tmp_path / "attempts").iterdir() if path != first] == []
+    finally:
+        dispose_workspace(first)
+
+
+def test_workspace_path_rejects_escape(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    assert resolve_workspace_path(workspace, "/workspace/output.md") == workspace / "output.md"
+    with pytest.raises(ValueError, match="inside"):
+        resolve_workspace_path(workspace, "../outside.txt")


### PR DESCRIPTION
## Summary

- extract one-adapter-call execution into `harness/artifact/execution.py`
- extract workspace materialization, fork, export, delta, confinement, and disposal into `workspace_port.py`
- extract task-owned verifier execution and retry handling into `verification.py`
- extract canonical trial record construction and artifact retention into `recording.py`
- keep `artifact_tasks.py` as the single application coordination path
- add a shared validated workspace-copy operation for safe attempt forks

## Review guide

1. Review `workspace_port.py` and `test_artifact_ports.py` for copy isolation, path confinement, symlink refusal, exact deltas, atomic export, and safe cleanup.
2. Review `execution.py` for one adapter call, output normalization, commit validation, and attempt values.
3. Review `verification.py` for verifier process truth, receipts, evaluation mapping, and bounded feedback retry operations.
4. Review `recording.py` for canonical record construction, attempt usage, workspace evidence, and materialization.
5. Review the reduced `artifact_tasks.py` to confirm that the end-to-end trial flow remains one readable path.

## Validation

- `72 passed` in the artifact, Harbor, local runtime, workspace conformance, and local CLI suite
- `13 passed` in the affected evolution integration suite
- Ruff check passed for `src/` and `tests/`
- Ruff format check passed for all 9 changed Python paths
- mypy passed for 10 affected source files
- generated catalogue check passed
- provenance field audit passed with no violations
- Python source distribution and wheel build passed

## Known unrelated baseline findings

- the current package ownership audit reports lifecycle dependency violations that PRD4 PR11 owns
- the learning-study artifact suite reports existing task-key case mismatches after the identity conversion
