### PR TITLE
PRD4: enforce the package dependency audit

### DIFF
--- a/scripts/audit_package_dependencies.py
+++ b/scripts/audit_package_dependencies.py
@@ -13,7 +13,10 @@ import subprocess
 import sys
 import tomllib
 from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import date
 from pathlib import Path
+from re import fullmatch
 
 OPTIONAL_RUNTIME_ROOTS = {
     "acp",
@@ -40,14 +43,49 @@ COMPOSITION_ROOTS = {
         "aec_bench.worlds.stewardship",
     ),
 }
+GENERIC_RUNTIME_ROOTS = {
+    "aec_bench.lifecycles.runtime": (
+        "aec_bench.lifecycles.catalogue",
+        "aec_bench.lifecycles.stormwater_design",
+        "aec_bench.lifecycles.structural_review",
+    ),
+    "aec_bench.worlds.runtime": (
+        "aec_bench.worlds.catalogue",
+        "aec_bench.worlds.monitoring",
+        "aec_bench.worlds.stewardship",
+    ),
+}
 IGNORED_SOURCE_PARTS = {"__pycache__", "node_modules"}
 DEFAULT_OWNER_POLICY_PATH = Path(__file__).with_name("owner_dependencies.toml")
 
 
+@dataclass(frozen=True)
+class OwnerDependencyException:
+    """One narrow, owner-approved exception to the declared dependency matrix."""
+
+    source_owner: str
+    target_owner: str
+    import_prefix: str
+    reason: str
+    expiry: date | None
+    review_condition: str | None
+    owner_approval: str
+
+
+def _load_owner_policy_document(path: Path) -> dict[str, object]:
+    try:
+        with path.open("rb") as policy_file:
+            document = tomllib.load(policy_file)
+    except FileNotFoundError as error:
+        raise ValueError(f"owner dependency policy file is missing: {path}") from error
+    if not isinstance(document, dict):
+        raise ValueError("owner dependency policy must be a TOML table")
+    return document
+
+
 def load_owner_dependency_policy(path: Path = DEFAULT_OWNER_POLICY_PATH) -> dict[str, set[str]]:
     """Load the complete owner dependency policy without importing source modules."""
-    with path.open("rb") as policy_file:
-        document = tomllib.load(policy_file)
+    document = _load_owner_policy_document(path)
     raw_owners = document.get("owners")
     if not isinstance(raw_owners, dict):
         raise ValueError("owner dependency policy must contain an owners table")
@@ -66,8 +104,113 @@ def load_owner_dependency_policy(path: Path = DEFAULT_OWNER_POLICY_PATH) -> dict
     return policy
 
 
