### PR TITLE
docs: add extension authoring guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,7 @@ authority.
 | [Project structure](PROJECT_STRUCTURE.md) | Guide | Current | Contributors and agents | Repository maintainers |
 | [Public API inventory](API_INVENTORY.md) | Normative | Current | Python and CLI integrators | Repository maintainers |
 | [World authoring](world-authoring.md) | Guide | Current | Task and interactive-world contributors | Task, engineering, world, and lifecycle owners |
+| [Extension authoring](extension-authoring.md) | Guide | Current | Contributors adding tasks, worlds, lifecycles, or execution backends | Repository maintainers and domain owners |
 | [Interactive-world runtime](protocols/interactive-world-runtime.md) | Protocol | Current | World, runtime, and transport contributors | World runtime and registered worlds |
 | [Staged evidence and publication](protocols/staged-evidence-and-publication.md) | Protocol | Current | Lifecycle and evaluation contributors | Lifecycle runtime and task owners |
 | [Learning Studies Gate A](adr/learning-studies-gate-a.md) | Decision | Current | Learning Studies and lifecycle contributors | Repository architecture review |

--- a/docs/extension-authoring.md
+++ b/docs/extension-authoring.md
@@ -1,0 +1,120 @@
+# AEC-Bench Extension Authoring
+
+| Field | Value |
+| --- | --- |
+| Class | Guide |
+| Status | Current |
+| Audience | Contributors adding tasks, worlds, lifecycles, or execution backends |
+| Owner | Repository maintainers and domain owners |
+
+This guide is the short route for adding a maintained AEC-Bench extension. Use
+the domain guide linked in each section for detailed contracts and examples.
+
+## Task
+
+Use the [add-task workflow](../src/aec_bench/init/skill_data/add-task/SKILL.md)
+to create the task package. For a parameterised calculation, use the
+[create-template workflow](../src/aec_bench/init/skill_data/create-template/SKILL.md).
+Keep the task instructions, environment, verifier, and task-owned assets in
+the task or template package.
+
+Give the task a readable key, a UUIDv7 identity, and a positive version. Set
+its lifecycle and visibility in `task.toml`. Validate the package before
+review:
+
+```bash
+uv run aec-bench task validate <task-dir>
+```
+
+The [world authoring guide](world-authoring.md) explains the task-family
+choice and the complete generation and validation path.
+
+## Interactive world
+
+Keep the state, actions, observations, transitions, and evaluation with the
+world owner. Put episode limits, decision freshness, recording, and provider
+execution at the host boundary. A world owner provides:
+
+1. An `InteractiveWorldDefinition` with build identity, profiles, and profile
+   metadata.
+2. One `InteractiveWorldOwnerDescriptor` in the owner package.
+3. One `WorldConformanceCase` from the owner-local conformance entry point.
+
+Add the owner import to
+[`src/aec_bench/catalogue.py`](../src/aec_bench/catalogue.py), then update the
+generated composition with:
+
+```bash
+uv run aec-bench catalogue build
+uv run aec-bench catalogue check
+uv run aec-bench conformance world <world-key>
+```
+
+The world key in the conformance command is the readable key used by the
+owner case, such as `monitoring/dam-seepage`. See
+[World Authoring](world-authoring.md) and the
+[interactive-world runtime protocol](protocols/interactive-world-runtime.md)
+for the state and host boundaries.
+
+## Lifecycle
+
+Keep the lifecycle metadata, checkpoints, materializer, verifier, executable
+source roots, and variants with the lifecycle owner. A lifecycle owner
+provides:
+
+1. A `LifecycleDefinition` with a UUIDv7 identity, readable key, positive
+   version, and template ID.
+2. One `LifecycleOwnerDescriptor` from the owner package.
+3. One `LifecycleConformanceCase` from the owner-local conformance entry
+   point.
+
+Add the owner import to
+[`src/aec_bench/catalogue.py`](../src/aec_bench/catalogue.py), then build and
+check the generated composition:
+
+```bash
+uv run aec-bench catalogue build
+uv run aec-bench catalogue check
+uv run aec-bench conformance lifecycle <lifecycle-key>
+```
+
+The [staged evidence protocol](protocols/staged-evidence-and-publication.md)
+defines checkpoint, visibility, and publication behaviour.
+
+## Harbor backend
+
+Implement the scheduler-facing backend boundary in
+[`src/aec_bench/harness/harbor_backend.py`](../src/aec_bench/harness/harbor_backend.py).
+Bind each submitted work item to its planned trial and preserve that identity
+through submission, inspection, collection, cancellation, reconciliation,
+attempt receipts, and finalization.
+
+Declare the backend capabilities required by the scheduler. Add a provider-free
+`HarborBackendConformanceCase` using the shared checks in
+[`src/aec_bench/harness/harbor_conformance.py`](../src/aec_bench/harness/harbor_conformance.py),
+then run the focused backend tests:
+
+```bash
+uv run pytest tests/harness/test_harbor_backend.py -q
+```
+
+Use a focused client fake at the transport boundary. The conformance case
+must exercise successful collection, repeated collection, unknown remote
+state, cancellation, retryable and terminal failures, persisted transport
+fields, and wrong-identity rejection.
+
+## Catalogue review
+
+The catalogue source is the explicit owner list. The generated Python modules
+are checked-in composition output. Build a JSON snapshot when reviewing a
+catalogue change and compare a later build with:
+
+```bash
+uv run aec-bench catalogue build --snapshot /tmp/aec-bench-catalogue.json
+uv run aec-bench catalogue diff --against /tmp/aec-bench-catalogue.json
+```
+
+Review identity, readable key, version, metadata, profile or variant
+registration, and owner conformance together. The UUIDv7 is the entity
+identity. Build-reference checksums record source integrity. Catalogue
+snapshots record semantic identity and metadata for review.

