### PR TITLE
Add executable Prime lifecycle training qualification

### DIFF
--- a/README.md
+++ b/README.md
@@ -777,6 +777,15 @@ content-bound artifacts. Live Prime commands remain explicit and require the
 user's Prime installation, credentials, and network access; the normal test
 suite makes no hosted calls.
 
+To qualify hydraulic lifecycle training data and tools without provider calls,
+use the [local hydraulic training qualification](docs/engineering-decision-experiments.md#hydraulic-training-qualification).
+It separates project lineages, retains verified scripted demonstrations, and
+writes a training handoff. Hosted execution and weight updates require separate
+validation. Lifecycle exports pin their runtime dependencies and verify adapter
+source bytes after installation. Prime training configuration targets the pinned
+CLI, includes explicit evaluation environments, supports `--checkpoint-id`, and
+rejects the removed difficulty-buffer configuration.
+
 ### Datasets
 
 Datasets separate semantic task selection from immutable byte identity. A

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -57,6 +57,12 @@ consumes those experiments and their ordinary trial evidence. It does not own a
 second execution or scoring path. See the
 [engineering decision guide](engineering-decision-experiments.md) for use and scope.
 
+Hydraulic training qualification under `experimentation.qualification` consumes
+`prime_lab` export, tool-runtime, and config interfaces. Prime owns protocol
+translation; the existing hydraulic lifecycle owns actions and reward. The
+qualification keeps project partitions and comparison controls in
+experimentation. `prime_lab` does not depend on experimentation.
+
 ### Artifact and workspace tasks
 
 An artifact task gives an agent an instruction and an execution environment.

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -883,11 +883,26 @@ remain `EvaluationResult` authority.
 
 Prime lifecycle export schema 3 retains each public lifecycle as one tar
 `ArtifactRef`. It records the generated package version, independent Prime
-protocol versions, and one `ProviderAdapterIdentity`. Clean source uses one
-full Git revision. Dirty or non-Git source uses one retained source snapshot.
+protocol versions, and one `ProviderAdapterIdentity`. New exports retain the
+adapter distribution source as a portable snapshot, including its exact runtime
+dependency versions. The same source bytes and dependencies validate from a
+checkout or an installed wheel. The snapshot is the reconstructive artifact;
+there is no second source inventory or repository revision for the same claim.
+Existing checkout-bound revision and snapshot references remain readable.
 The package does not persist an absolute repository root, source inventory,
 lifecycle-spec digest, or a second raw package digest. The reader keeps schema
 2 support for existing local packages.
+
+Prime lifecycle packages can optionally declare one `dataset_assignment` per
+package, with a caller-owned `group_id` and `train` or `eval` split. An assigned
+export requires both splits, assigns every package, and rejects a group that
+crosses splits. Revisions in distinct groups can share a lifecycle and variant
+ID. The local loader supplies training rows only for `split="train"`; evaluation
+and `all` loads have no training dataset. Unassigned exports remain evaluation
+only. These local qualification assignments do not change hosted or training
+qualification claims in the manifest. Infrastructure failures during lifecycle
+scoring propagate as `verifiers.InfraError`; incomplete, otherwise valid
+rollouts retain their task-owned zero reward.
 
 Adapter-only extraction metadata must not become task-semantic output. The
 lambda-RLM `__confidence__` key is reserved for extraction confidence and is

--- a/docs/PROVENANCE_POLICY.md
+++ b/docs/PROVENANCE_POLICY.md
@@ -87,6 +87,12 @@ for the same claim. Dirty source needs reconstructive bytes, such as a complete
 snapshot or a patch with its base revision. An opaque dirty-tree digest is not
 enough to reconstruct the source.
 
+Prime lifecycle exports identify the portable adapter distribution, not a
+checkout. They retain one reconstructive source snapshot with exact runtime
+dependency versions, including when exported from a checkout. This lets an
+installed wheel verify the same source bytes without repository metadata. The
+export does not add a Git revision or a second inventory for the same claim.
+
 Current DeepSeek evidence uses `ProviderAdapterIdentity.source_revision` or a
 reconstructive `source_snapshot`. The retained v2 reader keeps
 `aec_bench_revision` for its protected wire shape.

--- a/docs/engineering-decision-experiments.md
+++ b/docs/engineering-decision-experiments.md
@@ -144,3 +144,72 @@ evidence, late supported answers, handover omissions and contradictions, and exa
 pump replay. Do not turn deterministic control success into a model-performance,
 real-project, or RL-readiness claim. Weight training and its hosted integration remain
 separate work.
+
+## Hydraulic training qualification
+
+Run the local Prime qualification with the `prime` extra installed. From an
+installed environment, use a working directory outside the repository root:
+
+```bash
+python -m aec_bench.experimentation.qualification.hydraulic_training \
+  --output /tmp/aec-hydraulic-training
+```
+
+The repository's `agents/` directory can shadow the `openai-agents` dependency
+when Python starts from the repository root. The output directory must be empty.
+Use `--definition` to supply a `HydraulicExperiment` JSON file with non-empty
+train, development, and acceptance partitions. The default uses the existing
+synthetic hydraulic lineages and four revision conditions.
+
+The qualification assigns complete project lineages before materializing their
+revision siblings. It generates acceptance fixtures separately and excludes them
+from the Prime package. These are public synthetic fixtures assigned to an
+acceptance partition; they are not an independently sealed benchmark holdout.
+
+The output contains:
+
+- `definition.json`: generation conditions and partition membership.
+- `reference_trials/`: ordinary planned trials and ledger evidence from the
+  existing deterministic hydraulic experiment.
+- `environments/aec_hydraulic_training/`: a generated local Verifiers package
+  containing training and development groups.
+- `prime_controls/`: transcripts and task-verifier results from replay through
+  the actual Prime lifecycle tool interface.
+- `training_demonstrations.jsonl`: only successful training-group controls,
+  represented as messages and OpenAI-format tool definitions. Environment
+  observations are tool messages. Hidden verifier results and group metadata
+  are not model inputs. These are scripted demonstrations, not model samples.
+- `training.toml`: a one-step hosted handoff using the existing small-model
+  default. The environment ID resolves only after that package is installed or
+  published through an approved deployment procedure.
+- `qualification.json`: local checks, installed versions, package requirements,
+  and separate hosted-run and weight-update status.
+
+The command makes no provider calls. It checks terminal reward agreement,
+zero reward for incomplete work, and isolation between rollouts. A local pass
+establishes the tested tool and reward boundary. It does not establish a model
+weight update, SFT token-mask correctness, hosted dependency compatibility,
+physical-distribution coverage, or generalization. The generator still uses
+narrow synthetic parameter ranges and the existing calculation structure.
+
+The exported package pins the installed Prime dependency closure. Its retained
+source archive uses package-relative paths and includes those exact versions.
+The loader checks both source bytes and installed versions before accepting a
+rollout. Install the bound AEC-Bench wheel and generated environment together;
+a package version alone does not establish source equivalence.
+
+Before running training, verify the hosted Python and Verifiers versions against
+the generated package, install the bound AEC-Bench source, and confirm the model
+is available. For the SFT-to-RL comparison, verify that the RL run can start from
+the exact SFT checkpoint. The current open-source Prime trainer and the local
+AEC-Bench lifecycle package require different Python and Verifiers versions;
+these are separate runtime checks, not resolved by generating TOML.
+
+`aec-bench prime train-config --checkpoint-id` records an explicit Prime
+checkpoint. The generated configuration targets the pinned Prime CLI. It uses
+`eval.eval_base_model` and explicit `[[eval.env]]` entries with `split="eval"`,
+so the CLI includes evaluation in its API request. The command rejects the
+removed difficulty-buffer options. `aec-bench prime train` rejects incompatible
+fields and evaluation-only training splits before invoking Prime.
+Prime retains ownership of complete configuration and model validation. See
+[Prime's configuration reference](https://docs.primeintellect.ai/hosted-training/advanced-configs).

--- a/scripts/owner_dependencies.toml
+++ b/scripts/owner_dependencies.toml
@@ -35,7 +35,8 @@ may_depend_on = ["adapters", "contracts", "evaluation", "generation", "harness",
 may_depend_on = ["contracts"]
 
 [owners.experimentation]
-may_depend_on = ["adapters", "contracts", "evaluation", "evolution", "generation", "harness", "ledger", "lifecycles", "prime_agent", "providers", "tasks", "templates", "trials", "worlds"]
+may_depend_on = ["adapters", "contracts", "evaluation", "evolution", "generation", "harness", "ledger", "lifecycles", "prime_agent",
+  "prime_lab", "providers", "tasks", "templates", "trials", "worlds"]
 
 [owners.feedback]
 may_depend_on = ["contracts", "ledger", "tasks"]

--- a/src/aec_bench/cli/commands/prime.py
+++ b/src/aec_bench/cli/commands/prime.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 
 import fnmatch
 import json
-import math
 import subprocess
+import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TypedDict
@@ -21,6 +21,7 @@ from aec_bench.prime_lab.exporter import (
     PrimeExportHarnessMode,
     normalise_environment_id,
 )
+from aec_bench.prime_lab.training import render_train_config, validate_training_handoff
 
 app = typer.Typer(help="Export aec-bench tasks for Prime Lab.")
 
@@ -34,22 +35,6 @@ class _PrimePackageExport:
     env_id: str
     package_dir: Path
     task_count: int
-
-
-@dataclass(frozen=True)
-class _DifficultyRatio:
-    difficulty: str
-    ratio: float
-
-
-@dataclass(frozen=True)
-class _PrimeTrainBufferConfig:
-    env_ratios: list[float] | None = None
-    online_difficulty_filtering: bool = False
-    easy_threshold: float | None = None
-    hard_threshold: float | None = None
-    easy_fraction: float | None = None
-    hard_fraction: float | None = None
 
 
 class _SmokeCheckRow(TypedDict):
@@ -481,7 +466,7 @@ def prime_train_config(
     difficulty_ratio: list[str] | None = typer.Option(
         None,
         "--difficulty-ratio",
-        help="Difficulty sampling ratio as DIFFICULTY=RATIO; repeat to create one env block per difficulty.",
+        help="Unsupported: Prime removed the difficulty buffer.",
     ),
     harness: str | None = typer.Option(
         None,
@@ -494,6 +479,7 @@ def prime_train_config(
         min=1,
         help="Training examples passed through to load_environment args.",
     ),
+    checkpoint_id: str | None = typer.Option(None, "--checkpoint-id", help="Prime checkpoint to initialize training."),
     max_steps: int = typer.Option(20, "--max-steps", min=1),
     batch_size: int = typer.Option(32, "--batch-size", min=1),
     rollouts_per_example: int = typer.Option(4, "--rollouts-per-example", min=1),
@@ -509,35 +495,35 @@ def prime_train_config(
     online_difficulty_filtering: bool = typer.Option(
         False,
         "--online-difficulty-filtering",
-        help="Enable Prime's online difficulty buffer for hosted training.",
+        help="Unsupported: Prime removed the difficulty buffer.",
     ),
     easy_threshold: float = typer.Option(
         0.8,
         "--easy-threshold",
         min=0.0,
         max=1.0,
-        help="Reward threshold above which Prime treats examples as easy.",
+        help="Unsupported: Prime removed the difficulty buffer.",
     ),
     hard_threshold: float = typer.Option(
         0.2,
         "--hard-threshold",
         min=0.0,
         max=1.0,
-        help="Reward threshold below which Prime treats examples as hard.",
+        help="Unsupported: Prime removed the difficulty buffer.",
     ),
     easy_fraction: float = typer.Option(
         0.0,
         "--easy-fraction",
         min=0.0,
         max=1.0,
-        help="Fraction of easy examples retained when online filtering is enabled.",
+        help="Unsupported: Prime removed the difficulty buffer.",
     ),
     hard_fraction: float = typer.Option(
         0.0,
         "--hard-fraction",
         min=0.0,
         max=1.0,
-        help="Fraction of hard examples retained when online filtering is enabled.",
+        help="Unsupported: Prime removed the difficulty buffer.",
     ),
     adapters_keep_last: int = typer.Option(3, "--adapters-keep-last", min=1),
 ) -> None:
@@ -555,36 +541,36 @@ def prime_train_config(
     if num_examples is not None:
         base_env_args["num_examples"] = num_examples
 
-    parsed_difficulty_ratios = _parse_difficulty_ratios(difficulty_ratio or [])
-    env_args_list = _prime_train_env_args_list(
-        base_env_args=base_env_args,
-        difficulty=difficulty,
-        difficulty_ratios=parsed_difficulty_ratios,
-    )
-    buffer_config = _prime_train_buffer_config(
-        difficulty_ratios=parsed_difficulty_ratios,
-        online_difficulty_filtering=online_difficulty_filtering,
-        easy_threshold=easy_threshold,
-        hard_threshold=hard_threshold,
-        easy_fraction=easy_fraction,
-        hard_fraction=hard_fraction,
-    )
+    if (
+        difficulty_ratio
+        or online_difficulty_filtering
+        or (easy_threshold, hard_threshold, easy_fraction, hard_fraction) != (0.8, 0.2, 0.0, 0.0)
+    ):
+        raise typer.BadParameter(
+            "Prime removed the difficulty buffer; supply a current rollout-filter TOML to prime train"
+        )
+    if difficulty:
+        base_env_args["difficulty"] = difficulty[0] if len(difficulty) == 1 else difficulty
 
-    config_text = _render_train_config(
+    config_text = render_train_config(
         environment=environment,
         model=model,
         max_steps=max_steps,
         batch_size=batch_size,
         rollouts_per_example=rollouts_per_example,
         max_tokens=max_tokens,
-        env_args_list=env_args_list,
-        buffer_config=buffer_config,
+        env_args_list=[base_env_args],
         eval_interval=eval_interval,
         eval_num_examples=eval_num_examples,
         eval_rollouts_per_example=eval_rollouts_per_example,
         eval_base_model=not no_eval_base_model,
         adapters_keep_last=adapters_keep_last,
+        checkpoint_id=checkpoint_id,
     )
+    try:
+        validate_training_handoff(tomllib.loads(config_text))
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(config_text, encoding="utf-8")
     data = {
@@ -613,6 +599,10 @@ def prime_train(
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip Prime confirmation prompt."),
 ) -> None:
     """Launch a Hosted Training run through the Prime CLI."""
+    try:
+        validate_training_handoff(tomllib.loads(config_path.read_text(encoding="utf-8")))
+    except (OSError, ValueError) as exc:
+        raise typer.BadParameter(str(exc)) from exc
     _require_prime_runtime()
     command = ["prime", "train", str(config_path), "--plain"]
     for item in env_var or []:
@@ -1023,190 +1013,6 @@ def _parse_env_arg(item: str) -> tuple[str, object]:
     except json.JSONDecodeError:
         value = raw_value
     return key, value
-
-
-def _parse_difficulty_ratios(items: list[str]) -> list[_DifficultyRatio]:
-    ratios: list[_DifficultyRatio] = []
-    seen: set[str] = set()
-    for item in items:
-        difficulty, separator, raw_ratio = item.partition("=")
-        difficulty = difficulty.strip()
-        if not separator or not difficulty:
-            raise typer.BadParameter("--difficulty-ratio must use DIFFICULTY=RATIO format")
-        if difficulty in seen:
-            raise typer.BadParameter(f"duplicate --difficulty-ratio difficulty: {difficulty}")
-        try:
-            ratio = float(raw_ratio)
-        except ValueError as exc:
-            raise typer.BadParameter("--difficulty-ratio ratio must be a positive number") from exc
-        if not math.isfinite(ratio) or ratio <= 0:
-            raise typer.BadParameter("--difficulty-ratio ratio must be a positive number")
-        seen.add(difficulty)
-        ratios.append(_DifficultyRatio(difficulty=difficulty, ratio=ratio))
-    return ratios
-
-
-def _prime_train_env_args_list(
-    *,
-    base_env_args: dict[str, object],
-    difficulty: list[str] | None,
-    difficulty_ratios: list[_DifficultyRatio],
-) -> list[dict[str, object]]:
-    if difficulty_ratios:
-        env_args_list = []
-        for item in difficulty_ratios:
-            env_args = dict(base_env_args)
-            env_args["difficulty"] = item.difficulty
-            env_args_list.append(env_args)
-        return env_args_list
-
-    env_args = dict(base_env_args)
-    if difficulty:
-        env_args["difficulty"] = difficulty[0] if len(difficulty) == 1 else list(difficulty)
-    return [env_args]
-
-
-def _prime_train_buffer_config(
-    *,
-    difficulty_ratios: list[_DifficultyRatio],
-    online_difficulty_filtering: bool,
-    easy_threshold: float,
-    hard_threshold: float,
-    easy_fraction: float,
-    hard_fraction: float,
-) -> _PrimeTrainBufferConfig | None:
-    if not difficulty_ratios and not online_difficulty_filtering:
-        return None
-    return _PrimeTrainBufferConfig(
-        env_ratios=[item.ratio for item in difficulty_ratios] or None,
-        online_difficulty_filtering=online_difficulty_filtering,
-        easy_threshold=easy_threshold if online_difficulty_filtering else None,
-        hard_threshold=hard_threshold if online_difficulty_filtering else None,
-        easy_fraction=easy_fraction if online_difficulty_filtering else None,
-        hard_fraction=hard_fraction if online_difficulty_filtering else None,
-    )
-
-
-def _render_train_config(
-    *,
-    environment: str,
-    model: str,
-    max_steps: int,
-    batch_size: int,
-    rollouts_per_example: int,
-    max_tokens: int,
-    env_args_list: list[dict[str, object]],
-    buffer_config: _PrimeTrainBufferConfig | None,
-    eval_interval: int | None,
-    eval_num_examples: int | None,
-    eval_rollouts_per_example: int,
-    eval_base_model: bool,
-    adapters_keep_last: int,
-) -> str:
-    lines = [
-        f"model = {_toml_string(model)}",
-        f"max_steps = {max_steps}",
-        f"batch_size = {batch_size}",
-        f"rollouts_per_example = {rollouts_per_example}",
-        "",
-        "[sampling]",
-        f"max_tokens = {max_tokens}",
-    ]
-    for env_args in env_args_list:
-        lines.extend(
-            [
-                "",
-                "[[env]]",
-                f"id = {_toml_string(environment)}",
-            ]
-        )
-        if env_args:
-            lines.append(f"args = {_toml_inline_table(env_args)}")
-
-    if buffer_config is not None:
-        lines.extend(["", "[buffer]"])
-        lines.extend(_render_buffer_config_lines(buffer_config))
-
-    if eval_interval is not None:
-        lines.extend(
-            [
-                "",
-                "[eval]",
-                f"interval = {eval_interval}",
-            ]
-        )
-        if eval_num_examples is not None:
-            lines.append(f"num_examples = {eval_num_examples}")
-        lines.extend(
-            [
-                f"rollouts_per_example = {eval_rollouts_per_example}",
-                f"eval_base_model = {_toml_bool(eval_base_model)}",
-            ]
-        )
-
-    lines.extend(
-        [
-            "",
-            "[adapters]",
-            "interval = 0",
-            f"keep_last = {adapters_keep_last}",
-            "",
-        ]
-    )
-    return "\n".join(lines)
-
-
-def _render_buffer_config_lines(buffer_config: _PrimeTrainBufferConfig) -> list[str]:
-    values: dict[str, object] = {}
-    if buffer_config.env_ratios is not None:
-        values["env_ratios"] = buffer_config.env_ratios
-    if buffer_config.online_difficulty_filtering:
-        values["online_difficulty_filtering"] = True
-    if buffer_config.easy_threshold is not None:
-        values["easy_threshold"] = buffer_config.easy_threshold
-    if buffer_config.hard_threshold is not None:
-        values["hard_threshold"] = buffer_config.hard_threshold
-    if buffer_config.easy_fraction is not None:
-        values["easy_fraction"] = buffer_config.easy_fraction
-    if buffer_config.hard_fraction is not None:
-        values["hard_fraction"] = buffer_config.hard_fraction
-    return [f"{key} = {_toml_value(value)}" for key, value in values.items()]
-
-
-def _toml_inline_table(values: dict[str, object]) -> str:
-    bits = [f"{key} = {_toml_value(value)}" for key, value in values.items()]
-    return "{ " + ", ".join(bits) + " }"
-
-
-def _toml_value(value: object) -> str:
-    if isinstance(value, str):
-        return _toml_string(value)
-    if isinstance(value, bool):
-        return _toml_bool(value)
-    if isinstance(value, int) and not isinstance(value, bool):
-        return str(value)
-    if isinstance(value, float):
-        return _toml_float(value)
-    if isinstance(value, list):
-        return "[" + ", ".join(_toml_value(item) for item in value) + "]"
-    raise TypeError(f"unsupported TOML value: {value!r}")
-
-
-def _toml_string(value: str) -> str:
-    return json.dumps(value)
-
-
-def _toml_bool(value: bool) -> str:
-    return "true" if value else "false"
-
-
-def _toml_float(value: float) -> str:
-    if not math.isfinite(value):
-        raise TypeError(f"unsupported TOML float: {value!r}")
-    text = format(value, ".15g")
-    if "." not in text and "e" not in text.lower():
-        return f"{text}.0"
-    return text
 
 
 def _run_prime_command(command: list[str], *, cwd: Path | None) -> None:

--- a/src/aec_bench/experimentation/qualification/hydraulic_training.py
+++ b/src/aec_bench/experimentation/qualification/hydraulic_training.py
@@ -1,0 +1,300 @@
+# ABOUTME: Qualifies hydraulic lineage packages through the local Prime lifecycle environment.
+# ABOUTME: Retains deterministic control evidence and actor-visible training demonstrations without model calls.
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib
+import json
+import platform
+import tomllib
+from importlib.metadata import version
+from pathlib import Path
+from typing import Any
+
+from aec_bench.experimentation.engineering_decisions.definitions import HydraulicExperiment
+from aec_bench.experimentation.engineering_decisions.hydraulic_counterfactual import (
+    hydraulic_plan,
+    run_hydraulic_counterfactual,
+)
+from aec_bench.experimentation.engineering_decisions.records import publish_record, write_plan
+from aec_bench.lifecycles.catalogue import lifecycle_operation_resolver
+from aec_bench.lifecycles.runtime.lifecycle import read_lifecycle
+from aec_bench.lifecycles.stormwater_design.hydraulic_review import materialize_hydraulic_review_lifecycle
+from aec_bench.lifecycles.stormwater_design.hydraulics.lineages import HydraulicLineage
+from aec_bench.prime_lab.lifecycle_environment import load_local_lifecycle_environment
+from aec_bench.prime_lab.lifecycle_exporter import (
+    LifecycleDatasetAssignment,
+    PrimeLifecycleExportConfig,
+    PrimeLifecyclePackageRecord,
+    export_prime_lifecycle_environment,
+)
+from aec_bench.prime_lab.training import render_train_config, validate_training_handoff
+
+
+def qualify_hydraulic_training(output: Path, definition: HydraulicExperiment | None = None) -> dict[str, Any]:
+    """Generate disjoint public fixtures and exercise the installed Verifiers tool and reward boundary."""
+    definition = definition or HydraulicExperiment()
+    if {partition.split for partition in definition.partitions} != {"train", "development", "acceptance"}:
+        raise ValueError("training qualification requires train, development, and acceptance partitions")
+    output = Path(output).resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    if any(output.iterdir()):
+        raise ValueError("qualification output directory must be empty")
+    _write_json(output / "definition.json", definition.model_dump(mode="json"))
+    write_plan(
+        output / "reference_trials",
+        definition,
+        [
+            hydraulic_plan(definition.experiment_id, seed, revision, "none")
+            for partition in definition.partitions
+            if partition.split != "acceptance"
+            for seed in partition.seeds
+            for revision in definition.revisions
+        ],
+    )
+    assignments = {}
+    references = {}
+    # Split whole projects before deriving revision siblings. Acceptance stays outside the export.
+    for partition in definition.partitions:
+        for seed in partition.seeds:
+            lineage = HydraulicLineage(seed=seed)
+            for revision in definition.revisions:
+                destination = output / partition.split / str(seed) / revision
+                if partition.split == "acceptance":
+                    materialize_hydraulic_review_lifecycle(
+                        destination / "package", variant_id=revision, lineage=lineage
+                    )
+                    continue
+                record = run_hydraulic_counterfactual(destination, seed=seed, revision_id=revision)
+                publish_record(output / "reference_trials", record)
+                package = destination / "package"
+                assignment = LifecycleDatasetAssignment(
+                    group_id=lineage.lineage_id,
+                    split="train" if partition.split == "train" else "eval",
+                )
+                assignments[package] = assignment
+                references[(lineage.lineage_id, revision)] = destination
+    exported = export_prime_lifecycle_environment(
+        PrimeLifecycleExportConfig(
+            name="aec_hydraulic_training",
+            package_dirs=tuple(assignments),
+            dataset_assignments=assignments,
+            output_dir=output / "environments",
+            max_turns=128,
+        )
+    )
+    (output / "training.toml").write_text(
+        render_train_config(
+            environment=exported.environment_id,
+            model="Qwen/Qwen3.5-0.8B",
+            max_steps=1,
+            batch_size=4,
+            rollouts_per_example=4,
+            max_tokens=2048,
+            env_args_list=[{"split": "train"}],
+            eval_interval=1,
+            eval_num_examples=None,
+            eval_rollouts_per_example=1,
+            eval_base_model=True,
+            adapters_keep_last=1,
+        ),
+        encoding="utf-8",
+    )
+    config = tomllib.loads((output / "training.toml").read_text())
+    validate_training_handoff(config)
+    prime_config = importlib.import_module("prime_cli.commands.rl").RLConfig.model_validate(config)
+    if prime_config.eval.to_api_dict() is None:
+        raise ValueError("Prime configuration omits evaluation environments from its API request")
+    environment = load_local_lifecycle_environment(manifest_path=exported.manifest_path, split="train")
+    result = asyncio.run(_qualify(environment, references, output))
+    result["runtime"] = {
+        "python": platform.python_version(),
+        "prime": version("prime"),
+        "verifiers": version("verifiers"),
+    }
+    result["package_requirements"] = tomllib.loads((exported.package_dir / "pyproject.toml").read_text())["project"]
+    result["environment_package"] = str(exported.package_dir.relative_to(output))
+    result["training_config"] = "accepted_by_installed_prime_cli"
+    result["hosted_run"] = "not_run"
+    result["weight_update"] = "not_run"
+    result["pending_checks"] = [
+        "Install the bound AEC-Bench source and generated package in the hosted runtime.",
+        "Confirm the hosted Python and Verifiers versions accept the package requirements.",
+        "Confirm an exact SFT checkpoint can initialize the RL arm.",
+        "Run budgeted training, retain the resulting checkpoint, reload it, and evaluate it.",
+    ]
+    result["scope"] = "synthetic_deterministic_controls_not_model_learning_or_transfer"
+    _write_json(output / "qualification.json", result)
+    if not result["local_passed"]:
+        raise ValueError(f"local training qualification failed; inspect {output / 'qualification.json'}")
+    return result
+
+
+async def _qualify(environment: Any, references: dict[tuple[str, str], Path], output: Path) -> dict[str, Any]:
+    vf = importlib.import_module("verifiers")
+    checks = []
+    demonstrations = []
+    rows = list(environment.get_dataset()) + list(environment.get_eval_dataset())
+    for index, row in enumerate(rows):
+        record = PrimeLifecyclePackageRecord.model_validate_json(row["info"])
+        assignment = record.dataset_assignment
+        assert assignment is not None
+        reference = references[(assignment.group_id, record.variant_id)]
+        state = vf.State(input=dict(row))
+        state["trajectory_id"] = f"qualification-{index}"
+        state["completion"] = []
+        state["trajectory"] = []
+        await environment.setup_state(state)
+        messages = list(row["prompt"])
+        try:
+            package, run = reference / "package", reference / "run"
+            lifecycle = read_lifecycle(package, run, operation_resolver=lifecycle_operation_resolver(package, run))
+            for checkpoint in lifecycle["checkpoint_runs"]:
+                checkpoint_id = checkpoint["checkpoint_id"]
+                await _call(environment, state, messages, "read_workspace_file", {"path": "instruction.md"})
+                if checkpoint["operation_actions"]:
+                    await _call(
+                        environment,
+                        state,
+                        messages,
+                        "read_workspace_file",
+                        {
+                            "path": f"checkpoints/{checkpoint_id}/operations.json",
+                        },
+                    )
+                for action in checkpoint["operation_actions"]:
+                    await _call(
+                        environment,
+                        state,
+                        messages,
+                        "read_workspace_file",
+                        {
+                            "path": "operations/current-source.json",
+                        },
+                    )
+                    response = await _call(
+                        environment,
+                        state,
+                        messages,
+                        "execute_operation",
+                        {
+                            "checkpoint_id": checkpoint_id,
+                            "operation_id": action["operation_id"],
+                            "visible_source_state_sha256": action["visible_source_state_before_sha256"],
+                            "reason": "Reproduce the public deterministic calculation control.",
+                        },
+                    )
+                    payload = json.loads(response)
+                    if payload.get("status") not in {"completed", "already_current"}:
+                        raise ValueError(f"Prime rejected control operation: {payload}")
+                    for artifact in payload.get("artifacts", []):
+                        await _call(environment, state, messages, "read_workspace_file", {"path": artifact["path"]})
+                submission = (run / "episodes" / checkpoint_id / "submission.json").read_text()
+                await _call(
+                    environment,
+                    state,
+                    messages,
+                    "write_checkpoint_submission",
+                    {
+                        "checkpoint_id": checkpoint_id,
+                        "content": submission,
+                    },
+                )
+                await _call(environment, state, messages, "submit_checkpoint", {"checkpoint_id": checkpoint_id})
+            await environment.rubric.score_rollout(state)
+            passed = state.get("reward") == 1.0 and state.get("lifecycle_reward_status") == "verified"
+            checks.append({"group_id": assignment.group_id, "revision": record.variant_id, "passed": passed})
+            if assignment.split == "train" and passed:
+                demonstrations.append(
+                    {
+                        "messages": messages,
+                        "tools": [
+                            {"type": "function", "function": tool.model_dump(exclude_none=True)}
+                            for tool in environment.tool_defs
+                        ],
+                    }
+                )
+            _write_json(
+                output / "prime_controls" / f"{index}.json",
+                {
+                    "messages": messages,
+                    "reward": state.get("reward"),
+                    "verification": state.get("lifecycle_verification"),
+                },
+            )
+        finally:
+            await environment.rubric.cleanup(state)
+    # Start another rollout and verify that previous submissions and progress are absent.
+    incomplete = vf.State(input=dict(rows[0]))
+    incomplete["trajectory_id"] = "qualification-incomplete"
+    incomplete["completion"] = []
+    incomplete["trajectory"] = []
+    await environment.setup_state(incomplete)
+    try:
+        workspace = Path(incomplete["workspace_path"])
+        isolation_passed = not (workspace / "submissions" / "baseline_analysis.json").exists()
+        current = read_lifecycle(
+            Path(incomplete["package_dir"]),
+            Path(incomplete["run_dir"]),
+            operation_resolver=lifecycle_operation_resolver(
+                Path(incomplete["package_dir"]), Path(incomplete["run_dir"])
+            ),
+        )
+        isolation_passed = isolation_passed and current["active_checkpoint_id"] == "baseline_analysis"
+        await environment.rubric.score_rollout(incomplete)
+        incomplete_passed = (
+            incomplete.get("reward") == 0.0 and incomplete.get("lifecycle_reward_status") == "incomplete"
+        )
+    finally:
+        await environment.rubric.cleanup(incomplete)
+    (output / "training_demonstrations.jsonl").write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in demonstrations),
+        encoding="utf-8",
+    )
+    return {
+        "local_passed": all(check["passed"] for check in checks) and incomplete_passed and isolation_passed,
+        "controls": checks,
+        "incomplete_zero_reward": incomplete_passed,
+        "rollout_isolation": isolation_passed,
+        "training_demonstrations": len(demonstrations),
+    }
+
+
+async def _call(environment: Any, state: Any, messages: list[dict[str, Any]], name: str, args: dict[str, Any]) -> str:
+    call_id = f"control-{len(messages)}"
+    messages.append(
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": call_id, "type": "function", "function": {"name": name, "arguments": json.dumps(args)}}
+            ],
+        }
+    )
+    response = await environment.call_tool(name, environment.update_tool_args(name, args.copy(), [], state), call_id)
+    if not isinstance(response.content, str):
+        raise TypeError("Prime tool response must be text")
+    messages.append({"role": "tool", "tool_call_id": call_id, "content": response.content})
+    return response.content
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--definition", type=Path, help="HydraulicExperiment JSON with project partitions and revisions."
+    )
+    args = parser.parse_args()
+    definition = HydraulicExperiment.model_validate_json(args.definition.read_text()) if args.definition else None
+    print(json.dumps(qualify_hydraulic_training(args.output, definition), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aec_bench/prime_lab/lifecycle_environment.py
+++ b/src/aec_bench/prime_lab/lifecycle_environment.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import hashlib
 import importlib
 import json
+import math
 import random
 import tarfile
 import tempfile
@@ -42,6 +43,7 @@ from aec_bench.prime_lab.lifecycle_exporter import (
     _validated_source_project_root,
     load_prime_lifecycle_manifest,
 )
+from aec_bench.prime_lab.lifecycle_source import read_runtime_requirements, snapshot_lifecycle_source
 from aec_bench.providers.source_identity import resolve_provider_adapter_identity
 
 _SYSTEM_PROMPT = """You are completing one staged AEC evidence lifecycle in a single persistent interaction.
@@ -62,8 +64,8 @@ def load_local_lifecycle_environment(
     harness: str | None = None,
 ) -> Any:
     """Load one local-only persistent lifecycle environment from a strict manifest."""
-    if split not in {"eval", "all"}:
-        raise ValueError("local lifecycle exports support only split='eval' or split='all'")
+    if split not in {"train", "eval", "all"}:
+        raise ValueError("lifecycle exports support split='train', split='eval', or split='all'")
     if harness not in {None, "persistent_lifecycle"}:
         raise ValueError("local lifecycle exports require harness='persistent_lifecycle'")
     if num_examples is not None and num_examples <= 0:
@@ -84,10 +86,34 @@ def load_local_lifecycle_environment(
     else:
         _assert_source_provenance(manifest.source)
         records = manifest.packages
+    training_records: tuple[LifecyclePackageDocument, ...] = ()
+    assigned = isinstance(manifest, PrimeLifecycleExportManifest) and any(
+        record.dataset_assignment is not None for record in manifest.packages
+    )
+    if split == "train" and not assigned:
+        raise ValueError("training requires explicit disjoint lifecycle group assignments")
+    if assigned and split != "all":
+        evaluation_records = tuple(
+            record
+            for record in records
+            if isinstance(record, PrimeLifecyclePackageRecord)
+            and record.dataset_assignment is not None
+            and record.dataset_assignment.split == "eval"
+        )
+        if split == "train":
+            training_records = _select_records(
+                tuple(record for record in records if record not in evaluation_records),
+                variant=variant,
+                num_examples=num_examples,
+                seed=seed,
+            )
+        records = evaluation_records
     records = _select_records(records, variant=variant, num_examples=num_examples, seed=seed)
+    evaluation_dataset = _build_dataset(records)
+    records = training_records + records
     supports_evidence_requests = _records_support_evidence_requests(records)
     supports_lifecycle_operations = _records_support_lifecycle_operations(records)
-    dataset = _build_dataset(records)
+    dataset = _build_dataset(training_records) if training_records else None
     vf = importlib.import_module("verifiers")
     rubric = _build_lifecycle_rubric(vf)
     environment_type = _build_environment_type(
@@ -99,6 +125,7 @@ def load_local_lifecycle_environment(
         manifest=manifest,
         records=records,
         dataset=dataset,
+        eval_dataset=evaluation_dataset,
         rubric=rubric,
         manifest_root=resolved_manifest_path.parent,
         package_storage=package_storage,
@@ -230,6 +257,7 @@ def _build_environment_type(
             manifest: PrimeLifecycleManifestDocument,
             records: tuple[PrimeLifecyclePackageRecord, ...] | tuple[LegacyPrimeLifecyclePackageRecord, ...],
             dataset: Any,
+            eval_dataset: Any,
             rubric: Any,
             manifest_root: Path,
             package_storage: tempfile.TemporaryDirectory[str] | None,
@@ -256,7 +284,7 @@ def _build_environment_type(
                 tools=[],
                 max_turns=manifest.max_turns,
                 dataset=dataset,
-                eval_dataset=dataset,
+                eval_dataset=eval_dataset,
                 rubric=rubric,
                 system_prompt=system_prompt,
             )
@@ -356,6 +384,22 @@ def _build_lifecycle_rubric(vf: Any) -> Any:
     class AecBenchLifecycleRubric(vf.Rubric):  # type: ignore[misc]
         def __init__(self) -> None:
             super().__init__(funcs=[aec_bench_lifecycle_reward])
+
+        async def _call_individual_reward_func(self, func: Any, state: Any) -> float:
+            # A failed verifier is infrastructure failure, not a negative training example.
+            try:
+                reward = float(await func(state=state))
+                if not math.isfinite(reward) or not 0 <= reward <= 1:
+                    raise ValueError("lifecycle reward must be finite and in [0, 1]")
+                return reward
+            except Exception as cause:
+                error = cause if isinstance(cause, vf.InfraError) else vf.InfraError("AEC lifecycle verifier failed")
+                state["error"] = error
+                state["reward"] = None
+                state["metrics"] = {}
+                if error is cause:
+                    raise
+                raise error from cause
 
         @vf.cleanup  # type: ignore[untyped-decorator]
         async def cleanup_lifecycle_state(self, state: dict[str, Any]) -> None:
@@ -463,7 +507,19 @@ def _assert_source_provenance(
     if manifest_root is None:
         raise ValueError("current Prime lifecycle source provenance requires its manifest root")
     if expected.source_snapshot is not None:
-        _verify_artifact_ref(expected.source_snapshot, root=manifest_root)
+        snapshot = _verify_artifact_ref(expected.source_snapshot, root=manifest_root)
+        requirements = read_runtime_requirements(snapshot)
+        if requirements is not None:
+            with tempfile.TemporaryDirectory(prefix="aec-prime-source-check-") as temporary:
+                actual = snapshot_lifecycle_source(
+                    Path(__file__).resolve().parents[1],
+                    Path(temporary) / "provider-source.tar",
+                    package_version=_distribution_version("aec-bench"),
+                    requirements=requirements,
+                )
+            if actual != expected:
+                raise ValueError("installed aec-bench source identity does not match lifecycle export")
+            return
     source_root = _validated_source_project_root(Path(__file__).resolve().parents[3])
     with tempfile.TemporaryDirectory(prefix="aec-prime-source-check-") as temporary:
         current_actual = resolve_provider_adapter_identity(

--- a/src/aec_bench/prime_lab/lifecycle_exporter.py
+++ b/src/aec_bench/prime_lab/lifecycle_exporter.py
@@ -11,7 +11,7 @@ import tempfile
 import textwrap
 import tomllib
 import warnings
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from importlib import metadata as importlib_metadata
 from pathlib import Path
 from typing import Any, Literal
@@ -28,10 +28,8 @@ from aec_bench.lifecycles.runtime.lifecycle import (
     load_evidence_lifecycle_spec,
 )
 from aec_bench.prime_lab.exporter import DEFAULT_PRIME_ENVIRONMENTS_DIR, normalise_environment_id
-from aec_bench.providers.source_identity import (
-    resolve_provider_adapter_identity,
-    write_deterministic_source_snapshot,
-)
+from aec_bench.prime_lab.lifecycle_source import lifecycle_runtime_requirements, snapshot_lifecycle_source
+from aec_bench.providers.source_identity import write_deterministic_source_snapshot
 
 
 class LegacyPrimeLifecycleSourceProvenance(StrictModel):
@@ -95,6 +93,13 @@ class PrimeLifecycleProtocolVersions(StrictModel):
     lifecycle_operation: Literal["1"] = "1"
 
 
+class LifecycleDatasetAssignment(StrictModel):
+    """Caller-owned lineage membership for local training qualification."""
+
+    group_id: NonEmptyStr
+    split: Literal["train", "eval"]
+
+
 class PrimeLifecyclePackageRecord(StrictModel):
     package: ArtifactRef
     template_id: NonEmptyStr
@@ -103,6 +108,8 @@ class PrimeLifecyclePackageRecord(StrictModel):
     lifecycle_id: NonEmptyStr
     checkpoint_ids: tuple[NonEmptyStr, ...] = Field(min_length=1)
     initial_instruction: NonEmptyStr
+
+    dataset_assignment: LifecycleDatasetAssignment | None = None
 
     _package_dir: Path | None = PrivateAttr(default=None)
 
@@ -142,7 +149,25 @@ class PrimeLifecycleExportManifest(StrictModel):
 
     @model_validator(mode="after")
     def validate_packages(self) -> PrimeLifecycleExportManifest:
-        identities = [(record.lifecycle_id, record.variant_id) for record in self.packages]
+        identities = [
+            (
+                record.lifecycle_id,
+                record.variant_id,
+                record.dataset_assignment.group_id if record.dataset_assignment else None,
+            )
+            for record in self.packages
+        ]
+        assignments = [record.dataset_assignment for record in self.packages]
+        if any(assignments):
+            if not all(assignments):
+                raise ValueError("every lifecycle package requires a dataset assignment")
+            groups: dict[str, str] = {}
+            for assignment in assignments:
+                assert assignment is not None
+                if groups.setdefault(assignment.group_id, assignment.split) != assignment.split:
+                    raise ValueError("a lifecycle group cannot cross training and evaluation splits")
+            if set(groups.values()) != {"train", "eval"}:
+                raise ValueError("training qualification requires non-empty train and eval groups")
         if len(set(identities)) != len(identities):
             raise ValueError("duplicate lifecycle package identity")
         artifact_ids = [record.package.artifact_id for record in self.packages]
@@ -173,6 +198,7 @@ class PrimeLifecycleExportConfig:
     description: str | None = None
     max_turns: int = 60
     aec_bench_root: Path | None = None
+    dataset_assignments: dict[Path, LifecycleDatasetAssignment] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -203,8 +229,14 @@ def export_prime_lifecycle_environment(config: PrimeLifecycleExportConfig) -> Pr
             key=lambda record: (record.template_id, record.lifecycle_id, record.variant_id, record.package_dir),
         )
     )
+    assignments = {Path(path).resolve(): assignment for path, assignment in config.dataset_assignments.items()}
+    if assignments and set(assignments) != {record.package_dir for record in records}:
+        raise ValueError("dataset assignments must match the selected lifecycle packages exactly")
     duplicate_paths = [str(record.package_dir) for record in records]
-    duplicate_identities = [(record.lifecycle_id, record.variant_id) for record in records]
+    duplicate_identities = [
+        (record.lifecycle_id, record.variant_id, assignments[record.package_dir].group_id if assignments else None)
+        for record in records
+    ]
     if len(set(duplicate_paths)) != len(duplicate_paths) or len(set(duplicate_identities)) != len(duplicate_identities):
         raise ValueError("duplicate lifecycle package reference")
 
@@ -212,28 +244,30 @@ def export_prime_lifecycle_environment(config: PrimeLifecycleExportConfig) -> Pr
     package_dir = output_dir / environment_id
     _assert_destination_is_safe(package_dir, environment_id, records)
 
-    source_root = _validated_source_project_root(
-        Path(config.aec_bench_root).resolve()
-        if config.aec_bench_root is not None
-        else Path(__file__).resolve().parents[3]
-    )
-    source_paths = _prime_source_paths(source_root)
+    if config.aec_bench_root is None:
+        package_root = Path(__file__).resolve().parents[1]
+    else:
+        source_root = _validated_source_project_root(Path(config.aec_bench_root))
+        package_root = source_root / "src" / "aec_bench"
+        if not package_root.is_dir():
+            package_root = source_root / "aec_bench"
+    requirements = lifecycle_runtime_requirements()
 
     output_dir.mkdir(parents=True, exist_ok=True)
     staging = Path(tempfile.mkdtemp(prefix=f".{environment_id}.tmp-", dir=output_dir))
     try:
         module_dir = staging / environment_id
         module_dir.mkdir(parents=True)
-        source = resolve_provider_adapter_identity(
-            adapter_id="aec-bench/prime-lifecycle",
+        source = snapshot_lifecycle_source(
+            package_root,
+            module_dir / "provider-source.tar",
             package_version=_distribution_version("aec-bench"),
-            source_root=source_root,
-            source_paths=source_paths,
-            snapshot_path=module_dir / "provider-source.tar",
-            snapshot_artifact_id="provider-source.tar",
+            requirements=requirements,
         )
         packaged_records = tuple(
-            _archive_lifecycle_package(record, module_dir=module_dir, index=index)
+            _archive_lifecycle_package(record, module_dir=module_dir, index=index).model_copy(
+                update={"dataset_assignment": assignments.get(record.package_dir)}
+            )
             for index, record in enumerate(records)
         )
         manifest = PrimeLifecycleExportManifest(
@@ -253,17 +287,16 @@ def export_prime_lifecycle_environment(config: PrimeLifecycleExportConfig) -> Pr
                 version=config.version,
                 description=config.description,
                 aec_bench_version=source.package_version,
+                requirements=requirements,
             ),
         )
         _write_text(staging / "README.md", _render_local_readme(environment_id, packaged_records))
         recheck_path = staging / ".source-recheck.tar"
-        actual_source = resolve_provider_adapter_identity(
-            adapter_id="aec-bench/prime-lifecycle",
+        actual_source = snapshot_lifecycle_source(
+            package_root,
+            recheck_path,
             package_version=source.package_version,
-            source_root=source_root,
-            source_paths=source_paths,
-            snapshot_path=recheck_path,
-            snapshot_artifact_id="provider-source.tar",
+            requirements=lifecycle_runtime_requirements(),
         )
         recheck_path.unlink(missing_ok=True)
         if actual_source != source:
@@ -444,12 +477,12 @@ def _render_local_pyproject(
     version: str,
     description: str | None,
     aec_bench_version: str,
+    requirements: dict[str, str],
 ) -> str:
     package_description = description or "Local persistent AEC evidence-lifecycle environment"
     dependencies = [
-        "datasets>=4.0",
-        "verifiers>=0.1.14,<0.2",
         f"aec-bench[prime]=={aec_bench_version}",
+        *(f"{name}=={version}" for name, version in requirements.items()),
     ]
     dependency_lines = ",\n".join(f"    {json.dumps(item)}" for item in dependencies)
     return textwrap.dedent(
@@ -499,14 +532,14 @@ def _render_local_readme(
 
         ## Local loading
 
-        Install the exact `aec-bench` version declared in `pyproject.toml` from its release artifact or
-        source distribution. Then install this generated package without replacing that resolved runtime.
+        Install the bound `aec-bench` wheel and this generated package together. The generated package
+        pins the resolved runtime dependencies. Loading verifies those versions and the adapter source
+        bytes, so another build with the same package version is not sufficient.
         Run the import from outside the aec-bench repository root so the repository `agents/` directory
         cannot shadow the installed `openai-agents` package used by Verifiers.
 
         ```bash
-        uv pip install /absolute/path/to/aec_bench-0.1.0-py3-none-any.whl
-        uv pip install --no-deps /absolute/path/to/generated-package
+        uv pip install /absolute/path/to/aec_bench-0.1.0-py3-none-any.whl /absolute/path/to/generated-package
         cd /tmp
         python \\
           -c "from {environment_id} import load_environment; print(type(load_environment()).__name__)"

--- a/src/aec_bench/prime_lab/lifecycle_source.py
+++ b/src/aec_bench/prime_lab/lifecycle_source.py
@@ -1,0 +1,107 @@
+# ABOUTME: Binds lifecycle adapters to portable source bytes and resolved runtime dependencies.
+# ABOUTME: Uses the same archive representation in source checkouts and installed wheels.
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import tarfile
+from importlib import metadata
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+
+from aec_bench.contracts.artifacts import ArtifactRef
+from aec_bench.contracts.provider_provenance import ProviderAdapterIdentity
+from aec_bench.providers.source_identity import write_deterministic_source_snapshot
+
+REQUIREMENTS_MEMBER = "runtime-requirements.json"
+
+
+def lifecycle_runtime_requirements() -> dict[str, str]:
+    """Resolve the installed AEC-Bench Prime dependency closure, including active extras."""
+    pending = [("aec-bench", frozenset({"prime"}))]
+    visited: set[tuple[str, frozenset[str]]] = set()
+    versions: dict[str, str] = {}
+    while pending:
+        name, extras = pending.pop()
+        name = canonicalize_name(name)
+        if (name, extras) in visited:
+            continue
+        visited.add((name, extras))
+        distribution = metadata.distribution(name)
+        if name != "aec-bench":
+            versions[name] = distribution.version
+        for raw in distribution.requires or ():
+            requirement = Requirement(raw)
+            if requirement.marker is not None and not any(
+                requirement.marker.evaluate({"extra": extra}) for extra in {"", *extras}
+            ):
+                continue
+            if requirement.url is not None:
+                raise ValueError(f"Prime runtime dependency requires an installable version: {requirement.name}")
+            installed = metadata.version(requirement.name)
+            if not requirement.specifier.contains(installed, prereleases=True):
+                raise ValueError(f"installed Prime dependency does not satisfy {requirement}")
+            pending.append((requirement.name, frozenset(requirement.extras)))
+    return dict(sorted(versions.items()))
+
+
+def snapshot_lifecycle_source(
+    package_root: Path, destination: Path, *, package_version: str, requirements: dict[str, str]
+) -> ProviderAdapterIdentity:
+    """Retain distribution bytes without absolute paths or checkout metadata."""
+    paths = (
+        package_root / "prime_lab",
+        package_root / "lifecycles",
+        package_root / "contracts" / "provider_provenance.py",
+        package_root / "providers" / "source_identity.py",
+    )
+    write_deterministic_source_snapshot(root=package_root.parent, source_paths=paths, destination=destination)
+    content = (json.dumps(requirements, sort_keys=True, indent=2) + "\n").encode()
+    with tarfile.open(destination, "a") as archive:
+        member = tarfile.TarInfo(REQUIREMENTS_MEMBER)
+        member.size = len(content)
+        member.mode = 0o644
+        archive.addfile(member, io.BytesIO(content))
+    data = destination.read_bytes()
+    return ProviderAdapterIdentity(
+        adapter_id="aec-bench/prime-lifecycle",
+        package_version=package_version,
+        source_snapshot=ArtifactRef(
+            artifact_id="provider-source.tar",
+            sha256=hashlib.sha256(data).hexdigest(),
+            size_bytes=len(data),
+            media_type="application/x-tar",
+        ),
+    )
+
+
+def read_runtime_requirements(snapshot: Path) -> dict[str, str] | None:
+    """Read portable archives; older checkout-bound snapshots have no dependency member."""
+    with tarfile.open(snapshot) as archive:
+        names = archive.getnames()
+        if REQUIREMENTS_MEMBER not in names:
+            return None
+        if names.count(REQUIREMENTS_MEMBER) != 1:
+            raise ValueError("duplicate Prime runtime requirements")
+        member = archive.getmember(REQUIREMENTS_MEMBER)
+        if not member.isfile() or member.size > 1_000_000:
+            raise ValueError("invalid Prime runtime requirements member")
+        stream = archive.extractfile(member)
+        assert stream is not None
+        requirements = json.load(stream)
+    if not isinstance(requirements, dict) or not requirements:
+        raise ValueError("Prime runtime requirements must be a non-empty version map")
+    for name, version in requirements.items():
+        if not isinstance(name, str) or not isinstance(version, str):
+            raise ValueError("Prime runtime requirements must contain package names and versions")
+        requirement = Requirement(f"{name}=={version}")
+        if requirement.url is not None or str(requirement.specifier) != f"=={version}":
+            raise ValueError("Prime runtime requirements must use exact versions")
+        installed = metadata.version(name)
+        if installed != version:
+            raise ValueError(f"Prime runtime dependency mismatch: {name} requires {version}, installed {installed}")
+    return requirements

--- a/src/aec_bench/prime_lab/training.py
+++ b/src/aec_bench/prime_lab/training.py
@@ -1,0 +1,162 @@
+# ABOUTME: Renders Prime hosted training configuration for CLI and qualification callers.
+# ABOUTME: Keeps external TOML field spelling at one provider boundary.
+
+from __future__ import annotations
+
+import json
+import math
+
+
+def render_train_config(
+    *,
+    environment: str,
+    model: str,
+    max_steps: int,
+    batch_size: int,
+    rollouts_per_example: int,
+    max_tokens: int,
+    env_args_list: list[dict[str, object]],
+    eval_interval: int | None,
+    eval_num_examples: int | None,
+    eval_rollouts_per_example: int,
+    eval_base_model: bool,
+    adapters_keep_last: int,
+    checkpoint_id: str | None = None,
+) -> str:
+    lines = [
+        f"model = {_toml_string(model)}",
+        f"max_steps = {max_steps}",
+        f"batch_size = {batch_size}",
+        f"rollouts_per_example = {rollouts_per_example}",
+        "",
+        "[sampling]",
+        f"max_tokens = {max_tokens}",
+    ]
+    if checkpoint_id is not None:
+        lines.insert(4, f"checkpoint_id = {_toml_string(checkpoint_id)}")
+    for env_args in env_args_list:
+        lines.extend(
+            [
+                "",
+                "[[env]]",
+                f"id = {_toml_string(environment)}",
+            ]
+        )
+        if env_args:
+            lines.append(f"args = {_toml_inline_table(env_args)}")
+
+    if eval_interval is not None:
+        lines.extend(
+            [
+                "",
+                "[eval]",
+                f"interval = {eval_interval}",
+            ]
+        )
+        if eval_num_examples is not None:
+            lines.append(f"num_examples = {eval_num_examples}")
+        lines.extend(
+            [
+                f"rollouts_per_example = {eval_rollouts_per_example}",
+                f"eval_base_model = {_toml_bool(eval_base_model)}",
+            ]
+        )
+
+        for env_args in env_args_list:
+            evaluation_args = dict(env_args)
+            evaluation_args["split"] = "eval"
+            if eval_num_examples is not None:
+                evaluation_args["num_examples"] = eval_num_examples
+            else:
+                evaluation_args.pop("num_examples", None)
+            lines.extend(
+                [
+                    "",
+                    "[[eval.env]]",
+                    f"id = {_toml_string(environment)}",
+                    f"args = {_toml_inline_table(evaluation_args)}",
+                ]
+            )
+
+    lines.extend(
+        [
+            "",
+            "[adapters]",
+            "interval = 0",
+            f"keep_last = {adapters_keep_last}",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _toml_inline_table(values: dict[str, object]) -> str:
+    bits = [f"{key} = {_toml_value(value)}" for key, value in values.items()]
+    return "{ " + ", ".join(bits) + " }"
+
+
+def _toml_value(value: object) -> str:
+    if isinstance(value, str):
+        return _toml_string(value)
+    if isinstance(value, bool):
+        return _toml_bool(value)
+    if isinstance(value, int) and not isinstance(value, bool):
+        return str(value)
+    if isinstance(value, float):
+        return _toml_float(value)
+    if isinstance(value, list):
+        return "[" + ", ".join(_toml_value(item) for item in value) + "]"
+    raise TypeError(f"unsupported TOML value: {value!r}")
+
+
+def _toml_string(value: str) -> str:
+    return json.dumps(value)
+
+
+def _toml_bool(value: bool) -> str:
+    return "true" if value else "false"
+
+
+def _toml_float(value: float) -> str:
+    if not math.isfinite(value):
+        raise TypeError(f"unsupported TOML float: {value!r}")
+    text = format(value, ".15g")
+    if "." not in text and "e" not in text.lower():
+        return f"{text}.0"
+    return text
+
+
+def validate_training_handoff(config: dict[str, object]) -> None:
+    """Reject known unsafe or removed fields before handing a config to Prime.
+
+    Prime still owns complete configuration and model-availability validation.
+    This check needs no credentials and does not establish hosted compatibility.
+    """
+    if not isinstance(config.get("model"), str) or not str(config["model"]).strip():
+        raise ValueError("training requires an explicit model")
+    checkpoint = config.get("checkpoint_id")
+    if checkpoint is not None and (not isinstance(checkpoint, str) or not checkpoint.strip()):
+        raise ValueError("checkpoint_id must be a non-empty string")
+    if "buffer" in config:
+        raise ValueError("Prime removed the difficulty buffer; use a current rollout-filter configuration")
+    evaluation = config.get("eval", {})
+    if isinstance(evaluation, dict) and "skip_first_step" in evaluation:
+        raise ValueError("the pinned Prime CLI uses eval.eval_base_model instead of eval.skip_first_step")
+    environments = config.get("env")
+    if not isinstance(environments, list) or not environments:
+        raise ValueError("training requires at least one environment")
+    for environment in environments:
+        if not isinstance(environment, dict):
+            raise ValueError("training environment must be a table")
+        arguments = environment.get("args", {})
+        if isinstance(arguments, dict) and arguments.get("split") in ("eval", "all", "test", "acceptance"):
+            raise ValueError("an evaluation-only split cannot supply training data")
+    for key in ("max_steps", "batch_size", "rollouts_per_example"):
+        value = config.get(key)
+        if type(value) is not int or value <= 0:
+            raise ValueError(f"{key} must be a positive integer")
+    batch_size = config["batch_size"]
+    rollouts = config["rollouts_per_example"]
+    assert isinstance(batch_size, int) and isinstance(rollouts, int)
+    if batch_size % rollouts:
+        raise ValueError("batch_size must be divisible by rollouts_per_example")

--- a/tests/experimentation/qualification/test_hydraulic_training.py
+++ b/tests/experimentation/qualification/test_hydraulic_training.py
@@ -1,0 +1,47 @@
+# ABOUTME: Proves local hydraulic training qualification uses real tools and disjoint project groups.
+# ABOUTME: Checks that only verified training controls enter assistant/tool demonstration rows.
+
+import json
+from pathlib import Path
+
+import pytest
+
+from aec_bench.experimentation.engineering_decisions.definitions import HydraulicExperiment
+from aec_bench.experimentation.qualification.hydraulic_training import qualify_hydraulic_training
+
+
+def test_local_qualification_retains_only_training_demonstrations(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vf = pytest.importorskip("verifiers")
+    monkeypatch.syspath_prepend(str(Path(vf.__file__).parents[1]))
+    definition = HydraulicExperiment(revisions=("administrative_no_op",))
+    report = qualify_hydraulic_training(tmp_path / "qualification", definition)
+    assert report["local_passed"]
+    assert report["training_config"] == "accepted_by_installed_prime_cli"
+    assert report["rollout_isolation"]
+    assert report["incomplete_zero_reward"]
+    assert len(report["controls"]) == 2
+    assert report["training_demonstrations"] == 1
+    assert report["hosted_run"] == report["weight_update"] == "not_run"
+    output = tmp_path / "qualification"
+    demos = [json.loads(line) for line in (output / "training_demonstrations.jsonl").read_text().splitlines()]
+    assert len(demos) == 1
+    messages = demos[0]["messages"]
+    assert sum(message["role"] == "system" for message in messages) == 1
+    calls = [call for message in messages for call in message.get("tool_calls", [])]
+    assert len(calls) <= 128
+    assert any(call["function"]["name"] == "read_workspace_file" for call in calls)
+    assert sum(call["function"]["name"] == "submit_checkpoint" for call in calls) == 3
+    assert all(tool["type"] == "function" for tool in demos[0]["tools"])
+    assert all("state" not in tool["function"]["parameters"]["properties"] for tool in demos[0]["tools"])
+    assert "dataset_assignment" not in json.dumps(demos)
+    assert "lifecycle_verification" not in json.dumps(demos)
+    # Acceptance fixtures exist locally but are not included in the transferable environment.
+    manifest = json.loads(
+        (output / report["environment_package"] / "aec_hydraulic_training" / "lifecycle_manifest.json").read_text()
+    )
+    assert len(manifest["packages"]) == 2
+    assert len(list((output / "acceptance").glob("*/administrative_no_op/package/lifecycle.json"))) == 1
+    with pytest.raises(ValueError, match="must be empty"):
+        qualify_hydraulic_training(output, definition)

--- a/tests/prime_lab/lifecycle_runtime_probe.py
+++ b/tests/prime_lab/lifecycle_runtime_probe.py
@@ -28,7 +28,7 @@ def main() -> None:
         path = Path(mutation_path)
         path.write_text(path.read_text(encoding="utf-8") + "\nmutated\n", encoding="utf-8")
 
-    dataset_row = dict(environment.dataset[0])
+    dataset_row = dict(environment.get_eval_dataset()[0])
     state = vf.State(input=dataset_row)
     state["task"] = dataset_row
     state["trajectory_id"] = request["trajectory_id"]

--- a/tests/prime_lab/test_exporter.py
+++ b/tests/prime_lab/test_exporter.py
@@ -1380,11 +1380,12 @@ def test_prime_train_config_writes_hosted_baby_qwen_config(tmp_path: Path) -> No
     assert payload["eval"]["num_examples"] == 10
     assert payload["eval"]["rollouts_per_example"] == 1
     assert payload["eval"]["eval_base_model"] is True
+    assert payload["eval"]["env"][0]["args"]["split"] == "eval"
     assert payload["adapters"]["interval"] == 0
     assert payload["adapters"]["keep_last"] == 3
 
 
-def test_prime_train_config_writes_online_difficulty_buffer_config(tmp_path: Path) -> None:
+def test_prime_train_config_rejects_removed_difficulty_buffer(tmp_path: Path) -> None:
     config_path = tmp_path / "configs" / "rl" / "aec-filtered-ratios.toml"
 
     result = runner.invoke(
@@ -1429,25 +1430,12 @@ def test_prime_train_config_writes_online_difficulty_buffer_config(tmp_path: Pat
         ],
     )
 
-    assert result.exit_code == 0, result.output
-    payload = tomllib.loads(config_path.read_text(encoding="utf-8"))
-    assert [env["args"]["difficulty"] for env in payload["env"]] == ["easy", "medium", "hard"]
-    assert payload["env"][0]["args"] == {
-        "split": "all",
-        "harness": "stateful",
-        "difficulty": "easy",
-    }
-    assert payload["buffer"] == {
-        "env_ratios": [0.45, 0.40, 0.15],
-        "online_difficulty_filtering": True,
-        "easy_threshold": 0.8,
-        "hard_threshold": 0.2,
-        "easy_fraction": 0.25,
-        "hard_fraction": 0.25,
-    }
+    assert result.exit_code != 0
+    assert "removed the difficulty buffer" in unstyle(result.output)
+    assert not config_path.exists()
 
 
-def test_prime_train_config_rejects_duplicate_difficulty_ratios(tmp_path: Path) -> None:
+def test_prime_train_config_rejects_removed_difficulty_ratios(tmp_path: Path) -> None:
     config_path = tmp_path / "configs" / "rl" / "aec-filtered-ratios.toml"
 
     result = runner.invoke(
@@ -1469,12 +1457,16 @@ def test_prime_train_config_rejects_duplicate_difficulty_ratios(tmp_path: Path) 
     )
 
     assert result.exit_code != 0
-    assert "duplicate --difficulty-ratio difficulty" in unstyle(result.output)
+    assert "removed the difficulty buffer" in unstyle(result.output)
 
 
 def test_prime_train_runs_hosted_training_config(monkeypatch, tmp_path: Path) -> None:
     config_path = tmp_path / "aec-train.toml"
-    config_path.write_text('model = "Qwen/Qwen3.5-0.8B"\n', encoding="utf-8")
+    config_path.write_text(
+        'model = "Qwen/Qwen3.5-0.8B"\nmax_steps = 1\nbatch_size = 4\nrollouts_per_example = 4\n'
+        '[[env]]\nid = "aec-hydraulic"\nargs = {split = "train"}\n',
+        encoding="utf-8",
+    )
     calls: list[tuple[list[str], Path | None, bool]] = []
 
     def fake_run(command: list[str], *, cwd: Path | None = None, check: bool = False):

--- a/tests/prime_lab/test_lifecycle_exporter.py
+++ b/tests/prime_lab/test_lifecycle_exporter.py
@@ -77,7 +77,8 @@ def test_lifecycle_export_retains_content_addressed_public_packages_without_loca
 
     pyproject = tomllib.loads((result.package_dir / "pyproject.toml").read_text(encoding="utf-8"))
     dependencies = cast(list[str], pyproject["project"]["dependencies"])
-    assert "verifiers>=0.1.14,<0.2" in dependencies
+    assert any(item.startswith("verifiers==") for item in dependencies)
+    assert any(item.startswith("pydantic==") for item in dependencies)
     assert "aec-bench[prime]==0.1.0" in dependencies
     assert "uv" not in pyproject.get("tool", {})
     readme = (result.package_dir / "README.md").read_text(encoding="utf-8")
@@ -87,7 +88,7 @@ def test_lifecycle_export_retains_content_addressed_public_packages_without_loca
     assert "prime train" not in readme
     assert "vf-eval" not in readme
     assert "uv pip install /absolute/path/to/aec_bench-0.1.0-py3-none-any.whl" in readme
-    assert "uv pip install --no-deps /absolute/path/to/generated-package" in readme
+    assert "/absolute/path/to/generated-package" in readme
 
 
 def test_lifecycle_export_is_deterministic_and_preserves_existing_output_on_rejection(tmp_path: Path) -> None:
@@ -261,7 +262,7 @@ def test_generated_lifecycle_environment_loads_outside_repo_root(tmp_path: Path)
     outside = tmp_path / "outside"
     outside.mkdir()
     environment = os.environ.copy()
-    environment["PYTHONPATH"] = str(result.package_dir)
+    environment["PYTHONPATH"] = os.pathsep.join([str(result.package_dir), str(REPOSITORY_ROOT / "src")])
     process = subprocess.run(
         [
             sys.executable,
@@ -269,7 +270,7 @@ def test_generated_lifecycle_environment_loads_outside_repo_root(tmp_path: Path)
             (
                 "from stormwater_outside_import import load_environment; "
                 "env = load_environment(); "
-                "print(type(env).__name__, len(env.dataset), env.max_turns, "
+                "print(type(env).__name__, len(env.get_eval_dataset()), env.max_turns, "
                 "env.execution_mode, env.memory_visibility_policy)"
             ),
         ],
@@ -599,7 +600,7 @@ def test_generated_lifecycle_environment_rejects_path_escape_and_archive_drift(t
     outside = tmp_path / "outside-drift"
     outside.mkdir()
     environment = os.environ.copy()
-    environment["PYTHONPATH"] = str(result.package_dir)
+    environment["PYTHONPATH"] = os.pathsep.join([str(result.package_dir), str(REPOSITORY_ROOT / "src")])
     drift = subprocess.run(
         [sys.executable, "-c", f"from {result.environment_id} import load_environment; load_environment()"],
         cwd=outside,
@@ -769,8 +770,7 @@ def _run_generated_probe(
     outside.mkdir()
     environment = os.environ.copy()
     python_paths = [str(package_dir)]
-    if extra_python_path is not None:
-        python_paths.append(str(extra_python_path))
+    python_paths.append(str(extra_python_path if extra_python_path is not None else REPOSITORY_ROOT / "src"))
     environment["PYTHONPATH"] = os.pathsep.join(python_paths)
     process = subprocess.run(
         [sys.executable, str(RUNTIME_PROBE), environment_id],

--- a/tests/prime_lab/test_lifecycle_source.py
+++ b/tests/prime_lab/test_lifecycle_source.py
@@ -1,0 +1,58 @@
+# ABOUTME: Tests portable lifecycle source identity and exact runtime dependency checks.
+# ABOUTME: Proves relocation is safe while source and dependency changes remain rejected.
+
+import tarfile
+from importlib.metadata import version
+from pathlib import Path
+
+import pytest
+
+from aec_bench.prime_lab import lifecycle_environment as runtime
+from aec_bench.prime_lab.lifecycle_source import (
+    lifecycle_runtime_requirements,
+    read_runtime_requirements,
+    snapshot_lifecycle_source,
+)
+
+
+def test_portable_source_validation_accepts_installed_layout_and_rejects_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    package = Path(runtime.__file__).parents[1]
+    manifest_root = tmp_path / "environment"
+    snapshot = manifest_root / "provider-source.tar"
+    identity = snapshot_lifecycle_source(
+        package, snapshot, package_version=version("aec-bench"), requirements={"pydantic": version("pydantic")}
+    )
+    installed = tmp_path / "site-packages" / "aec_bench"
+    with tarfile.open(snapshot) as archive:
+        # This archive was produced above from trusted repository files.
+        archive.extractall(installed.parent, filter="data")
+    monkeypatch.setattr(runtime, "__file__", str(installed / "prime_lab" / "lifecycle_environment.py"))
+    assert not (installed.parent / "pyproject.toml").exists()
+    runtime._assert_source_provenance(identity, manifest_root=manifest_root)
+    marker = installed / "prime_lab" / "unexpected.py"
+    marker.write_text("CHANGED = True\n")
+    with pytest.raises(ValueError, match="source identity"):
+        runtime._assert_source_provenance(identity, manifest_root=manifest_root)
+    marker.unlink()
+    target = installed / "prime_lab" / "lifecycle_environment.py"
+    target.write_text(target.read_text() + "\n# changed\n")
+    with pytest.raises(ValueError, match="source identity"):
+        runtime._assert_source_provenance(identity, manifest_root=manifest_root)
+
+
+def test_runtime_dependency_drift_is_rejected(tmp_path: Path) -> None:
+    snapshot = tmp_path / "provider-source.tar"
+    snapshot_lifecycle_source(
+        Path(runtime.__file__).parents[1], snapshot, package_version="0.1.0", requirements={"pydantic": "0.0.0"}
+    )
+    with pytest.raises(ValueError, match="dependency mismatch: pydantic"):
+        read_runtime_requirements(snapshot)
+
+
+def test_runtime_requirements_cover_active_prime_dependencies() -> None:
+    requirements = lifecycle_runtime_requirements()
+    assert {"prime", "verifiers", "datasets", "pydantic", "openai-agents"} <= requirements.keys()
+    assert "aec-bench" not in requirements
+    assert all(version(name) == selected for name, selected in requirements.items())

--- a/tests/prime_lab/test_lifecycle_training.py
+++ b/tests/prime_lab/test_lifecycle_training.py
@@ -1,0 +1,96 @@
+# ABOUTME: Tests explicit group splits and verifier failures at the Prime lifecycle boundary.
+# ABOUTME: Uses generated public hydraulic lineages and the installed Verifiers scoring runtime.
+
+import asyncio
+from pathlib import Path
+from typing import Any, Literal
+
+import pytest
+
+from aec_bench.prime_lab import lifecycle_environment as runtime
+
+
+def test_lifecycle_verifier_error_does_not_become_training_reward(monkeypatch: pytest.MonkeyPatch) -> None:
+    vf = pytest.importorskip("verifiers")
+
+    async def broken(state: Any) -> float:
+        raise ValueError("invalid verifier evidence")
+
+    monkeypatch.setattr(runtime, "aec_bench_lifecycle_reward", broken)
+    rubric = runtime._build_lifecycle_rubric(vf)
+    state = vf.State(input={"prompt": [], "answer": "", "info": {}})
+    state["completion"] = []
+    with pytest.raises(vf.InfraError):
+        asyncio.run(rubric.score_rollout(state))
+    assert state["reward"] is None
+    assert isinstance(state["error"], vf.InfraError)
+
+
+def test_explicit_group_split_supports_revision_siblings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import json
+
+    vf = pytest.importorskip("verifiers")
+    monkeypatch.syspath_prepend(str(Path(vf.__file__).parents[1]))
+
+    from aec_bench.lifecycles.stormwater_design.hydraulic_review import materialize_hydraulic_review_lifecycle
+    from aec_bench.lifecycles.stormwater_design.hydraulics.lineages import HydraulicLineage
+    from aec_bench.prime_lab.lifecycle_exporter import (
+        LifecycleDatasetAssignment,
+        PrimeLifecycleExportConfig,
+        export_prime_lifecycle_environment,
+    )
+
+    assignments = {}
+    groups: tuple[tuple[int, Literal["train", "eval"]], ...] = ((2, "train"), (8, "eval"))
+    for seed, split in groups:
+        lineage = HydraulicLineage(seed=seed)
+        for revision in ("administrative_no_op", "major_idf_revision"):
+            package = materialize_hydraulic_review_lifecycle(
+                tmp_path / str(seed) / revision,
+                variant_id=revision,
+                lineage=lineage,
+            )
+            assignments[package] = LifecycleDatasetAssignment(group_id=lineage.lineage_id, split=split)
+    exported = export_prime_lifecycle_environment(
+        PrimeLifecycleExportConfig(
+            name="hydraulic_training_test",
+            package_dirs=tuple(assignments),
+            dataset_assignments=assignments,
+            output_dir=tmp_path / "exports",
+        )
+    )
+    environment = runtime.load_local_lifecycle_environment(manifest_path=exported.manifest_path, split="train")
+    train = [json.loads(row["info"])["dataset_assignment"]["group_id"] for row in environment.get_dataset()]
+    evaluation = [json.loads(row["info"])["dataset_assignment"]["group_id"] for row in environment.get_eval_dataset()]
+    assert len(train) == len(evaluation) == 2
+    assert set(train).isdisjoint(evaluation)
+    eval_only = runtime.load_local_lifecycle_environment(manifest_path=exported.manifest_path)
+    assert eval_only.dataset is None
+    assert len(eval_only.get_eval_dataset()) == 2
+    # A caller cannot put revision siblings in different splits.
+    path = next(iter(assignments))
+    assignments[path] = LifecycleDatasetAssignment(group_id=HydraulicLineage(seed=2).lineage_id, split="eval")
+    with pytest.raises(ValueError, match="cannot cross"):
+        export_prime_lifecycle_environment(
+            PrimeLifecycleExportConfig(
+                name="leaking_training_test",
+                package_dirs=tuple(assignments),
+                dataset_assignments=assignments,
+                output_dir=tmp_path / "exports",
+            )
+        )
+
+
+@pytest.mark.parametrize("reward", [float("nan"), float("inf"), -0.1, 1.1])
+def test_lifecycle_invalid_reward_aborts_scoring(monkeypatch: pytest.MonkeyPatch, reward: float) -> None:
+    vf = pytest.importorskip("verifiers")
+
+    async def invalid(state: Any) -> float:
+        return reward
+
+    monkeypatch.setattr(runtime, "aec_bench_lifecycle_reward", invalid)
+    state = vf.State(input={"prompt": [], "answer": "", "info": {}})
+    state["completion"] = []
+    with pytest.raises(vf.InfraError):
+        asyncio.run(runtime._build_lifecycle_rubric(vf).score_rollout(state))
+    assert state["reward"] is None

--- a/tests/prime_lab/test_training.py
+++ b/tests/prime_lab/test_training.py
@@ -1,0 +1,61 @@
+# ABOUTME: Checks the current Prime hosted config handoff without hosted access.
+# ABOUTME: Rejects evaluation-only data and removed fields before any training command starts.
+
+import tomllib
+
+import pytest
+
+from aec_bench.prime_lab.training import render_train_config, validate_training_handoff
+
+
+@pytest.mark.parametrize("eval_base_model", [True, False])
+def test_checkpoint_handoff_and_base_evaluation(eval_base_model: bool) -> None:
+    config = tomllib.loads(
+        render_train_config(
+            environment="hydraulic",
+            model="Qwen/Qwen3.5-0.8B",
+            max_steps=1,
+            batch_size=4,
+            rollouts_per_example=4,
+            max_tokens=2048,
+            env_args_list=[{"split": "train", "num_examples": 50}],
+            eval_interval=1,
+            eval_num_examples=None,
+            eval_rollouts_per_example=1,
+            eval_base_model=eval_base_model,
+            adapters_keep_last=1,
+            checkpoint_id="cp_test",
+        )
+    )
+    validate_training_handoff(config)
+    assert config["checkpoint_id"] == "cp_test"
+    prime = pytest.importorskip("prime_cli.commands.rl")
+    validated = prime.RLConfig.model_validate(config)
+    evaluation = validated.eval.to_api_dict()
+    assert evaluation is not None
+    assert evaluation["eval_base_model"] is eval_base_model
+    assert evaluation["environments"][0]["args"] == {"split": "eval"}
+    assert config["env"][0]["args"]["num_examples"] == 50
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        {"buffer": {}},
+        {"eval": {"skip_first_step": False}},
+        {"env": [{"id": "hydraulic", "args": {"split": "eval"}}]},
+        {"env": [{"id": "hydraulic", "args": {"split": "all"}}]},
+        {"batch_size": 3},
+        {"max_steps": True},
+    ],
+)
+def test_invalid_handoff_is_rejected(extra: dict[str, object]) -> None:
+    config = {
+        "model": "model",
+        "max_steps": 1,
+        "batch_size": 4,
+        "rollouts_per_example": 4,
+        "env": [{"id": "hydraulic", "args": {"split": "train"}}],
+    }
+    with pytest.raises(ValueError):
+        validate_training_handoff(config | extra)


### PR DESCRIPTION
## Summary

Add an executable hydraulic lifecycle qualification command that generates disjoint project groups, replays deterministic controls through the real Verifiers tools, and writes verified training demonstrations, a generated environment, and a Prime training configuration.

The generated environment now works from an installed AEC-Bench wheel. Its source snapshot uses package-relative paths and binds exact runtime dependency versions. The training configuration targets the pinned Prime CLI and explicitly includes evaluation environments; the previous generated configuration was rejected by that CLI and could omit evaluation from the API request.

- Keep revision siblings in the same project split and acceptance fixtures outside the exported environment.
- Treat verifier failures as infrastructure errors; preserve zero reward for valid incomplete work.
- Add checkpoint initialization to training configuration. Reject evaluation-only training splits and removed difficulty-buffer options, and remove the obsolete buffer renderer.
- Update the user guide, contracts, provenance policy, and dependency ownership.

### Review order

1. `prime_lab/lifecycle_exporter.py` and `lifecycle_environment.py`: split assignment, runtime isolation, and task-owned reward.
2. `prime_lab/lifecycle_source.py`: portable source identity and exact dependency validation.
3. `prime_lab/training.py` and the Prime CLI changes: configuration accepted by the pinned provider parser, with explicit evaluation data.
4. `experimentation/qualification/hydraulic_training.py` and its tests: the complete executable workflow.

## Verification

- `pytest tests/prime_lab/ tests/experimentation/qualification/test_hydraulic_training.py -q`: 119 passed. The subsequent expanded configuration test file also passed all 8 cases.
- `pytest tests/test_package_ownership.py tests/test_public_api_inventory.py tests/test_provenance_policy.py tests/test_provenance_manifest_discovery.py tests/docs/test_documentation_ownership.py -q`: 114 passed.
- `ruff check src/ tests/` and `ruff format --check src/ tests/`: passed.
- Focused mypy checks with `--follow-imports=silent` on eight changed implementation/test files: passed.
- `python scripts/check_provenance_fields.py --check`: passed, zero violations.
- `uv build`: source distribution and wheel built successfully.
- Installed the wheel and generated environment into a fresh Python 3.13.2 environment. The exported package loaded four training rows and four separate evaluation rows, and the installed Prime parser retained the evaluation API payload.
- Ran `python -m aec_bench.experimentation.qualification.hydraulic_training --output /tmp/aec-hydraulic-installed-proof` from that installation, outside the checkout: all eight controls passed, four verified training demonstrations were written, rollout isolation passed, and incomplete work received zero reward.
- Changed documentation link targets and `git diff --check`: passed.

### Limits

These checks use deterministic scripted controls, not model learning. Hosted installation, paid model rollouts, SFT token masking, checkpoint transfer, and weight updates remain unverified. No paid run or publication was performed. Earlier repository-wide mypy failures remain unresolved; the type-check result above is scoped. No production dependency versions were upgraded.

## Provenance

- [ ] No
- [x] Yes

The change uses the existing `ProviderAdapterIdentity` and `ArtifactRef` boundary for one reconstructive adapter source snapshot. The Prime integration owns it. The canonical archive contains selected adapter/lifecycle source files under package-relative paths and exact resolved runtime dependency versions. Generated package dependencies pin the same versions.

The loader checks the artifact reference, installed dependency versions, and current source bytes before loading and setting up a rollout. A source or dependency mismatch fails closed. The task lifecycle verifier remains the reward authority. Existing checkout-bound source references and schema-2 manifests remain readable. No second per-file inventory or repository revision is added for the same source claim.
