### PR TITLE
Fix training splits, verifier errors, and evaluation metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,6 +715,16 @@ uv run aec-bench prime smoke \
   --task electrical/rlm-test
 ```
 
+Generated task packages use a fixed 80/20 split by sorted task ID. The default
+`split="train"` supplies separate training and evaluation datasets. Filters,
+shuffling, and limits apply within each split. A required empty split is an
+error. Use `split="eval"` for evaluation rows, or `split="all"` to evaluate all
+rows without a training dataset. The smoke command uses `all`, including for
+single-task packages. Instance separation does not prove task-family separation.
+Verifier crashes, timeouts, missing output, and invalid rewards stop scoring
+with `verifiers.InfraError`; they are not zero-reward training samples. A valid
+zero reward still means that the verifier completed and awarded zero.
+
 Run a hosted Prime eval against an existing Hub environment:
 
 ```bash
@@ -853,6 +863,12 @@ uv run aec-bench evaluate -e experiment-001 --report report.html
 # Filter by model or adapter
 uv run aec-bench evaluate -e experiment-001 --model "<model-id>"
 ```
+
+`evaluate`, `report summary`, `report leaderboard`, and lifecycle-study
+summaries keep unknown costs separate from free trials.
+If any trial lacks an estimated cost, `total_cost_usd` is null. The summary also
+reports `known_cost_usd`, `n_costed`, and `n_uncosted`. Text and HTML reports
+show the unknown total with its known subtotal.
 
 Published evaluation regimes use one artifact reference as their compatibility
 identity. Inspect one regime or compare two regimes with semantic field paths:

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -627,6 +627,13 @@ evaluation extensions. Invalid or unparseable output cannot carry positive
 reward. Presentation code consumes this record and does not recalculate a
 competing result.
 
+The `evaluate`, `report summary`, and `report leaderboard` commands, and
+lifecycle-study summaries, report `total_cost_usd: null` when any included
+trial has no estimated cost. `known_cost_usd` is the sum of known costs;
+`n_costed` and `n_uncosted` give coverage. An explicit zero is a known cost.
+These rules apply to each complete summary and its groups. Text and HTML
+summary reports show unknown totals and the known subtotal.
+
 Task-specific verifier details can remain in their owning evidence artifact
 while the common evaluation envelope reports the normalized result.
 
@@ -636,6 +643,24 @@ hydraulic fields to the shared envelope. New task-specific details stay in a
 typed owner-specific evidence artifact and enter the common result through its
 normalized fields and evidence reference. Moving the stewardship field needs
 an approved persisted-record migration.
+
+The pump evaluator derives terminal physical review from the current operating
+boundaries: review is required if a pump is not assured for outage planning.
+Its combined physical/service review flag also includes any unserved capacity
+in the verified run. These diagnostic flags do not change the integrity gates
+or turn a valid evidence record into a failed record.
+
+Terminal overdue durations sum positive deadline exceedances over obligations
+that are not fulfilled. Calendar deadlines use the station calendar. Runtime
+deadlines use the affected pump's cumulative runtime. Each obligation counts
+separately; the sums are obligation-seconds, not elapsed station time.
+
+`handover_count` counts recorded actor-tenure changes. The current world does
+not record required handover contents, so `handover_omission_count` remains a
+reserved zero in the frozen format. It is not a measured absence of omissions
+and must not be used as a training or acceptance criterion. Likewise,
+`decision_time_invalid_count` is an aggregate actor-action validity indicator
+(0 or 1), not a count of individual invalid decisions.
 
 Lifecycle verification records are boundary contracts. Lifecycle progression
 can validate and store them without importing scoring policy from

--- a/src/aec_bench/cli/commands/evaluate.py
+++ b/src/aec_bench/cli/commands/evaluate.py
@@ -14,6 +14,7 @@ import typer
 from aec_bench import __version__
 from aec_bench.cli.commands.config import resolve_path
 from aec_bench.cli.output import console, emit
+from aec_bench.communication.cost_display import format_summary_cost
 
 
 def evaluate_experiment(
@@ -134,7 +135,7 @@ def _print_overview_table(
 
     table.add_row("Total Trials", str(summary.get("n_trials", 0)))
     table.add_row("Mean Reward", f"{summary.get('mean_reward', 0):.3f}")
-    table.add_row("Total Cost", f"${summary.get('total_cost_usd', 0):.2f}")
+    table.add_row("Total Cost", format_summary_cost(summary))
 
     console.print(table)
 
@@ -160,7 +161,7 @@ def _print_adapter_table(by_adapter: dict[str, Any]) -> None:
             f"{metrics.get('mean_reward', 0):.3f}",
             f"{metrics.get('perfect_rate', 0):.1%}",
             f"{metrics.get('zero_rate', 0):.1%}",
-            f"${metrics.get('total_cost_usd', 0):.2f}",
+            format_summary_cost(metrics),
         )
 
     console.print(table)
@@ -187,7 +188,7 @@ def _print_task_table(by_task: dict[str, Any]) -> None:
             f"{metrics.get('mean_reward', 0):.3f}",
             f"{metrics.get('perfect_rate', 0):.1%}",
             f"{metrics.get('zero_rate', 0):.1%}",
-            f"${metrics.get('total_cost_usd', 0):.2f}",
+            format_summary_cost(metrics),
         )
 
     console.print(table)

--- a/src/aec_bench/cli/commands/report.py
+++ b/src/aec_bench/cli/commands/report.py
@@ -10,6 +10,7 @@ import typer
 from aec_bench.cli.commands.config import resolve_path
 from aec_bench.cli.optional_dependencies import require_optional_extra
 from aec_bench.cli.output import console, emit, print_success
+from aec_bench.communication.cost_display import format_summary_cost
 
 app = typer.Typer(help="Generate reports and analysis from ledger data.")
 
@@ -50,7 +51,7 @@ def summary(
     def _render(d: dict[str, Any]) -> None:
         console.print(f"[bold]Experiment Summary[/bold] ({d['n_trials']} trials)")
         console.print(f"  Mean reward: [green]{d['mean_reward']:.3f}[/green]")
-        console.print(f"  Total cost:  ${d.get('total_cost_usd', 0):.2f}")
+        console.print(f"  Total cost:  {format_summary_cost(d)}")
 
         by_adapter = d.get("by_adapter", {})
         if by_adapter:
@@ -135,7 +136,7 @@ def leaderboard(
                 str(entry.get("n_trials", 0)),
                 f"{entry.get('mean_reward', 0):.3f}",
                 f"{entry.get('perfect_trial_rate', 0):.1%}",
-                f"${entry.get('total_cost_usd', 0):.2f}",
+                format_summary_cost(entry),
             )
 
         console.print(table)

--- a/src/aec_bench/communication/cost_display.py
+++ b/src/aec_bench/communication/cost_display.py
@@ -1,0 +1,16 @@
+# ABOUTME: Formats an established cost summary for text and HTML reports.
+# ABOUTME: Keeps unknown totals distinct from a known zero cost.
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def format_summary_cost(summary: Mapping[str, Any]) -> str:
+    total = summary.get("total_cost_usd")
+    if total is not None:
+        return f"${total:.2f}"
+    known = summary.get("known_cost_usd")
+    missing = summary.get("n_uncosted")
+    if known is not None and missing is not None:
+        return f"Unknown (${known:.2f} known; {missing} uncosted)"
+    return "Unknown"

--- a/src/aec_bench/communication/html_report.py
+++ b/src/aec_bench/communication/html_report.py
@@ -7,6 +7,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+from aec_bench.communication.cost_display import format_summary_cost
 from aec_bench.evaluation.artifact import EvaluationArtifact
 
 
@@ -23,7 +24,7 @@ def _build_overview_section(summary: dict[str, Any], experiment_id: str) -> str:
     """Build the overview statistics section."""
     n_trials = summary.get("n_trials", 0)
     mean_reward = summary.get("mean_reward", 0.0)
-    total_cost = summary.get("total_cost_usd", 0.0)
+    total_cost = format_summary_cost(summary)
     return f"""
     <div class="card">
       <h2>Overview</h2>
@@ -42,7 +43,7 @@ def _build_overview_section(summary: dict[str, Any], experiment_id: str) -> str:
         </div>
         <div class="stat">
           <span class="stat-label">Total Cost</span>
-          <span class="stat-value">${total_cost:.2f}</span>
+          <span class="stat-value">{total_cost}</span>
         </div>
       </div>
     </div>
@@ -57,12 +58,12 @@ def _build_group_table(title: str, group_data: dict[str, dict[str, Any]]) -> str
     for name, metrics in sorted(group_data.items()):
         n = metrics.get("n_trials", 0)
         reward = metrics.get("mean_reward", 0.0)
-        cost = metrics.get("total_cost_usd", 0.0)
+        cost = format_summary_cost(metrics)
         color = _reward_color(reward)
         rows.append(
             f'<tr><td>{name}</td><td class="num">{n}</td>'
             f'<td class="num" style="color:{color}">{reward:.3f}</td>'
-            f'<td class="num">${cost:.2f}</td></tr>'
+            f'<td class="num">{cost}</td></tr>'
         )
     return f"""
     <div class="card">

--- a/src/aec_bench/communication/metrics.py
+++ b/src/aec_bench/communication/metrics.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 from typing import Any
 
 from aec_bench.contracts.trial_record import TrialRecord
+from aec_bench.evaluation.costs import summarize_costs
 
 
 def mean_reward(records: Sequence[TrialRecord]) -> float:
@@ -20,8 +21,8 @@ def perfect_trial_rate(records: Sequence[TrialRecord]) -> float:
     return perfect_count / len(records)
 
 
-def total_cost_usd(records: Sequence[TrialRecord]) -> float:
-    return sum(record.cost.estimated_cost_usd or 0.0 for record in records if record.cost is not None)
+def total_cost_usd(records: Sequence[TrialRecord]) -> float | None:
+    return summarize_costs(records)["total_cost_usd"]
 
 
 def coerce_int(value: Any, fallback: int = 0) -> int:

--- a/src/aec_bench/communication/metrics.py
+++ b/src/aec_bench/communication/metrics.py
@@ -9,16 +9,13 @@ from aec_bench.evaluation.costs import summarize_costs
 
 
 def mean_reward(records: Sequence[TrialRecord]) -> float:
-    if not records:
-        return 0.0
-    return sum(record.evaluation.reward for record in records) / len(records)
+    rewards = [record.evaluation.reward for record in records if record.evaluation is not None]
+    return sum(rewards) / len(rewards) if rewards else 0.0
 
 
 def perfect_trial_rate(records: Sequence[TrialRecord]) -> float:
-    if not records:
-        return 0.0
-    perfect_count = sum(1 for record in records if record.evaluation.reward >= 1.0)
-    return perfect_count / len(records)
+    rewards = [record.evaluation.reward for record in records if record.evaluation is not None]
+    return sum(reward >= 1.0 for reward in rewards) / len(rewards) if rewards else 0.0
 
 
 def total_cost_usd(records: Sequence[TrialRecord]) -> float | None:

--- a/src/aec_bench/communication/report_builder.py
+++ b/src/aec_bench/communication/report_builder.py
@@ -12,9 +12,9 @@ from aec_bench.communication.metrics import (
     mean_reward,
     perfect_trial_rate,
     resolve_agent_name,
-    total_cost_usd,
 )
 from aec_bench.contracts.trial_record import TrialRecord
+from aec_bench.evaluation.costs import summarize_costs
 
 
 @dataclass(frozen=True)
@@ -25,7 +25,10 @@ class LeaderboardEntry:
     n_trials: int
     mean_reward: float
     perfect_trial_rate: float
-    total_cost_usd: float
+    total_cost_usd: float | None
+    known_cost_usd: float
+    n_costed: int
+    n_uncosted: int
 
 
 @dataclass(frozen=True)
@@ -51,7 +54,8 @@ def leaderboard_to_dict(report: LeaderboardReport) -> dict[str, Any]:
                 **asdict(entry),
                 "mean_reward": round(entry.mean_reward, 4),
                 "perfect_trial_rate": round(entry.perfect_trial_rate, 4),
-                "total_cost_usd": round(entry.total_cost_usd, 4),
+                "total_cost_usd": round(entry.total_cost_usd, 4) if entry.total_cost_usd is not None else None,
+                "known_cost_usd": round(entry.known_cost_usd, 4),
             }
             for entry in report.entries
         ]
@@ -67,5 +71,5 @@ def _build_entry(experiment_id: str, records: Sequence[TrialRecord]) -> Leaderbo
         n_trials=len(records),
         mean_reward=mean_reward(records),
         perfect_trial_rate=perfect_trial_rate(records),
-        total_cost_usd=total_cost_usd(records),
+        **summarize_costs(records),
     )

--- a/src/aec_bench/evaluation/costs.py
+++ b/src/aec_bench/evaluation/costs.py
@@ -1,0 +1,30 @@
+# ABOUTME: Aggregates known trial costs and reports gaps without treating them as free.
+# ABOUTME: Supplies one cost definition to evaluation, study, and leaderboard summaries.
+
+from collections.abc import Sequence
+from typing import TypedDict
+
+from aec_bench.contracts.trial_record import TrialRecord
+
+
+class CostSummary(TypedDict):
+    total_cost_usd: float | None
+    known_cost_usd: float
+    n_costed: int
+    n_uncosted: int
+
+
+def summarize_costs(records: Sequence[TrialRecord]) -> CostSummary:
+    costs = [
+        record.cost.estimated_cost_usd
+        for record in records
+        if record.cost is not None and record.cost.estimated_cost_usd is not None
+    ]
+    known_cost = sum(costs, 0.0)
+    n_uncosted = len(records) - len(costs)
+    return {
+        "total_cost_usd": None if n_uncosted else known_cost,
+        "known_cost_usd": known_cost,
+        "n_costed": len(costs),
+        "n_uncosted": n_uncosted,
+    }

--- a/src/aec_bench/evaluation/pipeline.py
+++ b/src/aec_bench/evaluation/pipeline.py
@@ -11,6 +11,7 @@ from typing import Any
 from aec_bench.contracts.evaluation_result import ConfidenceMetadata
 from aec_bench.contracts.trial_record import TrialRecord
 from aec_bench.evaluation.aggregation import BehavioralTraceClassifier, summarize_behavioral_records
+from aec_bench.evaluation.costs import summarize_costs
 from aec_bench.evaluation.stats import mean
 from aec_bench.evaluation.trace_summary import summarize_trial_traces
 
@@ -44,14 +45,13 @@ def summarize_evaluation_records(
     n_trials = len(records)
     evaluated_records = [record for record in records if record.evaluation is not None]
     rewards = [record.evaluation.reward for record in evaluated_records if record.evaluation is not None]
-    total_cost = sum(record.cost.estimated_cost_usd or 0.0 for record in records if record.cost is not None)
 
     summary: dict[str, Any] = {
         "n_trials": n_trials,
         "n_evaluated": len(evaluated_records),
         "n_unevaluated": n_trials - len(evaluated_records),
         "mean_reward": mean(rewards),
-        "total_cost_usd": total_cost,
+        **summarize_costs(records),
         "by_adapter": _group_summary(records, key_fn=lambda record: record.agent.adapter),
         "by_task_prefix": _group_summary(
             records,
@@ -117,11 +117,11 @@ def _group_summary(
     records: list[TrialRecord],
     *,
     key_fn: Callable[[TrialRecord], str],
-) -> dict[str, dict[str, float | int]]:
+) -> dict[str, dict[str, object]]:
     grouped: dict[str, list[TrialRecord]] = defaultdict(list)
     for record in records:
         grouped[str(key_fn(record))].append(record)
-    result: dict[str, dict[str, float | int]] = {}
+    result: dict[str, dict[str, object]] = {}
     for key, group_records in sorted(grouped.items()):
         rewards = [record.evaluation.reward for record in group_records if record.evaluation is not None]
         n = len(rewards)
@@ -133,8 +133,6 @@ def _group_summary(
             "mean_reward": mean(rewards),
             "perfect_rate": sum(1 for r in rewards if r >= 1.0) / n if n else 0.0,
             "zero_rate": sum(1 for r in rewards if r <= 0.0) / n if n else 0.0,
-            "total_cost_usd": sum(
-                record.cost.estimated_cost_usd or 0.0 for record in group_records if record.cost is not None
-            ),
+            **summarize_costs(group_records),
         }
     return result

--- a/src/aec_bench/experimentation/lifecycle_studies/evaluation.py
+++ b/src/aec_bench/experimentation/lifecycle_studies/evaluation.py
@@ -11,6 +11,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from aec_bench.contracts.evaluation_result import EvaluationResult
 from aec_bench.contracts.trial_record import ArtifactReference, TrialRecord
 from aec_bench.evaluation.artifact import (
     EvaluationArtifact,
@@ -44,8 +45,8 @@ def build_lifecycle_ablation_evaluation(
 
     completed = sum(_record_completed(record) for record in records)
     failed = len(records) - completed
-    passed = sum(record.evaluation.reward >= 1.0 for record in records)
-    rewards = [record.evaluation.reward for record in records]
+    passed = sum(_evaluation(record).reward >= 1.0 for record in records)
+    rewards = [_evaluation(record).reward for record in records]
     summary = {
         "study_design": plan.study_design.model_dump(mode="json"),
         "planned_trials": plan.trial_count,
@@ -102,7 +103,7 @@ def _group_records(
 
     result: list[dict[str, Any]] = []
     for key, group in sorted(grouped.items()):
-        rewards = [record.evaluation.reward for record in group]
+        rewards = [_evaluation(record).reward for record in group]
         retentions = [retention for record in group if (retention := _retention(record)) is not None]
         completed = sum(_record_completed(record) for record in group)
         executions = [record.lifecycle_execution for record in group]
@@ -278,7 +279,7 @@ def _read_artifact_json(
 
 
 def _retention(record: TrialRecord) -> float | None:
-    breakdown = record.evaluation.breakdown
+    breakdown = _evaluation(record).breakdown
     if not isinstance(breakdown, dict):
         return None
     semantic = breakdown.get("semantic_transition")
@@ -295,12 +296,13 @@ def _record_completed(record: TrialRecord) -> bool:
     return bool(
         record.lifecycle_execution is not None
         and record.lifecycle_execution.status == "completed"
+        and record.evaluation is not None
         and record.evaluation.validity.verifier_completed
     )
 
 
 def _operational_metric(record: TrialRecord, name: str) -> int:
-    breakdown = record.evaluation.breakdown
+    breakdown = _evaluation(record).breakdown
     operational = breakdown.get("operational_metrics") if isinstance(breakdown, dict) else None
     value = operational.get(name) if isinstance(operational, dict) else None
     if not isinstance(value, int) or isinstance(value, bool) or value < 0:
@@ -310,3 +312,9 @@ def _operational_metric(record: TrialRecord, name: str) -> int:
 
 def _mean(values: Sequence[float | int]) -> float:
     return sum(values) / len(values) if values else 0.0
+
+
+def _evaluation(record: TrialRecord) -> EvaluationResult:
+    if record.evaluation is None:
+        raise ValueError(f"lifecycle ablation summary requires an evaluation: {record.trial_id}")
+    return record.evaluation

--- a/src/aec_bench/experimentation/lifecycle_studies/evaluation.py
+++ b/src/aec_bench/experimentation/lifecycle_studies/evaluation.py
@@ -17,6 +17,7 @@ from aec_bench.evaluation.artifact import (
     EvaluationFilters,
     write_evaluation_artifact,
 )
+from aec_bench.evaluation.costs import summarize_costs
 from aec_bench.experimentation.lifecycle_studies.ablation_plan import (
     LifecycleAblationManifest,
     LifecycleAblationPlan,
@@ -53,7 +54,7 @@ def build_lifecycle_ablation_evaluation(
         "failed_trials": failed,
         "passed_trials": passed,
         "mean_reward": _mean(rewards),
-        "total_cost_usd": sum(record.cost.estimated_cost_usd or 0.0 for record in records if record.cost is not None),
+        **summarize_costs(records),
         "groups": _group_records(records, planned),
     }
     record_digest = hashlib.sha256(
@@ -162,9 +163,7 @@ def _group_records(
                 "passed": sum(reward >= 1.0 for reward in rewards),
                 "mean_reward": _mean(rewards),
                 "mean_retention": _mean(retentions) if retentions else None,
-                "total_cost_usd": sum(
-                    record.cost.estimated_cost_usd or 0.0 for record in group if record.cost is not None
-                ),
+                **summarize_costs(group),
                 "turn_budget_scope": "per_session",
                 "max_turns_per_session": max_turns_per_session,
                 "total_sessions": sum(session_counts),

--- a/src/aec_bench/prime_lab/doctor.py
+++ b/src/aec_bench/prime_lab/doctor.py
@@ -38,9 +38,9 @@ def load_generated_environment(package_dir: Path, env_id: str) -> PrimeCheck:
     env["PYTHONPATH"] = f"{package_dir}{os.pathsep}{existing_pythonpath}" if existing_pythonpath else str(package_dir)
     code = (
         "from verifiers import load_environment\n"
-        f"env = load_environment({env_id!r})\n"
+        f"env = load_environment({env_id!r}, split='all')\n"
         "print(type(env).__name__)\n"
-        "print(len(env.dataset))\n"
+        "print(len(env.get_eval_dataset()))\n"
     )
     result = _run([sys.executable, "-c", code], env=env, cwd=package_dir)
     if result.returncode == 0:
@@ -85,6 +85,8 @@ def run_prime_eval_smoke(
         env_id,
         "--model",
         model,
+        "--env-args",
+        '{"split":"all"}',
         "--num-examples",
         "1",
         "--rollouts-per-example",

--- a/src/aec_bench/prime_lab/exporter.py
+++ b/src/aec_bench/prime_lab/exporter.py
@@ -272,7 +272,7 @@ def _render_pyproject(name: str, version: str, description: str | None) -> str:
         readme = "README.md"
         requires-python = ">=3.10"
         tags = ["aec-bench", "aec", "benchmark"]
-        dependencies = ["datasets>=4.0", "verifiers>=0.1.10"]
+        dependencies = ["datasets>=4.0", "verifiers==0.1.14"]
 
         [build-system]
         requires = ["hatchling"]
@@ -308,6 +308,25 @@ def _render_readme(name: str, records: list[dict[str, Any]]) -> str:
 
         {environment_summary}
 
+        ## Training and evaluation
+
+        The default `split="train"` uses a fixed 80/20 task-instance split and
+        provides separate training and evaluation datasets. Split membership is
+        set by sorted task ID before difficulty filters, shuffling, or limits.
+        A required split with no tasks is an error. Training requires at least
+        two tasks. These splits do not prove separation between task families.
+
+        `split="eval"` provides only the evaluation dataset. `split="all"`
+        evaluates all selected tasks and provides no training dataset; use it
+        for a one-task smoke test. The aliases `validation`, `val`, and `test`
+        select evaluation; `any` and `full` select all tasks.
+
+        Verifier failures raise `verifiers.InfraError` and stop scoring, including
+        group scoring. A failed verifier is not a zero-reward training sample.
+        A completed verifier can return any finite numeric reward in [0, 1].
+        The generated package pins Verifiers because it overrides its reward
+        invocation hook to preserve these errors.
+
         ## Tasks
 
         {task_lines}
@@ -316,7 +335,7 @@ def _render_readme(name: str, records: list[dict[str, Any]]) -> str:
 
         ```bash
         uv pip install -e .