--- a/tests/architecture/test_extension_contributor_workflow.py
+++ b/tests/architecture/test_extension_contributor_workflow.py
@@ -1,0 +1,248 @@
+# ABOUTME: Exercises the owner-descriptor workflow for a test-local world and lifecycle extension.
+# ABOUTME: Proves conformance entry points and catalogue rendering without adding production registrations.
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from uuid import UUID
+
+from aec_bench.catalogue import render_lifecycle_catalogue, render_world_catalogue
+from aec_bench.contracts.evidence_lifecycle import EvidenceCheckpointSpec, EvidenceLifecycleSpec, LifecycleTaskMetadata
+from aec_bench.contracts.identity import EntityIdentity, EntityKey, MemberIdentity
+from aec_bench.contracts.interactive_world import InteractiveWorldProfileRef, WorldBuildRef
+from aec_bench.contracts.task_definition import Difficulty, Lifecycle, Visibility
+from aec_bench.lifecycles.conformance import LifecycleConformanceCase, build_lifecycle_conformance_case
+from aec_bench.lifecycles.runtime.definition import LifecycleDefinition, LifecycleOwnerDescriptor
+from aec_bench.lifecycles.runtime.lifecycle import run_lifecycle
+from aec_bench.worlds.conformance import WorldConformanceCase, WorldConformanceScenario, run_world_conformance
+from aec_bench.worlds.runtime.definition import (
+    InteractiveWorldDefinition,
+    InteractiveWorldOwnerDescriptor,
+    InteractiveWorldProfileMetadata,
+    LoadedInteractiveWorldProfile,
+)
+from aec_bench.worlds.runtime.world_logic import ActionRejected, Transition
+from tests.support.lifecycle_episode import deterministic_episode_environment
+
+
+@dataclass(frozen=True, slots=True)
+class _MockState:
+    step: int
+
+
+@dataclass(frozen=True, slots=True)
+class _MockObservation:
+    step: int
+
+
+_MOCK_WORLD_IDENTITY = EntityIdentity(
+    id=UUID("01a056f1-af83-7d01-8e6f-5b72d4c6a101"),
+    key=EntityKey("examples/contributor-world"),
+    version=1,
+)
+_MOCK_PROFILE_IDENTITY = MemberIdentity(
+    id=UUID("01a056f1-af83-7d02-8e6f-5b72d4c6a102"),
+    key=EntityKey("examples/contributor-world/default"),
+    version=1,
+    parent_id=_MOCK_WORLD_IDENTITY.id,
+    registration_id="default",
+)
+_MOCK_PROFILE = InteractiveWorldProfileRef(
+    task_world_id="contributor-world",
+    profile_id="default",
+    profile_content_sha256=hashlib.sha256(b"contributor-world-profile").hexdigest(),
+)
+
+
+def _mock_world_definition() -> InteractiveWorldDefinition:
+    return InteractiveWorldDefinition(
+        identity=_MOCK_WORLD_IDENTITY,
+        build=WorldBuildRef(
+            task_world_id="contributor-world",
+            entry_point="tests.architecture.test_extension_contributor_workflow:_mock_world_definition",
+            artifact_sha256="a" * 64,
+        ),
+        title="Contributor example world",
+        summary="A small deterministic world used by the contributor workflow test.",
+        domain="examples",
+        tags=("example", "contributor"),
+        capabilities=frozenset(),
+        profiles=(_MOCK_PROFILE,),
+        profile_identities=(_MOCK_PROFILE_IDENTITY,),
+        profile_metadata=(
+            InteractiveWorldProfileMetadata(
+                profile_id="default",
+                title="Default profile",
+                summary="A deterministic profile for the contributor workflow test.",
+                category="example",
+                difficulty=Difficulty.EASY,
+                lifecycle=Lifecycle.PROPOSED,
+                visibility=Visibility.PUBLIC,
+                tags=("example",),
+            ),
+        ),
+        profile_loader=lambda reference: LoadedInteractiveWorldProfile(reference=reference, value={"step": 0}),
+    )
+
+
+def _mock_world_conformance_case() -> WorldConformanceCase:
+    def transition(state: _MockState, action: str) -> Transition[_MockState, str] | ActionRejected:
+        if state.step != 0:
+            return ActionRejected(code="world-terminated", message="the example world is complete")
+        if action != "finish":
+            return ActionRejected(code="invalid-action", message="finish is the only action at step zero")
+        return Transition(state=_MockState(step=1), output="finished", termination_reason="complete")
+
+    def scenario(_seed: int) -> WorldConformanceScenario:
+        return WorldConformanceScenario(
+            initial_state=lambda _seed: _MockState(step=0),
+            observe=lambda state: _MockObservation(step=state.step),
+            transition=transition,
+            actions=("finish",),
+            invalid_action="unknown",
+            assert_observation_safe=lambda observation: isinstance(observation, _MockObservation),
+            assert_state_valid=lambda state: isinstance(state, _MockState),
+            evaluate=lambda state: {"complete": state.step == 1},
+            state_codec=lambda state: json.dumps({"step": state.step}).encode(),
+            state_decoder=lambda payload: _MockState(**json.loads(payload)),
+            observation_codec=lambda observation: json.dumps({"step": observation.step}).encode(),
+            observation_decoder=lambda payload: _MockObservation(**json.loads(payload)),
+            state_size_bound=100,
+            observation_size_bound=100,
+            assert_owner_conformance=lambda _seed: None,
+        )
+
+    return WorldConformanceCase(
+        world_key="examples/contributor-world",
+        scenario=scenario,
+        requires_terminal_rejection=True,
+    )
+
+
+MOCK_WORLD_DESCRIPTOR = InteractiveWorldOwnerDescriptor(
+    task_world_id="contributor-world",
+    entry_point="tests.architecture.test_extension_contributor_workflow:_mock_world_definition",
+    conformance_entry_point="tests.architecture.test_extension_contributor_workflow:_mock_world_conformance_case",
+)
+
+
+def _mock_lifecycle_case() -> LifecycleConformanceCase:
+    return build_lifecycle_conformance_case(_mock_lifecycle_definition())
+
+
+_MOCK_LIFECYCLE_IDENTITY = EntityIdentity(
+    id=UUID("01a056f1-af83-7d03-8e6f-5b72d4c6a103"),
+    key=EntityKey("examples/contributor-lifecycle"),
+    version=1,
+)
+_MOCK_LIFECYCLE_METADATA = LifecycleTaskMetadata(
+    identity=_MOCK_LIFECYCLE_IDENTITY,
+    template_id="contributor-example-lifecycle",
+    name="Contributor example lifecycle",
+    discipline="examples",
+)
+_MOCK_LIFECYCLE_SPEC = EvidenceLifecycleSpec(
+    lifecycle_id="contributor-example-lifecycle",
+    checkpoints=[
+        EvidenceCheckpointSpec(
+            checkpoint_id="review",
+            title="Example review",
+            release_path="releases/review",
+            instruction_path="instructions/review.md",
+            submission_path="submissions/review.json",
+        )
+    ],
+)
+
+
+def _mock_lifecycle_materializer(output_dir: Path) -> Path:
+    output = Path(output_dir)
+    output.mkdir(parents=True, exist_ok=True)
+    (output / "template.json").write_text(
+        json.dumps(_MOCK_LIFECYCLE_METADATA.model_dump(mode="json")), encoding="utf-8"
+    )
+    (output / "lifecycle.json").write_text(json.dumps(_MOCK_LIFECYCLE_SPEC.model_dump(mode="json")), encoding="utf-8")
+    (output / "instructions").mkdir()
+    (output / "instructions" / "review.md").write_text("Review the released example evidence.\n", encoding="utf-8")
+    (output / "releases" / "review").mkdir(parents=True)
+    (output / "releases" / "review" / "notice.md").write_text("Example evidence.\n", encoding="utf-8")
+    return output
+
+
+def _mock_lifecycle_definition() -> LifecycleDefinition:
+    return LifecycleDefinition(
+        metadata=_MOCK_LIFECYCLE_METADATA,
+        lifecycle=_MOCK_LIFECYCLE_SPEC,
+        materializer=_mock_lifecycle_materializer,
+        verifier=lambda _package, _run: {"status": "pass"},
+        executable_source_roots=(Path(__file__).resolve(),),
+    )
+
+
+def _write_mock_submission(context: dict[str, object]) -> dict[str, str]:
+    submission = Path(str(context["workspace"])) / str(context["submission_path"])
+    submission.parent.mkdir(parents=True, exist_ok=True)
+    submission.write_text(json.dumps({"checkpoint_id": context["checkpoint_id"]}), encoding="utf-8")
+    return {"adapter": "deterministic"}
+
+
+MOCK_LIFECYCLE_DESCRIPTOR = LifecycleOwnerDescriptor(
+    definition=_mock_lifecycle_definition(),
+    conformance_entry_point="tests.architecture.test_extension_contributor_workflow:_mock_lifecycle_case",
+)
+
+
+def test_test_local_owners_run_conformance_and_render_into_generated_catalogues(tmp_path: Path) -> None:
+    world_case = MOCK_WORLD_DESCRIPTOR.load_conformance_case()
+    assert isinstance(world_case, WorldConformanceCase)
+    result = run_world_conformance(world_case)
+    assert result["world_key"] == "examples/contributor-world"
+
+    lifecycle_case = MOCK_LIFECYCLE_DESCRIPTOR.load_conformance_case()
+    assert isinstance(lifecycle_case, LifecycleConformanceCase)
+    assert lifecycle_case.template_id == "contributor-example-lifecycle"
+    package = lifecycle_case.definition.materializer(tmp_path / "package")
+    result = run_lifecycle(
+        package,
+        tmp_path / "run",
+        episode_environment=deterministic_episode_environment(
+            lambda context: _write_mock_submission(context),
+        ),
+    )
+    assert result["status"] == "complete"
+
+    world_owner = (
+        "contributor-world",
+        "tests.architecture.test_extension_contributor_workflow",
+        "MOCK_WORLD_DESCRIPTOR",
+        "MOCK_WORLD_DESCRIPTOR",
+    )
+    lifecycle_owner = (
+        "contributor-lifecycle",
+        "tests.architecture.test_extension_contributor_workflow",
+        "MOCK_LIFECYCLE_DESCRIPTOR",
+        "MOCK_LIFECYCLE_DESCRIPTOR",
+    )
+    world_catalogue = render_world_catalogue((world_owner,))
+    lifecycle_catalogue = render_lifecycle_catalogue((lifecycle_owner,))
+    assert "MOCK_WORLD_DESCRIPTOR," in world_catalogue
+    assert "MOCK_LIFECYCLE_DESCRIPTOR," in lifecycle_catalogue
+
+
+def test_mock_world_owner_definition_has_readable_uuidv7_identity() -> None:
+    definition = MOCK_WORLD_DESCRIPTOR.load()
+
+    assert definition.identity.key == "examples/contributor-world"
+    assert definition.identity.id.version == 7
+    assert definition.identity.version == 1
+
+
+def test_mock_lifecycle_owner_definition_has_readable_uuidv7_identity() -> None:
+    definition = MOCK_LIFECYCLE_DESCRIPTOR.load()
+
+    assert definition.identity.key == "examples/contributor-lifecycle"
+    assert definition.identity.id.version == 7
+    assert definition.identity.version == 1

