### PR TITLE
PRD4: define the public API inventory

### DIFF
--- a/docs/API_INVENTORY.md
+++ b/docs/API_INVENTORY.md
@@ -1,0 +1,65 @@
+# AEC-Bench public API inventory
+
+| Field | Value |
+| --- | --- |
+| Class | Normative |
+| Status | Current |
+
+This document is the public surface inventory for the current AEC-Bench
+release. The entries below are the import paths and commands that callers may
+rely on. The compatibility tests named in each row keep the inventory tied to
+the installed code.
+
+## Python imports
+
+Supported Python imports are documented, tested, and stable within the
+project's declared version policy. Import the named objects from the listed
+module; other modules under `aec_bench` are implementation details unless this
+inventory names them.
+
+| Import path | Classification | Public objects | Compatibility test |
+| --- | --- | --- | --- |
+| `aec_bench` | Supported | `__version__`, `worlds` | `tests/test_public_api_inventory.py` |
+| `aec_bench.worlds` | Supported | `WorldInfo`, `WorldProfileInfo`, `WorldTask`, `branch_world`, `find`, `get`, `list`, `load_profile`, `load_world_task`, `profiles`, `task`, `tasks_for_branches` | `tests/test_public_api_inventory.py`, `tests/worlds/test_public_api.py` |
+| `aec_bench.trials` | Supported | `PlannedTrial`, `plan_trials` | `tests/test_public_api_inventory.py`, `tests/contracts/test_run_plan.py` |
+| `aec_bench.harness.world_trials` | Supported | `run_world_experiment` | `tests/test_public_api_inventory.py`, `tests/deepseek_harness/test_runtime.py` |
+| `aec_bench.harness.dam_seepage_trial` | Supported | `run_dam_seepage_trial` | `tests/test_public_api_inventory.py`, `tests/deepseek_harness/test_runtime.py` |
+| `aec_bench.harness.prime_world_actor` | Supported | `run_prime_world_actor_session` | `tests/test_public_api_inventory.py`, `tests/deepseek_harness/test_runtime.py` |
+| `aec_bench.evolution` | Supported | `CandidateChecks`, `CandidateProposal`, `CandidateProposalRequest`, `ProposalStatus`, `ReportWriter`, `build_avo`, `build_local_checks`, `gate_candidate`, `next_evolution_state`, `run_evolution`, `run_evolution_from_config` | `tests/test_public_api_inventory.py`, `tests/evolution/test_core.py` |
+| `aec_bench.experimentation.meta_harness` | Supported | `run_harness_study` | `tests/test_public_api_inventory.py`, `tests/experimentation/test_meta_harness.py` |
+| `aec_bench.adapters.deepseek_harness` | Experimental | `DeepSeekHarnessAdapter` | `tests/test_public_api_inventory.py`, `tests/deepseek_harness/test_sdk_integration.py` |
+
+The experimental entries are documented and tested, but their interfaces may
+change with a clear changelog entry.
+
+The `aec_bench.experimentation.meta_harness` entry is the runtime-neutral
+functional composition API used by the documented candidate study workflow.
+Its other module-level names remain implementation details unless listed here.
+
+All other `aec_bench.*` imports, including package implementation modules and
+package `__init__` details not listed above, are internal. They may change as
+the repository is simplified.
+
+## CLI commands
+
+`aec-bench` is the supported installed command. Its registered command names
+are listed here so a new command cannot become public by accident.
+
+| Classification | Command names |
+| --- | --- |
+| Supported | `init`, `run`, `run-local`, `import`, `import-local`, `import-prime-eval`, `evaluate`, `remediate`, `tui`, `web`, `search`, `report`, `evaluation`, `evidence`, `ledger`, `config`, `catalogue`, `conformance`, `generate`, `dataset`, `evolve`, `swarm`, `task`, `library`, `prime`, `meta-harness` |
+
+Optional integrations keep the same command names and report their required
+installation when the relevant extra is not installed.
+
+## Deprecation
+
+Supported Python imports and CLI commands receive a deprecation notice before
+removal. A deprecation notice names the replacement and the release or date
+that removes the surface.
+
+Experimental surfaces receive a changelog entry when their interface changes.
+Legacy surfaces are listed only when a real migration requires them. A legacy
+surface must emit a structured deprecation warning and state its removal
+condition. Legacy entries are added to this inventory when a migration surface
+is part of the supported boundary.

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,7 @@ authority.
 | [Invariants](INVARIANTS.md) | Normative | Normative | All contributors | Benchmark governance |
 | [Provenance policy](PROVENANCE_POLICY.md) | Normative | Current | Contributors adding persisted or public identity and evidence fields | Contracts and benchmark governance |
 | [Project structure](PROJECT_STRUCTURE.md) | Guide | Current | Contributors and agents | Repository maintainers |
