### PR TITLE
Fix PRD4 nightly qualification gaps

### DIFF
--- a/src/aec_bench/ledger/local_lock.py
+++ b/src/aec_bench/ledger/local_lock.py
@@ -3,15 +3,16 @@
 
 from __future__ import annotations
 
-import fcntl
 import os
 import stat
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path, PurePosixPath
-from typing import NoReturn
+from typing import NoReturn, Protocol, cast
 
 from aec_bench.ledger.durability import mkdir_durable
+
+_PLATFORM_NAME = os.name
 
 
 class LocalFileLockError(RuntimeError):
@@ -23,6 +24,13 @@ class LocalFileLockConfinementError(LocalFileLockError):
 
 
 type LocalFileLockErrorFactory = Callable[[LocalFileLockError], BaseException]
+
+
+class _WindowsLocking(Protocol):
+    LK_LOCK: int
+    LK_UNLCK: int
+
+    def locking(self, descriptor: int, operation: int, length: int) -> None: ...
 
 
 @contextmanager
@@ -41,7 +49,7 @@ def exclusive_local_file_lock(
                 Path(root).absolute(),
                 relative_path,
             )
-            fcntl.flock(lock_descriptor, fcntl.LOCK_EX)
+            _acquire_platform_lock(lock_descriptor)
         except LocalFileLockError as lock_error:
             _close_after_setup_failure(lock_descriptor, directory_descriptors, lock_error)
             _raise_lock_error(lock_error, error_factory)
@@ -75,6 +83,8 @@ def _open_confined_lock(root: Path, relative_path: str) -> tuple[list[int], int]
     parts = _relative_lock_parts(relative_path)
     if root.name in {"", ".", ".."}:
         raise LocalFileLockConfinementError("local lock root must select one directory")
+    if _PLATFORM_NAME == "nt":
+        return [], _open_confined_windows_lock(root, parts)
     try:
         mkdir_durable(root)
     except OSError as cause:
@@ -91,6 +101,86 @@ def _open_confined_lock(root: Path, relative_path: str) -> tuple[list[int], int]
         _close_after_setup_failure(None, descriptors, error)
         raise
     return descriptors, lock_descriptor
+
+
+def _open_confined_windows_lock(root: Path, parts: tuple[str, ...]) -> int:
+    """Open one confined lock without POSIX descriptor-relative operations."""
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+        if _is_windows_link(root) or not root.is_dir():
+            raise LocalFileLockConfinementError("local lock root is unsafe")
+        parent = root
+        for part in parts[:-1]:
+            parent = parent / part
+            try:
+                parent.mkdir(mode=0o700)
+            except FileExistsError:
+                pass
+            if _is_windows_link(parent) or not parent.is_dir():
+                raise LocalFileLockConfinementError(
+                    "local lock parent directory is unsafe",
+                )
+        return _open_private_windows_regular_file(parent / parts[-1])
+    except LocalFileLockError:
+        raise
+    except OSError as cause:
+        raise LocalFileLockError(f"local lock cannot be prepared: {cause}") from cause
+
+
+def _is_windows_link(path: Path) -> bool:
+    return path.is_symlink() or path.is_junction()
+
+
+def _open_private_windows_regular_file(path: Path) -> int:
+    flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_BINARY", 0)
+    try:
+        descriptor = os.open(path, flags, 0o600)
+    except OSError as cause:
+        raise LocalFileLockConfinementError(f"local lock file is unsafe: {cause}") from cause
+    try:
+        selected = path.lstat()
+        opened = os.fstat(descriptor)
+        if (
+            stat.S_ISLNK(selected.st_mode)
+            or not stat.S_ISREG(selected.st_mode)
+            or not stat.S_ISREG(opened.st_mode)
+            or (selected.st_dev, selected.st_ino) != (opened.st_dev, opened.st_ino)
+        ):
+            raise LocalFileLockConfinementError("local lock target is not a safe regular file")
+        if opened.st_size == 0:
+            os.write(descriptor, b"\0")
+            os.fsync(descriptor)
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        return descriptor
+    except BaseException as error:
+        _close_after_setup_failure(descriptor, [], error)
+        raise
+
+
+def _acquire_platform_lock(descriptor: int) -> None:
+    if _PLATFORM_NAME == "nt":
+        import msvcrt
+
+        backend = cast(_WindowsLocking, msvcrt)
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        backend.locking(descriptor, backend.LK_LOCK, 1)
+        return
+    import fcntl
+
+    fcntl.flock(descriptor, fcntl.LOCK_EX)
+
+
+def _release_platform_lock(descriptor: int) -> None:
+    if _PLATFORM_NAME == "nt":
+        import msvcrt
+
+        backend = cast(_WindowsLocking, msvcrt)
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        backend.locking(descriptor, backend.LK_UNLCK, 1)
+        return
+    import fcntl
+
+    fcntl.flock(descriptor, fcntl.LOCK_UN)
 
 
 def _relative_lock_parts(relative_path: str) -> tuple[str, ...]:
@@ -197,7 +287,7 @@ def _release_and_close(
     errors: list[tuple[str, BaseException]] = []
     if lock_descriptor is not None:
         try:
-            fcntl.flock(lock_descriptor, fcntl.LOCK_UN)
+            _release_platform_lock(lock_descriptor)
         except BaseException as cause:
             errors.append(("release", cause))
     errors.extend(_close_descriptors(lock_descriptor, directory_descriptors))

--- a/tests/experimentation/lifecycle_studies/test_ablation.py
+++ b/tests/experimentation/lifecycle_studies/test_ablation.py
@@ -956,7 +956,7 @@ def test_schema_one_validation_rejects_every_mutated_record_semantic(tmp_path: P
         with pytest.raises(ValueError, match="historical TrialRecord does not match"):
             retention_runtime.validate_lifecycle_ablation_record(forged, manifest, trial)
     manifest_mutations: tuple[Callable[[dict[str, Any]], None], ...] = (
-        lambda payload: payload["source"].__setitem__("reason", "forged source"),
+        lambda payload: payload.__setitem__("source", {"kind": "git", "revision": "f" * 40}),
         lambda payload: payload["agent"]["configuration"].__setitem__("requested_model", "forged-model"),
     )
     for mutate_manifest in manifest_mutations:

--- a/tests/harness/test_provider_broker.py
+++ b/tests/harness/test_provider_broker.py
@@ -133,7 +133,7 @@ def test_broker_process_disables_linux_dumpability(
 def test_broker_pins_model_and_budget_and_returns_content_addressed_receipt(
     tmp_path: Path,
 ) -> None:
-    socket_path = Path("/private/tmp") / (
+    socket_path = Path("/tmp") / (
         "aec-broker-" + hashlib.sha256(str(tmp_path).encode("utf-8")).hexdigest()[:16] + ".sock"
     )
     policy = ProviderBrokerPolicy(
@@ -243,7 +243,7 @@ def test_broker_enforces_main_and_auxiliary_call_budgets_independently(
     max_main_calls: int,
     max_auxiliary_calls: int,
 ) -> None:
-    socket_path = Path("/private/tmp") / (
+    socket_path = Path("/tmp") / (
         "aec-broker-planes-"
         + hashlib.sha256(
             f"{tmp_path}:{limited_plane.value}".encode(),
@@ -335,7 +335,7 @@ def test_broker_enforces_main_and_auxiliary_call_budgets_independently(
 def test_broker_rejects_unbound_call_plane_before_provider_effect(
     tmp_path: Path,
 ) -> None:
-    socket_path = Path("/private/tmp") / (
+    socket_path = Path("/tmp") / (
         "aec-broker-plane-spoof-" + hashlib.sha256(str(tmp_path).encode("utf-8")).hexdigest()[:16] + ".sock"
     )
     policy = ProviderBrokerPolicy(
@@ -441,7 +441,7 @@ class _EffectUnknownReplayClient(ReplayRlmClient):
 def test_broker_closes_with_typed_effect_unknown_evidence_after_provider_exception(
     tmp_path: Path,
 ) -> None:
-    socket_path = Path("/private/tmp") / (
+    socket_path = Path("/tmp") / (
         "aec-broker-effect-unknown-" + hashlib.sha256(str(tmp_path).encode("utf-8")).hexdigest()[:16] + ".sock"
     )
     receipt_path = tmp_path / "provider-broker-receipt.json"
@@ -512,7 +512,7 @@ def test_broker_closes_with_typed_effect_unknown_evidence_after_provider_excepti
 def test_broker_persists_known_call_before_post_effect_transport_failure(
     tmp_path: Path,
 ) -> None:
-    socket_path = Path("/private/tmp") / (
+    socket_path = Path("/tmp") / (
         "aec-broker-transport-" + hashlib.sha256(str(tmp_path).encode("utf-8")).hexdigest()[:16] + ".sock"
     )
     receipt_path = tmp_path / "provider-broker-receipt.json"
@@ -589,7 +589,7 @@ def test_broker_persists_known_call_before_post_effect_transport_failure(
 def test_broker_preserves_admission_error_precedence_before_provider_effect(
     tmp_path: Path,
 ) -> None:
-    socket_path = Path("/private/tmp") / (
+    socket_path = Path("/tmp") / (
         "aec-broker-precedence-" + hashlib.sha256(str(tmp_path).encode("utf-8")).hexdigest()[:16] + ".sock"
     )
     policy = ProviderBrokerPolicy(
@@ -654,7 +654,7 @@ def test_broker_preserves_admission_error_precedence_before_provider_effect(
 def test_broker_denies_decoding_failure_without_closing_provider_authority(
     tmp_path: Path,
 ) -> None:
-    socket_path = Path("/private/tmp") / (
+    socket_path = Path("/tmp") / (
         "aec-broker-decode-" + hashlib.sha256(str(tmp_path).encode("utf-8")).hexdigest()[:16] + ".sock"
     )
     policy = ProviderBrokerPolicy(

--- a/tests/ledger/test_world_runtime_durability.py
+++ b/tests/ledger/test_world_runtime_durability.py
@@ -6,13 +6,16 @@ from __future__ import annotations
 import ast
 import multiprocessing
 import stat
+import sys
 from contextlib import chdir
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Protocol
 
 import pytest
 
 import aec_bench.ledger.durability as lower_durability
+import aec_bench.ledger.local_lock as local_lock
 import aec_bench.lifecycles.runtime.operation_store as lifecycle_operation_store
 import aec_bench.lifecycles.runtime.request_store as lifecycle_store
 import aec_bench.worlds.runtime.rollout_repository as rollout_repository
@@ -160,6 +163,27 @@ def test_exclusive_local_file_lock_allows_concurrent_first_acquisition(tmp_path:
             if process.is_alive():
                 process.kill()
             process.join()
+
+
+def test_exclusive_local_file_lock_uses_windows_backend(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[int, int]] = []
+    windows_backend = SimpleNamespace(
+        LK_LOCK=1,
+        LK_UNLCK=2,
+        locking=lambda descriptor, operation, length: calls.append(
+            (operation, length),
+        ),
+    )
+    monkeypatch.setattr(local_lock, "_PLATFORM_NAME", "nt")
+    monkeypatch.setitem(sys.modules, "msvcrt", windows_backend)
+
+    with exclusive_local_file_lock(tmp_path / "run", "locks/world.lock"):
+        assert (tmp_path / "run" / "locks" / "world.lock").read_bytes() == b"\0"
+
+    assert calls == [(1, 1), (2, 1)]
 
 
 @pytest.mark.parametrize("unsafe_kind", ("symbolic-link", "directory"))


### PR DESCRIPTION
## Summary

- add a standard-library Windows backend for confined local file locks
- use portable Unix socket paths in provider broker tests
- update lifecycle history validation to mutate the current run source contract

## Validation

- `uv run pytest -q tests/ledger/test_world_runtime_durability.py tests/experimentation/lifecycle_studies/test_ablation.py::test_schema_one_validation_rejects_every_mutated_record_semantic tests/harness/test_provider_broker.py` — 36 passed, 1 skipped
- Ruff check — passed
- Ruff format check — passed
- mypy for `src/aec_bench/ledger/local_lock.py` — passed
- `git diff --check` — passed

## Review order

1. `src/aec_bench/ledger/local_lock.py` and its durability test
2. provider broker test paths
3. lifecycle historical validation mutation