--- a/tests/docs/test_documentation_ownership.py
+++ b/tests/docs/test_documentation_ownership.py
@@ -50,6 +50,7 @@ EXPECTED_REPOSITORY_DOCS = {
     "research/learning-studies/release-a/studies/A03-artifact-retention-and-interference.md",
     "research/learning-studies/release-a/studies/A04-artifact-composition.md",
     "world-authoring.md",
+    "extension-authoring.md",
 }
 MAINTAINED_INDEX_TARGETS = {
     "AGENTS.md",
@@ -73,6 +74,7 @@ MAINTAINED_INDEX_TARGETS = {
     "protocols/interactive-world-runtime.md",
     "protocols/staged-evidence-and-publication.md",
     "world-authoring.md",
+    "extension-authoring.md",
 }
 MARKDOWN_LINK = re.compile(r"!?\[[^\]]*\]\((?P<target>[^)]+)\)")
 FIXED_TEST_COUNT = re.compile(r"\b\d[\d,]*\s+(?:tests?|test cases)\b", re.IGNORECASE)


### PR DESCRIPTION
## Summary

- add the current contributor path for tasks, interactive worlds, lifecycles, and Harbor backends
- document catalogue build, check, diff, and conformance commands
- add a test-local UUIDv7 world and lifecycle extension exercise
- keep the maintained documentation index and ownership checks current

## Validation

- `uv run pytest tests/architecture/test_extension_contributor_workflow.py tests/docs/test_documentation_ownership.py tests/worlds/test_generated_catalogue.py tests/lifecycles/test_generated_catalogue.py tests/cli/test_catalogue_commands.py tests/cli/test_conformance.py -q` — 45 passed
- `uv run ruff check tests/architecture/test_extension_contributor_workflow.py tests/docs/test_documentation_ownership.py`
- `uv run ruff format --check tests/architecture/test_extension_contributor_workflow.py tests/docs/test_documentation_ownership.py`
- `uv run aec-bench catalogue check`
- `git diff --check`