### PR TITLE
Scope PRD4 platform qualification by operating system

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -130,7 +130,8 @@ jobs:
           enable-cache: true
       - name: Install base dependencies
         run: uv sync --frozen
-      - name: Run portable path and storage checks
+      - name: Run POSIX path and storage checks
+        if: runner.os == 'Linux'
         run: >-
           uv run pytest -q
           tests/contracts/test_identity.py
@@ -138,6 +139,14 @@ jobs:
           tests/ledger/test_api.py
           tests/ledger/test_durable_file_replacement.py
           tests/ledger/test_evidence_index.py
+      - name: Run Windows path and package checks
+        if: runner.os == 'Windows'
+        run: >-
+          uv run pytest -q
+          tests/contracts/test_identity.py
+          tests/tasks/test_loader.py::test_resolve_task_instance_dir_matches_key_when_physical_path_spelling_differs
+          tests/tasks/test_loader.py::test_resolve_task_instance_dir_rejects_escape_and_missing_key
+          tests/test_release_manifest.py
 
   prime-qualification:
     name: Prime world qualification

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,8 @@ jobs:
           enable-cache: true
       - name: Install base dependencies
         run: uv sync --frozen
-      - name: Run portable release boundary checks
+      - name: Run POSIX release boundary checks
+        if: runner.os == 'Linux'
         run: >-
           uv run pytest -q
           tests/contracts/test_identity.py
@@ -137,6 +138,14 @@ jobs:
           tests/ledger/test_api.py
           tests/ledger/test_durable_file_replacement.py
           tests/ledger/test_evidence_index.py
+          tests/test_release_manifest.py
+      - name: Run Windows release path checks
+        if: runner.os == 'Windows'
+        run: >-
+          uv run pytest -q
+          tests/contracts/test_identity.py
+          tests/tasks/test_loader.py::test_resolve_task_instance_dir_matches_key_when_physical_path_spelling_differs
+          tests/tasks/test_loader.py::test_resolve_task_instance_dir_rejects_escape_and_missing_key
           tests/test_release_manifest.py
 
   release-gate:


### PR DESCRIPTION
## Summary

- keep POSIX durability and evidence-store checks on Ubuntu
- run portable identity, task-path, and package-manifest checks on Windows
- apply the same platform boundary to nightly and release qualification

## Reason

The PRD4 platform requirement is a Linux job plus a Windows path-validation job. The shared matrix was also running POSIX descriptor durability tests on Windows. Those tests require POSIX filesystem operations by contract.

## Validation

- Windows path test set executed locally: 51 passed
- `git diff --check` — passed
- nightly run `33448516595`: all eight full-suite shards and every non-Windows qualification job passed; only the incorrectly scoped Windows POSIX test set failed