+| [Public API inventory](API_INVENTORY.md) | Normative | Current | Python and CLI integrators | Repository maintainers |
 | [World authoring](world-authoring.md) | Guide | Current | Task and interactive-world contributors | Task, engineering, world, and lifecycle owners |
 | [Interactive-world runtime](protocols/interactive-world-runtime.md) | Protocol | Current | World, runtime, and transport contributors | World runtime and registered worlds |
 | [Staged evidence and publication](protocols/staged-evidence-and-publication.md) | Protocol | Current | Lifecycle and evaluation contributors | Lifecycle runtime and task owners |

--- a/tests/docs/test_documentation_ownership.py
+++ b/tests/docs/test_documentation_ownership.py
@@ -13,6 +13,7 @@ SKILL_ROOT = REPO_ROOT / "src" / "aec_bench" / "init" / "skill_data"
 DOMAIN_CHECK_ROOT = SKILL_ROOT / "domain-check"
 EXPECTED_REPOSITORY_DOCS = {
     "AGENTS.md",
+    "API_INVENTORY.md",
     "ARCHITECTURE.md",
     "CONTRACTS.md",
     "INVARIANTS.md",
@@ -52,6 +53,7 @@ EXPECTED_REPOSITORY_DOCS = {
 }
 MAINTAINED_INDEX_TARGETS = {
     "AGENTS.md",
+    "API_INVENTORY.md",
     "ARCHITECTURE.md",
     "CONTRACTS.md",
     "INVARIANTS.md",

--- a/tests/test_public_api_inventory.py
+++ b/tests/test_public_api_inventory.py
@@ -1,0 +1,134 @@
+# ABOUTME: Verifies the documented AEC-Bench import and command surfaces.
+# ABOUTME: Prevents package facades and CLI registrations from growing without review.
+
+from __future__ import annotations
+
+import ast
+import importlib
+import re
+from pathlib import Path
+from types import ModuleType
+
+INVENTORY = Path("docs/API_INVENTORY.md")
+MAIN_CLI = Path("src/aec_bench/cli/main.py")
+
+
+def _python_inventory() -> dict[str, tuple[str, tuple[str, ...]]]:
+    text = INVENTORY.read_text(encoding="utf-8")
+    entries: dict[str, tuple[str, tuple[str, ...]]] = {}
+    pattern = re.compile(r"^\| `([^`]+)` \| (Supported|Experimental|Legacy) \| (.*?) \|", re.MULTILINE)
+    for module_name, classification, objects in pattern.findall(text):
+        assert module_name not in entries, f"duplicate public API inventory entry: {module_name}"
+        entries[module_name] = (classification, tuple(re.findall(r"`([^`]+)`", objects)))
+    return entries
+
+
+def _module(module_name: str) -> ModuleType:
+    return importlib.import_module(module_name)
+
+
+def _source_declares(module_name: str, object_name: str) -> bool:
+    source = _source_path(module_name)
+    tree = ast.parse(source.read_text(encoding="utf-8"))
+    return any(
+        isinstance(node, ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef) and node.name == object_name
+        for node in tree.body
+    ) or any(
+        isinstance(node, ast.Import | ast.ImportFrom)
+        and any((alias.asname or alias.name.rsplit(".", 1)[-1]) == object_name for alias in node.names)
+        for node in tree.body
+    )
+
+
+def _source_all(module_name: str) -> tuple[str, ...]:
+    source = _source_path(module_name)
+    tree = ast.parse(source.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "__all__" for target in node.targets
+        ):
+            value = ast.literal_eval(node.value)
+            return tuple(value)
+    return ()
+
+
+def _source_path(module_name: str) -> Path:
+    source = Path("src", *module_name.split(".")).with_suffix(".py")
+    if source.is_file():
+        return source
+    return Path("src", *module_name.split("."), "__init__.py")
+
+
+def _registered_cli_commands() -> set[str]:
+    tree = ast.parse(MAIN_CLI.read_text(encoding="utf-8"))
+    commands: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr == "command" and node.args and isinstance(node.args[0], ast.Constant):
+            commands.add(str(node.args[0].value))
+        if node.func.attr == "add_typer":
+            for keyword in node.keywords:
+                if keyword.arg == "name" and isinstance(keyword.value, ast.Constant):
+                    commands.add(str(keyword.value.value))
+    return commands
+
+
+def _supported_cli_commands() -> set[str]:
+    text = INVENTORY.read_text(encoding="utf-8")
+    match = re.search(r"^\| Supported \| (.*?) \|$", text, re.MULTILINE)
+    assert match is not None
+    return set(re.findall(r"`([^`]+)`", match.group(1)))
+
+
+def test_inventory_has_one_classification_for_each_documented_python_surface() -> None:
+    entries = _python_inventory()
+    assert entries
+    assert all(classification in {"Supported", "Experimental", "Legacy"} for classification, _ in entries.values())
+    assert "aec_bench" in entries
+    assert "aec_bench.worlds" in entries
+
+
+def test_supported_facade_exports_match_the_inventory() -> None:
+    entries = _python_inventory()
+    for module_name, (classification, objects) in entries.items():
+        if classification != "Supported":
+            continue
+        for object_name in objects:
+            try:
+                module = _module(module_name)
+            except ModuleNotFoundError:
+                # Optional extras are not installed in the core test profile.
+                assert _source_declares(module_name, object_name), f"{module_name}.{object_name} is missing"
+            else:
+                assert hasattr(module, object_name), f"{module_name}.{object_name} is missing"
+
+    package_facades = [module_name for module_name in entries if _source_path(module_name).name == "__init__.py"]
+    for module_name in package_facades:
+        _, expected = entries[module_name]
+        try:
+            module = _module(module_name)
+        except ModuleNotFoundError:
+            assert _source_all(module_name) == expected
+        else:
+            assert tuple(module.__all__) == expected
+
+
+def test_experimental_surfaces_are_importable_without_becoming_root_exports() -> None:
+    entries = _python_inventory()
+    root = _module("aec_bench")
+    for module_name, (classification, objects) in entries.items():
+        if classification != "Experimental":
+            continue
+        module = _module(module_name)
+        declared = getattr(module, "__all__", ())
+        for object_name in objects:
+            if declared:
+                assert object_name in declared, f"{module_name}.{object_name} is not declared"
+            else:
+                assert hasattr(module, object_name), f"{module_name}.{object_name} is missing"
+        assert module_name.rsplit(".", 1)[0] not in root.__all__
+
+
+def test_registered_cli_commands_match_the_inventory() -> None:
+    assert _registered_cli_commands() == _supported_cli_commands()


### PR DESCRIPTION
## Summary

- add the normative inventory for supported and experimental Python imports and registered CLI commands
- define the deprecation information required before a supported surface is removed
- lock inventoried package-facade exports and top-level CLI registrations to prevent accidental API growth
- connect the inventory to the maintained documentation index and ownership checks

## Review order

1. `docs/API_INVENTORY.md`
2. `tests/test_public_api_inventory.py`
3. `docs/README.md`
4. `tests/docs/test_documentation_ownership.py`

## Validation

- focused inventory and documentation checks (`15 passed`)
- documented API compatibility suites with declared extras (`128 passed`)
- Ruff lint and format checks for changed Python tests
- mypy for changed Python tests
- `git diff --check`

## Scope

This is PR 13 of the PRD 4 sequence. It inventories existing caller surfaces. It does not add a new public import or command.