-        uv run vf-eval {name}
+        uv run vf-eval {name} --env-args '{{"split":"all"}}'
         ```
 
         ## Prime Lab
@@ -324,7 +343,7 @@ def _render_readme(name: str, records: list[dict[str, Any]]) -> str:
         ```bash
         prime env install {name} --path prime-rl/environments
         prime env push
-        prime eval run <owner>/{name} -m <model> -n 20 -r 1 --max-tokens 2048
+        prime eval run <owner>/{name} -m <model> -n 20 -r 1 --max-tokens 2048 --env-args '{{"split":"all"}}'
         prime train run configs/lab/{name}.toml
         ```
         """
@@ -341,6 +360,84 @@ def _requires_stateful_workspace(records: list[dict[str, Any]]) -> bool:
     return any(record.get("environment_kind") == PrimeHarnessKind.STATEFUL_WORKSPACE.value for record in records)
 
 
+def _render_scoring_and_split_helpers() -> str:
+    return """def _select_task_splits(
+    split: str,
+    difficulty: str | list[str] | None,
+    num_examples: int | None,
+    seed: int | None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    normalized = split.strip().lower().replace("_", "-")
+    if normalized not in {"train", "eval", "validation", "val", "test", "all", "any", "full"}:
+        raise ValueError(f"unsupported split: {split}")
+    tasks = sorted(TASKS, key=lambda task: task["task_id"])
+    if normalized in {"all", "any", "full"}:
+        train, evaluation = [], tasks
+    else:
+        if len(tasks) < 2:
+            raise ValueError("train/eval splits require at least two tasks; use split='all' for evaluation only")
+        boundary = max(1, min(len(tasks) - 1, int(len(tasks) * 0.8)))
+        train = tasks[:boundary] if normalized == "train" else []
+        evaluation = tasks[boundary:]
+
+    def select(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        if difficulty is not None:
+            allowed = {difficulty} if isinstance(difficulty, str) else set(difficulty)
+            rows = [task for task in rows if task.get("difficulty") in allowed]
+        if seed is not None:
+            random.Random(seed).shuffle(rows)
+        if num_examples is not None and num_examples >= 0:
+            rows = rows[:num_examples]
+        if not rows:
+            raise ValueError("no tasks remain in a required split after filtering")
+        return rows
+
+    return (select(train) if normalized == "train" else []), select(evaluation)
+
+
+class AecBenchRubric(vf.Rubric):
+    async def _call_individual_reward_func(self, func: Any, state: vf.State) -> float:
+        # Verifiers' default hook turns exceptions into zero rewards. Abort scoring
+        # instead, so a broken verifier cannot create a training penalty.
+        try:
+            return await func(completion=state["completion"], info=state["info"], state=state)
+        except Exception as cause:
+            error = cause if isinstance(cause, vf.InfraError) else vf.InfraError("AEC verifier execution failed")
+            state["error"] = error
+            state["reward"] = None
+            state["metrics"] = {}
+            if error is cause:
+                raise
+            raise error from cause
+
+
+def _score_submission(task_dir: Path, timeout_seconds: int) -> float:
+    reward_path = task_dir.parent / "reward.json"
+    verifier = task_dir / "tests" / "verify.py"
+    try:
+        reward_path.unlink(missing_ok=True)
+        if not verifier.is_file():
+            raise vf.InfraError("AEC verifier is missing")
+        process = subprocess.run(
+            [sys.executable, str(verifier), "--input", str(task_dir / "output.md"), "--output", str(reward_path)],
+            cwd=task_dir,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+        if process.returncode != 0:
+            raise vf.InfraError(f"AEC verifier exited with status {process.returncode}")
+        payload = json.loads(reward_path.read_text(encoding="utf-8"))
+        reward = payload.get("reward") if isinstance(payload, dict) else None
+        if type(reward) not in (int, float) or not math.isfinite(reward) or not 0 <= reward <= 1:
+            raise vf.InfraError("AEC verifier reward must be a finite number in [0, 1]")
+        return float(reward)
+    except (OSError, ValueError, subprocess.TimeoutExpired) as cause:
+        raise vf.InfraError("AEC verifier failed to produce a valid reward") from cause
+"""
+
+
 def _render_single_turn_environment_py(records: list[dict[str, Any]]) -> str:
     task_json = json.dumps(records, indent=2)
     return f"""# ABOUTME: Prime Lab environment generated from selected aec-bench tasks.
@@ -349,6 +446,7 @@ def _render_single_turn_environment_py(records: list[dict[str, Any]]) -> str:
 from __future__ import annotations
 
 import json
+import math
 import random
 import subprocess
 import sys
@@ -371,48 +469,18 @@ def load_environment(
     harness: str | None = None,
 ) -> vf.Environment:
     del harness
-    tasks = _select_tasks(
+    train_tasks, eval_tasks = _select_task_splits(
         split=split,
         difficulty=difficulty,
         num_examples=num_examples,
         seed=seed,
     )
-    dataset = _dataset_from_tasks(tasks, workspace=False)
-    rubric = vf.Rubric(funcs=[aec_bench_reward])
-    return vf.SingleTurnEnv(dataset=dataset, eval_dataset=dataset, rubric=rubric)
+    dataset = _dataset_from_tasks(train_tasks, workspace=False) if train_tasks else None
+    eval_dataset = _dataset_from_tasks(eval_tasks, workspace=False)
+    return vf.SingleTurnEnv(dataset=dataset, eval_dataset=eval_dataset, rubric=AecBenchRubric(funcs=[aec_bench_reward]))
 
 
-def _select_tasks(
-    split: str,
-    difficulty: str | list[str] | None,
-    num_examples: int | None,
-    seed: int | None,
-) -> list[dict[str, Any]]:
-    selected = list(TASKS)
-    if difficulty is not None:
-        allowed = {{difficulty}} if isinstance(difficulty, str) else set(difficulty)
-        selected = [task for task in selected if task.get("difficulty") in allowed]
-    selected = _split_tasks(selected, split)
-    if seed is not None:
-        rng = random.Random(seed)
-        rng.shuffle(selected)
-    if num_examples is not None and num_examples >= 0:
-        selected = selected[:num_examples]
-    return selected
-
-
-def _split_tasks(tasks: list[dict[str, Any]], split: str) -> list[dict[str, Any]]:
-    normalized = (split or "train").strip().lower().replace("_", "-")
-    if normalized in {{"all", "any", "full"}}:
-        return list(tasks)
-    if len(tasks) < 5:
-        return list(tasks)
-    boundary = max(1, min(len(tasks) - 1, int(len(tasks) * 0.8)))
-    if normalized == "train":
-        return list(tasks[:boundary])
-    if normalized in {{"eval", "validation", "val", "test"}}:
-        return list(tasks[boundary:])
-    raise ValueError(f"unsupported split: {{split}}")
+{_render_scoring_and_split_helpers()}
 
 
 def _dataset_from_tasks(tasks: list[dict[str, Any]], *, workspace: bool) -> Dataset:
@@ -439,7 +507,7 @@ def _dataset_from_tasks(tasks: list[dict[str, Any]], *, workspace: bool) -> Data
 
 
 async def aec_bench_reward(
-    completion: list[dict[str, Any]], info: dict[str, Any] | str
+    completion: list[dict[str, Any]], info: dict[str, Any] | str, state: vf.State | None = None
 ) -> float:
     task_info = json.loads(info) if isinstance(info, str) else info
     response = _completion_text(completion)
@@ -452,33 +520,8 @@ async def aec_bench_reward(
         task_dir = temp_path / "task"
         _copy_resource_tree(task_resource, task_dir)
 
-        output_path = task_dir / "output.md"
-        reward_path = temp_path / "reward.json"
-        output_path.write_text(response, encoding="utf-8")
-
-        verifier = task_dir / "tests" / "verify.py"
-        if not verifier.exists():
-            return 0.0
-
-        process = subprocess.run(
-            [
-                sys.executable,
-                str(verifier),
-                "--input",
-                str(output_path),
-                "--output",
-                str(reward_path),
-            ],
-            cwd=task_dir,
-            capture_output=True,
-            text=True,
-            timeout=timeout_seconds,
-            check=False,
-        )
-        if process.returncode != 0 or not reward_path.exists():
-            return 0.0
-        payload = json.loads(reward_path.read_text(encoding="utf-8"))
-        return float(payload.get("reward", 0.0))
+        (task_dir / "output.md").write_text(response, encoding="utf-8")
+        return _score_submission(task_dir, timeout_seconds)
 
 
 def _completion_text(completion: list[dict[str, Any]]) -> str:
@@ -513,6 +556,7 @@ def _render_stateful_environment_py(records: list[dict[str, Any]]) -> str:
 from __future__ import annotations
 
 import json
+import math
 import random
 import shlex
 import shutil
@@ -741,53 +785,24 @@ def load_environment(
     harness: str | None = None,
 ) -> vf.Environment:
     del harness
-    tasks = _select_tasks(
+    train_tasks, eval_tasks = _select_task_splits(
         split=split,
         difficulty=difficulty,
         num_examples=num_examples,
         seed=seed,
     )
-    dataset = _dataset_from_tasks(tasks, workspace=True)
-    rubric = vf.Rubric(funcs=[aec_bench_reward])
+    dataset = _dataset_from_tasks(train_tasks, workspace=True) if train_tasks else None
+    eval_dataset = _dataset_from_tasks(eval_tasks, workspace=True)
+    rubric = AecBenchRubric(funcs=[aec_bench_reward])
     return AecBenchStatefulWorkspaceEnv(
-        tasks=tasks,
+        tasks=train_tasks + eval_tasks,
         dataset=dataset,
-        eval_dataset=dataset,
+        eval_dataset=eval_dataset,
         rubric=rubric,
     )
 
 
-def _select_tasks(
-    split: str,
-    difficulty: str | list[str] | None,
-    num_examples: int | None,
-    seed: int | None,
-) -> list[dict[str, Any]]:
-    selected = list(TASKS)
-    if difficulty is not None:
-        allowed = {{difficulty}} if isinstance(difficulty, str) else set(difficulty)
-        selected = [task for task in selected if task.get("difficulty") in allowed]
-    selected = _split_tasks(selected, split)
-    if seed is not None:
-        rng = random.Random(seed)
-        rng.shuffle(selected)
-    if num_examples is not None and num_examples >= 0:
-        selected = selected[:num_examples]
-    return selected
-
-
-def _split_tasks(tasks: list[dict[str, Any]], split: str) -> list[dict[str, Any]]:
-    normalized = (split or "train").strip().lower().replace("_", "-")
-    if normalized in {{"all", "any", "full"}}:
-        return list(tasks)
-    if len(tasks) < 5:
-        return list(tasks)
-    boundary = max(1, min(len(tasks) - 1, int(len(tasks) * 0.8)))
-    if normalized == "train":
-        return list(tasks[:boundary])
-    if normalized in {{"eval", "validation", "val", "test"}}:
-        return list(tasks[boundary:])
-    raise ValueError(f"unsupported split: {{split}}")
+{_render_scoring_and_split_helpers()}
 
 
 def _dataset_from_tasks(tasks: list[dict[str, Any]], *, workspace: bool) -> Dataset:
@@ -879,32 +894,6 @@ async def aec_bench_reward(
         _copy_resource_tree(task_resource, task_dir)
         (task_dir / "output.md").write_text(response, encoding="utf-8")
         return _score_submission(task_dir, timeout_seconds)
-
-
-def _score_submission(task_dir: Path, timeout_seconds: int) -> float:
-    reward_path = task_dir.parent / "reward.json"
-    verifier = task_dir / "tests" / "verify.py"
-    if not verifier.exists():
-        return 0.0
-    process = subprocess.run(
-        [
-            sys.executable,
-            str(verifier),
-            "--input",
-            str(task_dir / "output.md"),
-            "--output",
-            str(reward_path),
-        ],
-        cwd=task_dir,
-        capture_output=True,
-        text=True,
-        timeout=timeout_seconds,
-        check=False,
-    )
-    if process.returncode != 0 or not reward_path.exists():
-        return 0.0
-    payload = json.loads(reward_path.read_text(encoding="utf-8"))
-    return float(payload.get("reward", 0.0))
 
 
 def _completion_text(completion: list[dict[str, Any]]) -> str:

--- a/src/aec_bench/worlds/stewardship/wastewater_pump_station/evaluation.py
+++ b/src/aec_bench/worlds/stewardship/wastewater_pump_station/evaluation.py
@@ -171,11 +171,22 @@ def evaluate(
         terminal_stewardship_available=terminal_stewardship_available,
         errors=tuple(dict.fromkeys(errors)),
     )
+    physical_review_required = any(
+        not state.physical.availability(pump.pump_id).assured_for_outage_planning for pump in state.physical.pumps
+    )
+    open_obligations = tuple(
+        obligation for obligation in state.obligations if obligation.status is not PumpStationObligationStatus.FULFILLED
+    )
     terminal = StewardshipTerminalLiability(
-        review_required_physical_state=False,
+        review_required_physical_state=physical_review_required,
         active_restriction_count=len(state.active_restriction_ids),
-        overdue_calendar_seconds=0,
-        overdue_affected_pump_runtime_seconds=0,
+        overdue_calendar_seconds=sum(
+            max(0, state.calendar_seconds - obligation.due_calendar_seconds) for obligation in open_obligations
+        ),
+        overdue_affected_pump_runtime_seconds=sum(
+            max(0, state.physical.pump(obligation.pump_id).exposure.runtime_seconds - obligation.due_runtime_seconds)
+            for obligation in open_obligations
+        ),
         breached_obligation_count=breached_obligations,
         unresolved_verification_count=sum(
             "verification" in item.work_type and item.item_id in closing_work for item in state.backlog
@@ -187,7 +198,9 @@ def evaluate(
     )
     metrics = StewardshipMetricVector(
         decision_time_invalid_count=0 if report.actor_actions_valid else 1,
-        physical_service_review_required=False,
+        physical_service_review_required=(
+            physical_review_required or report.conservation.duty.unserved_capacity_seconds > 0
+        ),
         maintenance_intervention_count=sum(
             receipt.action_or_control_kind
             in {
@@ -202,6 +215,8 @@ def evaluate(
         evidence_integrity_gap_count=evidence_gaps,
         consumed_maintenance_resource_count=consumed_resources,
         handover_count=_handover_count(steps),
+        # The frozen format reserves this field. The world has no handover-content
+        # contract, so zero is not a measured absence of omissions (docs/CONTRACTS.md).
         handover_omission_count=0,
         terminal_liability=terminal,
     )

--- a/tests/communication/test_report_builder.py
+++ b/tests/communication/test_report_builder.py
@@ -47,3 +47,23 @@ def test_build_leaderboard_groups_trials_by_experiment() -> None:
     assert payload["entries"][0]["mean_reward"] == 0.5
     assert payload["entries"][0]["perfect_trial_rate"] == 0.5
     assert payload["entries"][1]["mean_reward"] == 0.5
+
+
+def test_leaderboard_costs_distinguish_unknown_and_free_experiments() -> None:
+    from aec_bench.communication.metrics import total_cost_usd
+
+    records = [
+        make_trial_record(trial_id="known", experiment_id="partial", cost={"estimated_cost_usd": 0.25}),
+        make_trial_record(trial_id="unknown", experiment_id="partial", cost=None),
+        make_trial_record(trial_id="free", experiment_id="free", cost={"estimated_cost_usd": 0.0}),
+    ]
+    entries = leaderboard_to_dict(build_leaderboard(records))["entries"]
+    free, partial = entries
+    assert free["total_cost_usd"] == 0.0
+    assert free["n_uncosted"] == 0
+    assert partial["total_cost_usd"] is None
+    assert partial["known_cost_usd"] == 0.25
+    assert partial["n_costed"] == 1
+    assert partial["n_uncosted"] == 1
+    assert total_cost_usd(records) is None
+    assert total_cost_usd([]) == 0.0

--- a/tests/communication/test_report_builder.py
+++ b/tests/communication/test_report_builder.py
@@ -67,3 +67,13 @@ def test_leaderboard_costs_distinguish_unknown_and_free_experiments() -> None:
     assert partial["n_uncosted"] == 1
     assert total_cost_usd(records) is None
     assert total_cost_usd([]) == 0.0
+
+
+def test_leaderboard_metrics_exclude_trials_without_evaluation() -> None:
+    from aec_bench.communication.metrics import mean_reward, perfect_trial_rate
+
+    records = [make_trial_record(), make_trial_record(trial_id="unevaluated", evaluation=None)]
+    assert mean_reward(records) == 1.0
+    assert perfect_trial_rate(records) == 1.0
+    assert mean_reward(records[1:]) == 0.0
+    assert perfect_trial_rate(records[1:]) == 0.0

--- a/tests/evaluation/test_evaluate_cli.py
+++ b/tests/evaluation/test_evaluate_cli.py
@@ -4,6 +4,7 @@
 import json
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 from aec_bench.cli.main import app
@@ -120,3 +121,70 @@ def test_evaluate_empty_results(tmp_path: Path) -> None:
     assert result.exit_code == 1
     envelope = json.loads(result.output)
     assert envelope["status"] == "error"
+
+
+def test_unknown_cost_survives_json_text_and_html_reports(tmp_path: Path) -> None:
+    for trial_id, cost in [("known", {"estimated_cost_usd": 0.25}), ("unknown", None)]:
+        write_trial_record(
+            ledger_root=tmp_path,
+            record=make_trial_record(trial_id=trial_id, experiment_id="costs", cost=cost),
+        )
+    report_path = tmp_path / "costs.html"
+    result = runner.invoke(
+        app,
+        [
+            "--text",
+            "evaluate",
+            "--experiment",
+            "costs",
+            "--ledger-root",
+            str(tmp_path),
+            "--report",
+            str(report_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Unknown" in result.output
+    html = report_path.read_text()
+    assert "Unknown ($0.25 known; 1 uncosted)" in html
+    assert '"total_cost_usd": null' in html
+    result = runner.invoke(
+        app,
+        [
+            "--text",
+            "report",
+            "summary",
+            "--experiment-id",
+            "costs",
+            "--ledger-root",
+            str(tmp_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Unknown ($0.25 known; 1 uncosted)" in result.output
+
+
+def test_leaderboard_renders_unknown_cost(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from aec_bench.communication import standalone
+    from aec_bench.communication.report_builder import build_leaderboard, leaderboard_to_dict
+
+    records = [make_trial_record(cost=None)]
+
+    def build_artifact(**kwargs: object) -> dict[str, object]:
+        return {"leaderboard": leaderboard_to_dict(build_leaderboard(records))}
+
+    monkeypatch.setattr(standalone, "build_leaderboard_artifact", build_artifact)
+    result = runner.invoke(
+        app,
+        [
+            "--text",
+            "report",
+            "leaderboard",
+            "--ledger-root",
+            str(tmp_path),
+            "--tasks-root",
+            str(tmp_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Unknown" in result.output

--- a/tests/evaluation/test_summary.py
+++ b/tests/evaluation/test_summary.py
@@ -18,6 +18,29 @@ from aec_bench.evaluation.pipeline import summarize_evaluation_records
 from tests.support.trial_record_factories import make_trial_record
 
 
+@pytest.mark.parametrize("missing", [None, {"estimated_cost_usd": None}])
+def test_unknown_cost_is_not_a_free_trial(missing: object) -> None:
+    records = [
+        make_trial_record(trial_id="known", cost={"estimated_cost_usd": 0.25}),
+        make_trial_record(trial_id="unknown", cost=missing),
+        make_trial_record(trial_id="free", cost={"estimated_cost_usd": 0.0}),
+    ]
+    summary = summarize_evaluation_records(records)
+    for metrics in [summary, summary["by_adapter"]["tool_loop"], summary["by_experiment"]["experiment-001"]]:
+        assert metrics["total_cost_usd"] is None
+        assert metrics["known_cost_usd"] == 0.25
+        assert metrics["n_costed"] == 2
+        assert metrics["n_uncosted"] == 1
+
+
+def test_empty_cost_total_is_zero_and_complete_cost_total_includes_free_trials() -> None:
+    assert summarize_evaluation_records([])["total_cost_usd"] == 0.0
+    summary = summarize_evaluation_records([make_trial_record(cost={"estimated_cost_usd": 0.0})])
+    assert summary["total_cost_usd"] == 0.0
+    assert summary["n_costed"] == 1
+    assert summary["n_uncosted"] == 0
+
+
 class StubClassifier:
     def classify_trace(self, trace: BehavioralTrace) -> ClassifiedTrace:
         classifications: list[TurnClassification] = []

--- a/tests/experimentation/lifecycle_studies/test_ablation.py
+++ b/tests/experimentation/lifecycle_studies/test_ablation.py
@@ -2007,6 +2007,9 @@ def test_lifecycle_ablation_evaluation_reads_only_core_trial_records(tmp_path: P
 
     first = build_lifecycle_ablation_evaluation(manifest)
     summary = first.summary
+    assert summary["total_cost_usd"] is None
+    assert summary["known_cost_usd"] == 0.0
+    assert summary["n_uncosted"] == 1
     assert summary["planned_trials"] == 1
     assert summary["invocation_records"] == 1
     assert summary["completed_trials"] == 1
@@ -2031,7 +2034,10 @@ def test_lifecycle_ablation_evaluation_reads_only_core_trial_records(tmp_path: P
             "passed": 1,
             "mean_reward": 1.0,
             "mean_retention": 1.0,
-            "total_cost_usd": 0.0,
+            "total_cost_usd": None,
+            "known_cost_usd": 0.0,
+            "n_costed": 0,
+            "n_uncosted": 1,
             "turn_budget_scope": "per_session",
             "max_turns_per_session": 10,
             "total_sessions": 3,

--- a/tests/experimentation/lifecycle_studies/test_ablation.py
+++ b/tests/experimentation/lifecycle_studies/test_ablation.py
@@ -2360,3 +2360,18 @@ class _TerminalProviderFailurePersistentRegistry(_GoldPersistentRegistry):
 
         adapter.execute = execute
         return adapter
+
+
+def test_ablation_metrics_require_an_evaluation() -> None:
+    from aec_bench.experimentation.lifecycle_studies.evaluation import (
+        _operational_metric,
+        _record_completed,
+        _retention,
+    )
+    from tests.support.trial_record_factories import make_trial_record
+
+    record = make_trial_record(evaluation=None)
+    assert not _record_completed(record)
+    for read_metric in (lambda: _retention(record), lambda: _operational_metric(record, "requests")):
+        with pytest.raises(ValueError, match="requires an evaluation"):
+            read_metric()

--- a/tests/prime_lab/test_exporter.py
+++ b/tests/prime_lab/test_exporter.py
@@ -186,7 +186,7 @@ def test_export_creates_prime_lab_package(tmp_path: Path) -> None:
     assert (package_dir / "README.md").exists()
     assert (package_dir / "aec_voltage_drop" / "environment.py").exists()
     assert (package_dir / "aec_voltage_drop" / "tasks" / "electrical" / "voltage-drop" / "instruction.md").exists()
-    assert 'dependencies = ["datasets>=4.0", "verifiers>=0.1.10"]' in (package_dir / "pyproject.toml").read_text(
+    assert 'dependencies = ["datasets>=4.0", "verifiers==0.1.14"]' in (package_dir / "pyproject.toml").read_text(
         encoding="utf-8"
     )
     assert 'tags = ["aec-bench", "aec", "benchmark"]' in (package_dir / "pyproject.toml").read_text(encoding="utf-8")
@@ -412,7 +412,7 @@ def test_generated_stateful_package_loads_outside_repo_root(tmp_path: Path) -> N
             sys.executable,
             "-c",
             "from verifiers import load_environment; "
-            "env = load_environment('aec_workspace_task'); "
+            "env = load_environment('aec_workspace_task', split='all'); "
             "print(type(env).__name__)",
         ],
         cwd=tmp_path,
@@ -471,9 +471,9 @@ def test_generated_stateful_workspace_tools_score_with_verifier(tmp_path: Path) 
             "    run_command,\n"
             "    submit_answer,\n"
             ")\n"
-            "environment = load_environment()\n"
+            "environment = load_environment(split='all')\n"
             "state = asyncio.run(environment.setup_state(\n"
-            "    vf.State.for_task(environment.dataset[0])\n"
+            "    vf.State.for_task(environment.get_eval_dataset()[0])\n"
             "))\n"
             "workspace = Path(state['workspace_path'])\n"
             "private_task = Path(state['task_path'])\n"
@@ -545,9 +545,9 @@ def test_generated_stateful_write_file_keeps_rollout_open_for_workspace_alias(
             "    write_file,\n"
             "    submit_answer,\n"
             ")\n"
-            "environment = load_environment()\n"
+            "environment = load_environment(split='all')\n"
             "state = asyncio.run(environment.setup_state(\n"
-            "    vf.State.for_task(environment.dataset[0])\n"
+            "    vf.State.for_task(environment.get_eval_dataset()[0])\n"
             "))\n"
             "commands = state['workspace']\n"
             "written = write_file('/workspace/output.md', '42', commands)\n"
@@ -831,7 +831,7 @@ def test_prime_smoke_runs_eval_from_generated_package(monkeypatch, tmp_path: Pat
     assert pwd_file.read_text(encoding="utf-8").strip() == str(output_dir / "aec_voltage_drop")
 
 
-def test_exported_environment_filters_training_tasks_by_difficulty(tmp_path: Path) -> None:
+def test_exported_environment_filters_evaluation_tasks_by_difficulty(tmp_path: Path) -> None:
     tasks_root = tmp_path / "tasks"
     _make_task(tasks_root, "electrical/easy-a", difficulty="easy")
     _make_task(tasks_root, "electrical/easy-b", difficulty="easy")
@@ -852,11 +852,11 @@ def test_exported_environment_filters_training_tasks_by_difficulty(tmp_path: Pat
         "import sys\n"
         f"sys.path.insert(0, {str(result.package_dir)!r})\n"
         "from aec_difficulty_filter.environment import load_environment\n"
-        "env = load_environment(difficulty=['easy'], num_examples=1, seed=7)\n"
-        "print(len(env.dataset))\n"
-        "print(env.dataset[0]['answer'])\n"
+        "env = load_environment(split='all', difficulty=['easy'], num_examples=1, seed=7)\n"
+        "print(len(env.get_eval_dataset()))\n"
+        "print(env.get_eval_dataset()[0]['answer'])\n"
         "eval_env = load_environment(split='eval', difficulty='hard')\n"
-        "print(eval_env.dataset[0]['answer'])\n"
+        "print(eval_env.get_eval_dataset()[0]['answer'])\n"
     )
     process = subprocess.run(
         [sys.executable, "-c", code],
@@ -896,7 +896,7 @@ def test_exported_environment_uses_disjoint_train_and_eval_splits(tmp_path: Path
         "train_env = load_environment(split='train', difficulty='easy', seed=7)\n"
         "eval_env = load_environment(split='eval', difficulty='easy', seed=7)\n"
         "train_ids = {row['answer'] for row in train_env.dataset}\n"
-        "eval_ids = {row['answer'] for row in eval_env.dataset}\n"
+        "eval_ids = {row['answer'] for row in eval_env.get_eval_dataset()}\n"
         "print(len(train_ids))\n"
         "print(len(eval_ids))\n"
         "print(bool(train_ids & eval_ids))\n"
@@ -1488,3 +1488,18 @@ def test_prime_train_runs_hosted_training_config(monkeypatch, tmp_path: Path) ->
     assert result.exit_code == 0, result.output
     assert calls == [(["prime", "train", str(config_path), "--plain"], None, True)]
     assert '"config_path":' in result.output
+
+
+def test_prime_eval_smoke_selects_all_tasks_without_training_rows(monkeypatch: pytest.MonkeyPatch) -> None:
+    from aec_bench.prime_lab import doctor
+
+    commands: list[list[str]] = []
+
+    def run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(doctor, "_run", run)
+    assert doctor.run_prime_eval_smoke(env_id="single-task", model="test-model").ok
+    command = commands[0]
+    assert json.loads(command[command.index("--env-args") + 1]) == {"split": "all"}

--- a/tests/prime_lab/test_generated_environment_integrity.py
+++ b/tests/prime_lab/test_generated_environment_integrity.py
@@ -1,0 +1,183 @@
+# ABOUTME: Tests training splits and verifier failures in installed-style Prime exports.
+# ABOUTME: Exercises both generated harnesses through the real Verifiers dataset and rubric APIs.
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+from aec_bench.prime_lab.exporter import PrimeExportHarnessMode, PrimeLabExportConfig, export_prime_lab_environment
+from tests.prime_lab.test_exporter import _make_task
+
+try:
+    vf = importlib.import_module("verifiers")
+except ModuleNotFoundError:
+    pytest.skip("requires the Prime optional dependencies", allow_module_level=True)
+
+
+@pytest.fixture(params=[PrimeExportHarnessMode.SINGLE_TURN, PrimeExportHarnessMode.STATEFUL_WORKSPACE])
+def generated(request: pytest.FixtureRequest, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    tasks_root = tmp_path / "tasks"
+    task_ids = [f"electrical/task-{index}" for index in range(10)]
+    for index, task_id in enumerate(task_ids):
+        _make_task(tasks_root, task_id, difficulty="easy" if index % 2 == 0 else "hard")
+    name = f"integrity_{tmp_path.name}"
+    result = export_prime_lab_environment(
+        PrimeLabExportConfig(
+            name=name,
+            tasks_root=tasks_root,
+            task_ids=task_ids,
+            output_dir=tmp_path / "exports",
+            harness_mode=request.param,
+        )
+    )
+    # Match installed imports: the repository agents directory is not openai-agents.
+    assert vf.__file__ is not None
+    monkeypatch.syspath_prepend(str(Path(vf.__file__).parents[1]))
+    if request.param is PrimeExportHarnessMode.STATEFUL_WORKSPACE:
+        pytest.importorskip("agents.function_schema")
+    monkeypatch.syspath_prepend(str(result.package_dir))
+    return importlib.import_module(f"{result.package_dir.name}.environment")
+
+
+def test_training_environment_has_disjoint_evaluation_rows(generated: ModuleType) -> None:
+    environment = generated.load_environment()
+    train = {row["answer"] for row in environment.get_dataset()}
+    evaluation = {row["answer"] for row in environment.get_eval_dataset()}
+    assert len(train) == 8
+    assert len(evaluation) == 2
+    assert train.isdisjoint(evaluation)
+
+
+def test_filtering_and_shuffling_preserve_split_membership(generated: ModuleType) -> None:
+    baseline = generated.load_environment()
+    environment = generated.load_environment(difficulty="easy", num_examples=2, seed=17)
+    train = {row["answer"] for row in environment.get_dataset()}
+    evaluation = {row["answer"] for row in environment.get_eval_dataset()}
+    assert train <= {row["answer"] for row in baseline.get_dataset()}
+    assert evaluation <= {row["answer"] for row in baseline.get_eval_dataset()}
+    assert train.isdisjoint(evaluation)
+
+
+def test_small_training_set_is_disjoint_and_single_task_requires_explicit_evaluation(generated: ModuleType) -> None:
+    generated.__dict__["TASKS"] = generated.TASKS[:4]
+    environment = generated.load_environment()
+    assert len(environment.get_dataset()) == 3
+    assert len(environment.get_eval_dataset()) == 1
+    generated.__dict__["TASKS"] = generated.TASKS[:1]
+    with pytest.raises(ValueError, match="at least two"):
+        generated.load_environment()
+    environment = generated.load_environment(split="all")
+    assert environment.dataset is None
+    assert len(environment.get_eval_dataset()) == 1
+
+
+@pytest.mark.parametrize("split", ["eval", "all", "validation", "test"])
+def test_evaluation_only_environment_does_not_supply_training_rows(generated: ModuleType, split: str) -> None:
+    environment = generated.load_environment(split=split)
+    assert environment.dataset is None
+    assert len(environment.get_eval_dataset()) == (10 if split == "all" else 2)
+
+
+def test_invalid_split_and_empty_filtered_split_are_rejected(generated: ModuleType) -> None:
+    with pytest.raises(ValueError, match="unsupported split"):
+        generated.load_environment(split="typo")
+    with pytest.raises(ValueError, match="no tasks"):
+        generated.load_environment(difficulty="medium")
+
+
+def _state(environment: Any) -> dict[str, Any]:
+    state: dict[str, Any] = vf.State.for_task(environment.get_eval_dataset()[0])
+    state["completion"] = [{"role": "assistant", "content": "42"}]
+    return state
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failure",
+    [
+        "missing",
+        "crash",
+        "no_reward",
+        "malformed",
+        "out_of_range",
+        "nonfinite",
+        "boolean",
+        "timeout",
+        "missing_key",
+        "array",
+    ],
+)
+async def test_verifier_failure_remains_an_error_in_the_rubric(generated: ModuleType, failure: str) -> None:
+    environment = generated.load_environment(split="all")
+    state = _state(environment)
+    info = json.loads(state["info"])
+    assert generated.__file__ is not None
+    verifier = Path(generated.__file__).parent / "tasks" / info["task_id"] / "tests" / "verify.py"
+    if failure == "missing":
+        verifier.unlink()
+    else:
+        sources = {
+            "crash": "raise RuntimeError('verifier failed')\n",
+            "no_reward": "pass\n",
+            "timeout": "import time; time.sleep(2)\n",
+            "missing_key": "'{}'",
+            "array": "'[]'",
+            "malformed": "'not json'",
+            "out_of_range": "'{\"reward\": 2}'",
+            "nonfinite": "'{\"reward\": NaN}'",
+            "boolean": "'{\"reward\": true}'",
+        }
+        source = sources[failure]
+        if failure not in {"crash", "no_reward", "timeout"}:
+            source = f"import sys\nfrom pathlib import Path\nPath(sys.argv[-1]).write_text({source})\n"
+        verifier.write_text(source)
+    if failure == "timeout":
+        state["info"] = json.dumps({**info, "verifier_timeout_seconds": 1})
+    await environment.setup_state(state)
+    with pytest.raises(vf.InfraError):
+        await environment.rubric.score_rollout(state)
+    assert isinstance(state["error"], vf.InfraError)
+    assert state["reward"] is None
+    if state.get("workspace_path"):
+        assert not Path(state["workspace_path"]).exists()
+
+
+@pytest.mark.asyncio
+async def test_valid_zero_and_group_rewards_are_preserved(generated: ModuleType) -> None:
+    environment = generated.load_environment(split="all")
+    right, wrong = _state(environment), _state(environment)
+    wrong["completion"] = [{"role": "assistant", "content": "incorrect"}]
+    await environment.rubric.score_group([right, wrong])
+    assert [right["reward"], wrong["reward"]] == [1.0, 0.0]
+    assert right["error"] is None and wrong["error"] is None
+
+
+@pytest.mark.asyncio
+async def test_verifier_error_aborts_group_scoring(generated: ModuleType) -> None:
+    environment = generated.load_environment(split="all")
+    healthy = _state(environment)
+    broken = vf.State.for_task(environment.get_eval_dataset()[1])
+    broken["completion"] = [{"role": "assistant", "content": "42"}]
+    info = json.loads(broken["info"])
+    assert generated.__file__ is not None
+    verifier = Path(generated.__file__).parent / "tasks" / info["task_id"] / "tests" / "verify.py"
+    verifier.unlink()
+    with pytest.raises(vf.InfraError):
+        await environment.rubric.score_group([healthy, broken])
+    assert isinstance(broken["error"], vf.InfraError)
+    assert broken["reward"] is None
+
+
+def test_stale_reward_cannot_hide_a_verifier_that_writes_nothing(generated: ModuleType, tmp_path: Path) -> None:
+    task_dir = tmp_path / "private-task"
+    (task_dir / "tests").mkdir(parents=True)
+    (task_dir / "tests" / "verify.py").write_text("pass\n")
+    (tmp_path / "reward.json").write_text('{"reward": 1}')
+    with pytest.raises(vf.InfraError):
+        generated._score_submission(task_dir, 10)

--- a/tests/worlds/stewardship/wastewater_pump_station/test_evaluation.py
+++ b/tests/worlds/stewardship/wastewater_pump_station/test_evaluation.py
@@ -3,9 +3,13 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 
+import pytest
+
 from aec_bench.worlds.stewardship.wastewater_pump_station.evaluation import (
+    evaluate,
     evaluate_pump_station_reference_run,
 )
 from aec_bench.worlds.stewardship.wastewater_pump_station.reference_controller import (
@@ -38,3 +42,89 @@ def test_current_evaluation_is_stable_after_durable_reload(tmp_path: Path) -> No
     assert first.evidence.initial_state_id == completed.run.manifest.initial_state_id
     assert first.evidence.terminal_state_id == completed.run.state.state_id
     assert first.gates.artifact_and_replay_integrity
+
+
+@pytest.mark.parametrize("calendar_late,runtime_late", [(0, 0), (-1, -1), (11, 0), (0, 7), (11, 7)])
+def test_terminal_overdue_uses_each_open_obligations_own_clocks(
+    tmp_path: Path, calendar_late: int, runtime_late: int
+) -> None:
+    from aec_bench.worlds.stewardship.wastewater_pump_station.stewardship_models import (
+        PumpStationObligationStatus,
+    )
+
+    run = PumpStationWorldRun.create_reference_system(
+        repository=PumpStationWorldRunRepository(tmp_path / "run"),
+        run_id="overdue-run",
+        episode_id="overdue-episode",
+        world_branch_id="overdue-branch",
+    )
+    state = run.state
+    affected_pump_id = state.obligations[0].pump_id
+    pump_a, pump_b, pump_c = (
+        replace(pump, exposure=replace(pump.exposure, runtime_seconds=100 if pump.pump_id == affected_pump_id else 500))
+        for pump in state.physical.pumps
+    )
+    state = replace(
+        state,
+        physical=replace(state.physical, calendar_seconds=1000, pumps=(pump_a, pump_b, pump_c)),
+    )
+    original = state.obligations[0]
+    runtime = state.physical.pump(original.pump_id).exposure.runtime_seconds
+    # Both clocks are absolute readings. An ACTIVE status alone does not prove timeliness.
+    obligation = replace(
+        original,
+        status=PumpStationObligationStatus.ACTIVE,
+        due_calendar_seconds=state.calendar_seconds - calendar_late,
+        due_runtime_seconds=runtime - runtime_late,
+    )
+    fulfilled = replace(obligation, obligation_id="fulfilled", status=PumpStationObligationStatus.FULFILLED)
+    second = replace(obligation, obligation_id="second-open")
+    state = replace(state, obligations=(obligation, second, fulfilled))
+    result = evaluate(
+        state, run.verify(), (), manifest_content_id="a" * 64, initial_state_id=run.manifest.initial_state_id
+    )
+    assert result.metrics.terminal_liability.overdue_calendar_seconds == 2 * max(0, calendar_late)
+    assert result.metrics.terminal_liability.overdue_affected_pump_runtime_seconds == 2 * max(0, runtime_late)
+
+
+def test_terminal_physical_review_uses_current_operating_boundaries(tmp_path: Path) -> None:
+    from aec_bench.worlds.stewardship.wastewater_pump_station.physical_models import PumpStationPumpMode
+
+    run = PumpStationWorldRun.create_reference_system(
+        repository=PumpStationWorldRunRepository(tmp_path / "run"),
+        run_id="review-run",
+        episode_id="review-episode",
+        world_branch_id="review-branch",
+    )
+    state = run.state
+    physical = state.physical
+    for pump in physical.pumps:
+        physical = physical.with_boundary_mode(pump.pump_id, PumpStationPumpMode.SERVICE_AVAILABLE, "test-evidence")
+    healthy = replace(state, physical=physical)
+    report = run.verify()
+    result = evaluate(healthy, report, (), manifest_content_id="a" * 64, initial_state_id=run.manifest.initial_state_id)
+    assert not result.metrics.terminal_liability.review_required_physical_state
+    restricted = replace(
+        healthy, physical=physical.with_boundary_mode("pump-a", PumpStationPumpMode.RUN_IN_SERVICE, "test")
+    )
+    result = evaluate(
+        restricted, report, (), manifest_content_id="a" * 64, initial_state_id=run.manifest.initial_state_id
+    )
+    assert result.metrics.terminal_liability.review_required_physical_state
+    assert result.metrics.physical_service_review_required
+    # Service shortfall remains relevant even after the closing boundary is restored.
+    shortfall = replace(
+        report,
+        conservation=replace(
+            report.conservation,
+            duty=replace(
+                report.conservation.duty,
+                unserved_capacity_seconds=12,
+            ),
+        ),
+    )
+    result = evaluate(
+        healthy, shortfall, (), manifest_content_id="a" * 64, initial_state_id=run.manifest.initial_state_id
+    )
+    assert not result.metrics.terminal_liability.review_required_physical_state
+    assert result.metrics.physical_service_review_required


### PR DESCRIPTION
## Summary

Prime task exports reused training rows for evaluation and converted verifier failures into zero rewards. Cost summaries treated missing estimates as free trials, and several pump diagnostics always returned zero or false. This change corrects those four behaviors.

- Split task instances before filtering, shuffling, or limiting rows. Training receives separate train/eval datasets; `eval` and `all` are evaluation-only. A required empty split fails, and the smoke command explicitly selects `all`.
- Share verifier execution and split logic across both generated harnesses. Verifier crashes, timeouts, absent output, and invalid rewards raise `verifiers.InfraError`, including through group scoring. Valid zero rewards remain valid. Generated packages pin Verifiers to the tested `0.1.14` because the rubric overrides its reward invocation hook.
- Use one cost calculation for evaluation, leaderboard, and lifecycle-study summaries. Incomplete totals are null, with `known_cost_usd`, `n_costed`, and `n_uncosted`. CLI and HTML displays handle unknown totals.
- Derive pump review flags from operating boundaries and service shortfall. Sum overdue obligation durations against station calendar and affected-pump runtime. Document the metric meanings without changing the frozen pump schema or integrity gates.

### Review order

1. `prime_lab/exporter.py` and `tests/prime_lab/test_generated_environment_integrity.py`: split behavior, rubric error propagation, valid rewards, and workspace cleanup. `doctor.py` updates the smoke caller.
2. `evaluation/costs.py`, summary callers, and report renderers: one cost rule and its end-to-end tests.
3. The pump evaluator, its tests, and `docs/CONTRACTS.md`: diagnostic definitions and measurement limits.

## Verification

Commands were run with the worktree's Python 3.13 environment and installed optional dependencies.

- `pytest -q tests/prime_lab/ tests/evaluation/ tests/communication/ tests/worlds/stewardship/wastewater_pump_station/`: 381 passed, 6 skipped before the final cost-summary extension.
- `pytest -q tests/prime_lab/test_generated_environment_integrity.py`: 42 passed, including stateful workspace cleanup after verifier errors.
- Final cost checks: `pytest -q tests/evaluation/ tests/communication/`: 158 passed, 6 skipped.
- Final lifecycle/boundary checks: `pytest -q tests/experimentation/lifecycle_studies/ tests/test_package_ownership.py tests/test_public_api_inventory.py tests/test_release_manifest.py`: 250 passed.
- `ruff check src/ tests/`, `ruff format --check src/ tests/`, and `git diff --check`: passed.
- `uv build --offline`: source distribution and wheel built successfully.
- Full `mypy`: not green. Both this change and a source snapshot of main at `929a260e` report the same 2,946 errors in 344 files. Comparison after normalizing line numbers found no added or removed error diagnostics.

### Limits

- Instance separation does not establish task-family separation.
- The world does not record required handover contents. The frozen `handover_omission_count` remains explicitly unmeasured and is not a training or acceptance criterion. `decision_time_invalid_count` remains an aggregate validity indicator.
- No hosted training, live provider evaluation, or hosted integration was run.

## Provenance

- [x] No
- [ ] Yes

No benchmark provenance fields are added. Existing trial and pump evidence identities are unchanged.


## CI correction

Handle absent evaluations in communication metrics and lifecycle summaries. Reward aggregates exclude unevaluated trials; lifecycle summaries reject missing required evaluation data with a clear error. Both regression tests failed before the correction. Strict type checking now passes for all 12 changed source files.

Validation: all 90 communication and lifecycle-ablation regression tests passed; Ruff lint and formatting passed.
