### PR TITLE
CI: add required pull request gate

### DIFF
--- a/.github/workflows/required-pr.yml
+++ b/.github/workflows/required-pr.yml
@@ -1,0 +1,217 @@
+# ABOUTME: Runs the fast, provider-free checks required for every pull request.
+# ABOUTME: Keeps the aggregate branch-protection target stable while qualification jobs remain in ci.yml.
+
+name: Required PR checks
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  architecture-contracts:
+    name: Required · architecture and contracts
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.13.2
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13.2"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Install locked dependencies
+        run: uv sync --frozen --all-extras
+
+      - name: Check package dependency direction
+        run: uv run python scripts/audit_package_dependencies.py --check
+
+      - name: Check ownership and contracts
+        run: >-
+          uv run pytest -q
+          tests/test_package_ownership.py
+          tests/contracts/
+          tests/test_provenance_policy.py
+          tests/test_provenance_manifest_discovery.py
+
+      - name: Check identity, paths, catalogue, and visibility
+        run: >-
+          uv run pytest -q
+          tests/contracts/test_identity.py
+          tests/harness/compilation/test_task_snapshot.py
+          tests/cli/test_catalogue_commands.py
+          tests/tasks/
+          tests/docs/test_documentation_ownership.py
+          tests/feedback/test_assignment.py
+          tests/feedback/test_review_service.py
+          tests/communication/test_query.py
+
+      - name: Check generated catalogues
+        run: uv run aec-bench catalogue check
+
+  core-behavior:
+    name: Required · core behavior
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.13.2
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13.2"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Install locked dependencies
+        run: uv sync --frozen
+
+      - name: Check artifact application and evidence
+        run: >-
+          uv run pytest -q
+          tests/harness/test_artifact_adapter.py
+          tests/harness/test_artifact_ports.py
+          tests/harness/test_artifact_recipes.py
+          tests/harness/test_artifact_tasks.py
+          tests/harness/test_verifier_conformance.py
+          tests/harness/test_workspace_conformance.py
+          tests/harness/test_workspace_evidence.py
+          tests/ledger/test_evidence_index.py
+          tests/ledger/test_evidence_run_store.py
+
+      - name: Check world runtime and lifecycle conformance
+        run: >-
+          uv run pytest -q
+          tests/worlds/runtime/
+          tests/worlds/monitoring/
+          tests/worlds/test_pump_station_world_conformance.py
+          tests/lifecycles/runtime/
+          tests/lifecycles/test_lifecycle_conformance.py
+          tests/lifecycles/test_finalization.py
+
+      - name: Check scheduler and query behavior
+        run: >-
+          uv run pytest -q
+          tests/harness/test_scheduler.py
+          tests/execution/test_scheduler.py
+          tests/communication/test_query.py
+
+  quality:
+    name: Required · quality and package
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.13.2
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13.2"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Install locked dependencies
+        run: uv sync --frozen --all-extras
+
+      - name: Check maintained Python lint
+        run: uv run ruff check src/ tests/ scripts/audit_package_dependencies.py scripts/run_changed_owner_tests.py
+
+      - name: Check maintained Python formatting
+        run: uv run ruff format --check src/ tests/ scripts/audit_package_dependencies.py scripts/run_changed_owner_tests.py
+
+      - name: Check authority, contracts, application, and owner types
+        run: >-
+          uv run mypy
+          src/aec_bench/contracts/
+          src/aec_bench/evolution/application.py
+          src/aec_bench/execution/
+          src/aec_bench/worlds/
+          src/aec_bench/lifecycles/
+          scripts/audit_package_dependencies.py
+          scripts/run_changed_owner_tests.py
+
+      - name: Build provider-free wheel
+        run: uv build --wheel
+
+      - name: Verify isolated base installation
+        run: >-
+          python tests/packaging/verify_wheel_profiles.py
+          --wheel dist/aec_bench-0.1.0-py3-none-any.whl
+          --profile base
+
+      - name: Check public CLI help and startup
+        run: >-
+          uv run aec-bench --help
+          && uv run aec-bench catalogue --help
+
+  changed-owner-tests:
+    name: Required · changed-owner representatives
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.13.2
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13.2"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Install locked dependencies
+        run: uv sync --frozen --all-extras
+
+      - name: Run representatives for changed owners
+        env:
+          AEC_BENCH_BASE_REVISION: ${{ github.event.pull_request.base.sha }}
+        run: uv run python scripts/run_changed_owner_tests.py --base-revision "$AEC_BENCH_BASE_REVISION"
+
+  required-pr-gate:
+    name: Required PR gate
+    if: always()
+    needs:
+      - architecture-contracts
+      - core-behavior
+      - quality
+      - changed-owner-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require all mandatory checks
+        if: >-
+          needs['architecture-contracts'].result != 'success' ||
+          needs['core-behavior'].result != 'success' ||
+          needs.quality.result != 'success' ||
+          needs['changed-owner-tests'].result != 'success'
+        run: exit 1
+
+      - name: Report required checks passed
+        run: echo "Required pull-request checks passed."