-def validate_owner_dependency_policy(owner_graph: dict[str, set[str]], policy: dict[str, set[str]]) -> tuple[str, ...]:
+def load_owner_dependency_exceptions(path: Path = DEFAULT_OWNER_POLICY_PATH) -> tuple[OwnerDependencyException, ...]:
+    """Load narrow exceptions from the same maintained owner policy."""
+    document = _load_owner_policy_document(path)
+    raw_exceptions = document.get("exceptions", {})
+    if not isinstance(raw_exceptions, dict):
+        raise ValueError("owner dependency exceptions must be a TOML table")
+    exceptions: list[OwnerDependencyException] = []
+    required = {"source_owner", "target_owner", "import_prefix", "reason", "owner_approval"}
+    for name, raw_exception in sorted(raw_exceptions.items()):
+        if not isinstance(name, str) or not name:
+            raise ValueError("owner dependency exception names must be non-empty strings")
+        if not isinstance(raw_exception, dict):
+            raise ValueError(f"owner dependency exception is invalid: {name}")
+        fields = set(raw_exception)
+        if not required.issubset(fields) or fields - required - {"expiry", "review_condition"}:
+            raise ValueError(f"owner dependency exception fields are invalid: {name}")
+        if "expiry" not in fields and "review_condition" not in fields:
+            raise ValueError(f"owner dependency exception requires expiry or review_condition: {name}")
+        values = {field: raw_exception[field] for field in required}
+        if any(not isinstance(value, str) or not value.strip() for value in values.values()):
+            raise ValueError(f"owner dependency exception values are invalid: {name}")
+        import_prefix = values["import_prefix"].strip()
+        if not import_prefix.startswith("aec_bench.") or "*" in import_prefix or len(import_prefix.split(".")) < 3:
+            raise ValueError(f"owner dependency exception import prefix is too broad: {name}")
+        expiry_value = raw_exception.get("expiry")
+        if expiry_value is not None and not isinstance(expiry_value, date | str):
+            raise ValueError(f"owner dependency exception expiry is invalid: {name}")
+        try:
+            expiry = date.fromisoformat(expiry_value) if isinstance(expiry_value, str) else expiry_value
+        except ValueError as error:
+            raise ValueError(f"owner dependency exception expiry is invalid: {name}") from error
+        review_condition = raw_exception.get("review_condition")
+        if review_condition is not None and (
+            not isinstance(review_condition, str)
+            or fullmatch(r"review-by:\d{4}-\d{2}-\d{2}", review_condition.strip()) is None
+        ):
+            raise ValueError(f"owner dependency exception review condition is invalid: {name}")
+        if review_condition is not None:
+            try:
+                date.fromisoformat(review_condition.strip().removeprefix("review-by:"))
+            except ValueError as error:
+                raise ValueError(f"owner dependency exception review condition is invalid: {name}") from error
+        exceptions.append(
+            OwnerDependencyException(
+                source_owner=values["source_owner"].strip(),
+                target_owner=values["target_owner"].strip(),
+                import_prefix=import_prefix,
+                reason=values["reason"].strip(),
+                expiry=expiry,
+                review_condition=review_condition.strip() if review_condition is not None else None,
+                owner_approval=values["owner_approval"].strip(),
+            )
+        )
+    return tuple(exceptions)
+
+
+def validate_owner_dependency_exceptions(
+    owner_graph: dict[str, set[str]],
+    owner_imports: dict[tuple[str, str], set[str]],
+    exceptions: Iterable[OwnerDependencyException],
+) -> tuple[tuple[str, ...], dict[tuple[str, str], set[str]]]:
+    """Validate exceptions and return their narrow import prefixes by owner edge."""
+    owners = set(owner_graph)
+    violations: list[str] = []
+    allowed_prefixes: dict[tuple[str, str], set[str]] = {}
+    today = date.today()
+    for exception in exceptions:
+        label = f"{exception.source_owner} -> {exception.target_owner} ({exception.import_prefix})"
+        if exception.source_owner not in owners:
+            violations.append(f"exception declares unknown source owner: {label}")
+            continue
+        if exception.target_owner not in owners:
+            violations.append(f"exception declares unknown target owner: {label}")
+            continue
+        edge = (exception.source_owner, exception.target_owner)
+        if exception.target_owner not in owner_graph[exception.source_owner]:
+            violations.append(f"exception does not match an observed owner dependency: {label}")
+            continue
+        if exception.expiry is not None and exception.expiry < today:
+            violations.append(f"exception is expired: {label}")
+            continue
+        if exception.review_condition is not None:
+            review_date = date.fromisoformat(exception.review_condition.removeprefix("review-by:"))
+            if review_date < today:
+                violations.append(f"exception review is overdue: {label}")
+                continue
+        imports = owner_imports.get(edge, set())
+        if not any(
+            imported == exception.import_prefix or imported.startswith(f"{exception.import_prefix}.")
+            for imported in imports
+        ):
+            violations.append(f"exception import prefix does not match an observed import: {label}")
+            continue
+        allowed_prefixes.setdefault(edge, set()).add(exception.import_prefix)
+    return tuple(sorted(violations)), allowed_prefixes
+
+
+def validate_owner_dependency_policy(
+    owner_graph: dict[str, set[str]],
+    policy: dict[str, set[str]],
+    *,
+    owner_imports: dict[tuple[str, str], set[str]] | None = None,
+    exception_prefixes: dict[tuple[str, str], set[str]] | None = None,
+) -> tuple[str, ...]:
     """Return deterministic violations between the declared and observed owner graph."""
