### PR TITLE
PRD4: extract lifecycle reducer

### DIFF
--- a/src/aec_bench/lifecycles/runtime/lifecycle.py
+++ b/src/aec_bench/lifecycles/runtime/lifecycle.py
@@ -44,6 +44,14 @@ from aec_bench.lifecycles.runtime.operation_store import (
     _sync_lifecycle_operation_ledger,
     _write_lifecycle_operation_catalog,
 )
+from aec_bench.lifecycles.runtime.reducer import (
+    reduce_branch,
+    reduce_fail_attempt,
+    reduce_open_attempt,
+    reduce_release,
+    reduce_revisit,
+    reduce_submit,
+)
 from aec_bench.lifecycles.runtime.request_protocol import (
     EvidenceLifecycleError as EvidenceLifecycleError,
 )
@@ -54,7 +62,6 @@ from aec_bench.lifecycles.runtime.request_protocol import (
     EvidenceRequestResolutionManifest as EvidenceRequestResolutionManifest,
 )
 from aec_bench.lifecycles.runtime.request_protocol import (
-    _append_transition,
     _branch_action_state_sha256,
     _checkpoint,
     _evidence_request_catalog,
@@ -91,7 +98,6 @@ from aec_bench.lifecycles.runtime.request_store import (
 from aec_bench.lifecycles.runtime.state import (
     CheckpointAttemptRecord,
     CheckpointAttemptStatus,
-    CheckpointRevisitRecord,
     CheckpointRunRecord,
     CheckpointRunStatus,
     EvidenceLifecycleRunState,
@@ -99,7 +105,6 @@ from aec_bench.lifecycles.runtime.state import (
     EvidenceRequestRejection,
     LifecycleBranchRecord,
     LifecycleRunStatus,
-    LifecycleTransitionKind,
 )
 
 LifecycleVerifier = Callable[[Path, Path], dict[str, Any] | LifecycleVerificationResult]
@@ -231,9 +236,6 @@ def _release_checkpoint_locked(
     instruction = _preflight_checkpoint(package, checkpoint)
     released_files = _materialize_checkpoint_release(package, run, checkpoint, instruction)
 
-    checkpoint_run = state.checkpoint(checkpoint.checkpoint_id)
-    checkpoint_run.status = CheckpointRunStatus.ACTIVE
-    checkpoint_run.released_files = released_files
     previous_checkpoint_id = next(
         (
             item.checkpoint_id
@@ -242,15 +244,14 @@ def _release_checkpoint_locked(
         ),
         None,
     )
-    _append_transition(
+    state = reduce_release(
         state,
-        kind=LifecycleTransitionKind.RELEASE,
-        from_checkpoint_id=previous_checkpoint_id,
-        to_checkpoint_id=checkpoint.checkpoint_id,
+        checkpoint_id=checkpoint.checkpoint_id,
+        released_files=tuple(released_files),
+        previous_checkpoint_id=previous_checkpoint_id,
         reason="Evidence released for active review.",
-    )
-    state.status = LifecycleRunStatus.AWAITING_CHECKPOINT_SUBMISSION
-    state.active_checkpoint_id = checkpoint.checkpoint_id
+    ).state
+    checkpoint_run = state.checkpoint(checkpoint.checkpoint_id)
     _write_evidence_request_catalog(run, checkpoint, checkpoint_run)
     if state.schema_version == "7":
         assert operation_resolver is not None
@@ -525,25 +526,13 @@ def _submit_checkpoint_locked(
     submission_sha256 = _sha256(archive_path)
     _write_json(episode_dir / "result.json", copy.deepcopy(episode_result or {}))
 
-    checkpoint_run = state.checkpoint(checkpoint_id)
-    checkpoint_run.status = CheckpointRunStatus.SUBMITTED
-    checkpoint_run.submission_path = checkpoint.submission_path
-    checkpoint_run.submission_sha256 = submission_sha256
-    if checkpoint_run.active_attempt is not None:
-        checkpoint_run.active_attempt.status = CheckpointAttemptStatus.SUBMITTED
-    _append_transition(
+    state = reduce_submit(
         state,
-        kind=LifecycleTransitionKind.SUBMIT,
-        from_checkpoint_id=checkpoint_id,
-        to_checkpoint_id=None,
+        checkpoint_id=checkpoint_id,
+        submission_path=checkpoint.submission_path,
+        submission_sha256=submission_sha256,
         reason="Checkpoint submission archived.",
-    )
-    state.active_checkpoint_id = None
-    state.status = (
-        LifecycleRunStatus.COMPLETE
-        if all(item.status == CheckpointRunStatus.SUBMITTED for item in state.checkpoint_runs)
-        else LifecycleRunStatus.AWAITING_EVIDENCE_RELEASE
-    )
+    ).state
     _write_state(run, state)
     _sync_transition_ledger(run, state)
     append_ledger_entry(
@@ -655,108 +644,22 @@ def _branch_lifecycle_locked(
     ):
         raise EvidenceLifecycleError("selected checkpoint parent state changed before branching")
 
-    checkpoint_runs: list[CheckpointRunRecord] = []
-    for index, checkpoint in enumerate(spec.checkpoints):
-        if index < branch_index:
-            inherited = parent_state.checkpoint(checkpoint.checkpoint_id)
-            if inherited.status != CheckpointRunStatus.SUBMITTED:
-                raise EvidenceLifecycleError(f"parent checkpoint dependency is incomplete: {checkpoint.checkpoint_id}")
-            checkpoint_runs.append(
-                CheckpointRunRecord(
-                    checkpoint_id=checkpoint.checkpoint_id,
-                    status=CheckpointRunStatus.SUBMITTED,
-                    released_files=list(inherited.released_files),
-                    submission_path=inherited.submission_path,
-                    submission_sha256=inherited.submission_sha256,
-                    attempts=[
-                        attempt.model_copy(deep=True, update={"inherited_from_parent": True})
-                        for attempt in inherited.attempts
-                    ],
-                    evidence_request_budget=inherited.evidence_request_budget,
-                    evidence_request_budget_remaining=inherited.evidence_request_budget_remaining,
-                    evidence_request_actions=[
-                        action.model_copy(deep=True, update={"inherited_from_parent": True})
-                        for action in inherited.evidence_request_actions
-                    ],
-                    operation_budget=inherited.operation_budget,
-                    operation_budget_remaining=inherited.operation_budget_remaining,
-                    operation_actions=[
-                        action.model_copy(deep=True, update={"inherited_from_parent": True})
-                        for action in inherited.operation_actions
-                    ],
-                    inherited_from_parent=True,
-                )
-            )
-        elif index == branch_index:
-            checkpoint_runs.append(
-                CheckpointRunRecord(
-                    checkpoint_id=checkpoint.checkpoint_id,
-                    status=CheckpointRunStatus.ACTIVE,
-                    released_files=list(parent_checkpoint.released_files),
-                    attempts=[
-                        attempt.model_copy(deep=True, update={"inherited_from_parent": True})
-                        for attempt in parent_checkpoint.attempts
-                    ],
-                    evidence_request_budget=parent_checkpoint.evidence_request_budget,
-                    evidence_request_budget_remaining=parent_checkpoint.evidence_request_budget_remaining,
-                    evidence_request_actions=[
-                        action.model_copy(deep=True, update={"inherited_from_parent": True})
-                        for action in parent_checkpoint.evidence_request_actions
-                    ],
-                    operation_budget=parent_checkpoint.operation_budget,
-                    operation_budget_remaining=parent_checkpoint.operation_budget_remaining,
-                    operation_actions=[
-                        action.model_copy(deep=True, update={"inherited_from_parent": True})
-                        for action in parent_checkpoint.operation_actions
-                    ],
-                )
-            )
-        else:
-            request_budget = (
-                checkpoint.conditional_evidence.request_budget if checkpoint.conditional_evidence is not None else 0
-            )
-            checkpoint_runs.append(
-                CheckpointRunRecord(
-                    checkpoint_id=checkpoint.checkpoint_id,
-                    evidence_request_budget=request_budget,
-                    evidence_request_budget_remaining=request_budget,
-                    operation_budget=(
-                        checkpoint.conditional_operations.operation_budget
-                        if checkpoint.conditional_operations is not None
-                        else 0
-                    ),
-                    operation_budget_remaining=(
-                        checkpoint.conditional_operations.operation_budget
-                        if checkpoint.conditional_operations is not None
-                        else 0
-                    ),
-                )
-            )
-
-    state = EvidenceLifecycleRunState(
-        schema_version=parent_state.schema_version,
-        lifecycle_id=spec.lifecycle_id,
-        lifecycle_spec_sha256=parent_state.lifecycle_spec_sha256,
-        package_sha256=parent_state.package_sha256,
-        status=LifecycleRunStatus.AWAITING_CHECKPOINT_SUBMISSION,
-        active_checkpoint_id=checkpoint_id,
-        checkpoint_runs=checkpoint_runs,
-        branch=LifecycleBranchRecord(
-            branch_id=branch_id,
-            parent_run_dir=str(parent_run),
-            branched_from_checkpoint_id=checkpoint_id,
-            parent_submission_sha256=parent_checkpoint.submission_sha256,
-            parent_action_state_sha256=parent_action_state_sha256,
-            reason=reason,
-        ),
-    )
-    _append_transition(
-        state,
-        kind=LifecycleTransitionKind.BRANCH,
-        from_checkpoint_id=checkpoint_id,
-        to_checkpoint_id=checkpoint_id,
+    branch = LifecycleBranchRecord(
+        branch_id=branch_id,
+        parent_run_dir=str(parent_run),
+        branched_from_checkpoint_id=checkpoint_id,
+        parent_submission_sha256=parent_checkpoint.submission_sha256,
+        parent_action_state_sha256=parent_action_state_sha256,
         reason=reason,
     )
+    state = reduce_branch(
+        parent_state,
+        checkpoints=spec.checkpoints,
+        branch_index=branch_index,
+        branch=branch,
+        checkpoint_id=checkpoint_id,
+        reason=reason,
+    ).state
 
     branch_run.parent.mkdir(parents=True, exist_ok=True)
     staging_run = Path(tempfile.mkdtemp(prefix=f".{branch_run.name}.tmp-", dir=branch_run.parent))
@@ -865,27 +768,18 @@ def _open_checkpoint_attempt_locked(
     checkpoint_id = state.active_checkpoint_id
     if checkpoint_id is None:
         raise EvidenceLifecycleError("no checkpoint is active")
-    checkpoint_run = state.checkpoint(checkpoint_id)
-    active_attempt = checkpoint_run.active_attempt
-    if active_attempt is not None and active_attempt.session_id == session_id:
-        if episode_request_sha256 is not None and active_attempt.episode_request_sha256 != episode_request_sha256:
-            raise EvidenceLifecycleError("active checkpoint attempt request hash changed")
-        return _attempt_context(active_attempt)
-    if active_attempt is not None:
-        active_attempt.status = CheckpointAttemptStatus.INTERRUPTED
-    previous = checkpoint_run.last_attempt
-
-    sequence = len(checkpoint_run.attempts) + 1
-    attempt = CheckpointAttemptRecord(
-        attempt_id=f"{checkpoint_id}.attempt-{sequence:03d}",
+    prior_active_attempt = state.checkpoint(checkpoint_id).active_attempt
+    state = reduce_open_attempt(
+        state,
+        checkpoint_id=checkpoint_id,
         session_id=session_id,
-        sequence=sequence,
         execution_mode=execution_mode,
-        status=CheckpointAttemptStatus.ACTIVE,
-        resumed_from_attempt_id=previous.attempt_id if previous is not None else None,
         episode_request_sha256=episode_request_sha256,
-    )
-    checkpoint_run.attempts.append(attempt)
+    ).state
+    attempt = state.checkpoint(checkpoint_id).last_attempt
+    assert attempt is not None
+    if prior_active_attempt is not None and prior_active_attempt.session_id == session_id:
+        return _attempt_context(attempt)
     _write_state(run, state)
     append_ledger_entry(
         _ledger_path(run),
@@ -948,8 +842,14 @@ def _fail_checkpoint_attempt_locked(
             f"active attempt belongs to {attempt.session_id}; cannot fail it from {session_id}"
         )
 
-    attempt.status = CheckpointAttemptStatus.FAILED
-    attempt.failure_kind = failure_kind
+    state = reduce_fail_attempt(
+        state,
+        checkpoint_id=checkpoint_id,
+        session_id=session_id,
+        failure_kind=failure_kind,
+    ).state
+    attempt = state.checkpoint(checkpoint_id).last_attempt
+    assert attempt is not None
     _write_state(run, state)
     append_ledger_entry(
         _ledger_path(run),
@@ -1000,29 +900,16 @@ def _revisit_checkpoint_locked(
     spec = load_evidence_lifecycle_spec(package)
     state = _load_state(package, run, spec, operation_resolver=operation_resolver, lock_held=True)
     _assert_prior_submissions_unchanged(run, state)
-    try:
-        checkpoint_run = state.checkpoint(checkpoint_id)
-    except KeyError as exc:
-        raise EvidenceLifecycleError(f"unknown checkpoint: {checkpoint_id}") from exc
-    if checkpoint_run.status != CheckpointRunStatus.SUBMITTED:
-        raise EvidenceLifecycleError(f"checkpoint is not available for revisit: {checkpoint_id}")
-
     archive_path = run / "episodes" / checkpoint_id / "submission.json"
     instruction_path = _workspace(run) / "checkpoints" / checkpoint_id / "instruction.md"
-    revisit = CheckpointRevisitRecord(
-        revisit_id=f"revisit-{len(state.revisits) + 1:03d}",
-        checkpoint_id=checkpoint_id,
-        requested_from_checkpoint_id=state.active_checkpoint_id,
-        reason=reason,
-    )
-    state.revisits.append(revisit)
-    _append_transition(
+    reduction = reduce_revisit(
         state,
-        kind=LifecycleTransitionKind.REVISIT,
-        from_checkpoint_id=revisit.requested_from_checkpoint_id,
-        to_checkpoint_id=checkpoint_id,
+        checkpoint_id=checkpoint_id,
         reason=reason,
     )
+    state = reduction.state
+    revisit = state.revisits[-1]
+    checkpoint_run = state.checkpoint(checkpoint_id)
     _write_state(run, state)
     _sync_transition_ledger(run, state)
     append_ledger_entry(

--- a/src/aec_bench/lifecycles/runtime/reducer.py
+++ b/src/aec_bench/lifecycles/runtime/reducer.py
@@ -1,0 +1,336 @@
+# ABOUTME: Applies pure lifecycle checkpoint transition decisions.
+# ABOUTME: Returns detached canonical state with transition events for the lifecycle application.
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from aec_bench.contracts.evidence_lifecycle import EvidenceCheckpointSpec
+from aec_bench.lifecycles.runtime.request_protocol import EvidenceLifecycleError
+from aec_bench.lifecycles.runtime.state import (
+    CheckpointAttemptRecord,
+    CheckpointAttemptStatus,
+    CheckpointRevisitRecord,
+    CheckpointRunRecord,
+    CheckpointRunStatus,
+    EvidenceLifecycleRunState,
+    LifecycleBranchRecord,
+    LifecycleRunStatus,
+    LifecycleTransitionKind,
+    LifecycleTransitionRecord,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class LifecycleReduction:
+    """Pure lifecycle decision output consumed by the application and stores."""
+
+    state: EvidenceLifecycleRunState
+    events: tuple[LifecycleTransitionRecord, ...] = ()
+
+
+def reduce_release(
+    state: EvidenceLifecycleRunState,
+    *,
+    checkpoint_id: str,
+    released_files: tuple[str, ...],
+    reason: str,
+    previous_checkpoint_id: str | None,
+) -> LifecycleReduction:
+    """Release the next checkpoint in a detached state copy."""
+    if state.status != LifecycleRunStatus.AWAITING_EVIDENCE_RELEASE or state.active_checkpoint_id is not None:
+        raise EvidenceLifecycleError("lifecycle is not awaiting evidence release")
+    checkpoint = _checkpoint(state, checkpoint_id)
+    if checkpoint.status != CheckpointRunStatus.PENDING:
+        raise EvidenceLifecycleError(f"checkpoint is not pending: {checkpoint_id}")
+    updated = state.model_copy(deep=True)
+    checkpoint = updated.checkpoint(checkpoint_id)
+    checkpoint.status = CheckpointRunStatus.ACTIVE
+    checkpoint.released_files = list(released_files)
+    updated.active_checkpoint_id = checkpoint_id
+    updated.status = LifecycleRunStatus.AWAITING_CHECKPOINT_SUBMISSION
+    event = _transition(
+        updated,
+        kind=LifecycleTransitionKind.RELEASE,
+        from_checkpoint_id=previous_checkpoint_id,
+        to_checkpoint_id=checkpoint_id,
+        reason=reason,
+    )
+    return _result(updated, event)
+
+
+def reduce_submit(
+    state: EvidenceLifecycleRunState,
+    *,
+    checkpoint_id: str,
+    submission_path: str,
+    submission_sha256: str,
+    reason: str,
+) -> LifecycleReduction:
+    """Submit the active checkpoint in a detached state copy."""
+    if state.status != LifecycleRunStatus.AWAITING_CHECKPOINT_SUBMISSION:
+        raise EvidenceLifecycleError("lifecycle is not awaiting checkpoint submission")
+    if state.active_checkpoint_id != checkpoint_id:
+        raise EvidenceLifecycleError(f"checkpoint is not active: {checkpoint_id}")
+    updated = state.model_copy(deep=True)
+    checkpoint = updated.checkpoint(checkpoint_id)
+    checkpoint.status = CheckpointRunStatus.SUBMITTED
+    checkpoint.submission_path = submission_path
+    checkpoint.submission_sha256 = submission_sha256
+    if checkpoint.active_attempt is not None:
+        checkpoint.active_attempt.status = CheckpointAttemptStatus.SUBMITTED
+    updated.active_checkpoint_id = None
+    updated.status = (
+        LifecycleRunStatus.COMPLETE
+        if all(item.status == CheckpointRunStatus.SUBMITTED for item in updated.checkpoint_runs)
+        else LifecycleRunStatus.AWAITING_EVIDENCE_RELEASE
+    )
+    event = _transition(
+        updated,
+        kind=LifecycleTransitionKind.SUBMIT,
+        from_checkpoint_id=checkpoint_id,
+        to_checkpoint_id=None,
+        reason=reason,
+    )
+    return _result(updated, event)
+
+
+def reduce_open_attempt(
+    state: EvidenceLifecycleRunState,
+    *,
+    checkpoint_id: str,
+    session_id: str,
+    execution_mode: str,
+    episode_request_sha256: str | None,
+) -> LifecycleReduction:
+    """Open or resume one checkpoint attempt without performing I/O."""
+    if state.active_checkpoint_id != checkpoint_id:
+        raise EvidenceLifecycleError("no checkpoint is active")
+    updated = state.model_copy(deep=True)
+    checkpoint = updated.checkpoint(checkpoint_id)
+    active_attempt = checkpoint.active_attempt
+    if active_attempt is not None and active_attempt.session_id == session_id:
+        if episode_request_sha256 is not None and active_attempt.episode_request_sha256 != episode_request_sha256:
+            raise EvidenceLifecycleError("active checkpoint attempt request hash changed")
+        return LifecycleReduction(state=updated)
+    if active_attempt is not None:
+        active_attempt.status = CheckpointAttemptStatus.INTERRUPTED
+    previous = checkpoint.last_attempt
+    attempt = CheckpointAttemptRecord(
+        attempt_id=f"{checkpoint_id}.attempt-{len(checkpoint.attempts) + 1:03d}",
+        session_id=session_id,
+        sequence=len(checkpoint.attempts) + 1,
+        execution_mode=execution_mode,
+        status=CheckpointAttemptStatus.ACTIVE,
+        resumed_from_attempt_id=previous.attempt_id if previous is not None else None,
+        episode_request_sha256=episode_request_sha256,
+    )
+    checkpoint.attempts.append(attempt)
+    return _result(updated, None)
+
+
+def reduce_fail_attempt(
+    state: EvidenceLifecycleRunState,
+    *,
+    checkpoint_id: str,
+    session_id: str,
+    failure_kind: str,
+) -> LifecycleReduction:
+    """Fail the active checkpoint attempt in a detached state copy."""
+    if state.active_checkpoint_id != checkpoint_id:
+        raise EvidenceLifecycleError("no checkpoint is active")
+    updated = state.model_copy(deep=True)
+    attempt = updated.checkpoint(checkpoint_id).active_attempt
+    if attempt is None:
+        raise EvidenceLifecycleError("no checkpoint attempt is active")
+    if attempt.session_id != session_id:
+        raise EvidenceLifecycleError(
+            f"active attempt belongs to {attempt.session_id}; cannot fail it from {session_id}"
+        )
+    attempt.status = CheckpointAttemptStatus.FAILED
+    attempt.failure_kind = failure_kind
+    return _result(updated, None)
+
+
+def reduce_revisit(
+    state: EvidenceLifecycleRunState,
+    *,
+    checkpoint_id: str,
+    reason: str,
+) -> LifecycleReduction:
+    """Record a revisit of a submitted checkpoint in a detached state copy."""
+    updated = state.model_copy(deep=True)
+    checkpoint = updated.checkpoint(checkpoint_id)
+    if checkpoint.status != CheckpointRunStatus.SUBMITTED:
+        raise EvidenceLifecycleError(f"checkpoint is not available for revisit: {checkpoint_id}")
+    revisit = CheckpointRevisitRecord(
+        revisit_id=f"revisit-{len(updated.revisits) + 1:03d}",
+        checkpoint_id=checkpoint_id,
+        requested_from_checkpoint_id=updated.active_checkpoint_id,
+        reason=reason,
+    )
+    updated.revisits.append(revisit)
+    event = _transition(
+        updated,
+        kind=LifecycleTransitionKind.REVISIT,
+        from_checkpoint_id=revisit.requested_from_checkpoint_id,
+        to_checkpoint_id=checkpoint_id,
+        reason=reason,
+    )
+    return _result(updated, event)
+
+
+def reduce_branch(
+    parent_state: EvidenceLifecycleRunState,
+    *,
+    checkpoints: Sequence[EvidenceCheckpointSpec],
+    branch_index: int,
+    branch: LifecycleBranchRecord,
+    checkpoint_id: str,
+    reason: str,
+) -> LifecycleReduction:
+    """Construct inherited, reopened, and pending branch state and its transition."""
+    if branch_index < 0 or branch_index >= len(checkpoints):
+        raise EvidenceLifecycleError(f"branch checkpoint index is out of range: {branch_index}")
+    if checkpoints[branch_index].checkpoint_id != checkpoint_id:
+        raise EvidenceLifecycleError("branch checkpoint index does not match checkpoint id")
+    parent_checkpoint = _checkpoint(parent_state, checkpoint_id)
+    if parent_checkpoint.status != CheckpointRunStatus.SUBMITTED:
+        raise EvidenceLifecycleError(f"checkpoint is not available for branching: {checkpoint_id}")
+    checkpoint_runs: list[CheckpointRunRecord] = []
+    for index, checkpoint in enumerate(checkpoints):
+        if index < branch_index:
+            inherited = _checkpoint(parent_state, checkpoint.checkpoint_id)
+            if inherited.status != CheckpointRunStatus.SUBMITTED:
+                raise EvidenceLifecycleError(f"parent checkpoint dependency is incomplete: {checkpoint.checkpoint_id}")
+            checkpoint_runs.append(
+                CheckpointRunRecord(
+                    checkpoint_id=checkpoint.checkpoint_id,
+                    status=CheckpointRunStatus.SUBMITTED,
+                    released_files=list(inherited.released_files),
+                    submission_path=inherited.submission_path,
+                    submission_sha256=inherited.submission_sha256,
+                    attempts=[
+                        attempt.model_copy(deep=True, update={"inherited_from_parent": True})
+                        for attempt in inherited.attempts
+                    ],
+                    evidence_request_budget=inherited.evidence_request_budget,
+                    evidence_request_budget_remaining=inherited.evidence_request_budget_remaining,
+                    evidence_request_actions=[
+                        action.model_copy(deep=True, update={"inherited_from_parent": True})
+                        for action in inherited.evidence_request_actions
+                    ],
+                    operation_budget=inherited.operation_budget,
+                    operation_budget_remaining=inherited.operation_budget_remaining,
+                    operation_actions=[
+                        action.model_copy(deep=True, update={"inherited_from_parent": True})
+                        for action in inherited.operation_actions
+                    ],
+                    inherited_from_parent=True,
+                )
+            )
+        elif index == branch_index:
+            checkpoint_runs.append(
+                CheckpointRunRecord(
+                    checkpoint_id=checkpoint.checkpoint_id,
+                    status=CheckpointRunStatus.ACTIVE,
+                    released_files=list(parent_checkpoint.released_files),
+                    attempts=[
+                        attempt.model_copy(deep=True, update={"inherited_from_parent": True})
+                        for attempt in parent_checkpoint.attempts
+                    ],
+                    evidence_request_budget=parent_checkpoint.evidence_request_budget,
+                    evidence_request_budget_remaining=parent_checkpoint.evidence_request_budget_remaining,
+                    evidence_request_actions=[
+                        action.model_copy(deep=True, update={"inherited_from_parent": True})
+                        for action in parent_checkpoint.evidence_request_actions
+                    ],
+                    operation_budget=parent_checkpoint.operation_budget,
+                    operation_budget_remaining=parent_checkpoint.operation_budget_remaining,
+                    operation_actions=[
+                        action.model_copy(deep=True, update={"inherited_from_parent": True})
+                        for action in parent_checkpoint.operation_actions
+                    ],
+                )
+            )
+        else:
+            request_budget = (
+                checkpoint.conditional_evidence.request_budget if checkpoint.conditional_evidence is not None else 0
+            )
+            operation_budget = (
+                checkpoint.conditional_operations.operation_budget
+                if checkpoint.conditional_operations is not None
+                else 0
+            )
+            checkpoint_runs.append(
+                CheckpointRunRecord(
+                    checkpoint_id=checkpoint.checkpoint_id,
+                    evidence_request_budget=request_budget,
+                    evidence_request_budget_remaining=request_budget,
+                    operation_budget=operation_budget,
+                    operation_budget_remaining=operation_budget,
+                )
+            )
+    updated = EvidenceLifecycleRunState(
+        schema_version=parent_state.schema_version,
+        lifecycle_id=parent_state.lifecycle_id,
+        lifecycle_spec_sha256=parent_state.lifecycle_spec_sha256,
+        package_sha256=parent_state.package_sha256,
+        status=LifecycleRunStatus.AWAITING_CHECKPOINT_SUBMISSION,
+        active_checkpoint_id=checkpoint_id,
+        checkpoint_runs=checkpoint_runs,
+        branch=branch.model_copy(deep=True),
+    )
+    event = _transition(
+        updated,
+        kind=LifecycleTransitionKind.BRANCH,
+        from_checkpoint_id=checkpoint_id,
+        to_checkpoint_id=checkpoint_id,
+        reason=reason,
+    )
+    return _result(updated, event)
+
+
+def _transition(
+    state: EvidenceLifecycleRunState,
+    *,
+    kind: LifecycleTransitionKind,
+    from_checkpoint_id: str | None,
+    to_checkpoint_id: str | None,
+    reason: str,
+) -> LifecycleTransitionRecord:
+    event = LifecycleTransitionRecord(
+        transition_id=f"transition-{len(state.transitions) + 1:03d}",
+        kind=kind,
+        from_checkpoint_id=from_checkpoint_id,
+        to_checkpoint_id=to_checkpoint_id,
+        reason=reason,
+    )
+    state.transitions.append(event)
+    return event
+
+
+def _checkpoint(state: EvidenceLifecycleRunState, checkpoint_id: str) -> CheckpointRunRecord:
+    try:
+        return state.checkpoint(checkpoint_id)
+    except KeyError as exc:
+        raise EvidenceLifecycleError(f"unknown checkpoint: {checkpoint_id}") from exc
+
+
+def _result(
+    state: EvidenceLifecycleRunState,
+    event: LifecycleTransitionRecord | None,
+) -> LifecycleReduction:
+    return LifecycleReduction(state=state, events=() if event is None else (event,))
+
+
+__all__ = (
+    "LifecycleReduction",
+    "reduce_fail_attempt",
+    "reduce_branch",
+    "reduce_open_attempt",
+    "reduce_release",
+    "reduce_revisit",
+    "reduce_submit",
+)

--- a/tests/lifecycles/runtime/test_reducer.py
+++ b/tests/lifecycles/runtime/test_reducer.py
@@ -1,0 +1,309 @@
+# ABOUTME: Tests pure lifecycle transition decisions without filesystem effects.
+# ABOUTME: Covers state isolation, transition identities, and public lifecycle errors.
+
+from __future__ import annotations
+
+import pytest
+
+from aec_bench.contracts.evidence_lifecycle import (
+    ConditionalEvidenceSpec,
+    EvidenceCheckpointSpec,
+    EvidenceRequestSpec,
+)
+from aec_bench.lifecycles.runtime.reducer import (
+    LifecycleReduction,
+    reduce_branch,
+    reduce_fail_attempt,
+    reduce_open_attempt,
+    reduce_release,
+    reduce_revisit,
+    reduce_submit,
+)
+from aec_bench.lifecycles.runtime.request_protocol import EvidenceLifecycleError
+from aec_bench.lifecycles.runtime.state import (
+    CheckpointAttemptRecord,
+    CheckpointAttemptStatus,
+    CheckpointRunRecord,
+    CheckpointRunStatus,
+    EvidenceLifecycleRunState,
+    LifecycleBranchRecord,
+    LifecycleRunStatus,
+)
+
+
+def _state(*checkpoint_runs: CheckpointRunRecord, **updates: object) -> EvidenceLifecycleRunState:
+    return EvidenceLifecycleRunState(
+        lifecycle_id="lifecycle.test",
+        lifecycle_spec_sha256="a" * 64,
+        package_sha256="b" * 64,
+        checkpoint_runs=list(checkpoint_runs),
+        **updates,
+    )
+
+
+def _submitted(checkpoint_id: str = "first") -> CheckpointRunRecord:
+    return CheckpointRunRecord(
+        checkpoint_id=checkpoint_id,
+        status=CheckpointRunStatus.SUBMITTED,
+        submission_path=f"submissions/{checkpoint_id}.json",
+        submission_sha256="c" * 64,
+    )
+
+
+def _active(checkpoint_id: str = "first") -> CheckpointRunRecord:
+    return CheckpointRunRecord(checkpoint_id=checkpoint_id, status=CheckpointRunStatus.ACTIVE)
+
+
+def _checkpoint_spec(checkpoint_id: str, *, request_budget: int | None = None) -> EvidenceCheckpointSpec:
+    conditional_evidence = None
+    if request_budget is not None:
+        conditional_evidence = ConditionalEvidenceSpec(
+            request_budget=request_budget,
+            requests=tuple(
+                EvidenceRequestSpec(
+                    request_id=f"request-{index}",
+                    title="Request",
+                    description="Request declared evidence.",
+                )
+                for index in range(request_budget)
+            ),
+        )
+    return EvidenceCheckpointSpec(
+        checkpoint_id=checkpoint_id,
+        title=checkpoint_id,
+        release_path=f"releases/{checkpoint_id}",
+        instruction_path=f"instructions/{checkpoint_id}.md",
+        submission_path=f"submissions/{checkpoint_id}.json",
+        conditional_evidence=conditional_evidence,
+    )
+
+
+def test_release_returns_detached_state_and_event() -> None:
+    original = _state(CheckpointRunRecord(checkpoint_id="first"))
+
+    reduction = reduce_release(
+        original,
+        checkpoint_id="first",
+        released_files=("source/input.txt",),
+        previous_checkpoint_id=None,
+        reason="release",
+    )
+
+    assert isinstance(reduction, LifecycleReduction)
+    assert original.status == LifecycleRunStatus.AWAITING_EVIDENCE_RELEASE
+    assert original.checkpoint("first").status == CheckpointRunStatus.PENDING
+    assert reduction.state.status == LifecycleRunStatus.AWAITING_CHECKPOINT_SUBMISSION
+    assert reduction.state.checkpoint("first").released_files == ["source/input.txt"]
+    assert reduction.events[0].transition_id == "transition-001"
+
+
+def test_submit_updates_attempt_and_does_not_mutate_input() -> None:
+    attempt = CheckpointAttemptRecord(
+        attempt_id="first.attempt-001",
+        session_id="session-001",
+        sequence=1,
+        execution_mode="fresh_context",
+        status=CheckpointAttemptStatus.ACTIVE,
+    )
+    original = _state(
+        _active("first").model_copy(update={"attempts": [attempt]}),
+        status=LifecycleRunStatus.AWAITING_CHECKPOINT_SUBMISSION,
+        active_checkpoint_id="first",
+    )
+
+    reduction = reduce_submit(
+        original,
+        checkpoint_id="first",
+        submission_path="submissions/first.json",
+        submission_sha256="d" * 64,
+        reason="submit",
+    )
+
+    assert original.checkpoint("first").status == CheckpointRunStatus.ACTIVE
+    assert original.checkpoint("first").active_attempt is not None
+    assert reduction.state.checkpoint("first").status == CheckpointRunStatus.SUBMITTED
+    assert reduction.state.checkpoint("first").attempts[0].status == CheckpointAttemptStatus.SUBMITTED
+
+
+def test_open_and_fail_attempt_keep_prior_state_unchanged() -> None:
+    original = _state(
+        _active(),
+        status=LifecycleRunStatus.AWAITING_CHECKPOINT_SUBMISSION,
+        active_checkpoint_id="first",
+    )
+    opened = reduce_open_attempt(
+        original,
+        checkpoint_id="first",
+        session_id="session-001",
+        execution_mode="fresh_context",
+        episode_request_sha256=None,
+    )
+    failed = reduce_fail_attempt(
+        opened.state,
+        checkpoint_id="first",
+        session_id="session-001",
+        failure_kind="provider_error",
+    )
+
+    assert original.checkpoint("first").attempts == []
+    assert opened.state.checkpoint("first").active_attempt is not None
+    assert failed.state.checkpoint("first").last_attempt is not None
+    assert failed.state.checkpoint("first").last_attempt.status == CheckpointAttemptStatus.FAILED
+
+
+def test_revisit_returns_detached_state_and_rejects_unsubmitted_checkpoint() -> None:
+    original = _state(_submitted())
+    reduction = reduce_revisit(original, checkpoint_id="first", reason="inspect")
+
+    assert original.revisits == []
+    assert reduction.state.revisits[0].revisit_id == "revisit-001"
+    assert reduction.events[0].kind.value == "revisit"
+
+    with pytest.raises(EvidenceLifecycleError, match="checkpoint is not available for revisit: second"):
+        reduce_revisit(_state(CheckpointRunRecord(checkpoint_id="second")), checkpoint_id="second", reason="inspect")
+
+
+def test_branch_constructs_canonical_state_and_does_not_mutate_parent() -> None:
+    parent = _state(
+        _submitted("first"),
+        _submitted("second"),
+        run_authorization_sha256="f" * 64,
+    )
+    branch = LifecycleBranchRecord(
+        branch_id="branch-001",
+        parent_run_dir="/tmp/parent",
+        branched_from_checkpoint_id="first",
+        parent_submission_sha256="c" * 64,
+        parent_action_state_sha256="e" * 64,
+        reason="recheck",
+    )
+
+    reduction = reduce_branch(
+        parent,
+        checkpoints=[_checkpoint_spec("first"), _checkpoint_spec("second")],
+        branch_index=1,
+        branch=branch,
+        checkpoint_id="second",
+        reason="recheck",
+    )
+
+    assert parent.branch is None
+    assert parent.status == LifecycleRunStatus.AWAITING_EVIDENCE_RELEASE
+    assert reduction.state.branch is not None
+    assert reduction.state.active_checkpoint_id == "second"
+    assert reduction.state.status == LifecycleRunStatus.AWAITING_CHECKPOINT_SUBMISSION
+    assert reduction.state.run_authorization_sha256 is None
+    assert reduction.events[0].kind.value == "branch"
+
+
+def test_branch_rejects_incomplete_inherited_dependency() -> None:
+    parent = EvidenceLifecycleRunState.model_construct(
+        lifecycle_id="lifecycle.test",
+        lifecycle_spec_sha256="a" * 64,
+        package_sha256="b" * 64,
+        status=LifecycleRunStatus.AWAITING_CHECKPOINT_SUBMISSION,
+        active_checkpoint_id="second",
+        checkpoint_runs=[_submitted("first"), _active("second"), _submitted("third")],
+        revisits=[],
+        transitions=[],
+        branch=None,
+    )
+    branch = LifecycleBranchRecord(
+        branch_id="branch-001",
+        parent_run_dir="/tmp/parent",
+        branched_from_checkpoint_id="third",
+        parent_submission_sha256="c" * 64,
+        parent_action_state_sha256="e" * 64,
+        reason="recheck",
+    )
+
+    with pytest.raises(EvidenceLifecycleError, match="parent checkpoint dependency is incomplete: second"):
+        reduce_branch(
+            parent,
+            checkpoints=[_checkpoint_spec("first"), _checkpoint_spec("second"), _checkpoint_spec("third")],
+            branch_index=2,
+            branch=branch,
+            checkpoint_id="third",
+            reason="recheck",
+        )
+
+
+def test_branch_rejects_invalid_index_and_unsubmitted_target() -> None:
+    parent = _state(_submitted("first"), CheckpointRunRecord(checkpoint_id="second"))
+    branch = LifecycleBranchRecord(
+        branch_id="branch-001",
+        parent_run_dir="/tmp/parent",
+        branched_from_checkpoint_id="second",
+        parent_submission_sha256="c" * 64,
+        parent_action_state_sha256="e" * 64,
+        reason="recheck",
+    )
+    checkpoints = [_checkpoint_spec("first"), _checkpoint_spec("second")]
+
+    with pytest.raises(EvidenceLifecycleError, match="branch checkpoint index is out of range: 2"):
+        reduce_branch(
+            parent,
+            checkpoints=checkpoints,
+            branch_index=2,
+            branch=branch,
+            checkpoint_id="second",
+            reason="recheck",
+        )
+    with pytest.raises(EvidenceLifecycleError, match="branch checkpoint index does not match checkpoint id"):
+        reduce_branch(
+            parent,
+            checkpoints=checkpoints,
+            branch_index=0,
+            branch=branch,
+            checkpoint_id="second",
+            reason="recheck",
+        )
+    with pytest.raises(EvidenceLifecycleError, match="checkpoint is not available for branching: second"):
+        reduce_branch(
+            parent,
+            checkpoints=checkpoints,
+            branch_index=1,
+            branch=branch,
+            checkpoint_id="second",
+            reason="recheck",
+        )
+
+
+def test_branch_initialises_future_checkpoint_budgets_from_specs() -> None:
+    parent = _state(_submitted("first"), _submitted("second"))
+    branch = LifecycleBranchRecord(
+        branch_id="branch-001",
+        parent_run_dir="/tmp/parent",
+        branched_from_checkpoint_id="second",
+        parent_submission_sha256="c" * 64,
+        parent_action_state_sha256="e" * 64,
+        reason="recheck",
+    )
+
+    reduction = reduce_branch(
+        parent,
+        checkpoints=[
+            _checkpoint_spec("first"),
+            _checkpoint_spec("second"),
+            _checkpoint_spec("third", request_budget=2),
+        ],
+        branch_index=1,
+        branch=branch,
+        checkpoint_id="second",
+        reason="recheck",
+    )
+
+    future = reduction.state.checkpoint("third")
+    assert future.evidence_request_budget == 2
+    assert future.evidence_request_budget_remaining == 2
+
+
+def test_reducer_maps_invalid_checkpoint_to_evidence_lifecycle_error() -> None:
+    with pytest.raises(EvidenceLifecycleError, match="unknown checkpoint: missing"):
+        reduce_release(
+            _state(CheckpointRunRecord(checkpoint_id="first")),
+            checkpoint_id="missing",
+            released_files=(),
+            previous_checkpoint_id=None,
+            reason="release",
+        )


### PR DESCRIPTION
## Summary

- move lifecycle state decisions into a pure reducer that returns detached state and transition records
- keep locks, filesystem work, ledgers, and persistence in the lifecycle application
- make branch inheritance, reopened checkpoints, and future checkpoint budgets explicit reducer rules

## Review order

1. `src/aec_bench/lifecycles/runtime/reducer.py`
2. `src/aec_bench/lifecycles/runtime/lifecycle.py`
3. `tests/lifecycles/runtime/test_reducer.py`

## Validation

- `uv run pytest tests/lifecycles/ -q` — 660 passed
- runtime and lifecycle conformance selection — 284 passed
- focused reducer, lifecycle, branch, and CLI selection — 114 passed
- `uv run ruff check src/ tests/`
- Ruff format check for changed files
- targeted mypy check
- `uv run aec-bench catalogue check`
- provenance audit — zero violations
- `uv build`