--- a/scripts/run_changed_owner_tests.py
+++ b/scripts/run_changed_owner_tests.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# ABOUTME: Selects representative tests for source owners changed by a pull request.
+# ABOUTME: Runs additive owner evidence without importing the package or relying on shell-generated test paths.
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+OWNER_TESTS: dict[str, tuple[str, ...]] = {
+    "adapters": ("tests/adapters/test_base_capabilities.py",),
+    "agents": ("tests/agents/test_env.py",),
+    "catalogue": (
+        "tests/cli/test_catalogue_commands.py",
+        "tests/worlds/test_generated_catalogue.py",
+        "tests/lifecycles/test_generated_catalogue.py",
+    ),
+    "cli": ("tests/cli/test_output.py",),
+    "communication": ("tests/communication/test_behavioral_report.py",),
+    "config": ("tests/test_config_resolution.py",),
+    "contracts": ("tests/contracts/test_identity.py",),
+    "dataset": ("tests/dataset/test_identity_v2.py",),
+    "evaluation": ("tests/evaluation/test_artifact.py",),
+    "evolution": ("tests/evolution/test_core.py",),
+    "execution": ("tests/execution/test_scheduler.py",),
+    "experimentation": ("tests/experimentation/test_meta_harness.py",),
+    "feedback": ("tests/feedback/test_assignment.py",),
+    "generation": ("tests/generation/test_sampler.py",),
+    "harness": ("tests/harness/test_artifact_ports.py",),
+    "images": ("tests/images/test_extensions.py",),
+    "init": ("tests/cli/test_init.py",),
+    "ledger": ("tests/ledger/test_evidence_index.py",),
+    "lifecycles": ("tests/lifecycles/test_lifecycle_conformance.py",),
+    "model_routing": ("tests/adapters/test_provider_routing.py",),
+    "prime_agent": ("tests/prime_agent/test_batch.py",),
+    "prime_lab": ("tests/prime_lab/test_eval_import.py",),
+    "providers": ("tests/providers/test_source_identity.py",),
+    "remediation": ("tests/remediation/test_section_resolver.py",),
+    "search": ("tests/web/test_search_page.py",),
+    "synthesis": ("tests/synthesis/test_engine.py",),
+    "tasks": ("tests/tasks/test_loader.py",),
+    "templates": ("tests/templates/test_contracts.py",),
+    "trajectory": ("tests/trajectory/test_contract.py",),
+    "trials": ("tests/harness/test_trial.py",),
+    "tui": ("tests/tui/test_app_modes.py",),
+    "web": ("tests/web/test_schemas.py",),
+    "worlds": ("tests/worlds/test_catalogue.py",),
+}
+
+
+def _changed_paths(root: Path, base_revision: str) -> tuple[str, ...]:
+    result = subprocess.run(
+        ["git", "-C", str(root), "diff", "--name-only", "--diff-filter=ACMR", f"{base_revision}...HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return tuple(path for path in result.stdout.splitlines() if path)
+
+
+def _owner_for_source(path: str) -> str | None:
+    prefix = "src/aec_bench/"
+    if not path.startswith(prefix):
+        return None
+    relative = path.removeprefix(prefix)
+    owner = relative.split("/", 1)[0]
+    return owner if owner in OWNER_TESTS else "*"
+
+
+def _test_paths(changed_paths: tuple[str, ...]) -> tuple[str, ...]:
+    selected: set[str] = set()
+    unknown_source_change = False
+    for path in changed_paths:
+        if path.startswith("tests/"):
+            selected.add(path)
+            continue
+        owner = _owner_for_source(path)
+        if owner == "*":
+            unknown_source_change = True
+        elif owner is not None:
+            selected.update(OWNER_TESTS[owner])
+    if unknown_source_change:
+        return ("tests/",)
+    return tuple(sorted(selected))
+
+
+def _changed_source_paths(changed_paths: tuple[str, ...]) -> tuple[str, ...]:
+    """Return changed maintained Python sources for the focused type check."""
+    return tuple(sorted(path for path in changed_paths if path.startswith("src/aec_bench/") and path.endswith(".py")))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run representative tests for owners changed since a pull-request base revision."
+    )
+    parser.add_argument("--base-revision", required=True, help="Git revision at the pull-request base.")
+    parser.add_argument("--root", type=Path, default=Path.cwd(), help="Repository root.")
+    args = parser.parse_args()
+
+    changed_paths = _changed_paths(args.root.resolve(), args.base_revision)
+    paths = _test_paths(changed_paths)
+    if not paths:
+        print("No owner-specific tests selected.")
+        return 0
+    print("Running changed-owner representatives:", " ".join(paths))
+    pytest_result = subprocess.run([sys.executable, "-m", "pytest", "-q", *paths], cwd=args.root, check=False)
+    if pytest_result.returncode != 0:
+        return pytest_result.returncode
+
+    source_paths = _changed_source_paths(changed_paths)
+    if not source_paths:
+        print("No changed source files require type checking.")
+        return 0
+    print("Type-checking changed source files:", " ".join(source_paths))
+    return subprocess.run(
+        [sys.executable, "-m", "mypy", "--follow-imports=skip", *source_paths], cwd=args.root, check=False
+    ).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/aec_bench/experimentation/learning_studies/worlds.py
+++ b/src/aec_bench/experimentation/learning_studies/worlds.py
@@ -299,9 +299,7 @@ class _WorldLearningCoordinator:
         initialise_learner_state(
             state_root,
             memory_seed_root=(
-                self._initial_memory_root
-                if treatment_kind is WorldLearningTreatmentKind.STRUCTURED_MEMORY
-                else None
+                self._initial_memory_root if treatment_kind is WorldLearningTreatmentKind.STRUCTURED_MEMORY else None
             ),
         )
         return self._handle(arm_run.arm_run_id, arm_run.treatment_id, "initial", state_root)
@@ -536,7 +534,7 @@ class _WorldLearningCoordinator:
         handle: LearnerStateHandle[WorldLearnerState],
         arm_run: PlannedArmRun,
     ) -> WorldLearnerState:
-        state = handle.value
+        state: WorldLearnerState = handle.value
         if state.arm_run_id != arm_run.arm_run_id:
             raise ValueError(
                 f"cross-arm-path-detected: state belongs to {state.arm_run_id}, requested by {arm_run.arm_run_id}"

--- a/tests/communication/test_query.py
+++ b/tests/communication/test_query.py
@@ -4,6 +4,7 @@
 from pathlib import Path
 
 from aec_bench.communication.query import query_report_records
+from aec_bench.contracts.identity import EntityKind, new_entity_id
 from aec_bench.contracts.task_definition import Visibility
 from aec_bench.ledger.writer import write_trial_record
 from tests.support.trial_record_factories import make_trial_record
@@ -96,6 +97,7 @@ def _write_task_instance(*, tasks_root: Path, relative_path: str, visibility: Vi
     )
     (instance_dir / "tests" / "test.sh").write_text("#!/bin/bash\n", encoding="utf-8")
     (instance_dir / "task.toml").write_text(
-        f'[agent]\ntimeout_sec = 600\n\n[metadata]\nvisibility = "{visibility.value}"\n',
+        f'[identity]\nid = "{new_entity_id(EntityKind.TASK)}"\nkey = "{relative_path}"\nversion = 1\n\n'
+        f'[agent]\ntimeout_sec = 600\n\n[metadata]\nlifecycle = "active"\nvisibility = "{visibility.value}"\n',
         encoding="utf-8",
     )

--- a/tests/contracts/test_contract_compatibility_boundaries.py
+++ b/tests/contracts/test_contract_compatibility_boundaries.py
@@ -14,9 +14,17 @@ from aec_bench.contracts.evaluation_generation.lifecycle import (
 )
 
 
+def _module_exists(module_name: str) -> bool:
+    """Return whether an optional module exists, including when its parent is absent."""
+    try:
+        return importlib.util.find_spec(module_name) is not None
+    except ModuleNotFoundError:
+        return False
+
+
 def test_historical_pilot_contract_paths_are_owned_by_the_experiment() -> None:
-    assert importlib.util.find_spec("aec_bench.contracts.phase_nine_calibration") is None
-    assert importlib.util.find_spec("aec_bench.contracts.compatibility.phase91a_v1") is None
+    assert not _module_exists("aec_bench.contracts.phase_nine_calibration")
+    assert not _module_exists("aec_bench.contracts.compatibility.phase91a_v1")
 
 
 def test_importing_one_contract_does_not_load_historical_experiment_contracts() -> None:
@@ -43,7 +51,7 @@ def test_importing_one_contract_does_not_load_historical_experiment_contracts() 
     assert result.returncode == 0, result.stderr
 
 
-def test_trajectory_contract_does_not_import_trial_record_contracts() -> None:
+def test_trajectory_contract_does_not_import_run_accounting_contract() -> None:
     result = subprocess.run(
         [
             sys.executable,
@@ -51,7 +59,7 @@ def test_trajectory_contract_does_not_import_trial_record_contracts() -> None:
             (
                 "import sys; "
                 "import aec_bench.contracts.trajectory; "
-                "assert 'aec_bench.contracts.trial_record' not in sys.modules"
+                "assert 'aec_bench.contracts.run_accounting' not in sys.modules"
             ),
         ],
         check=False,
@@ -66,18 +74,8 @@ def test_completed_batch_has_one_execution_accounting_surface() -> None:
     assert "accounting_evidence" not in GovernedBatchExecutionClosure.model_fields
     assert "accounting_evidence" not in GovernedBatchTerminalEvidence.model_fields
     assert "accounting_assignments" not in GovernedBatchTerminalEvidence.model_fields
-    assert (
-        importlib.util.find_spec(
-            "aec_bench.meta_harness.compatibility.phase91a_accounting_v1",
-        )
-        is None
-    )
-    assert (
-        importlib.util.find_spec(
-            "aec_bench.meta_harness.phase_nine_calibration_accounting",
-        )
-        is None
-    )
+    assert not _module_exists("aec_bench.meta_harness.compatibility.phase91a_accounting_v1")
+    assert not _module_exists("aec_bench.meta_harness.phase_nine_calibration_accounting")
 
 
 def test_governed_batch_has_no_unreleased_phase_specific_execution_surface() -> None:
@@ -86,7 +84,7 @@ def test_governed_batch_has_no_unreleased_phase_specific_execution_surface() -> 
         "aec_bench.meta_harness.phase91a_governed_pilot_adapter",
         "aec_bench.meta_harness.governed_pilot_execution",
     ):
-        assert importlib.util.find_spec(module_name) is None
+        assert not _module_exists(module_name)
 
     source_root = Path(__file__).parents[2] / "src" / "aec_bench"
     governed_pilot_schemas = tuple(
@@ -100,7 +98,7 @@ def test_execution_preflight_has_no_unreleased_phase_specific_surface() -> None:
         "aec_bench.meta_harness.phase91a_preflight",
         "aec_bench.meta_harness.phase_nine_calibration_controller",
     ):
-        assert importlib.util.find_spec(module_name) is None
+        assert not _module_exists(module_name)
 
     source_root = Path(__file__).parents[2] / "src" / "aec_bench"
     obsolete_schemas = {

--- a/tests/contracts/test_task_genome.py
+++ b/tests/contracts/test_task_genome.py
@@ -5,6 +5,7 @@ import pytest
 from pydantic import ValidationError
 
 from aec_bench.contracts.artifacts import ArtifactRef
+from aec_bench.contracts.identity import EntityIdentity, EntityKind, new_entity_id
 from aec_bench.contracts.task_genome import (
     DomainFrame,
     ExtractionSummary,
@@ -127,6 +128,11 @@ def test_reviewed_task_genome_requires_a_reviewer() -> None:
 def _snapshot() -> TaskSnapshotRef:
     return TaskSnapshotRef(
         task_id="electrical/voltage-drop",
+        task_identity=EntityIdentity(
+            id=new_entity_id(EntityKind.TASK),
+            key="electrical/voltage-drop",
+            version=1,
+        ),
         artifact=ArtifactRef(
             artifact_id=f"artifacts/sha256/{'2' * 64}",
             sha256="2" * 64,

--- a/tests/experimentation/learning_studies/test_dam_w01.py
+++ b/tests/experimentation/learning_studies/test_dam_w01.py
@@ -413,9 +413,7 @@ def test_acquisition_fidelity_fails_closed_on_missing_or_ambiguous_records() -> 
     plan = compile_w01_dam_study(study_run_id="w01-fidelity-inputs", agent=agent, compute=_COMPUTE)
     arm_run = next(item for item in plan.arm_runs if item.arm_id == "structured-memory")
     acquisition_step = next(
-        item
-        for item in arm_run.steps
-        if isinstance(item, CompiledExperienceStep) and item.role.value == "acquisition"
+        item for item in arm_run.steps if isinstance(item, CompiledExperienceStep) and item.role.value == "acquisition"
     )
 
     def arm_result(records: tuple[TrialRecord, ...]) -> ArmRunExecutionResult[object]:

--- a/tests/experimentation/qualification/test_repair_run.py
+++ b/tests/experimentation/qualification/test_repair_run.py
@@ -13,6 +13,7 @@ import pytest
 from pydantic import ValidationError
 
 from aec_bench.contracts.harness_kernel import KernelManifest
+from aec_bench.contracts.task_snapshot import ArtifactTaskSnapshotRef
 from aec_bench.contracts.trial_record import ArtifactReference
 from aec_bench.evolution.repair_lifecycle import (
     CompiledRepairCandidate,
@@ -541,9 +542,7 @@ def test_new_attempt_repeats_complete_pair_after_interrupted_parent_under_same_r
 
     claim_paths = tuple(sorted((artifacts_root / "repair-attempt-claims").glob("*/claim.json")))
     completion_paths = tuple(path.with_name("completion.json") for path in claim_paths)
-    records = tuple(
-        read_trial_record(path) for path in sorted(fixture.workflow.ledger_root.rglob("trial-*.json"))
-    )
+    records = tuple(read_trial_record(path) for path in sorted(fixture.workflow.ledger_root.rglob("trial-*.json")))
     assert second_result.result.status is RepairLoopStatus.ACCEPTED
     assert second_executor.calls == [(17, 1), (29, 1), (17, 2), (29, 2)]
     assert len(claim_paths) == 2
@@ -713,8 +712,8 @@ def test_prepare_repair_run_spec_pins_exact_task_and_world_snapshots(tmp_path: P
     spec = _spec(fixture)
 
     assert tuple(snapshot.task_id for snapshot in spec.task_snapshots) == fixture.request.pairing.task_ids
-    assert spec.task_snapshots[0].task_review is not None
-    assert spec.task_snapshots[0].task_review.profile_id == "aec.task-review.civil.repair"
+    assert isinstance(spec.task_snapshots[0], ArtifactTaskSnapshotRef)
+    assert spec.task_snapshots[0].task_identity.key == fixture.request.pairing.task_ids[0]
 
 
 @pytest.mark.parametrize("drift_kind", ("task", "task_review"))

--- a/tests/experimentation/qualification/test_repair_runtime.py
+++ b/tests/experimentation/qualification/test_repair_runtime.py
@@ -45,6 +45,7 @@ from aec_bench.contracts.harness_instance import (
     VerificationBindingConfig,
 )
 from aec_bench.contracts.harness_kernel import KernelRef, canonical_json_sha256
+from aec_bench.contracts.identity import EntityKind, new_entity_id
 from aec_bench.contracts.output_completion import (
     OutputCommitAttestation,
     OutputCompletionEvaluation,
@@ -2709,9 +2710,15 @@ def _write_task(tasks_root: Path, task_id: str) -> None:
     (task_dir / "environment").mkdir(parents=True)
     (task_dir / "tests").mkdir()
     (task_dir / "task.toml").write_text(
-        """
+        f"""
+[identity]
+id = "{new_entity_id(EntityKind.TASK)}"
+key = "{task_id}"
+version = 1
+
 [metadata]
 difficulty = "easy"
+lifecycle = "active"
 visibility = "public"
 tags = ["repair-runtime"]
 

--- a/tests/feedback/test_review_service.py
+++ b/tests/feedback/test_review_service.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from aec_bench.contracts.evaluation_result import Judgment
+from aec_bench.contracts.identity import EntityKind, new_entity_id
 from aec_bench.contracts.task_definition import Visibility
 from aec_bench.feedback.annotation_consumer import write_reviewer_profile
 from aec_bench.feedback.models import CalibrationReference, CalibrationStatus
@@ -248,6 +249,7 @@ def _write_task_instance(*, tasks_root: Path, relative_path: str, visibility: Vi
     )
     (instance_dir / "tests" / "test.sh").write_text("#!/bin/bash\n", encoding="utf-8")
     (instance_dir / "task.toml").write_text(
-        f'[agent]\ntimeout_sec = 600\n\n[metadata]\nvisibility = "{visibility.value}"\n',
+        f'[identity]\nid = "{new_entity_id(EntityKind.TASK)}"\nkey = "{relative_path}"\nversion = 1\n\n'
+        f'[agent]\ntimeout_sec = 600\n\n[metadata]\nlifecycle = "active"\nvisibility = "{visibility.value}"\n',
         encoding="utf-8",
     )

--- a/tests/test_required_pr_topology.py
+++ b/tests/test_required_pr_topology.py
@@ -1,0 +1,73 @@
+# ABOUTME: Verifies the required pull-request workflow and changed-owner test map.
+# ABOUTME: Keeps the branch-protection target, owner coverage, and selected test paths explicit.
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from scripts.run_changed_owner_tests import OWNER_TESTS, _changed_source_paths, _owner_for_source, _test_paths
+
+ROOT = Path(__file__).resolve().parents[1]
+OWNER_POLICY = ROOT / "scripts/owner_dependencies.toml"
+WORKFLOW = ROOT / ".github/workflows/required-pr.yml"
+
+
+def test_owner_test_map_matches_policy_and_points_to_existing_paths() -> None:
+    with OWNER_POLICY.open("rb") as policy_file:
+        owners = set(tomllib.load(policy_file)["owners"])
+
+    assert set(OWNER_TESTS) == owners
+    assert all((ROOT / path).exists() for paths in OWNER_TESTS.values() for path in paths)
+
+
+def test_changed_owner_selection_handles_known_unknown_and_non_source_paths() -> None:
+    assert _owner_for_source("src/aec_bench/worlds/runtime.py") == "worlds"
+    assert _owner_for_source("src/aec_bench/new_owner/module.py") == "*"
+    assert _owner_for_source("docs/README.md") is None
+
+    assert _test_paths(("docs/README.md",)) == ()
+    assert _test_paths(("tests/contracts/test_identity.py",)) == ("tests/contracts/test_identity.py",)
+    assert _test_paths(("src/aec_bench/worlds/runtime.py",)) == ("tests/worlds/test_catalogue.py",)
+    assert _test_paths(("src/aec_bench/new_owner/module.py",)) == ("tests/",)
+
+
+def test_changed_source_selection_is_exact_and_excludes_non_python_paths() -> None:
+    changed = (
+        "src/aec_bench/worlds/runtime.py",
+        "src/aec_bench/worlds/data.toml",
+        "tests/worlds/test_catalogue.py",
+        "docs/README.md",
+    )
+
+    assert _changed_source_paths(changed) == ("src/aec_bench/worlds/runtime.py",)
+
+
+@pytest.mark.skipif(shutil.which("ruby") is None, reason="Ruby is required to parse GitHub Actions YAML")
+def test_required_workflow_has_one_stable_aggregate_gate() -> None:
+    ruby = """
+require "json"
+require "yaml"
+document = YAML.load_file(ARGV.fetch(0))
+puts JSON.generate({"trigger" => document[true], "jobs" => document.fetch("jobs")})
+"""
+    parsed = subprocess.run(
+        ["ruby", "-e", ruby, str(WORKFLOW)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    document = json.loads(parsed.stdout)
+    jobs = document["jobs"]
+    mandatory = {"architecture-contracts", "core-behavior", "quality", "changed-owner-tests"}
+
+    assert document["trigger"] == {"pull_request": None}
+    assert mandatory <= set(jobs)
+    assert jobs["required-pr-gate"]["name"] == "Required PR gate"
+    assert jobs["required-pr-gate"]["if"] == "always()"
+    assert set(jobs["required-pr-gate"]["needs"]) == mandatory


### PR DESCRIPTION
## Summary

- add one stable `Required PR gate` for branch protection
- run architecture, core behaviour, quality, packaging, and changed-owner checks in parallel
- map every declared package owner to a focused representative test set
- type-check exact changed source files in addition to the maintained authority set
- update stale test fixtures to the current task identity and snapshot contracts

## Review order

1. `.github/workflows/required-pr.yml`
2. `scripts/run_changed_owner_tests.py`
3. `tests/test_required_pr_topology.py`
4. current-contract fixture updates

## Validation

- required workflow topology: 4 passed
- changed-owner representative map: 491 passed
- architecture groups: 842 passed and 184 passed
- core groups: 63 passed, 382 passed, and 32 passed
- focused current-contract and topology set: 22 passed
- Ruff lint: passed
- Ruff format: 2,444 files already formatted
- mypy authority set: 222 source files passed
- wheel build: passed
- isolated base wheel profile: passed
- catalogue check, dependency audit, and CLI startup: passed

## Platform note

One existing deterministic learning-study test runs only on macOS and fails under the local Seatbelt boundary. It is skipped on this Ubuntu workflow. The changed workflow does not change that test behaviour.