+    owner_imports = owner_imports or {}
+    exception_prefixes = exception_prefixes or {}
     actual_owners = set(owner_graph)
     policy_owners = set(policy)
     violations = [f"missing policy for owner: {owner}" for owner in sorted(actual_owners - policy_owners)]
@@ -77,7 +220,17 @@ def validate_owner_dependency_policy(owner_graph: dict[str, set[str]], policy: d
             violations.append(f"policy declares unknown dependency: {source} -> {target}")
     for source in sorted(actual_owners):
         for target in sorted(owner_graph[source] - policy.get(source, set())):
-            violations.append(f"undeclared owner dependency: {source} -> {target}")
+            edge = (source, target)
+            imports = owner_imports.get(edge)
+            prefixes = exception_prefixes.get(edge, set())
+            if imports is None:
+                violations.append(f"undeclared owner dependency: {source} -> {target}")
+            else:
+                violations.extend(
+                    f"undeclared owner import: {source} -> {imported}"
+                    for imported in sorted(imports)
+                    if not any(imported == prefix or imported.startswith(f"{prefix}.") for prefix in prefixes)
+                )
     return tuple(violations)
 
 
@@ -226,15 +379,23 @@ def build_audit(
 
     owners = sorted({owner for module in known_modules if (owner := _owner(module)) is not None})
     owner_graph: dict[str, set[str]] = {owner: set() for owner in owners}
+    owner_imports: dict[tuple[str, str], set[str]] = {}
     for source, targets in graph.items():
         source_owner = _owner(source)
         if source_owner is None:
             continue
-        owner_graph[source_owner].update(
-            target_owner
-            for target in targets
-            if (target_owner := _owner(target)) is not None and target_owner != source_owner
-        )
+        for target in targets:
+            target_owner = _owner(target)
+            if target_owner is None or target_owner == source_owner:
+                continue
+            owner_graph[source_owner].add(target_owner)
+            edge = (source_owner, target_owner)
+            owner_imports.setdefault(edge, set()).update(
+                imported_target
+                for imported in raw_internal[source]
+                if (imported_target := _known_target(imported, known_modules)) is not None
+                and _owner(imported_target) == target_owner
+            )
 
     owner_sccs = _strongly_connected_components(owner_graph)
     module_sccs = _strongly_connected_components(graph)
@@ -256,13 +417,41 @@ def build_audit(
             and any(name == root or name.startswith(f"{root}.") for name in imports)
         }
     )
+    generic_runtime_back_imports = sorted(
+        {
+            f"{module} -> {target}"
+            for runtime_root, concrete_prefixes in GENERIC_RUNTIME_ROOTS.items()
+            for module, imports in raw_internal.items()
+            if module == runtime_root or module.startswith(f"{runtime_root}.")
+            for imported in imports
+            if (target := _known_target(imported, known_modules)) is not None
+            and any(target == prefix or target.startswith(f"{prefix}.") for prefix in concrete_prefixes)
+        }
+    )
     optional_leakage = sorted(
         f"{module}: {', '.join(sorted(external_roots[module] & OPTIONAL_RUNTIME_ROOTS))}"
         for module in known_modules
         if _owner(module) in NEUTRAL_OWNERS and external_roots[module] & OPTIONAL_RUNTIME_ROOTS
     )
-    owner_policy = load_owner_dependency_policy(repository_root / "scripts" / DEFAULT_OWNER_POLICY_PATH.name)
-    owner_policy_violations = validate_owner_dependency_policy(owner_graph, owner_policy)
+    policy_path = repository_root / "scripts" / DEFAULT_OWNER_POLICY_PATH.name
+    try:
+        owner_policy = load_owner_dependency_policy(policy_path)
+        exceptions = load_owner_dependency_exceptions(policy_path)
+        exception_violations, exception_prefixes = validate_owner_dependency_exceptions(
+            owner_graph, owner_imports, exceptions
+        )
+        owner_policy_violations = list(exception_violations)
+        owner_policy_violations.extend(
+            validate_owner_dependency_policy(
+                owner_graph,
+                owner_policy,
+                owner_imports=owner_imports,
+                exception_prefixes=exception_prefixes,
+            )
+        )
+    except ValueError as error:
+        owner_policy = {}
+        owner_policy_violations = [str(error)]
 
     return {
         "schema_version": "1",
@@ -275,6 +464,7 @@ def build_audit(
         "top_level_strongly_connected_components": owner_sccs,
         "module_cycles_within_top_level_components": module_sccs_by_owner_cycle,
         "composition_root_back_imports": composition_back_imports,
+        "generic_runtime_back_imports": generic_runtime_back_imports,
         "optional_dependency_leakage": optional_leakage,
         "minimal_install_import_smoke": {
             "status": minimal_import_smoke,
@@ -292,6 +482,35 @@ def _current_commit(repository_root: Path) -> str:
         text=True,
     )
     return result.stdout.strip()
+
+
+def render_audit_report(audit: dict[str, object]) -> str:
+    """Render the owner graph and violations for a contributor-facing report."""
+    graph = audit.get("top_level_package_graph", {})
+    lines = ["Owner dependency graph:"]
+    if isinstance(graph, dict):
+        for owner, targets in sorted(graph.items()):
+            rendered_targets = ", ".join(str(target) for target in targets) if targets else "(none)"
+            lines.append(f"  {owner} -> {rendered_targets}")
+    failures = {
+        "owner dependency policy": audit.get("owner_dependency_policy_violations", []),
+        "top-level owner cycles": audit.get("top_level_strongly_connected_components", []),
+        "composition back-imports": audit.get("composition_root_back_imports", []),
+        "generic runtime back-imports": audit.get("generic_runtime_back_imports", []),
+        "optional dependency leakage": audit.get("optional_dependency_leakage", []),
+    }
+    active = {name: value for name, value in failures.items() if value}
+    if not active:
+        lines.append("Violations: none")
+        return "\n".join(lines)
+    lines.append("Violations:")
+    for name, values in active.items():
+        lines.append(f"  {name}:")
+        if isinstance(values, list | tuple):
+            lines.extend(f"    - {value}" for value in values)
+        else:
+            lines.append(f"    - {values}")
+    return "\n".join(lines)
 
 
 def main() -> int:
@@ -323,12 +542,15 @@ def main() -> int:
         "owner dependency policy": audit["owner_dependency_policy_violations"],
         "top-level owner cycles": audit["top_level_strongly_connected_components"],
         "composition back-imports": audit["composition_root_back_imports"],
+        "generic runtime back-imports": audit["generic_runtime_back_imports"],
         "optional dependency leakage": audit["optional_dependency_leakage"],
     }
     active_failures = {name: value for name, value in failures.items() if value}
-    if args.check and active_failures:
-        print(json.dumps(active_failures, indent=2, sort_keys=True), file=sys.stderr)
-        return 1
+    if args.check:
+        print(render_audit_report(audit), file=sys.stderr)
+        if active_failures:
+            print(json.dumps(active_failures, indent=2, sort_keys=True), file=sys.stderr)
+            return 1
     return 0
 
 

--- a/tests/test_package_ownership.py
+++ b/tests/test_package_ownership.py
@@ -12,8 +12,11 @@ from pathlib import Path
 import pytest
 
 from scripts.audit_package_dependencies import (
+    OwnerDependencyException,
     build_audit,
     load_owner_dependency_policy,
+    render_audit_report,
+    validate_owner_dependency_exceptions,
     validate_owner_dependency_policy,
 )
 
@@ -106,12 +109,338 @@ def test_owner_dependency_policy_reports_missing_and_forbidden_edges() -> None:
     )
 
 
+def test_owner_dependency_policy_reports_unknown_owner_and_target() -> None:
+    violations = validate_owner_dependency_policy(
+        {"contracts": set()},
+        {"contracts": {"missing"}, "unknown": set()},
+    )
+
+    assert violations == (
+        "policy declares unknown owner: unknown",
+        "policy declares unknown dependency: contracts -> missing",
+    )
+
+
 def test_owner_dependency_policy_loader_rejects_duplicate_targets(tmp_path: Path) -> None:
     policy_path = tmp_path / "owner_dependencies.toml"
     policy_path.write_text('[owners.contracts]\nmay_depend_on = ["ledger", "ledger"]\n', encoding="utf-8")
 
     with pytest.raises(ValueError, match="targets must be unique: contracts"):
         load_owner_dependency_policy(policy_path)
+
+
+def _dependency_fixture(
+    tmp_path: Path,
+    files: dict[str, str],
+    policy: str | None,
+) -> Path:
+    repository_root = tmp_path / "repository"
+    package_root = repository_root / "src" / "aec_bench"
+    package_root.mkdir(parents=True)
+    (package_root / "__init__.py").write_text("", encoding="utf-8")
+    for relative_path, source in files.items():
+        path = package_root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(source, encoding="utf-8")
+    if policy is not None:
+        policy_path = repository_root / "scripts" / "owner_dependencies.toml"
+        policy_path.parent.mkdir(parents=True, exist_ok=True)
+        policy_path.write_text(policy, encoding="utf-8")
+    return repository_root
+
+
+def _audit_fixture(repository_root: Path) -> dict[str, object]:
+    return build_audit(
+        repository_root=repository_root,
+        commit="fixture",
+        minimal_import_smoke="not-run",
+        minimal_import_command="",
+    )
+
+
+def test_dependency_audit_reports_missing_policy_deterministically(tmp_path: Path) -> None:
+    repository_root = _dependency_fixture(tmp_path, {"contracts/value.py": ""}, policy=None)
+
+    audit = _audit_fixture(repository_root)
+
+    assert audit["owner_dependency_policy_violations"] == [
+        f"owner dependency policy file is missing: {repository_root / 'scripts' / 'owner_dependencies.toml'}"
+    ]
+
+
+def test_dependency_audit_parses_source_without_importing_it(tmp_path: Path) -> None:
+    repository_root = _dependency_fixture(
+        tmp_path,
+        {"contracts/explosive.py": 'raise RuntimeError("audit must not import source")\n'},
+        policy="[owners.contracts]\nmay_depend_on = []\n",
+    )
+
+    audit = _audit_fixture(repository_root)
+
+    assert audit["owner_dependency_policy_violations"] == []
+
+
+def test_dependency_audit_reports_cycle_and_forbidden_edge(tmp_path: Path) -> None:
+    repository_root = _dependency_fixture(
+        tmp_path,
+        {
+            "alpha/one.py": "from aec_bench.beta.two import VALUE\n",
+            "beta/two.py": "from aec_bench.alpha.one import VALUE\n",
+        },
+        policy="[owners.alpha]\nmay_depend_on = []\n\n[owners.beta]\nmay_depend_on = []\n",
+    )
+
+    audit = _audit_fixture(repository_root)
+
+    assert audit["owner_dependency_policy_violations"] == [
+        "undeclared owner import: alpha -> aec_bench.beta.two",
+        "undeclared owner import: beta -> aec_bench.alpha.one",
+    ]
+    assert audit["top_level_strongly_connected_components"] == [["alpha", "beta"]]
+    report = render_audit_report(audit)
+    assert "alpha -> beta" in report
+    assert "Violations:" in report
+
+
+def test_dependency_audit_rejects_generic_runtime_back_import(tmp_path: Path) -> None:
+    repository_root = _dependency_fixture(
+        tmp_path,
+        {
+            "worlds/runtime/runner.py": "from aec_bench.worlds.monitoring.task import VALUE\n",
+            "worlds/monitoring/task.py": "VALUE = 1\n",
+        },
+        policy="[owners.worlds]\nmay_depend_on = []\n",
+    )
+
+    audit = _audit_fixture(repository_root)
+
+    assert audit["generic_runtime_back_imports"] == [
+        "aec_bench.worlds.runtime.runner -> aec_bench.worlds.monitoring.task",
+    ]
+
+
+def test_dependency_audit_rejects_optional_runtime_in_neutral_owner(tmp_path: Path) -> None:
+    repository_root = _dependency_fixture(
+        tmp_path,
+        {"contracts/provider_boundary.py": "import openai\n"},
+        policy="[owners.contracts]\nmay_depend_on = []\n",
+    )
+
+    audit = _audit_fixture(repository_root)
+
+    assert audit["optional_dependency_leakage"] == ["aec_bench.contracts.provider_boundary: openai"]
+
+
+def test_dependency_audit_accepts_a_current_narrow_exception(tmp_path: Path) -> None:
+    repository_root = _dependency_fixture(
+        tmp_path,
+        {
+            "alpha/one.py": "from aec_bench.beta.two import VALUE\n",
+            "beta/two.py": "VALUE = 1\n",
+        },
+        """
+[owners.alpha]
+may_depend_on = []
+
+[owners.beta]
+may_depend_on = []
+
+[exceptions.alpha-beta]
+source_owner = "alpha"
+target_owner = "beta"
+import_prefix = "aec_bench.beta.two"
+reason = "The current adapter boundary requires this narrow value import."
+expiry = "2099-12-31"
+owner_approval = "architecture-owner"
+""",
+    )
+
+    audit = _audit_fixture(repository_root)
+
+    assert audit["owner_dependency_policy_violations"] == []
+
+
+def test_dependency_audit_exception_does_not_waive_other_imports_on_same_edge(tmp_path: Path) -> None:
+    repository_root = _dependency_fixture(
+        tmp_path,
+        {
+            "alpha/one.py": ("from aec_bench.beta.two import VALUE\nfrom aec_bench.beta.three import OTHER\n"),
+            "beta/two.py": "VALUE = 1\n",
+            "beta/three.py": "OTHER = 2\n",
+        },
+        """
+[owners.alpha]
+may_depend_on = []
+
+[owners.beta]
+may_depend_on = []
+
+[exceptions.alpha-beta]
+source_owner = "alpha"
+target_owner = "beta"
+import_prefix = "aec_bench.beta.two"
+reason = "The current adapter boundary requires this narrow value import."
+expiry = "2099-12-31"
+owner_approval = "architecture-owner"
+""",
+    )
+
+    audit = _audit_fixture(repository_root)
+
+    assert audit["owner_dependency_policy_violations"] == [
+        "undeclared owner import: alpha -> aec_bench.beta.three",
+    ]
+
+
+def test_dependency_audit_rejects_expired_exception(tmp_path: Path) -> None:
+    repository_root = _dependency_fixture(
+        tmp_path,
+        {
+            "alpha/one.py": "from aec_bench.beta.two import VALUE\n",
+            "beta/two.py": "VALUE = 1\n",
+        },
+        """
+[owners.alpha]
+may_depend_on = []
+
+[owners.beta]
+may_depend_on = []
+
+[exceptions.alpha-beta]
+source_owner = "alpha"
+target_owner = "beta"
+import_prefix = "aec_bench.beta.two"
+reason = "Expired test exception."
+expiry = "2000-01-01"
+owner_approval = "architecture-owner"
+""",
+    )
+
+    audit = _audit_fixture(repository_root)
+
+    assert audit["owner_dependency_policy_violations"] == [
+        "exception is expired: alpha -> beta (aec_bench.beta.two)",
+        "undeclared owner import: alpha -> aec_bench.beta.two",
+    ]
+
+
+def test_dependency_audit_rejects_broad_exception_prefix(tmp_path: Path) -> None:
+    repository_root = _dependency_fixture(
+        tmp_path,
+        {"alpha/one.py": ""},
+        """
+[owners.alpha]
+may_depend_on = []
+
+[exceptions.broad]
+source_owner = "alpha"
+target_owner = "alpha"
+import_prefix = "aec_bench.alpha"
+reason = "Too broad."
+review_condition = "Never"
+owner_approval = "architecture-owner"
+""",
+    )
+
+    audit = _audit_fixture(repository_root)
+
+    assert audit["owner_dependency_policy_violations"] == [
+        "owner dependency exception import prefix is too broad: broad"
+    ]
+
+
+def test_dependency_audit_rejects_unenforceable_review_condition(tmp_path: Path) -> None:
+    repository_root = _dependency_fixture(
+        tmp_path,
+        {
+            "alpha/one.py": "from aec_bench.beta.two import VALUE\n",
+            "beta/two.py": "VALUE = 1\n",
+        },
+        """
+[owners.alpha]
+may_depend_on = []
+
+[owners.beta]
+may_depend_on = []
+
+[exceptions.unenforceable]
+source_owner = "alpha"
+target_owner = "beta"
+import_prefix = "aec_bench.beta.two"
+reason = "Free text cannot be checked."
+review_condition = "review this later"
+owner_approval = "architecture-owner"
+""",
+    )
+
+    audit = _audit_fixture(repository_root)
+
+    assert audit["owner_dependency_policy_violations"] == [
+        "owner dependency exception review condition is invalid: unenforceable"
+    ]
+
+
+@pytest.mark.parametrize(
+    ("review_condition", "expected_violations"),
+    (
+        ("review-by:2099-12-31", []),
+        (
+            "review-by:2000-01-01",
+            [
+                "exception review is overdue: alpha -> beta (aec_bench.beta.two)",
+                "undeclared owner import: alpha -> aec_bench.beta.two",
+            ],
+        ),
+    ),
+)
+def test_dependency_audit_enforces_exception_review_date(
+    tmp_path: Path,
+    review_condition: str,
+    expected_violations: list[str],
+) -> None:
+    repository_root = _dependency_fixture(
+        tmp_path,
+        {
+            "alpha/one.py": "from aec_bench.beta.two import VALUE\n",
+            "beta/two.py": "VALUE = 1\n",
+        },
+        f"""
+[owners.alpha]
+may_depend_on = []
+
+[owners.beta]
+may_depend_on = []
+
+[exceptions.alpha-beta]
+source_owner = "alpha"
+target_owner = "beta"
+import_prefix = "aec_bench.beta.two"
+reason = "The dependency is reviewed on a fixed date."
+review_condition = "{review_condition}"
+owner_approval = "architecture-owner"
+""",
+    )
+
+    audit = _audit_fixture(repository_root)
+
+    assert audit["owner_dependency_policy_violations"] == expected_violations
+
+
+def test_dependency_audit_exception_validation_rejects_unknown_owners() -> None:
+    exception = OwnerDependencyException(
+        source_owner="missing",
+        target_owner="unknown",
+        import_prefix="aec_bench.unknown.module",
+        reason="test",
+        expiry=None,
+        review_condition="test review",
+        owner_approval="owner",
+    )
+
+    violations, allowed_edges = validate_owner_dependency_exceptions({"contracts": set()}, {}, (exception,))
+
+    assert violations == ("exception declares unknown source owner: missing -> unknown (aec_bench.unknown.module)",)
+    assert allowed_edges == {}
 
 
 def test_neutral_contracts_and_domains_do_not_import_optional_runtimes() -> None:


### PR DESCRIPTION
## Summary

- make the standard-library AST dependency audit authoritative for the complete owner policy
- detect missing policy, unknown owners and targets, undeclared imports, owner cycles, runtime back-imports, composition back-imports, and optional provider leaks
- support owner-approved exceptions that apply only to a specific import prefix and have an enforceable expiry or review date
- add deterministic temporary-repository tests and a readable owner graph report

## Review order

1. `scripts/audit_package_dependencies.py`
2. `tests/test_package_ownership.py`

## Validation

- `python -m pytest tests/test_package_ownership.py -q` (`46 passed`)
- `python -m ruff check scripts/audit_package_dependencies.py tests/test_package_ownership.py`
- `python -m ruff format --check scripts/audit_package_dependencies.py tests/test_package_ownership.py`
- `python -m mypy scripts/audit_package_dependencies.py tests/test_package_ownership.py`
- `python3 scripts/audit_package_dependencies.py --check --commit review`
- `git diff --check`

## Scope

This is PR 12 of the PRD 4 sequence. It builds on the complete owner dependency matrix merged in PR 11.
